### PR TITLE
fix(sessioncatalog): repair incomplete sidebar projections / 自愈侧栏会话索引缺失

### DIFF
--- a/internal/sessioncatalog/catalog_test.go
+++ b/internal/sessioncatalog/catalog_test.go
@@ -93,6 +93,65 @@ func TestDirectoryScanReadyOnlyAfterFirstReconcile(t *testing.T) {
 	}
 }
 
+func TestReconcileRepairsReadyDirectoryMissingCatalogRows(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chat.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{
+		Scope: "global", TopicID: "topic", TopicTitle: "Existing conversation",
+		SchemaVersion: agent.BranchMetaCountsVersion, Turns: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	catalog, err := Open(ctx, Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	target := DirectoryTarget{Path: dir, Scope: "global"}
+	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate an upgrade/cache replacement that retained the completed
+	// directory marker but lost the rows used to render the sidebar.
+	if _, err := catalog.db.ExecContext(ctx, `DELETE FROM catalog_sessions WHERE directory=?`, dir); err != nil {
+		t.Fatal(err)
+	}
+	if catalog.HasWorkspaceRecords(ctx, "global", "") {
+		t.Fatal("test setup still has catalog session rows")
+	}
+
+	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
+		t.Fatal(err)
+	}
+	page, err := catalog.ListTopics(ctx, TopicPageRequest{Scope: "global", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 || page.Items[0].TopicID != "topic" || len(page.Items[0].Sessions) != 1 {
+		t.Fatalf("repaired page = %#v, want the existing conversation restored", page)
+	}
+
+	if _, err := catalog.db.ExecContext(ctx, `DELETE FROM catalog_topics WHERE topic_id='topic'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
+		t.Fatal(err)
+	}
+	page, err = catalog.ListTopics(ctx, TopicPageRequest{Scope: "global", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 || page.Items[0].TopicID != "topic" || len(page.Items[0].Sessions) != 1 {
+		t.Fatalf("repaired topic projection = %#v, want the existing conversation restored", page)
+	}
+}
+
 func TestListTopicsUsesStableKeysetCursor(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/sessioncatalog/catalog_test.go
+++ b/internal/sessioncatalog/catalog_test.go
@@ -93,65 +93,6 @@ func TestDirectoryScanReadyOnlyAfterFirstReconcile(t *testing.T) {
 	}
 }
 
-func TestReconcileRepairsReadyDirectoryMissingCatalogRows(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "chat.jsonl")
-	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := agent.SaveBranchMeta(path, agent.BranchMeta{
-		Scope: "global", TopicID: "topic", TopicTitle: "Existing conversation",
-		SchemaVersion: agent.BranchMetaCountsVersion, Turns: 1,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	catalog, err := Open(ctx, Options{InMemory: true, DisableRepair: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
-	target := DirectoryTarget{Path: dir, Scope: "global"}
-	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
-		t.Fatal(err)
-	}
-
-	// Simulate an upgrade/cache replacement that retained the completed
-	// directory marker but lost the rows used to render the sidebar.
-	if _, err := catalog.db.ExecContext(ctx, `DELETE FROM catalog_sessions WHERE directory=?`, dir); err != nil {
-		t.Fatal(err)
-	}
-	if catalog.HasWorkspaceRecords(ctx, "global", "") {
-		t.Fatal("test setup still has catalog session rows")
-	}
-
-	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
-		t.Fatal(err)
-	}
-	page, err := catalog.ListTopics(ctx, TopicPageRequest{Scope: "global", Limit: 50})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(page.Items) != 1 || page.Items[0].TopicID != "topic" || len(page.Items[0].Sessions) != 1 {
-		t.Fatalf("repaired page = %#v, want the existing conversation restored", page)
-	}
-
-	if _, err := catalog.db.ExecContext(ctx, `DELETE FROM catalog_topics WHERE topic_id='topic'`); err != nil {
-		t.Fatal(err)
-	}
-	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
-		t.Fatal(err)
-	}
-	page, err = catalog.ListTopics(ctx, TopicPageRequest{Scope: "global", Limit: 50})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(page.Items) != 1 || page.Items[0].TopicID != "topic" || len(page.Items[0].Sessions) != 1 {
-		t.Fatalf("repaired topic projection = %#v, want the existing conversation restored", page)
-	}
-}
-
 func TestListTopicsUsesStableKeysetCursor(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/sessioncatalog/reconcile.go
+++ b/internal/sessioncatalog/reconcile.go
@@ -147,42 +147,6 @@ func directorySignature(dir string) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-func (c *Catalog) directoryScanCanSkip(ctx context.Context, path, signature string) (bool, error) {
-	var previous, state string
-	var expected, present, unprojected int
-	err := c.db.QueryRowContext(ctx, `SELECT signature,state,total,
-		(SELECT COUNT(*) FROM catalog_sessions WHERE directory=? AND missing_since=0),
-		(SELECT COUNT(*) FROM catalog_sessions s
-		 WHERE s.directory=? AND s.missing_since=0 AND s.topic_id<>''
-		 AND NOT EXISTS (
-			 SELECT 1 FROM catalog_topics t
-			 WHERE t.scope=s.scope AND t.workspace_root=s.workspace_root AND t.topic_id=s.topic_id
-		 ))
-		FROM catalog_directories WHERE path=?`, path, path, path).Scan(&previous, &state, &expected, &present, &unprojected)
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	if previous != signature || state != "ready" {
-		return false, nil
-	}
-	// The directory row and session rows are one disposable projection, but an
-	// interrupted cache replacement can preserve the ready marker while losing
-	// session or topic rows. A signature-only fast path would then keep an
-	// unchanged on-disk conversation invisible forever. Reconcile whenever the
-	// completed file count or its topic projection is inconsistent.
-	if present != expected || unprojected != 0 {
-		return false, nil
-	}
-	var missing int
-	if err := c.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions WHERE directory=? AND missing_since>0`, path).Scan(&missing); err != nil {
-		return false, err
-	}
-	return missing == 0, nil
-}
-
 func (c *Catalog) directoryLock(path string) *sync.Mutex {
 	c.directoryLocksMu.Lock()
 	defer c.directoryLocksMu.Unlock()

--- a/internal/sessioncatalog/reconcile.go
+++ b/internal/sessioncatalog/reconcile.go
@@ -149,7 +149,16 @@ func directorySignature(dir string) (string, error) {
 
 func (c *Catalog) directoryScanCanSkip(ctx context.Context, path, signature string) (bool, error) {
 	var previous, state string
-	err := c.db.QueryRowContext(ctx, `SELECT signature,state FROM catalog_directories WHERE path=?`, path).Scan(&previous, &state)
+	var expected, present, unprojected int
+	err := c.db.QueryRowContext(ctx, `SELECT signature,state,total,
+		(SELECT COUNT(*) FROM catalog_sessions WHERE directory=? AND missing_since=0),
+		(SELECT COUNT(*) FROM catalog_sessions s
+		 WHERE s.directory=? AND s.missing_since=0 AND s.topic_id<>''
+		 AND NOT EXISTS (
+			 SELECT 1 FROM catalog_topics t
+			 WHERE t.scope=s.scope AND t.workspace_root=s.workspace_root AND t.topic_id=s.topic_id
+		 ))
+		FROM catalog_directories WHERE path=?`, path, path, path).Scan(&previous, &state, &expected, &present, &unprojected)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
 	}
@@ -157,6 +166,14 @@ func (c *Catalog) directoryScanCanSkip(ctx context.Context, path, signature stri
 		return false, err
 	}
 	if previous != signature || state != "ready" {
+		return false, nil
+	}
+	// The directory row and session rows are one disposable projection, but an
+	// interrupted cache replacement can preserve the ready marker while losing
+	// session or topic rows. A signature-only fast path would then keep an
+	// unchanged on-disk conversation invisible forever. Reconcile whenever the
+	// completed file count or its topic projection is inconsistent.
+	if present != expected || unprojected != 0 {
 		return false, nil
 	}
 	var missing int

--- a/internal/sessioncatalog/reconcile_integrity.go
+++ b/internal/sessioncatalog/reconcile_integrity.go
@@ -1,0 +1,32 @@
+package sessioncatalog
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+func (c *Catalog) directoryScanCanSkip(ctx context.Context, path, signature string) (bool, error) {
+	// Trust a ready marker only when its session and topic projections match
+	// the completed directory scan in the same SQLite read snapshot.
+	var expected, present, unprojected, missing int
+	err := c.db.QueryRowContext(ctx, `SELECT total,
+		(SELECT COUNT(*) FROM catalog_sessions WHERE directory=? AND missing_since=0),
+		(SELECT COUNT(*) FROM catalog_sessions s
+		 WHERE s.directory=? AND s.missing_since=0 AND s.topic_id<>''
+		 AND NOT EXISTS (
+			 SELECT 1 FROM catalog_topics t
+			 WHERE t.scope=s.scope AND t.workspace_root=s.workspace_root AND t.topic_id=s.topic_id
+		 )),
+		(SELECT COUNT(*) FROM catalog_sessions WHERE directory=? AND missing_since>0)
+		FROM catalog_directories
+		WHERE path=? AND signature=? AND state='ready'`,
+		path, path, path, path, signature).Scan(&expected, &present, &unprojected, &missing)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return present == expected && unprojected == 0 && missing == 0, nil
+}

--- a/internal/sessioncatalog/reconcile_integrity_test.go
+++ b/internal/sessioncatalog/reconcile_integrity_test.go
@@ -1,0 +1,77 @@
+package sessioncatalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/agent"
+)
+
+func TestReconcileRepairsPersistedReadyDirectoryMissingCatalogRows(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chat.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{
+		Scope: "global", TopicID: "topic", TopicTitle: "Existing conversation",
+		SchemaVersion: agent.BranchMetaCountsVersion, Turns: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	catalogPath := filepath.Join(t.TempDir(), "catalog.sqlite")
+	catalog := openIntegrityTestCatalog(t, ctx, catalogPath)
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	target := DirectoryTarget{Path: dir, Scope: "global"}
+	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := catalog.db.ExecContext(ctx, `DELETE FROM catalog_sessions WHERE directory=?`, dir); err != nil {
+		t.Fatal(err)
+	}
+	catalog = reopenIntegrityTestCatalog(t, ctx, catalog, catalogPath)
+	assertIntegrityRepair(t, ctx, catalog, target)
+
+	if _, err := catalog.db.ExecContext(ctx, `DELETE FROM catalog_topics WHERE topic_id='topic'`); err != nil {
+		t.Fatal(err)
+	}
+	catalog = reopenIntegrityTestCatalog(t, ctx, catalog, catalogPath)
+	assertIntegrityRepair(t, ctx, catalog, target)
+}
+
+func openIntegrityTestCatalog(t *testing.T, ctx context.Context, path string) *Catalog {
+	t.Helper()
+	catalog, err := Open(ctx, Options{Path: path, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return catalog
+}
+
+func reopenIntegrityTestCatalog(t *testing.T, ctx context.Context, catalog *Catalog, path string) *Catalog {
+	t.Helper()
+	if err := catalog.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return openIntegrityTestCatalog(t, ctx, path)
+}
+
+func assertIntegrityRepair(t *testing.T, ctx context.Context, catalog *Catalog, target DirectoryTarget) {
+	t.Helper()
+	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
+		t.Fatal(err)
+	}
+	page, err := catalog.ListTopics(ctx, TopicPageRequest{Scope: "global", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 || page.Items[0].TopicID != "topic" || len(page.Items[0].Sessions) != 1 {
+		t.Fatalf("repaired page = %#v, want the persisted conversation restored", page)
+	}
+}


### PR DESCRIPTION
## Summary

- Detect persisted ready directory projections whose live session-row count no longer matches the completed scan total.
- Verify that every indexed session with a topic ID still has a topic projection, and reconcile from authoritative JSONL files when either invariant is broken.
- Keep the integrity read in one SQLite snapshot and run its indexed scans only for a directory whose signature still matches and whose state is ready.
- Add disk-backed regression coverage that closes and reopens the catalog before repairing missing session and topic rows.

## Problem

A user reported existing workspace conversations disappearing from the sidebar after an application upgrade even though the session files remained on disk. This PR repairs the confirmed incomplete-projection state. The exact writer that originally created that state has not been reproduced, so the upgrade timing is treated as an observation rather than a proven database mutation path.

## Verification

- `go run ./tools/repolint`
- `go test ./internal/sessioncatalog/ -count=1`
- `go test -race ./internal/sessioncatalog/ -count=1`
- `go vet ./...`
- `go test ./... -count=1`
- `cd desktop && go test ./... -run "Test(ListProjectTopics|ProjectTreeSnapshot|UpgradeLegacy|SessionCatalog|ReconcileRepairsPersistedReadyDirectory).*" -count=1`

## Compatibility

- No persisted schema, JSONL format, or Wails contract changes.
- Existing JSONL sessions remain authoritative and are never rewritten by this repair.
- Previous versions can continue reading the same state; only the disposable catalog projection is regenerated when inconsistent.

## Performance

- The unchanged-ready-directory path adds indexed counts over that directory and primary-key topic lookups.
- Directories with a changed signature or non-ready state do not run the integrity subqueries.
- Reconciliation remains background-only; session JSONL files are decoded only when an inconsistency requires repair.

## Documentation impact

Documentation-impact: none - The repair is automatic and does not change user-facing configuration or workflows.

## Cache impact

Cache-impact: none - Session catalog reconciliation does not affect prompt construction or provider serialization.
Cache-guard: N/A - No prompt-cache-sensitive path changed.
System-prompt-review: N/A