### PR TITLE
test: make write-scope tests portable / 使写入范围测试跨平台

### DIFF
--- a/internal/completion/report_test.go
+++ b/internal/completion/report_test.go
@@ -3,6 +3,7 @@ package completion
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -213,7 +214,8 @@ func TestBuildRewritingAPathAfterReviewReopensIt(t *testing.T) {
 }
 
 func TestBuildIgnoresScratchWrites(t *testing.T) {
-	rep := Build(nil, ledgerOf(wrote("/tmp/btc_klines.py"), read("/tmp/btc_klines.py")))
+	scratchPath := filepath.Join(os.TempDir(), "btc_klines.py")
+	rep := Build(nil, ledgerOf(wrote(scratchPath), read(scratchPath)))
 	if rep.Mutations != 0 || len(rep.Changes) != 0 {
 		t.Fatalf("scratch write counted as a project mutation: mutations=%d changes=%+v", rep.Mutations, rep.Changes)
 	}
@@ -227,7 +229,11 @@ func TestBuildKeepsOutsideWrites(t *testing.T) {
 	workspace := filepath.Join(volumeRoot, "reasonix-project")
 	outside := filepath.Join(volumeRoot, "reasonix-external", "config.json")
 	rep := BuildAt(nil, ledgerOf(wrote(outside)), workspace, nil)
-	if rep.Mutations != 1 || len(rep.Changes) != 1 || rep.Changes[0].Path != outside {
+	expectedPath := outside
+	if runtime.GOOS == "windows" {
+		expectedPath = strings.ToLower(expectedPath)
+	}
+	if rep.Mutations != 1 || len(rep.Changes) != 1 || rep.Changes[0].Path != expectedPath {
 		t.Fatalf("outside write report = %+v, want one delivery mutation and named change", rep)
 	}
 	if got := gapKinds(rep); !slices.Equal(got, []string{"unverified_change", "unreviewed_change"}) {

--- a/internal/evidence/writescope_test.go
+++ b/internal/evidence/writescope_test.go
@@ -8,9 +8,12 @@ import (
 )
 
 func TestClassifyWriteScopeTempIsScratch(t *testing.T) {
-	cases := []string{"/tmp/btc_klines.py"}
-	if runtime.GOOS == "darwin" {
-		cases = append(cases, "/private/tmp/btc_klines.py")
+	cases := []string{filepath.Join(os.TempDir(), "btc_klines.py")}
+	if runtime.GOOS != "windows" {
+		cases = append(cases, "/tmp/btc_klines.py")
+		if runtime.GOOS == "darwin" {
+			cases = append(cases, "/private/tmp/btc_klines.py")
+		}
 	}
 	for _, path := range cases {
 		if got := ClassifyWriteScope(path, "/home/dev/project", nil); got != WriteScopeScratch {
@@ -31,8 +34,10 @@ func TestClassifyWriteScopeWorkspaceAndOutside(t *testing.T) {
 	if got := ClassifyWriteScope("parser.go", "", nil); got != WriteScopeWorkspace {
 		t.Fatalf("relative without root = %s, want workspace", got)
 	}
-	if got := ClassifyWriteScope("/home/dev/Notes/idea.md", root, nil); got != WriteScopeOutside {
-		t.Fatalf("home file = %s, want outside", got)
+	volumeRoot := filepath.VolumeName(os.TempDir()) + string(filepath.Separator)
+	outside := filepath.Join(volumeRoot, "reasonix-outside-home", "Notes", "idea.md")
+	if got := ClassifyWriteScope(outside, root, nil); got != WriteScopeOutside {
+		t.Fatalf("outside file = %s, want outside", got)
 	}
 }
 

--- a/internal/taskcontract/floor_test.go
+++ b/internal/taskcontract/floor_test.go
@@ -2,6 +2,8 @@ package taskcontract
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"reasonix/internal/evidence"
@@ -9,9 +11,13 @@ import (
 
 func deliveryWriteReceipt(t *testing.T, path string, floor PolicyFloor) evidence.Receipt {
 	t.Helper()
+	args, err := json.Marshal(map[string]string{"path": path})
+	if err != nil {
+		t.Fatalf("marshal path: %v", err)
+	}
 	return evidence.Receipt{
 		ToolName: "edit_file", Success: true, Write: true, Mutation: true,
-		Args: json.RawMessage(`{"path":"` + path + `"}`), Paths: []string{path},
+		Args: args, Paths: []string{path},
 		PolicyFloor: floor.String(),
 	}
 }
@@ -44,7 +50,7 @@ func TestDeliveryFloorWriteAddsStrictFullVerify(t *testing.T) {
 
 func TestDeliveryScratchWriteAddsNoFloorObligation(t *testing.T) {
 	c := New("")
-	c.AbsorbReceipt(1, deliveryWriteReceipt(t, "/tmp/btc_klines.py", PolicyFloorDelivery), "", false, false)
+	c.AbsorbReceipt(1, deliveryWriteReceipt(t, filepath.Join(os.TempDir(), "btc_klines.py"), PolicyFloorDelivery), "", false, false)
 	if hasObligationKind(c, ObligationFullVerify, 0, ReasonPolicyFloor) {
 		t.Fatalf("delivery scratch write must not create a floor obligation: %+v", c.Obligations)
 	}

--- a/internal/taskcontract/obligation_test.go
+++ b/internal/taskcontract/obligation_test.go
@@ -2,6 +2,8 @@ package taskcontract
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"reasonix/internal/evidence"
@@ -111,12 +113,20 @@ func TestMapWriterMatrix(t *testing.T) {
 	}
 
 	scratch := evidence.ClassifyEffect(evidence.EffectInput{
-		ToolName: "write_file", Args: json.RawMessage(`{"path":"/tmp/btc_klines.py"}`),
+		ToolName: "write_file", Args: mustJSONPath(filepath.Join(os.TempDir(), "btc_klines.py")),
 	})
 	got = MapWriter(scratch, 12, "", false)
 	if len(got.Preconditions) != 0 || len(got.PostSuccess) != 0 {
 		t.Fatalf("scratch write must not create duties: %+v", got)
 	}
+}
+
+func mustJSONPath(path string) json.RawMessage {
+	value, err := json.Marshal(map[string]string{"path": path})
+	if err != nil {
+		panic(err)
+	}
+	return value
 }
 
 func TestRebuildIsDeterministicAndInvalidates(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix deterministic Windows CI failures in write-scope, completion delivery, and task-contract tests.

## Problem
Windows treats Unix-only `/tmp` and `/home` fixtures as relative paths, and receipt normalization lowercases Windows paths. The latest `main-v2` CI failed in `internal/evidence`, `internal/completion`, and `internal/taskcontract`.

## Fix
Use `os.TempDir()` and the platform volume root for path fixtures, JSON-encode platform paths, and compare the normalized Windows expectation. Product behavior is unchanged.

## Verification
- `go test ./internal/evidence ./internal/completion ./internal/taskcontract`
- Windows amd64 test binaries compile for all three packages
- `git diff --check`

This is required before the v1.30.0 Stable candidate can pass release gates.