### PR TITLE
fix(desktop): update budgetWhyOverflow copy to match current numeric-card UI / 修正压缩提示文案引用

### DIFF
--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -3189,7 +3189,7 @@ export const en = {
   "context.budgetSourceOpencode": "OpenCode metadata",
   "context.budgetSourceLearned": "Learned from a 400",
   "context.budgetSourceUnknown": "Unknown",
-  "context.budgetWhyOverflow": "The usage ring is prompt ÷ window. A 63% prompt can still overflow because the provider also reserves completion tokens in the same window.",
+  "context.budgetWhyOverflow": "The budget card shows prompt ÷ window. A 63% prompt can still overflow because the provider also reserves completion tokens in the same window.",
   "context.budgetRecoveryClip": "Output was clipped before send so prompt + completion fit.",
   "context.budgetRecoveryRetry": "Recovered from a context 400 by lowering the output budget.",
   "context.budgetRecoveryCompacted": "Recovered from a context 400 by compacting once and retrying.",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -3189,7 +3189,7 @@ export const en = {
   "context.budgetSourceOpencode": "OpenCode metadata",
   "context.budgetSourceLearned": "Learned from a 400",
   "context.budgetSourceUnknown": "Unknown",
-  "context.budgetWhyOverflow": "The budget card shows prompt ÷ window. A 63% prompt can still overflow because the provider also reserves completion tokens in the same window.",
+  "context.budgetWhyOverflow": "The budget card shows prompt tokens, output reserve, and physical remaining. A prompt can still overflow because the provider reserves completion tokens in the same context window.",
   "context.budgetRecoveryClip": "Output was clipped before send so prompt + completion fit.",
   "context.budgetRecoveryRetry": "Recovered from a context 400 by lowering the output budget.",
   "context.budgetRecoveryCompacted": "Recovered from a context 400 by compacting once and retrying.",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -3275,7 +3275,7 @@ export const zhTW: Record<DictKey, string> = {
   "context.budgetSourceOpencode": "OpenCode 元資料",
   "context.budgetSourceLearned": "400 學習",
   "context.budgetSourceUnknown": "未知",
-  "context.budgetWhyOverflow": "預算卡片顯示的是 prompt ÷ 視窗。prompt 只用了 63% 仍可能超窗，因為服務端會把輸出預算算進同一個視窗。",
+  "context.budgetWhyOverflow": "預算卡片顯示 prompt、輸出預算和物理剩餘空間。即使 prompt 佔用不高，服務端為輸出預留的 token 仍可能使總量超過同一個上下文視窗。",
   "context.budgetRecoveryClip": "發送前已裁剪輸出，使 prompt + 輸出能放進視窗。",
   "context.budgetRecoveryRetry": "已透過下調輸出預算從上下文 400 中恢復。",
   "context.budgetRecoveryCompacted": "已壓縮一次並重試，從上下文 400 中恢復。",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -3275,7 +3275,7 @@ export const zhTW: Record<DictKey, string> = {
   "context.budgetSourceOpencode": "OpenCode 元資料",
   "context.budgetSourceLearned": "400 學習",
   "context.budgetSourceUnknown": "未知",
-  "context.budgetWhyOverflow": "圓環顯示的是 prompt ÷ 視窗。prompt 只用了 63% 仍可能超窗，因為服務端會把輸出預算算進同一個視窗。",
+  "context.budgetWhyOverflow": "預算卡片顯示的是 prompt ÷ 視窗。prompt 只用了 63% 仍可能超窗，因為服務端會把輸出預算算進同一個視窗。",
   "context.budgetRecoveryClip": "發送前已裁剪輸出，使 prompt + 輸出能放進視窗。",
   "context.budgetRecoveryRetry": "已透過下調輸出預算從上下文 400 中恢復。",
   "context.budgetRecoveryCompacted": "已壓縮一次並重試，從上下文 400 中恢復。",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -3192,7 +3192,7 @@ export const zh: Record<DictKey, string> = {
   "context.budgetSourceOpencode": "OpenCode 元数据",
   "context.budgetSourceLearned": "400 学习",
   "context.budgetSourceUnknown": "未知",
-  "context.budgetWhyOverflow": "圆环显示的是 prompt ÷ 窗口。prompt 只用了 63% 仍可能超窗，因为服务端会把输出预算算进同一个窗口。",
+  "context.budgetWhyOverflow": "预算卡片显示的是 prompt ÷ 窗口。prompt 只用了 63% 仍可能超窗，因为服务端会把输出预算算进同一个窗口。",
   "context.budgetRecoveryClip": "发送前已裁剪输出，使 prompt + 输出能放进窗口。",
   "context.budgetRecoveryRetry": "已通过下调输出预算从上下文 400 中恢复。",
   "context.budgetRecoveryCompacted": "已压缩一次并重试，从上下文 400 中恢复。",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -3192,7 +3192,7 @@ export const zh: Record<DictKey, string> = {
   "context.budgetSourceOpencode": "OpenCode 元数据",
   "context.budgetSourceLearned": "400 学习",
   "context.budgetSourceUnknown": "未知",
-  "context.budgetWhyOverflow": "预算卡片显示的是 prompt ÷ 窗口。prompt 只用了 63% 仍可能超窗，因为服务端会把输出预算算进同一个窗口。",
+  "context.budgetWhyOverflow": "预算卡片显示 prompt、输出预算和物理剩余空间。即使 prompt 占用不高，服务端为输出预留的 token 仍可能使总量超过同一上下文窗口。",
   "context.budgetRecoveryClip": "发送前已裁剪输出，使 prompt + 输出能放进窗口。",
   "context.budgetRecoveryRetry": "已通过下调输出预算从上下文 400 中恢复。",
   "context.budgetRecoveryCompacted": "已压缩一次并重试，从上下文 400 中恢复。",


### PR DESCRIPTION
## Summary

Update `context.budgetWhyOverflow` locale strings (en/zh/zh-TW) to replace the outdated "usage ring" / "圆环" / "圓環" reference with "budget card" / "预算卡片" / "預算卡片", matching the current UI which renders this note inside `ContextBudgetCard` (numeric card) rather than `ContextWindowRing` (creation layout only).

## Issues

Fixes #9084

## Verification

- Grep confirms all three locale files now reference "budget card" / "预算卡片" / "預算卡片" instead of "ring" / "圆环" / "圓環"
- No functional change — pure copy fix

## Documentation impact

Documentation-impact: none- locale string change only

## Cache impact

Cache-impact: none- no prompt, tool schema, or provider request changes
Cache-guard: none- not required - changed paths are outside provider-visible cache construction
System-prompt-review: none- no relevant changes.