### PR TITLE
fix(desktop): auto-grow resized composer for long drafts

### DIFF
--- a/desktop/frontend/src/__tests__/composer-content-sizing.test.ts
+++ b/desktop/frontend/src/__tests__/composer-content-sizing.test.ts
@@ -1,0 +1,68 @@
+// Run: tsx src/__tests__/composer-content-sizing.test.ts
+
+import { resolveComposerContentSizing } from "../lib/composerSizing";
+
+let passed = 0;
+let failed = 0;
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (actual === expected) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}\n`);
+    failed += 1;
+  }
+}
+
+console.log("\ncomposer content sizing");
+
+const automatic = resolveComposerContentSizing({
+  contentHeight: 86,
+  manualLogicalHeight: null,
+  maxLogicalHeight: 360,
+  reservedHeight: 58,
+});
+eq(automatic.inputHeight, 86, "automatic composer follows its content height");
+eq(automatic.logicalHeight, null, "automatic composer keeps natural card sizing");
+eq(automatic.overflow, false, "automatic composer stays overflow-free below the cap");
+
+const shortManual = resolveComposerContentSizing({
+  contentHeight: 22,
+  manualLogicalHeight: 128,
+  maxLogicalHeight: 360,
+  reservedHeight: 58,
+});
+eq(shortManual.inputHeight, 70, "manual height remains the minimum input baseline");
+eq(shortManual.logicalHeight, 128, "short content does not shrink below the manual baseline");
+
+const growingManual = resolveComposerContentSizing({
+  contentHeight: 108,
+  manualLogicalHeight: 128,
+  maxLogicalHeight: 360,
+  reservedHeight: 58,
+});
+eq(growingManual.inputHeight, 108, "content can grow beyond the manual input baseline");
+eq(growingManual.logicalHeight, 166, "manual composer grows to reveal the longer draft");
+eq(growingManual.overflow, false, "growing content remains visible before the cap");
+
+const cappedManual = resolveComposerContentSizing({
+  contentHeight: 420,
+  manualLogicalHeight: 128,
+  maxLogicalHeight: 360,
+  reservedHeight: 58,
+});
+eq(cappedManual.inputHeight, 302, "manual composer input stops at the viewport-aware cap");
+eq(cappedManual.logicalHeight, 360, "manual composer card stops at the logical maximum");
+eq(cappedManual.overflow, true, "content scrolls internally only after reaching the cap");
+
+const shrunkManual = resolveComposerContentSizing({
+  contentHeight: 30,
+  manualLogicalHeight: 128,
+  maxLogicalHeight: 360,
+  reservedHeight: 58,
+});
+eq(shrunkManual.logicalHeight, 128, "deleting content returns the composer to its manual baseline");
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/composer-resized-input-css.test.ts
+++ b/desktop/frontend/src/__tests__/composer-resized-input-css.test.ts
@@ -1,10 +1,9 @@
 // Run: tsx src/__tests__/composer-resized-input-css.test.ts
 //
 // Contract: in the user-resized composer (`.composer-card--resized`), the
-// input fills the fixed card height and scrolls internally. JS applies no
-// inline height in resized mode, so `height: auto` would collapse the
-// rows=1 textarea to a single visible line forever (regression shipped in
-// desktop-v1.17.11: typing multiline text kept the input one line tall).
+// input fills the available card height and can scroll internally. These CSS
+// fallbacks remain authoritative during a live resize, when JS temporarily
+// removes the content-derived inline height.
 
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";

--- a/desktop/frontend/src/__tests__/composer-run-strip.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-run-strip.test.tsx
@@ -512,8 +512,8 @@ console.log("\ncomposer run strip");
 
 // Resize consistency: --composer-height always carries the logical height in
 // every writer (React render, live drag, keyboard), with the run strip's
-// reservation isolated in a CSS calc — so dragging a resized composer during a
-// running turn cannot flash-shrink the card.
+// reservation isolated in a CSS calc. A manual height is the draft's minimum,
+// so content can grow above it without changing the saved resize baseline.
 {
   const stylesSource = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), "../styles.css"), "utf8");
   ok(
@@ -554,6 +554,48 @@ console.log("\ncomposer run strip");
   await rerender({ running: false, turnStartAt: undefined });
   eq(card.style.getPropertyValue("--composer-run-strip-reserved"), "0px", "idle card releases the strip reservation");
   eq(card.style.getPropertyValue("--composer-height"), "124px", "idle card keeps the user's logical height");
+
+  const textarea = document.querySelector(".composer__input") as HTMLTextAreaElement;
+  let measuredDraftHeight = 108;
+  Object.defineProperty(textarea, "scrollHeight", {
+    configurable: true,
+    get: () => measuredDraftHeight,
+  });
+  const updateDraft = async (value: string) => {
+    await act(async () => {
+      textarea.focus();
+      textarea.setSelectionRange(0, textarea.value.length);
+      const paste = new window.Event("paste", { bubbles: true, cancelable: true });
+      Object.defineProperty(paste, "clipboardData", {
+        configurable: true,
+        value: {
+          files: [],
+          items: [],
+          types: ["text/plain"],
+          getData: (kind: string) => (kind === "text" || kind === "text/plain" ? value : ""),
+        },
+      });
+      textarea.dispatchEvent(paste);
+      await flushTimers();
+    });
+  };
+
+  await updateDraft("a longer pasted draft");
+  eq(card.style.getPropertyValue("--composer-height"), "166px", "longer draft grows above the manual baseline");
+  eq(textarea.style.height, "108px", "content-derived input height reveals the longer draft");
+  eq(textarea.style.overflowY, "hidden", "draft stays scrollbar-free below the cap");
+
+  measuredDraftHeight = 22;
+  await updateDraft("short");
+  eq(card.style.getPropertyValue("--composer-height"), "124px", "shorter draft returns to the manual baseline");
+  eq(textarea.style.height, "66px", "manual baseline remains available to short drafts");
+
+  measuredDraftHeight = 420;
+  await updateDraft("an oversized pasted draft");
+  const viewportCap = Math.min(360, Math.floor(window.innerHeight * 0.4));
+  eq(card.style.getPropertyValue("--composer-height"), `${viewportCap}px`, "oversized draft stops at the viewport-aware cap");
+  eq(textarea.style.height, `${viewportCap - 58}px`, "oversized input uses the capped content viewport");
+  eq(textarea.style.overflowY, "auto", "oversized draft scrolls only after reaching the cap");
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -33,6 +33,7 @@ import type { ControllerLiveStore } from "../lib/useController";
 import { clearLayoutSize, loadOptionalLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
 import { createRafResizeUpdater } from "../lib/resizeDrag";
 import { observeComposerMenuViewport } from "../lib/composerMenuViewport";
+import { resolveComposerContentSizing } from "../lib/composerSizing";
 import { useToast } from "../lib/toast";
 import { type CollaborationMode, type CommandInfo, type ComposerInsertRequest, type ContextInfo, type DirEntry, type EffortInfo, type GoalRuntime, type HistoryMessage, type Mode, type PromptHistoryEntry, type QualityFloor, type SessionMeta, type SessionReference, type SlashArgItem, type SlashArgsResult, type ToolApprovalMode, type BalanceInfo } from "../lib/types";
 import {
@@ -394,10 +395,6 @@ function clampComposerHeight(height: number): number {
   return Math.min(Math.max(Math.round(height), COMPOSER_MIN_HEIGHT), composerMaxHeight());
 }
 
-function composerAutoInputMaxHeight(extraReservedHeight = 0): number {
-  return Math.max(32, composerMaxHeight() - COMPOSER_AUTO_RESERVED_HEIGHT - extraReservedHeight);
-}
-
 function loadComposerHeight(): number | null {
   return loadOptionalLayoutSize("composerHeight", clampComposerHeight);
 }
@@ -733,6 +730,8 @@ export function Composer({
   const [active, setActive] = useState(0);
   const [dismissed, setDismissed] = useState(false);
   const [dragOver, setDragOver] = useState(false);
+  // A saved manual height is a floor, not a hard cap: longer drafts may grow
+  // above it and return to it when their content shrinks.
   const [composerHeight, setComposerHeight] = useState<number | null>(loadComposerHeight);
   const [composerResizing, setComposerResizing] = useState(false);
   const [textareaAutoHeight, setTextareaAutoHeight] = useState<number | null>(null);
@@ -2927,11 +2926,6 @@ export function Composer({
   }, []);
 
   const measureTextareaAutoHeight = useCallback(() => {
-    if (composerHeight !== null) {
-      setTextareaAutoHeight(null);
-      setTextareaAutoOverflow(false);
-      return;
-    }
     // Creation empty hero starts single-line but must grow so multi-line drafts
     // stay readable before send (review: fixed 20px + overflow:hidden clipped).
     if (heroMode) {
@@ -2958,12 +2952,15 @@ export function Composer({
     const previousHeight = node?.style.height;
     if (node) node.style.height = "auto";
     const scrollHeight = richHeight || node?.scrollHeight || 0;
-    const maxHeight = composerAutoInputMaxHeight();
-    const nextHeight = Math.min(scrollHeight, maxHeight);
-    const nextOverflow = scrollHeight > maxHeight + 1;
+    const sizing = resolveComposerContentSizing({
+      contentHeight: scrollHeight,
+      manualLogicalHeight: composerHeight,
+      maxLogicalHeight: composerMaxHeight(),
+      reservedHeight: COMPOSER_AUTO_RESERVED_HEIGHT,
+    });
     if (node && previousHeight !== undefined) node.style.height = previousHeight;
-    setTextareaAutoHeight((current) => (current === nextHeight ? current : nextHeight));
-    setTextareaAutoOverflow((current) => (current === nextOverflow ? current : nextOverflow));
+    setTextareaAutoHeight((current) => (current === sizing.inputHeight ? current : sizing.inputHeight));
+    setTextareaAutoOverflow((current) => (current === sizing.overflow ? current : sizing.overflow));
   }, [composerHeight, heroMode, invocations.length]);
 
   useLayoutEffect(() => {
@@ -2971,7 +2968,6 @@ export function Composer({
   }, [text, measureTextareaAutoHeight]);
 
   useEffect(() => {
-    if (composerHeight !== null) return;
     let frame = 0;
     const update = () => {
       if (frame) window.cancelAnimationFrame(frame);
@@ -3009,7 +3005,7 @@ export function Composer({
 
     e.preventDefault();
     const startY = e.clientY;
-    const startHeight = composerHeight ?? composerLogicalHeight(card);
+    const startHeight = Math.max(composerHeight ?? COMPOSER_MIN_HEIGHT, composerLogicalHeight(card));
     let nextHeight = clampComposerHeight(startHeight);
     let moved = false;
     card.style.setProperty("--composer-height", `${nextHeight}px`);
@@ -3047,7 +3043,10 @@ export function Composer({
 
   const onComposerResizeKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
     const card = composerCardRef.current;
-    const current = composerHeight ?? (card ? composerLogicalHeight(card) : COMPOSER_MIN_HEIGHT);
+    const current = Math.max(
+      composerHeight ?? COMPOSER_MIN_HEIGHT,
+      card ? composerLogicalHeight(card) : COMPOSER_MIN_HEIGHT,
+    );
     const step = e.shiftKey ? 32 : 16;
     let next: number | null = null;
     if (e.key === "ArrowUp" || e.key === "PageUp") next = current + step;
@@ -3597,21 +3596,29 @@ export function Composer({
 
   // When the run strip is visible inside a user-resized card, the card grows
   // by the strip's reserved height so the meta row stays fully visible.
-  // --composer-height carries only the user's logical height; the reservation
-  // is a separate variable consumed by the CSS calc, so the live resize drag
-  // (which writes raw logical heights) stays consistent with this render path.
+  // --composer-height stays in logical card-height space. It may be the saved
+  // manual floor or a larger content-derived height; the run-strip reservation
+  // remains separate so the live resize writer uses the same coordinate space.
   const showRunStrip = Boolean(retry || running);
-  const composerCardStyle = composerHeight === null
+  const effectiveComposerHeight = composerHeight === null
+    ? null
+    : resolveComposerContentSizing({
+        contentHeight: textareaAutoHeight ?? 0,
+        manualLogicalHeight: composerHeight,
+        maxLogicalHeight: composerMaxHeight(),
+        reservedHeight: COMPOSER_AUTO_RESERVED_HEIGHT,
+      }).logicalHeight;
+  const composerCardStyle = effectiveComposerHeight === null
     ? undefined
     : ({
-        "--composer-height": `${composerHeight}px`,
+        "--composer-height": `${effectiveComposerHeight}px`,
         "--composer-run-strip-reserved": `${showRunStrip ? COMPOSER_RUN_STRIP_RESERVED : 0}px`,
       } as CSSProperties);
-  const textareaStyle = composerHeight === null && textareaAutoHeight !== null
+  const textareaStyle = !composerResizing && textareaAutoHeight !== null
     ? ({ height: `${textareaAutoHeight}px`, overflowY: textareaAutoOverflow ? "auto" : "hidden" } as CSSProperties)
     : undefined;
   const composerAutoExpanded = composerHeight === null && textareaAutoHeight !== null && textareaAutoHeight > 40;
-  const composerResizeValue = composerHeight ?? clampComposerHeight((textareaAutoHeight ?? 0) + COMPOSER_AUTO_RESERVED_HEIGHT);
+  const composerResizeValue = effectiveComposerHeight ?? clampComposerHeight((textareaAutoHeight ?? 0) + COMPOSER_AUTO_RESERVED_HEIGHT);
   void onSetMode;
   const chooseApprovalMode = (nextMode: ToolApprovalMode) => {
     onSetToolApprovalMode(nextMode);

--- a/desktop/frontend/src/lib/composerSizing.ts
+++ b/desktop/frontend/src/lib/composerSizing.ts
@@ -1,0 +1,35 @@
+export interface ComposerContentSizing {
+  inputHeight: number;
+  logicalHeight: number | null;
+  overflow: boolean;
+}
+
+export function resolveComposerContentSizing({
+  contentHeight,
+  manualLogicalHeight,
+  maxLogicalHeight,
+  reservedHeight,
+  minInputHeight = 32,
+}: {
+  contentHeight: number;
+  manualLogicalHeight: number | null;
+  maxLogicalHeight: number;
+  reservedHeight: number;
+  minInputHeight?: number;
+}): ComposerContentSizing {
+  const safeContentHeight = Math.max(0, contentHeight);
+  const maxInputHeight = Math.max(minInputHeight, maxLogicalHeight - reservedHeight);
+  const manualInputHeight = manualLogicalHeight === null
+    ? 0
+    : Math.max(minInputHeight, manualLogicalHeight - reservedHeight);
+  const inputHeight = Math.min(Math.max(safeContentHeight, manualInputHeight), maxInputHeight);
+  const logicalHeight = manualLogicalHeight === null
+    ? null
+    : Math.min(maxLogicalHeight, Math.max(manualLogicalHeight, inputHeight + reservedHeight));
+
+  return {
+    inputHeight,
+    logicalHeight,
+    overflow: safeContentHeight > maxInputHeight + 1,
+  };
+}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6649,9 +6649,9 @@ body > .mermaid-diagram--fullscreen {
   transition: border-color 0.12s;
 }
 .composer-card--resized {
-  /* --composer-height is always the user's logical height; the run strip's
-     reservation lives in this calc so the live resize drag (which writes the
-     raw logical height) and the React render path can never disagree. */
+  /* --composer-height excludes the run strip and may grow above the user's
+     saved minimum to reveal a longer draft. The strip reservation stays in
+     this calc so live resize and content sizing share one coordinate space. */
   height: calc(var(--composer-height) + var(--composer-run-strip-reserved, 0px));
   display: flex;
   flex-direction: column;
@@ -6659,10 +6659,9 @@ body > .mermaid-diagram--fullscreen {
 .composer-card:focus-within {
   border-color: var(--fg-faint);
 }
-/* Run strip: an in-flow bar at the top of the card. For user-resized cards
-   (fixed --composer-height), the JS adds the strip's reserved height so the
-   meta row stays fully visible. For auto-height cards the card grows
-   naturally. */
+/* Run strip: an in-flow bar at the top of the card. For user-sized cards JS
+   adds the strip's reserved height so the input's logical minimum is unchanged.
+   For natural-height cards the card grows without the explicit reservation. */
 .composer-run-strip {
   display: flex;
   align-items: center;
@@ -7081,8 +7080,8 @@ body > .mermaid-diagram--fullscreen {
   vertical-align: text-bottom;
 }
 .composer-card--resized .composer__rich-input {
-  /* Fill the user's fixed card height and scroll inside; height: auto would
-     collapse the input to its intrinsic height and break the resized layout. */
+  /* Fill the current logical card height during live resize; content sizing
+     supplies an inline height after the gesture settles. */
   height: 100%;
   min-height: 0;
   overflow-y: auto;
@@ -7102,8 +7101,8 @@ body > .mermaid-diagram--fullscreen {
   display: none;                    /* Chrome / Safari / Wails webview */
 }
 .composer-card--resized .composer__input {
-  /* The resized card gets no inline textarea height from JS; height: auto
-     would pin the rows=1 textarea to a single visible line forever. */
+  /* Fill the current logical card height during live resize; content sizing
+     supplies an inline height after the gesture settles. */
   height: 100%;
   min-height: 0;
   max-height: none;


### PR DESCRIPTION
## What

- let pasted or typed multiline drafts grow a manually resized composer above its saved height
- keep the user's manual height as the minimum baseline and shrink back to it when content becomes shorter
- preserve the viewport-aware maximum and only enable internal scrolling after that cap
- cover automatic, manual-baseline, growth, shrink, and capped-overflow behavior with unit and real Composer interaction tests
- remove a stale test assertion that confused the current Delivery quality floor with the retired Delivery execution mode

## Why

The Composer stopped measuring draft content as soon as a manual height existed. Its resized CSS then treated that saved height as a hard fixed height, so pasting a longer prompt could reveal fewer lines even when the card still had room to grow.

## Impact

Automatic composers keep their existing behavior. For manually resized composers, the saved height is now a floor rather than a hard cap. Drag and keyboard resize still start from the visible height, and oversized drafts continue to scroll inside the composer at the existing viewport-aware maximum.

Documentation-impact: none - Existing user documentation does not define composer draft sizing behavior.

## Checks

- pnpm build (ESLint, hooks/WAAPI/scroll/CSS/z-index checks, TypeScript, Vite production build, bundle budgets)
- tsx src/__tests__/composer-content-sizing.test.ts - 12 passed
- tsx src/__tests__/composer-resized-input-css.test.ts - 7 passed
- tsx src/__tests__/composer-run-strip.test.tsx - 64 passed
- git diff --check

## Existing local baseline blockers

- pnpm test:all stops in existing transcript test type-check errors unrelated to this change.
- go test ./... reaches unrelated failures in the e2e corpus seed fixture and Windows symlink-privilege tests; this PR changes no Go files.