### PR TITLE
refactor(config): shared project-config path resolution

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -2093,11 +2093,11 @@ func rememberPermissionRule(workspaceRoot, rule string) control.RememberResult {
 func rememberPermissionConfigPath(workspaceRoot string) string {
 	workspaceRoot = strings.TrimSpace(workspaceRoot)
 	if workspaceRoot != "" {
-		return filepath.Join(workspaceRoot, "reasonix.toml")
+		return config.ProjectConfigPath(workspaceRoot)
 	}
 	path := config.SourcePath()
 	if path == "" {
-		path = "reasonix.toml" // match Config.Save() fallback
+		path = config.ProjectConfigPath(".") // match Config.Save() fallback
 	}
 	return path
 }

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -3234,7 +3234,7 @@ allow = ["Bash(user)"]
 
 	const rule = "Edit(src/app.go)"
 	res := rememberPermissionRule(workspace, rule)
-	if !res.Saved || res.Path != filepath.Join(workspace, "reasonix.toml") {
+	if !res.Saved || res.Path != filepath.Join(workspace, ".reasonix", "config.toml") {
 		t.Fatalf("remember result = %+v, want saved to workspace config", res)
 	}
 
@@ -3242,7 +3242,7 @@ allow = ["Bash(user)"]
 	if hasPermissionRule(userCfg.Permissions.Allow, rule) {
 		t.Fatalf("workspace rule was written to user config: %v", userCfg.Permissions.Allow)
 	}
-	workspaceCfg := config.LoadForEdit(filepath.Join(workspace, "reasonix.toml"))
+	workspaceCfg := config.LoadForEdit(filepath.Join(workspace, ".reasonix", "config.toml"))
 	if !hasPermissionRule(workspaceCfg.Permissions.Allow, rule) {
 		t.Fatalf("workspace rule missing from project config: %v", workspaceCfg.Permissions.Allow)
 	}

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -147,10 +147,7 @@ func credentialEnvNamesForRoot(root string) []string {
 	root = resolveRoot(root)
 	cfg := Default()
 
-	projectTOML := "reasonix.toml"
-	if root != "." {
-		projectTOML = filepath.Join(root, "reasonix.toml")
-	}
+	projectTOML := ProjectConfigPath(root)
 	if uc := userConfigLoadPath(); uc != "" {
 		_ = mergeFile(cfg, uc)
 	}

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -903,10 +903,9 @@ func ClearPluginAuthenticationInSource(name string) (PluginEntry, bool, string, 
 // user switches tabs while the action is waiting on a lifecycle lock.
 func ClearPluginAuthenticationInSourceForRoot(root, name string) (PluginEntry, bool, string, error) {
 	resolvedRoot := resolveRoot(root)
-	projectTOML := "reasonix.toml"
+	projectTOML := ProjectConfigPath(resolvedRoot)
 	projectMCPJSON := mcpJSONFile
 	if resolvedRoot != "." {
-		projectTOML = filepath.Join(resolvedRoot, "reasonix.toml")
 		projectMCPJSON = filepath.Join(resolvedRoot, mcpJSONFile)
 	}
 	lockPaths := append([]string{}, userConfigCandidatePaths()...)
@@ -953,10 +952,7 @@ func ClearPluginAuthenticationInSourceForRoot(root, name string) (PluginEntry, b
 }
 
 func pluginTOMLSourcePathForRoot(root, name string) string {
-	projectTOML := "reasonix.toml"
-	if resolved := resolveRoot(root); resolved != "." {
-		projectTOML = filepath.Join(resolved, "reasonix.toml")
-	}
+	projectTOML := ProjectConfigPath(resolveRoot(root))
 	paths := append([]string{projectTOML}, userConfigCandidatePaths()...)
 	for _, path := range paths {
 		if strings.TrimSpace(path) == "" {
@@ -978,10 +974,9 @@ func pluginTOMLSourcePathForRoot(root, name string) string {
 // the highest priority.
 func MCPConfigPathForEntry(root string, entry PluginEntry) string {
 	resolvedRoot := resolveRoot(root)
-	projectTOML := "reasonix.toml"
+	projectTOML := ProjectConfigPath(resolvedRoot)
 	projectMCPJSON := mcpJSONFile
 	if resolvedRoot != "." {
-		projectTOML = filepath.Join(resolvedRoot, "reasonix.toml")
 		projectMCPJSON = filepath.Join(resolvedRoot, mcpJSONFile)
 	}
 	switch entry.Source {
@@ -1207,10 +1202,9 @@ func RemovePluginFromEffectiveSourceForRoot(root, name string) (PluginEntry, boo
 // of a now-shadowed source.
 func mcpConfigSourcePathsForRoot(root string) []string {
 	resolvedRoot := resolveRoot(root)
-	projectTOML := "reasonix.toml"
+	projectTOML := ProjectConfigPath(resolvedRoot)
 	projectMCPJSON := mcpJSONFile
 	if resolvedRoot != "." {
-		projectTOML = filepath.Join(resolvedRoot, "reasonix.toml")
 		projectMCPJSON = filepath.Join(resolvedRoot, mcpJSONFile)
 	}
 	paths := append([]string{}, userConfigCandidatePaths()...)
@@ -1412,10 +1406,7 @@ func RemovePluginFromSourcesForRoot(root, name string) (bool, error) {
 
 	userPaths := userConfigCandidatePaths()
 	resolvedRoot := resolveRoot(root)
-	projectTOML := "reasonix.toml"
-	if resolvedRoot != "." {
-		projectTOML = filepath.Join(resolvedRoot, "reasonix.toml")
-	}
+	projectTOML := ProjectConfigPath(resolvedRoot)
 	isUserPath := false
 	for _, path := range userPaths {
 		if samePath(path, projectTOML) {
@@ -2409,12 +2400,12 @@ func IsUserConfigPath(path string) bool {
 }
 
 // Save writes the configuration back to the file it was loaded from
-// (SourcePath), or to ./reasonix.toml when none exists yet — the conventional
-// project-local target a fresh GUI session would create.
+// (SourcePath), or to .reasonix/config.toml when none exists yet — the
+// conventional project-local target a fresh GUI session would create.
 func (c *Config) Save() error {
 	path := SourcePath()
 	if path == "" {
-		path = "reasonix.toml"
+		path = projectConfigLocal
 	}
 	return c.SaveTo(path)
 }
@@ -2424,10 +2415,7 @@ func (c *Config) Save() error {
 // are edited from their own TOML only, never from a runtime user+project merge.
 func (c *Config) SaveForRoot(root string) error {
 	root = resolveRoot(root)
-	projectTOML := "reasonix.toml"
-	if root != "." {
-		projectTOML = filepath.Join(root, "reasonix.toml")
-	}
+	projectTOML := ProjectConfigPath(root)
 	if _, err := os.Stat(projectTOML); err == nil {
 		projectCfg := LoadForEditWithoutCredentials(projectTOML)
 		return projectCfg.SaveTo(projectTOML)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -72,9 +72,9 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	cfg.setExpansionEnv(expansionEnv)
 	cfg.CredentialsStore = credentialsStoreMode()
 
-	projectTOML := "reasonix.toml"
-	if root != "." {
-		projectTOML = filepath.Join(root, "reasonix.toml")
+	projectTOML := ProjectConfigPath(root)
+	if bothProjectConfigsExist(root) {
+		slog.Warn("project config: reasonix.toml and .reasonix/config.toml both exist; reasonix.toml wins", "root", root)
 	}
 	if primary := userConfigPath(); primary != "" {
 		if _, err := resolveConfigAccessPath(primary, true); err != nil {
@@ -967,11 +967,7 @@ func MigrateLegacyAgentStepLimitsForRoot(root string) (bool, error) {
 	if userPath := userConfigLoadPath(); userPath != "" {
 		paths = append(paths, userPath)
 	}
-	projectPath := "reasonix.toml"
-	if root != "." {
-		projectPath = filepath.Join(root, "reasonix.toml")
-	}
-	paths = append(paths, projectPath)
+	paths = append(paths, ProjectConfigPath(root))
 
 	changedAny := false
 	seen := make(map[string]struct{}, len(paths))
@@ -1012,11 +1008,7 @@ func MigrateLegacyRedactToolOutputForRoot(root string) (bool, error) {
 	if userPath := userConfigLoadPath(); userPath != "" {
 		paths = append(paths, userPath)
 	}
-	projectPath := "reasonix.toml"
-	if root != "." {
-		projectPath = filepath.Join(root, "reasonix.toml")
-	}
-	paths = append(paths, projectPath)
+	paths = append(paths, ProjectConfigPath(root))
 
 	changedAny := false
 	seen := make(map[string]struct{}, len(paths))
@@ -1054,11 +1046,7 @@ func MigrateLegacyMemoryCompilerForRoot(root string) (bool, error) {
 	if userPath := userConfigLoadPath(); userPath != "" {
 		paths = append(paths, userPath)
 	}
-	projectPath := "reasonix.toml"
-	if root != "." {
-		projectPath = filepath.Join(root, "reasonix.toml")
-	}
-	paths = append(paths, projectPath)
+	paths = append(paths, ProjectConfigPath(root))
 
 	changedAny := false
 	seen := make(map[string]struct{}, len(paths))
@@ -1123,11 +1111,7 @@ func MigrateLegacyMultiThresholdCompactionForRoot(root string) (bool, error) {
 	if userPath := userConfigLoadPath(); userPath != "" {
 		paths = append(paths, userPath)
 	}
-	projectPath := "reasonix.toml"
-	if root != "." {
-		projectPath = filepath.Join(root, "reasonix.toml")
-	}
-	paths = append(paths, projectPath)
+	paths = append(paths, ProjectConfigPath(root))
 
 	changedAny := false
 	seen := make(map[string]struct{}, len(paths))

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -267,7 +267,7 @@ func migrateMCPToUserConfig(projectRoots []string) (*MCPGlobalMigrationResult, e
 		addEntries(loadPluginEntriesFromTOML(path))
 	}
 	for _, root := range normalizedMCPMigrationRoots(projectRoots) {
-		addEntries(loadPluginEntriesFromTOML(filepath.Join(root, "reasonix.toml")))
+		addEntries(append(loadPluginEntriesFromTOML(filepath.Join(root, projectConfigFile)), loadPluginEntriesFromTOML(filepath.Join(root, projectConfigLocal))...))
 		if entries, err := loadMCPJSON(filepath.Join(root, mcpJSONFile)); err == nil {
 			addEntries(entries)
 		}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -621,14 +621,53 @@ func SourcePath() string {
 	return SourcePathForRoot(".")
 }
 
+// Project config files. The standard location is <root>/.reasonix/config.toml,
+// mirroring the global <home>/.reasonix/config.toml. Legacy <root>/reasonix.toml
+// wins when present, so existing repositories keep working. New files are only
+// ever created at <root>/.reasonix/config.toml.
+const (
+	projectConfigFile  = "reasonix.toml"
+	projectConfigLocal = ".reasonix" + string(filepath.Separator) + "config.toml"
+)
+
+// projectConfigCandidates returns the legacy plain and standard local project
+// config paths for a resolved root.
+func projectConfigCandidates(root string) (plain, local string) {
+	root = resolveRoot(root)
+	plain, local = projectConfigFile, projectConfigLocal
+	if root != "." {
+		plain = filepath.Join(root, projectConfigFile)
+		local = filepath.Join(root, projectConfigLocal)
+	}
+	return plain, local
+}
+
+// ProjectConfigPath returns the project config file for root. <root>/reasonix.toml
+// (legacy) wins when present; otherwise the standard <root>/.reasonix/config.toml.
+// When none exists it returns .reasonix/config.toml, the creation default.
+func ProjectConfigPath(root string) string {
+	plain, local := projectConfigCandidates(root)
+	if _, err := os.Lstat(plain); err == nil {
+		return plain
+	}
+	return local
+}
+
+// bothProjectConfigsExist reports whether root holds both the legacy plain
+// reasonix.toml and the standard .reasonix/config.toml, i.e. the ambiguous
+// case where the plain file wins.
+func bothProjectConfigsExist(root string) bool {
+	plain, local := projectConfigCandidates(root)
+	_, plainErr := os.Lstat(plain)
+	_, localErr := os.Lstat(local)
+	return plainErr == nil && localErr == nil
+}
+
 // SourcePathForRoot returns the highest-priority config file that exists under
 // root, or "" if none. Equivalent to SourcePath() when root is ".".
 func SourcePathForRoot(root string) string {
 	root = resolveRoot(root)
-	projectTOML := "reasonix.toml"
-	if root != "." {
-		projectTOML = filepath.Join(root, "reasonix.toml")
-	}
+	projectTOML := ProjectConfigPath(root)
 	if _, err := os.Stat(projectTOML); err == nil {
 		return projectTOML
 	}
@@ -638,4 +677,20 @@ func SourcePathForRoot(root string) string {
 		}
 	}
 	return ""
+}
+
+// IsProjectConfigFile reports whether path is a recognized project config file:
+// <root>/reasonix.toml or <root>/.reasonix/config.toml. The user-global
+// <home>/.reasonix/config.toml is excluded.
+func IsProjectConfigFile(path string) bool {
+	if path == "" || path == userConfigPath() || path == legacyUserConfigPath() {
+		return false
+	}
+	switch filepath.Base(path) {
+	case "reasonix.toml":
+		return true
+	case "config.toml":
+		return filepath.Base(filepath.Dir(path)) == ".reasonix"
+	}
+	return false
 }

--- a/internal/config/project_config_discovery_test.go
+++ b/internal/config/project_config_discovery_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestProjectConfigPath pins the project-config discovery rule: reasonix.toml
+// wins when present, else the standard .reasonix/config.toml (the creation
+// default).
+func TestProjectConfigPath(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+
+	t.Run("legacy plain only", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := ProjectConfigPath(root); got != filepath.Join(root, "reasonix.toml") {
+			t.Fatalf("ProjectConfigPath = %q, want reasonix.toml", got)
+		}
+	})
+
+	t.Run("local only", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ".reasonix"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".reasonix", "config.toml"), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		want := filepath.Join(root, ".reasonix", "config.toml")
+		if got := ProjectConfigPath(root); got != want {
+			t.Fatalf("ProjectConfigPath = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("legacy plain wins over local", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(root, ".reasonix"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".reasonix", "config.toml"), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := ProjectConfigPath(root); got != filepath.Join(root, "reasonix.toml") {
+			t.Fatalf("ProjectConfigPath = %q, want reasonix.toml to win", got)
+		}
+	})
+
+	t.Run("neither defaults to local", func(t *testing.T) {
+		root := t.TempDir()
+		want := filepath.Join(root, ".reasonix", "config.toml")
+		if got := ProjectConfigPath(root); got != want {
+			t.Fatalf("ProjectConfigPath = %q, want %q default", got, want)
+		}
+	})
+
+	t.Run("bothProjectConfigsExist only for plain+local", func(t *testing.T) {
+		root := t.TempDir()
+		if bothProjectConfigsExist(root) {
+			t.Fatal("bothProjectConfigsExist true with no files")
+		}
+		if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if bothProjectConfigsExist(root) {
+			t.Fatal("bothProjectConfigsExist true with only the plain file")
+		}
+		if err := os.MkdirAll(filepath.Join(root, ".reasonix"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".reasonix", "config.toml"), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if !bothProjectConfigsExist(root) {
+			t.Fatal("bothProjectConfigsExist false with plain+local")
+		}
+	})
+}
+
+// TestLoadForRootProjectConfig pins discovery through a full load: the
+// standard .reasonix/config.toml is read, and reasonix.toml wins when present.
+func TestLoadForRootProjectConfig(t *testing.T) {
+	isolateUserConfigHome(t)
+	t.Setenv("REASONIX_HOME", "")
+
+	t.Run("local only", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ".reasonix"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".reasonix", "config.toml"), []byte("default_model = \"local/model\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadForRoot(root)
+		if err != nil {
+			t.Fatalf("LoadForRoot: %v", err)
+		}
+		if cfg.DefaultModel != "local/model" {
+			t.Fatalf("DefaultModel = %q, want .reasonix/config.toml content", cfg.DefaultModel)
+		}
+	})
+
+	t.Run("legacy plain wins over local", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ".reasonix"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".reasonix", "config.toml"), []byte("default_model = \"local/model\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte("default_model = \"plain/model\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadForRoot(root)
+		if err != nil {
+			t.Fatalf("LoadForRoot: %v", err)
+		}
+		if cfg.DefaultModel != "plain/model" {
+			t.Fatalf("DefaultModel = %q, want reasonix.toml to win", cfg.DefaultModel)
+		}
+	})
+}
+
+// TestSourcePathForRootPicksLocal pins that the source-resolution helper
+// follows the same rule so writes/edits target the loaded file.
+func TestSourcePathForRootPicksLocal(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".reasonix"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, ".reasonix", "config.toml")
+	if err := os.WriteFile(want, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := SourcePathForRoot(root); got != want {
+		t.Fatalf("SourcePathForRoot = %q, want %q", got, want)
+	}
+}
+
+// TestIsProjectConfigFile pins the recognizer and its user-config exclusion.
+func TestIsProjectConfigFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	if !IsProjectConfigFile(filepath.Join(home, "proj", "reasonix.toml")) {
+		t.Error("legacy plain reasonix.toml should be a project config")
+	}
+	if !IsProjectConfigFile(filepath.Join(home, "proj", ".reasonix", "config.toml")) {
+		t.Error(".reasonix/config.toml should be a project config")
+	}
+	if IsProjectConfigFile(userConfigPath()) {
+		t.Error("user config should not be a project config")
+	}
+	if IsProjectConfigFile(filepath.Join(home, "proj", "other.toml")) {
+		t.Error("unrelated file should not be a project config")
+	}
+}


### PR DESCRIPTION
# refactor(config): shared project-config path resolution

Introduces `ProjectConfigPath`, `bothProjectConfigsExist`, `IsProjectConfigFile` and their helper/constants, and routes project-config resolution in `load.go`, `credentials.go`, `edit.go`, `migrate.go`, `boot.go` through them.

PR **1 of 3** in a chained set. Downstream PRs (add cachecontext, auto-derive) build on this shared foundation.

## What changed
- `internal/config/paths.go`: `ProjectConfigPath` (legacy `reasonix.toml` wins, else `.reasonix/config.toml`), `projectConfigCandidates`, `bothProjectConfigsExist`, `IsProjectConfigFile`.
- `internal/config/edit.go`: `Config.Save()` fallback targets `.reasonix/config.toml`.
- `internal/boot/boot.go`: fallback uses `config.ProjectConfigPath(".")`.
- `internal/config/{load,credentials,migrate}.go`: route through `ProjectConfigPath`.
- `internal/config/project_config_discovery_test.go` + `internal/boot/boot_test.go`: precedence + user-config exclusion tests.
- `internal/tool/builtin/{session_guard,confine,managed_config}.go`, `internal/doctor/report.go`, `internal/repair/transaction.go`: route through shared helpers.

## Impact
- Cache-impact: none.
- Cache-guard: `go test ./internal/config/ ./internal/boot/` pass; `repolint` clean.
- Documentation-impact: none here (code-only); cachecontext docs land downstream.
