### PR TITLE
ci: add v3 Studio version line and drop v1 from issue forms / 为 Issue 表单新增 v3 Studio 并去掉 v1 选项

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for filing a bug. Pick which version line you're on below — it gets
-        labeled (`v1`/`v2`/`v3`) automatically, no maintainer action needed.
+        labeled (`v2`/`v3`) automatically, no maintainer action needed.
   - type: dropdown
     id: version-line
     attributes:
@@ -16,7 +16,6 @@ body:
       options:
         - "v2 — Go rewrite (1.x), main-v2 (active development)"
         - "v3 — Studio (2.x), studio"
-        - "v1 — Legacy TypeScript (0.x), maintenance only"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for filing a bug. Pick which version line you're on below — it gets
-        labeled (`v1`/`v2`) automatically, no maintainer action needed.
+        labeled (`v1`/`v2`/`v3`) automatically, no maintainer action needed.
   - type: dropdown
     id: version-line
     attributes:
@@ -15,6 +15,7 @@ body:
       description: Which line are you running?
       options:
         - "v2 — Go rewrite (1.x), main-v2 (active development)"
+        - "v3 — Studio (2.x), studio"
         - "v1 — Legacy TypeScript (0.x), maintenance only"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,6 +10,7 @@ body:
       description: Which line is this for?
       options:
         - "v2 — Go rewrite (1.x), main-v2 (active development)"
+        - "v3 — Studio (2.x), studio"
         - "v1 — Legacy TypeScript (0.x), maintenance only"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,6 @@ body:
       options:
         - "v2 — Go rewrite (1.x), main-v2 (active development)"
         - "v3 — Studio (2.x), studio"
-        - "v1 — Legacy TypeScript (0.x), maintenance only"
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/issue-version-label.yml
+++ b/.github/workflows/issue-version-label.yml
@@ -2,7 +2,7 @@ name: Label issue version
 
 # Issue forms can't let a reporter set a label directly (that needs triage rights),
 # so the bug/feature forms carry a "Version line" dropdown and this workflow reads
-# the submitted value and applies the matching v1/v2/v3 label on their behalf.
+# the submitted value and applies the matching v2/v3 label on their behalf.
 on:
   issues:
     types: [opened, edited]
@@ -26,7 +26,7 @@ jobs:
               body.split(/^###\s+/m).find((s) => new RegExp(`^${name}`, 'i').test(s)) || '';
 
             const lines = ['v1', 'v2', 'v3'];
-            const m = sectionOf('Version line').match(/\bv([123])\b/i);
+            const m = sectionOf('Version line').match(/\bv([23])\b/i);
             if (!m) {
               core.info('No version line found; nothing to label.');
               return;
@@ -34,15 +34,16 @@ jobs:
             let choice = 'v' + m[1];
 
             // The dropdown is a choice, and v2 sits first, so it gets picked by
-            // reporters who are actually on another line. `Exact version` is
+            // reporters who are actually on the other line. `Exact version` is
             // pasted from `reasonix --version`, so when it parses it is the
-            // better evidence: 0.x TypeScript (v1), 1.x Go rewrite (v2), 2.x
-            // Studio (v3, studio branch). Anything that does not parse (a
-            // commit sha, "main-v2", "studio") leaves the dropdown to decide.
+            // better evidence: 1.x Go rewrite (v2), 2.x Studio (v3, studio
+            // branch). 0.x is no longer a filing line. Anything that does not
+            // parse (a commit sha, "main-v2", "studio") leaves the dropdown
+            // to decide.
             const exact = sectionOf('Exact version').match(/\b(\d+)\.(\d+)\.(\d+)/);
             if (exact) {
               const major = Number(exact[1]);
-              const fromVersion = major === 0 ? 'v1' : major === 1 ? 'v2' : major === 2 ? 'v3' : null;
+              const fromVersion = major === 1 ? 'v2' : major === 2 ? 'v3' : null;
               if (fromVersion && fromVersion !== choice) {
                 core.info(`Version line says ${choice} but ${exact[0]} says ${fromVersion}; trusting the version.`);
                 choice = fromVersion;

--- a/.github/workflows/issue-version-label.yml
+++ b/.github/workflows/issue-version-label.yml
@@ -2,7 +2,7 @@ name: Label issue version
 
 # Issue forms can't let a reporter set a label directly (that needs triage rights),
 # so the bug/feature forms carry a "Version line" dropdown and this workflow reads
-# the submitted value and applies the matching v1/v2 label on their behalf.
+# the submitted value and applies the matching v1/v2/v3 label on their behalf.
 on:
   issues:
     types: [opened, edited]
@@ -25,7 +25,8 @@ jobs:
             const sectionOf = (name) =>
               body.split(/^###\s+/m).find((s) => new RegExp(`^${name}`, 'i').test(s)) || '';
 
-            const m = sectionOf('Version line').match(/\bv([12])\b/i);
+            const lines = ['v1', 'v2', 'v3'];
+            const m = sectionOf('Version line').match(/\bv([123])\b/i);
             if (!m) {
               core.info('No version line found; nothing to label.');
               return;
@@ -33,31 +34,34 @@ jobs:
             let choice = 'v' + m[1];
 
             // The dropdown is a choice, and v2 sits first, so it gets picked by
-            // reporters who are actually on 0.x. `Exact version` is pasted from
-            // `reasonix --version`, so when it parses it is the better evidence:
-            // 0.x is the TypeScript line, 1.x the Go rewrite. Anything that does
-            // not parse (a commit sha, "main-v2") leaves the dropdown to decide.
+            // reporters who are actually on another line. `Exact version` is
+            // pasted from `reasonix --version`, so when it parses it is the
+            // better evidence: 0.x TypeScript (v1), 1.x Go rewrite (v2), 2.x
+            // Studio (v3, studio branch). Anything that does not parse (a
+            // commit sha, "main-v2", "studio") leaves the dropdown to decide.
             const exact = sectionOf('Exact version').match(/\b(\d+)\.(\d+)\.(\d+)/);
             if (exact) {
-              const fromVersion = Number(exact[1]) === 0 ? 'v1' : 'v2';
-              if (fromVersion !== choice) {
+              const major = Number(exact[1]);
+              const fromVersion = major === 0 ? 'v1' : major === 1 ? 'v2' : major === 2 ? 'v3' : null;
+              if (fromVersion && fromVersion !== choice) {
                 core.info(`Version line says ${choice} but ${exact[0]} says ${fromVersion}; trusting the version.`);
                 choice = fromVersion;
               }
             }
-            const other = choice === 'v2' ? 'v1' : 'v2';
             await github.rest.issues.addLabels({
               ...context.repo,
               issue_number: context.issue.number,
               labels: [choice],
             });
-            // Keep v1/v2 mutually exclusive in case an edit flipped the choice.
-            try {
-              await github.rest.issues.removeLabel({
-                ...context.repo,
-                issue_number: context.issue.number,
-                name: other,
-              });
-            } catch (e) {
-              core.info(`No ${other} label to remove.`);
+            // Keep version-line labels mutually exclusive if an edit flipped the choice.
+            for (const other of lines.filter((l) => l !== choice)) {
+              try {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: context.issue.number,
+                  name: other,
+                });
+              } catch (e) {
+                core.info(`No ${other} label to remove.`);
+              }
             }

--- a/.github/workflows/pr-version-label.yml
+++ b/.github/workflows/pr-version-label.yml
@@ -2,7 +2,7 @@ name: Label PR version
 
 # Contributors (especially from forks) can't set labels themselves — that needs
 # triage rights. A PR's version line is fully determined by its base branch, so
-# this reads base.ref and applies v1/v2 on their behalf. pull_request_target runs
+# this reads base.ref and applies v1/v2/v3 on their behalf. pull_request_target runs
 # in the base repo's context so it has write access even for fork PRs; it only
 # reads trusted metadata (the base ref) and never checks out or runs PR code.
 on:
@@ -23,27 +23,28 @@ jobs:
       - uses: actions/github-script@v9
         with:
           script: |
+            const lineByBase = { v1: 'v1', 'main-v2': 'v2', studio: 'v3' };
+            const lines = Object.values(lineByBase);
             const base = context.payload.pull_request.base.ref;
-            const label = base === 'v1' ? 'v1'
-                        : base === 'main-v2' ? 'v2'
-                        : null;
+            const label = lineByBase[base] || null;
             if (!label) {
               core.info(`Base branch '${base}' isn't a release line; skipping.`);
               return;
             }
-            const other = label === 'v2' ? 'v1' : 'v2';
             await github.rest.issues.addLabels({
               ...context.repo,
               issue_number: context.payload.pull_request.number,
               labels: [label],
             });
-            // Drop the other line's label if the base was changed after opening.
-            try {
-              await github.rest.issues.removeLabel({
-                ...context.repo,
-                issue_number: context.payload.pull_request.number,
-                name: other,
-              });
-            } catch (e) {
-              core.info(`No ${other} label to remove.`);
+            // Drop other line labels if the base was changed after opening.
+            for (const other of lines.filter((l) => l !== label)) {
+              try {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: context.payload.pull_request.number,
+                  name: other,
+                });
+              } catch (e) {
+                core.info(`No ${other} label to remove.`);
+              }
             }

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -201,8 +201,9 @@ LE/BE, and GB18030 (a superset of GBK). This matches v1's behavior.
 
 ## Reporting issues
 
-Issues and PRs are labelled by line: **`v1`** (legacy TypeScript) and **`v2`**
-(Go). File new reports against the line you're using. The legacy `v1` line is in
-maintenance mode — bug fixes only, no new features.
+Issues and PRs are labelled by line: **`v1`** (legacy TypeScript), **`v2`**
+(Go, `main-v2`), and **`v3`** (Studio, `studio`). File new reports against the
+line you're using. The legacy `v1` line is in maintenance mode — bug fixes only,
+no new features.
 
 Questions? Open a [Discussion](https://github.com/esengine/DeepSeek-Reasonix/discussions).

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -201,9 +201,7 @@ LE/BE, and GB18030 (a superset of GBK). This matches v1's behavior.
 
 ## Reporting issues
 
-Issues and PRs are labelled by line: **`v1`** (legacy TypeScript), **`v2`**
-(Go, `main-v2`), and **`v3`** (Studio, `studio`). File new reports against the
-line you're using. The legacy `v1` line is in maintenance mode — bug fixes only,
-no new features.
+Issues and PRs are labelled by line: **`v2`** (Go, `main-v2`) and **`v3`**
+(Studio, `studio`). File new reports against the line you're using.
 
 Questions? Open a [Discussion](https://github.com/esengine/DeepSeek-Reasonix/discussions).

--- a/docs/MIGRATING.zh-CN.md
+++ b/docs/MIGRATING.zh-CN.md
@@ -133,6 +133,6 @@ Reasonix 1.0 支持读取和编辑 UTF-8、UTF-8 BOM、UTF-16 LE/BE 与 GB18030�
 
 ## 报告问题
 
-Issue 和 PR 按代码线标记：**`v1`** 表示旧 TypeScript 版，**`v2`** 表示 Go 版（`main-v2`），**`v3`** 表示 Studio（`studio`）。请按实际使用版本提交报告。旧 `v1` 线处于维护模式，只接收 bug 修复，不再新增功能。
+Issue 和 PR 按代码线标记：**`v2`** 表示 Go 版（`main-v2`），**`v3`** 表示 Studio（`studio`）。请按实际使用版本提交报告。
 
 如有问题，请发起 [Discussion](https://github.com/esengine/DeepSeek-Reasonix/discussions)。

--- a/docs/MIGRATING.zh-CN.md
+++ b/docs/MIGRATING.zh-CN.md
@@ -133,6 +133,6 @@ Reasonix 1.0 支持读取和编辑 UTF-8、UTF-8 BOM、UTF-16 LE/BE 与 GB18030�
 
 ## 报告问题
 
-Issue 和 PR 按代码线标记：**`v1`** 表示旧 TypeScript 版，**`v2`** 表示 Go 版。请按实际使用版本提交报告。旧 `v1` 线处于维护模式，只接收 bug 修复，不再新增功能。
+Issue 和 PR 按代码线标记：**`v1`** 表示旧 TypeScript 版，**`v2`** 表示 Go 版（`main-v2`），**`v3`** 表示 Studio（`studio`）。请按实际使用版本提交报告。旧 `v1` 线处于维护模式，只接收 bug 修复，不再新增功能。
 
 如有问题，请发起 [Discussion](https://github.com/esengine/DeepSeek-Reasonix/discussions)。


### PR DESCRIPTION
## Summary

- Add a `v3 — Studio (2.x), studio` option to the Bug report and Feature request **Version line** dropdowns.
- Remove the `v1` (legacy TypeScript) option from those forms. New reports are `v2` or `v3` only.
- Auto-label those issues as `v2`/`v3`, treat `Exact version` `1.x`/`2.x` as v2/v3, and no longer map `0.x` onto `v1`.
- Label PRs whose base is `studio` as `v3`.
- The `v3` GitHub label already exists: `Studio (2.x) — studio branch`.

## Issues

None.

## Verification

- Parsed `.github/ISSUE_TEMPLATE/bug_report.yml`, `.github/ISSUE_TEMPLATE/feature_request.yml`, and both version-label workflows as YAML.
- Confirmed both dropdowns list only `v2` and `v3`.
- Inspected the v2/v3 mappings: `1.x`/`2.x` Exact version map to `v2`/`v3`; PRs targeting `studio` map to `v3`.
- Confirmed the `v3` label exists on `esengine/DeepSeek-Reasonix`.

## Documentation impact

Documentation-impact: updated - `docs/MIGRATING.md` and `docs/MIGRATING.zh-CN.md` now list `v2` (`main-v2`) and `v3` Studio (`studio`) as the issue/PR reporting lines.

## Cache impact

Cache-impact: none - issue forms and version labels are not on the prompt-cache path.
Cache-guard: N/A - no provider-visible prompt, memory, tool, or serialization change.
System-prompt-review: N/A