### PR TITLE
fix(desktop): support macOS self-update on exFAT / 修复使用macOS在 exFAT 硬盘上无法自动更新

### DIFF
--- a/desktop/updater_mac.go
+++ b/desktop/updater_mac.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -48,9 +49,7 @@ var (
 	macHandoffCopy               = func(oldPath, newPath string) error {
 		return exec.Command("/usr/bin/ditto", oldPath, newPath).Run()
 	}
-	macHandoffRename = func(oldPath, newPath string) error {
-		return unix.RenameatxNp(unix.AT_FDCWD, oldPath, unix.AT_FDCWD, newPath, unix.RENAME_EXCL)
-	}
+	macHandoffRename  = macUpdateRenameNoReplace
 	macHandoffLogPath = func() string {
 		cacheDir, err := updateCacheDir()
 		if err != nil {
@@ -632,13 +631,36 @@ func retainMacHandoffNode(path, suffix string) (string, error) {
 
 var macUpdateCleanupAfterRename = func(string, string) {}
 
+// macUpdateRenameNoReplace uses RENAME_EXCL, then a best-effort existence
+// check on volumes such as exFAT that reject the exclusive flag.
+func macUpdateRenameNoReplace(oldPath, newPath string) error {
+	return macRenameNoReplace(macExclusiveRename, oldPath, newPath)
+}
+
+func macExclusiveRename(oldPath, newPath string) error {
+	return unix.RenameatxNp(unix.AT_FDCWD, oldPath, unix.AT_FDCWD, newPath, unix.RENAME_EXCL)
+}
+
+func macRenameNoReplace(exclusive func(string, string) error, oldPath, newPath string) error {
+	err := exclusive(oldPath, newPath)
+	if err == nil || !(errors.Is(err, syscall.ENOTSUP) || errors.Is(err, syscall.ENOSYS)) {
+		return err
+	}
+	if _, statErr := os.Lstat(newPath); statErr == nil {
+		return os.ErrExist
+	} else if !os.IsNotExist(statErr) {
+		return statErr
+	}
+	return os.Rename(oldPath, newPath)
+}
+
 func cleanupOwnedMacUpdateDirectory(path string, owner os.FileInfo) error {
 	if strings.TrimSpace(path) == "" || owner == nil || !owner.IsDir() {
 		return fmt.Errorf("macOS update cleanup identity is incomplete")
 	}
 	for attempt := range 16 {
 		cleanup := fmt.Sprintf("%s.reasonix-cleanup-%d-%d", path, time.Now().UTC().UnixNano(), attempt)
-		err := unix.RenameatxNp(unix.AT_FDCWD, path, unix.AT_FDCWD, cleanup, unix.RENAME_EXCL)
+		err := macUpdateRenameNoReplace(path, cleanup)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil
@@ -654,7 +676,7 @@ func cleanupOwnedMacUpdateDirectory(path string, owner os.FileInfo) error {
 			return statErr
 		}
 		if !os.SameFile(owner, actual) {
-			if restoreErr := unix.RenameatxNp(unix.AT_FDCWD, cleanup, unix.AT_FDCWD, path, unix.RENAME_EXCL); restoreErr != nil {
+			if restoreErr := macUpdateRenameNoReplace(cleanup, path); restoreErr != nil {
 				return fmt.Errorf("macOS update directory changed before cleanup; preserve replacement at %s: %w", cleanup, restoreErr)
 			}
 			return fmt.Errorf("macOS update directory changed before cleanup")

--- a/desktop/updater_mac.go
+++ b/desktop/updater_mac.go
@@ -631,8 +631,13 @@ func retainMacHandoffNode(path, suffix string) (string, error) {
 
 var macUpdateCleanupAfterRename = func(string, string) {}
 
-// macUpdateRenameNoReplace uses RENAME_EXCL, then a best-effort existence
-// check on volumes such as exFAT that reject the exclusive flag.
+// macUpdateRenameNoReplace prefers RENAME_EXCL. On volumes such as exFAT that
+// reject the exclusive flag, it falls back to an existence check followed by
+// os.Rename. That fallback is intentionally best-effort: callers must hold
+// Reasonix's mutation locks, and an uncooperative external writer can still
+// race between the check and the rename. An os.ErrExist result means that the
+// destination was observed before the fallback; it is not an atomic
+// no-replace guarantee.
 func macUpdateRenameNoReplace(oldPath, newPath string) error {
 	return macRenameNoReplace(macExclusiveRename, oldPath, newPath)
 }
@@ -647,11 +652,14 @@ func macRenameNoReplace(exclusive func(string, string) error, oldPath, newPath s
 		return err
 	}
 	if _, statErr := os.Lstat(newPath); statErr == nil {
-		return os.ErrExist
+		return fmt.Errorf("macOS update rename target already exists (best-effort under Reasonix mutation lock): %w", os.ErrExist)
 	} else if !os.IsNotExist(statErr) {
 		return statErr
 	}
-	return os.Rename(oldPath, newPath)
+	if err := os.Rename(oldPath, newPath); err != nil {
+		return fmt.Errorf("macOS update rename (best-effort under Reasonix mutation lock): %w", err)
+	}
+	return nil
 }
 
 func cleanupOwnedMacUpdateDirectory(path string, owner os.FileInfo) error {

--- a/desktop/updater_mac_payload_test.go
+++ b/desktop/updater_mac_payload_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -143,7 +144,7 @@ func TestMacUpdateRenameFallbackDoesNotReplaceExisting(t *testing.T) {
 	}
 	if err := macRenameNoReplace(func(string, string) error { return syscall.ENOTSUP }, source, destination); err == nil {
 		t.Fatal("fallback renamed over an existing destination")
-	} else if !errors.Is(err, os.ErrExist) {
+	} else if !errors.Is(err, os.ErrExist) || !strings.Contains(err.Error(), "best-effort under Reasonix mutation lock") {
 		t.Fatalf("fallback err = %v, want ErrExist", err)
 	}
 	for path, want := range map[string]string{source: "source", destination: "destination"} {

--- a/desktop/updater_mac_payload_test.go
+++ b/desktop/updater_mac_payload_test.go
@@ -1,0 +1,175 @@
+//go:build darwin
+
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"reasonix/internal/repair"
+)
+
+func TestMacUpdateHandoffPublishesPayloadDigestAcrossModeChange(t *testing.T) {
+	probeA := filepath.Join(t.TempDir(), "marker")
+	probeB := filepath.Join(t.TempDir(), "marker")
+	for _, path := range []string{probeA, probeB} {
+		if err := os.WriteFile(path, []byte("probe"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chmod(probeB, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	requireDistinctPOSIXMode(t, probeA, probeB)
+
+	root := t.TempDir()
+	oldApp := filepath.Join(root, "Reasonix.app")
+	newApp := filepath.Join(root, "staging", "Reasonix.app")
+	backupApp := oldApp + ".reasonix-update-backup"
+	pending := filepath.Join(root, "pending.json")
+	for _, dir := range []string{oldApp, newApp} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(oldApp, "marker"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(newApp, "marker"), []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pending, []byte("pending"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := repair.AppBundlePayloadTreeDigest(newApp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	strict, err := repair.AppBundleTreeDigest(newApp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload == strict {
+		t.Fatal("payload digest collapsed onto the strict digest")
+	}
+	tx := &repair.UpdateTransaction{
+		ToVersion:          "v2",
+		CreatedAt:          "2026-07-28T00:00:00Z",
+		TargetKind:         "app-bundle",
+		TargetPath:         oldApp,
+		BackupPath:         backupApp,
+		HandoffAppPath:     newApp,
+		HandoffAppTreeID:   payload,
+		HandoffStagingPath: filepath.Dir(newApp),
+		HandoffOwnerPID:    99999999,
+	}
+	installMacHandoffTestDeps(t, tx, pending, filepath.Join(root, "update.log"), nil)
+	originalCopy := macHandoffCopy
+	macHandoffCopy = func(oldPath, newPath string) error {
+		if err := originalCopy(oldPath, newPath); err != nil {
+			return err
+		}
+		copied := filepath.Join(newPath, "marker")
+		return os.Chmod(copied, 0o700)
+	}
+	originalOpen := openCommand
+	openCommand = func(args ...string) *exec.Cmd {
+		return exec.Command("/bin/sh", "-c", "exit 0")
+	}
+	t.Cleanup(func() {
+		macHandoffCopy = originalCopy
+		openCommand = originalOpen
+	})
+
+	if code := runMacUpdateHandoff(macHandoffConfigFor(tx)); code != 0 {
+		t.Fatal("handoff rejected a mode-only copy of a payload digest")
+	}
+	if got, err := os.ReadFile(filepath.Join(oldApp, "marker")); err != nil || string(got) != "new" {
+		t.Fatalf("installed marker = %q, %v", got, err)
+	}
+}
+
+func requireDistinctPOSIXMode(t *testing.T, a, b string) {
+	t.Helper()
+	modeA, err := os.Lstat(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modeB, err := os.Lstat(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modeA.Mode() == modeB.Mode() {
+		t.Skip("filesystem does not preserve POSIX mode bits")
+	}
+}
+
+func TestMacUpdateRenameFallsBackWhenExclusiveUnsupported(t *testing.T) {
+	for _, unsupported := range []error{syscall.ENOTSUP, syscall.ENOSYS} {
+		t.Run(unsupported.Error(), func(t *testing.T) {
+			dir := t.TempDir()
+			source := filepath.Join(dir, "source")
+			destination := filepath.Join(dir, "destination")
+			if err := os.WriteFile(source, []byte("payload"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := macRenameNoReplace(func(string, string) error { return unsupported }, source, destination); err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(destination)
+			if err != nil || string(got) != "payload" {
+				t.Fatalf("destination = %q, %v", got, err)
+			}
+			if _, err := os.Lstat(source); !os.IsNotExist(err) {
+				t.Fatalf("source still exists: %v", err)
+			}
+		})
+	}
+}
+
+func TestMacUpdateRenameFallbackDoesNotReplaceExisting(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	destination := filepath.Join(dir, "destination")
+	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(destination, []byte("destination"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := macRenameNoReplace(func(string, string) error { return syscall.ENOTSUP }, source, destination); err == nil {
+		t.Fatal("fallback renamed over an existing destination")
+	} else if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("fallback err = %v, want ErrExist", err)
+	}
+	for path, want := range map[string]string{source: "source", destination: "destination"} {
+		got, err := os.ReadFile(path)
+		if err != nil || string(got) != want {
+			t.Fatalf("%s = %q, %v; want %q", filepath.Base(path), got, err, want)
+		}
+	}
+}
+
+func TestMacUpdateRenameDoesNotFallbackOnOtherErrors(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	destination := filepath.Join(dir, "destination")
+	if err := os.WriteFile(source, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := macRenameNoReplace(func(string, string) error { return syscall.EPERM }, source, destination)
+	if !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("err = %v, want EPERM", err)
+	}
+	got, readErr := os.ReadFile(source)
+	if readErr != nil || string(got) != "payload" {
+		t.Fatalf("source = %q, %v", got, readErr)
+	}
+	if _, statErr := os.Lstat(destination); !os.IsNotExist(statErr) {
+		t.Fatalf("destination created after non-fallback error: %v", statErr)
+	}
+}

--- a/internal/repair/plan.go
+++ b/internal/repair/plan.go
@@ -702,26 +702,7 @@ func repairPlanTreeEntries(root string) ([]repairPlanTreeEntry, error) {
 // installed bundle contain the same bytes even though they live at different
 // paths.
 func repairPlanTreeContentStateID(root string) (string, error) {
-	info, err := os.Lstat(root)
-	if err != nil {
-		return "", err
-	}
-	if !info.IsDir() {
-		return "", fmt.Errorf("expected directory, got %s", info.Mode().Type())
-	}
-	entries, err := repairPlanTreeEntries(root)
-	if err != nil {
-		return "", err
-	}
-	for _, entry := range entries {
-		switch entry.Kind {
-		case "unreadable", "file-unreadable", "symlink-unreadable":
-			return "", fmt.Errorf("cannot read bundle entry %q", entry.Rel)
-		case "other":
-			return "", fmt.Errorf("unsupported bundle entry %q", entry.Rel)
-		}
-	}
-	return repairPlanStateID(entries), nil
+	return repairPlanTreeDigest(root, nil)
 }
 
 func repairPlanTreeStateIDFor(readRoot, identityRoot string) string {

--- a/internal/repair/plan_tree.go
+++ b/internal/repair/plan_tree.go
@@ -1,0 +1,90 @@
+package repair
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+)
+
+func repairPlanTreePayloadStateID(root string) (string, error) {
+	return repairPlanTreeDigest(root, repairPlanTreePayloadEntries)
+}
+
+// AppBundlePayloadTreeDigest is the macOS handoff identity that ignores POSIX
+// mode bits and AppleDouble sidecar files.
+func AppBundlePayloadTreeDigest(path string) (string, error) {
+	return repairPlanTreePayloadStateID(path)
+}
+
+func repairPlanTreeDigest(root string, adapt func([]repairPlanTreeEntry) []repairPlanTreeEntry) (string, error) {
+	info, err := os.Lstat(root)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("expected directory, got %s", info.Mode().Type())
+	}
+	entries, err := repairPlanTreeEntries(root)
+	if err != nil {
+		return "", err
+	}
+	if adapt != nil {
+		entries = adapt(entries)
+	}
+	for _, entry := range entries {
+		switch entry.Kind {
+		case "unreadable", "file-unreadable", "symlink-unreadable":
+			return "", fmt.Errorf("cannot read bundle entry %q", entry.Rel)
+		case "other":
+			return "", fmt.Errorf("unsupported bundle entry %q", entry.Rel)
+		}
+	}
+	return repairPlanStateID(entries), nil
+}
+
+func repairPlanTreeHandoffAppMatches(path, expected string) (bool, error) {
+	payload, err := repairPlanTreePayloadStateID(path)
+	if err != nil {
+		return false, err
+	}
+	if payload == expected {
+		return true, nil
+	}
+	strict, err := repairPlanTreeContentStateID(path)
+	if err != nil {
+		return false, err
+	}
+	return strict == expected, nil
+}
+
+// repairPlanTreePayloadEntries drops POSIX mode bits and AppleDouble sidecar
+// files that ditto cannot preserve on volumes such as exFAT.
+func repairPlanTreePayloadEntries(entries []repairPlanTreeEntry) []repairPlanTreeEntry {
+	have := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		have[entry.Rel] = struct{}{}
+	}
+	out := make([]repairPlanTreeEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Kind == "file" && appleDoubleSidecarRel(entry.Rel, have) {
+			continue
+		}
+		entry.Mode = 0
+		out = append(out, entry)
+	}
+	return out
+}
+
+func appleDoubleSidecarRel(rel string, have map[string]struct{}) bool {
+	base := path.Base(rel)
+	if !strings.HasPrefix(base, "._") || base == "._" {
+		return false
+	}
+	sibling := strings.TrimPrefix(base, "._")
+	if dir := path.Dir(rel); dir != "." {
+		sibling = dir + "/" + sibling
+	}
+	_, ok := have[sibling]
+	return ok
+}

--- a/internal/repair/plan_tree_test.go
+++ b/internal/repair/plan_tree_test.go
@@ -1,0 +1,335 @@
+package repair
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func requireDistinctPOSIXMode(t *testing.T, a, b string) {
+	t.Helper()
+	modeA, err := os.Lstat(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modeB, err := os.Lstat(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modeA.Mode() == modeB.Mode() {
+		t.Skip("filesystem does not preserve POSIX mode bits")
+	}
+}
+
+func TestRepairPlanTreeContentStateIDIncludesPOSIXMode(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	for _, root := range []string{a, b} {
+		if err := os.Mkdir(filepath.Join(root, "Contents"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "Contents", "marker"), []byte("hello"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chmod(filepath.Join(b, "Contents", "marker"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	requireDistinctPOSIXMode(t, filepath.Join(a, "Contents", "marker"), filepath.Join(b, "Contents", "marker"))
+	idA, err := repairPlanTreeContentStateID(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idB, err := repairPlanTreeContentStateID(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idA == idB {
+		t.Fatal("strict digest ignored a POSIX mode change")
+	}
+}
+
+func TestRepairPlanTreePayloadStateIDIgnoresPOSIXMode(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	for _, root := range []string{a, b} {
+		if err := os.Mkdir(filepath.Join(root, "Contents"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "Contents", "marker"), []byte("hello"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chmod(filepath.Join(b, "Contents", "marker"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	requireDistinctPOSIXMode(t, filepath.Join(a, "Contents", "marker"), filepath.Join(b, "Contents", "marker"))
+	idA, err := repairPlanTreePayloadStateID(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idB, err := repairPlanTreePayloadStateID(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idA != idB {
+		t.Fatal("payload digest changed for a POSIX mode-only copy")
+	}
+}
+
+func TestRepairPlanTreePayloadStateIDIgnoresAppleDoubleSidecarFile(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	for _, root := range []string{a, b} {
+		if err := os.Mkdir(filepath.Join(root, "Contents"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "Contents", "Info.plist"), []byte("plist"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(b, "Contents", "._Info.plist"), []byte("appledouble"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idA, err := repairPlanTreePayloadStateID(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idB, err := repairPlanTreePayloadStateID(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idA != idB {
+		t.Fatal("payload digest changed for an AppleDouble sidecar file")
+	}
+	strictA, err := repairPlanTreeContentStateID(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	strictB, err := repairPlanTreeContentStateID(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strictA == strictB {
+		t.Fatal("strict digest ignored an AppleDouble sidecar file")
+	}
+}
+
+func TestRepairPlanTreePayloadStateIDHashesAppleDoubleDirectory(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	for _, root := range []string{a, b} {
+		if err := os.Mkdir(filepath.Join(root, "Contents"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(b, "._Contents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	idA, err := repairPlanTreePayloadStateID(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idB, err := repairPlanTreePayloadStateID(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idA == idB {
+		t.Fatal("payload digest ignored a ._ directory")
+	}
+}
+
+func TestRepairPlanTreePayloadStateIDHashesAppleDoubleSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on Windows CI")
+	}
+	a := t.TempDir()
+	b := t.TempDir()
+	for _, root := range []string{a, b} {
+		if err := os.WriteFile(filepath.Join(root, "marker"), []byte("hello"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink("marker", filepath.Join(b, "._marker")); err != nil {
+		t.Fatal(err)
+	}
+	idA, err := repairPlanTreePayloadStateID(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idB, err := repairPlanTreePayloadStateID(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idA == idB {
+		t.Fatal("payload digest ignored a ._ symlink")
+	}
+}
+
+func TestRepairPlanTreePayloadStateIDDetectsPayloadChange(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	if err := os.WriteFile(filepath.Join(a, "marker"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(b, "marker"), []byte("other"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idA, err := repairPlanTreePayloadStateID(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idB, err := repairPlanTreePayloadStateID(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idA == idB {
+		t.Fatal("payload digest ignored a content change")
+	}
+}
+
+func TestRepairPlanTreePayloadStateIDDetectsExtraFile(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	if err := os.WriteFile(filepath.Join(a, "marker"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(b, "marker"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(b, "extra"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idA, err := repairPlanTreePayloadStateID(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idB, err := repairPlanTreePayloadStateID(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idA == idB {
+		t.Fatal("payload digest ignored an extra file")
+	}
+}
+
+func TestRepairPlanTreePayloadStateIDHashesOrphanAppleDoubleName(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	if err := os.WriteFile(filepath.Join(a, "marker"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(b, "marker"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(b, "._orphan"), []byte("sidecar"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idA, err := repairPlanTreePayloadStateID(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idB, err := repairPlanTreePayloadStateID(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idA == idB {
+		t.Fatal("payload digest ignored an orphan ._ file")
+	}
+}
+
+func TestRepairPlanTreeHandoffAppMatchesLegacyStrictDigest(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "marker"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	strict, err := repairPlanTreeContentStateID(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := repairPlanTreePayloadStateID(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strict == payload {
+		t.Fatal("payload digest collapsed onto the strict digest")
+	}
+	matched, err := repairPlanTreeHandoffAppMatches(root, strict)
+	if err != nil || !matched {
+		t.Fatalf("legacy strict digest rejected: matched=%v err=%v", matched, err)
+	}
+	matched, err = repairPlanTreeHandoffAppMatches(root, payload)
+	if err != nil || !matched {
+		t.Fatalf("payload digest rejected: matched=%v err=%v", matched, err)
+	}
+}
+
+func TestVerifyAppBundleUpdateHandoffReplacementAcceptsModeOnlyCopy(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	for _, root := range []string{src, dst} {
+		if err := os.WriteFile(filepath.Join(root, "marker"), []byte("hello"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chmod(filepath.Join(dst, "marker"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	requireDistinctPOSIXMode(t, filepath.Join(src, "marker"), filepath.Join(dst, "marker"))
+	payload, err := repairPlanTreePayloadStateID(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := &UpdateTransaction{TargetKind: "app-bundle", HandoffAppTreeID: payload}
+	if err := VerifyAppBundleUpdateHandoffReplacement(tx, dst); err != nil {
+		t.Fatalf("mode-only copy rejected: %v", err)
+	}
+}
+
+func TestVerifyAppBundleUpdateHandoffReplacementAcceptsLegacyStrictDigest(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "marker"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	strict, err := repairPlanTreeContentStateID(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := &UpdateTransaction{TargetKind: "app-bundle", HandoffAppTreeID: strict}
+	if err := VerifyAppBundleUpdateHandoffReplacement(tx, root); err != nil {
+		t.Fatalf("legacy strict digest rejected: %v", err)
+	}
+}
+
+func TestPrepareAppBundleUpdateHandoffRecordsPayloadAppDigest(t *testing.T) {
+	tx, _ := prepareTestAppBundleHandoff(t)
+	payload, err := repairPlanTreePayloadStateID(tx.HandoffAppPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	strict, err := repairPlanTreeContentStateID(tx.HandoffAppPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tx.HandoffAppTreeID != payload {
+		t.Fatalf("staged app digest = %s, want payload %s", tx.HandoffAppTreeID, payload)
+	}
+	if tx.HandoffAppTreeID == strict {
+		t.Fatal("staged app digest used the strict tree identity")
+	}
+	backup, err := repairPlanTreeContentStateID(tx.TargetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tx.BackupTreeID != backup {
+		t.Fatalf("backup digest = %s, want strict %s", tx.BackupTreeID, backup)
+	}
+	staging, err := repairPlanTreeContentStateID(tx.HandoffStagingPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tx.HandoffStagingTreeID != staging {
+		t.Fatalf("staging digest = %s, want strict %s", tx.HandoffStagingTreeID, staging)
+	}
+}

--- a/internal/repair/update.go
+++ b/internal/repair/update.go
@@ -382,7 +382,7 @@ func PrepareAppBundleUpdateHandoff(fromVersion, toVersion, appPath, backupPath, 
 		return nil, fmt.Errorf("prepare update: lock targets: %w", err)
 	}
 	defer unlockTargets()
-	tx.HandoffAppTreeID, err = repairPlanTreeContentStateID(tx.HandoffAppPath)
+	tx.HandoffAppTreeID, err = repairPlanTreePayloadStateID(tx.HandoffAppPath)
 	if err != nil {
 		return nil, fmt.Errorf("prepare update: stage bundle digest: %w", err)
 	}
@@ -1345,14 +1345,14 @@ func VerifyAppBundleUpdateHandoffSource(tx *UpdateTransaction) error {
 	if err := validateAppBundleHandoffSourcePaths(tx); err != nil {
 		return err
 	}
-	actual, err := repairPlanTreeContentStateID(tx.HandoffAppPath)
+	matched, err := repairPlanTreeHandoffAppMatches(tx.HandoffAppPath, tx.HandoffAppTreeID)
 	if err != nil {
 		return fmt.Errorf("read staged bundle digest: %w", err)
 	}
-	if actual != tx.HandoffAppTreeID {
+	if !matched {
 		return fmt.Errorf("staged bundle changed after verification")
 	}
-	actual, err = repairPlanTreeContentStateID(tx.HandoffStagingPath)
+	actual, err := repairPlanTreeContentStateID(tx.HandoffStagingPath)
 	if err != nil {
 		return fmt.Errorf("read staging directory digest: %w", err)
 	}
@@ -1423,11 +1423,11 @@ func verifyAppBundleUpdateHandoffReplacement(tx *UpdateTransaction, path, subjec
 	if strings.TrimSpace(tx.HandoffAppTreeID) == "" {
 		return fmt.Errorf("handoff target digest is missing")
 	}
-	actual, err := repairPlanTreeContentStateID(path)
+	matched, err := repairPlanTreeHandoffAppMatches(path, tx.HandoffAppTreeID)
 	if err != nil {
 		return fmt.Errorf("read %s bundle digest: %w", subject, err)
 	}
-	if actual != tx.HandoffAppTreeID {
+	if !matched {
 		return fmt.Errorf("%s bundle differs from verified staging", subject)
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Add a macOS-updater-only fallback when `RENAME_EXCL` returns `ENOTSUP` or `ENOSYS`: confirm that the destination is absent, then use a regular rename.
- Separate app payload identity from strict repair-tree identity. Payload verification ignores POSIX mode changes and AppleDouble regular files that have matching siblings.
- Preserve strict backup and staging identities, compatibility with legacy strict-digest transactions, and the existing Linux, Windows, and generic repair rename behavior.
- Add regression coverage for exFAT rename fallback, destination protection, payload copying, AppleDouble filtering, and legacy transactions.

## Issues

Fixes #9152

## Verification

- `go test ./internal/repair -count=1 -timeout=180s`
- `cd desktop && go test . -count=1 -timeout=180s`
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -c -o /dev/null ./internal/repair`
- `CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go test -c -o /dev/null ./internal/repair`
- `go run ./tools/repolint`
- Manually updated the test app from v1.25.4 to v1.29.0 on APFS.
- Manually updated the test app from v1.25.4 to v1.29.0 on exFAT.
- Confirmed that the update helper logged `replacement app bundle launched`.
- Confirmed that the production installation was not modified during testing.

## Documentation impact

Documentation-impact: none - this restores the existing macOS self-update behavior without changing the user-facing workflow.

## Cache impact

Cache-impact: none - no prompt, provider, memory, or tool-prefix content changes.
Cache-guard: N/A - the change is isolated to macOS update handoff and repair-tree verification.
System-prompt-review: N/A