### PR TITLE
feat(extension): expose provider/model in Extension Protocol v2 / 扩展协议暴露当前会话的 provider/model

### DIFF
--- a/internal/agent/extensions.go
+++ b/internal/agent/extensions.go
@@ -169,7 +169,7 @@ func (a *Agent) interceptProviderRequest(ctx context.Context, req provider.Reque
 	if d == nil {
 		return req, nil
 	}
-	payload := dispatch.ProviderRequestPayload{Request: providerconv.RequestToProtocol(req)}
+	payload := dispatch.ProviderRequestPayload{Request: providerconv.RequestToProtocol(req, a.svc.prov.Name(), a.modelRef)}
 	result, err := d.Intercept(ctx, extension.PointProviderRequest, &payload)
 	if err != nil {
 		return provider.Request{}, err

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -351,7 +351,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		},
 	})
 	extensionMgr, err := preflightExtensionRuntimes(ctx, config.ReasonixHomeDir(), extensionBoot{
-		session:   protocol.SessionContext{SessionID: sessionID, WorkspaceRoot: root, Generation: generation},
+		session:   protocol.SessionContext{SessionID: sessionID, WorkspaceRoot: root, Provider: entry.Kind, Model: modelRef, Generation: generation},
 		ui:        extUIHub,
 		onWarning: extWarn,
 	}, opts.Extensions, planForPreflight(opts, generation))
@@ -1949,7 +1949,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		mcpSpecs:     mcpSpecs,
 		providers:    baseResolver.Catalog(),
 	}, generation, extensionBoot{
-		session:            protocol.SessionContext{SessionID: sessionID, WorkspaceRoot: root, Generation: generation},
+		session:            protocol.SessionContext{SessionID: sessionID, WorkspaceRoot: root, Provider: entry.Kind, Model: modelRef, Generation: generation},
 		ui:                 extUIHub,
 		onWarning:          extWarn,
 		skipPromptStrategy: shouldSkipPromptStrategy(opts.PreviousPlan),

--- a/internal/extension/protocol/dto_lifecycle.go
+++ b/internal/extension/protocol/dto_lifecycle.go
@@ -57,6 +57,8 @@ type ManifestExpectation struct {
 type SessionContext struct {
 	SessionID     string `json:"sessionId" validate:"nonempty"`
 	WorkspaceRoot string `json:"workspaceRoot" validate:"nonempty"`
+	Provider      string `json:"provider,omitempty"`
+	Model         string `json:"model,omitempty"`
 	Generation    uint64 `json:"generation"`
 	// Epoch is the dependency-identity fingerprint for this component generation.
 	Epoch string `json:"epoch,omitempty"`

--- a/internal/extension/protocol/dto_provider.go
+++ b/internal/extension/protocol/dto_provider.go
@@ -93,6 +93,8 @@ type ProviderResponseFormat struct {
 // extension to stream. Nil Messages/Tools arrays are invalid; empty arrays
 // are the canonical form.
 type ProviderRequest struct {
+	Provider       string                  `json:"provider,omitempty"`
+	Model          string                  `json:"model,omitempty"`
 	Messages       []ProviderMessage       `json:"messages"`
 	Tools          []ProviderToolSchema    `json:"tools"`
 	Temperature    *float64                `json:"temperature,omitempty"`

--- a/internal/extension/providerconv/providerconv.go
+++ b/internal/extension/providerconv/providerconv.go
@@ -89,7 +89,7 @@ func ToolCallsFromProtocol(calls []protocol.ProviderToolCall) []provider.ToolCal
 
 // RequestToProtocol copies a completion request into the credential-free wire
 // form the host sends to an extension-hosted provider.
-func RequestToProtocol(req provider.Request) protocol.ProviderRequest {
+func RequestToProtocol(req provider.Request, providerName, model string) protocol.ProviderRequest {
 	tools := make([]protocol.ProviderToolSchema, 0, len(req.Tools))
 	for _, s := range req.Tools {
 		tools = append(tools, protocol.ProviderToolSchema{
@@ -103,6 +103,8 @@ func RequestToProtocol(req provider.Request) protocol.ProviderRequest {
 		responseFormat = &protocol.ProviderResponseFormat{Type: req.ResponseFormat.Type}
 	}
 	return protocol.ProviderRequest{
+		Provider:       providerName,
+		Model:          model,
 		Messages:       MessagesToProtocol(req.Messages),
 		Tools:          tools,
 		Temperature:    req.Temperature,

--- a/internal/extension/providerconv/providerconv_test.go
+++ b/internal/extension/providerconv/providerconv_test.go
@@ -31,7 +31,7 @@ func TestRequestRoundTripPreservesProviderVisibleFields(t *testing.T) {
 		ResponseFormat: &provider.ResponseFormat{Type: "json_object"},
 	}
 
-	back := RequestFromProtocol(RequestToProtocol(req))
+	back := RequestFromProtocol(RequestToProtocol(req, "test-provider", "test-model"))
 	if len(back.Messages) != len(req.Messages) || len(back.Tools) != 1 {
 		t.Fatalf("round trip = %+v", back)
 	}
@@ -54,7 +54,7 @@ func TestRequestRoundTripPreservesProviderVisibleFields(t *testing.T) {
 	if back.ResponseFormat == nil || back.ResponseFormat.Type != "json_object" {
 		t.Fatalf("response format = %+v", back.ResponseFormat)
 	}
-	if RequestFromProtocol(RequestToProtocol(provider.Request{})).ResponseFormat != nil {
+	if RequestFromProtocol(RequestToProtocol(provider.Request{}, "", "")).ResponseFormat != nil {
 		t.Fatal("nil response format must stay nil")
 	}
 }

--- a/internal/extension/providerext/provider.go
+++ b/internal/extension/providerext/provider.go
@@ -144,7 +144,7 @@ func (r *Resolver) open(ctx context.Context, p *Provider, client ProviderClient,
 		ProviderRef: p.ref,
 		Model:       p.descriptor.Model,
 		Effort:      effort,
-		Request:     providerconv.RequestToProtocol(request),
+		Request:     providerconv.RequestToProtocol(request, p.ref, p.descriptor.Model),
 		SeqBase:     1,
 	})
 	cancelOpen()

--- a/sdk/go/types_generated.go
+++ b/sdk/go/types_generated.go
@@ -172,6 +172,8 @@ type CapabilityWire struct {
 type SessionContext struct {
 	SessionID     string `json:"sessionId" validate:"nonempty"`
 	WorkspaceRoot string `json:"workspaceRoot" validate:"nonempty"`
+	Provider      string `json:"provider,omitempty"`
+	Model         string `json:"model,omitempty"`
 	Generation    uint64 `json:"generation"`
 	Epoch         string `json:"epoch,omitempty"`
 }
@@ -375,6 +377,8 @@ type StreamOpenParams struct {
 
 // ProviderRequest is a generated Extension Protocol v2 wire DTO.
 type ProviderRequest struct {
+	Provider       string                  `json:"provider,omitempty"`
+	Model          string                  `json:"model,omitempty"`
 	Messages       []ProviderMessage       `json:"messages"`
 	Tools          []ProviderToolSchema    `json:"tools"`
 	Temperature    *float64                `json:"temperature,omitempty"`


### PR DESCRIPTION
## Summary

Add `Provider` and `Model` fields to `ProviderRequest` and `SessionContext` in the Extension Protocol v2, so extension interceptors can distinguish which provider/model the current session uses.

## Motivation

Community plugins like dsh-anchored and pi-deepseek-anchor apply model-specific optimizations (anchored-standard bootstrap for DeepSeek V4). Without provider/model in the protocol, these plugins either activate for all models (harming Claude/GPT/Qwen) or require fragile workarounds (reading `.jsonl.meta` files).

## Changes

| File | Change |
|------|--------|
| `protocol/dto_provider.go` | `ProviderRequest` gains `Provider`/`Model` fields (`omitempty`) |
| `protocol/dto_lifecycle.go` | `SessionContext` gains `Provider`/`Model` fields (`omitempty`) |
| `providerconv/providerconv.go` | `RequestToProtocol` takes `providerName, model` params |
| `agent/extensions.go` | Passes `a.svc.prov.Name()` and `a.modelRef` |
| `boot/boot.go` | Populates `SessionContext` with `entry.Kind` and `modelRef` |
| `sdk/go/types_generated.go` | SDK types mirror protocol changes |
| `providerconv_test.go` | Updated test calls |

## Backward compatibility

Both new fields use `omitempty` — existing plugins that don't read them are unaffected. The wire shape is additive only.

## Issues

Fixes #9113

## Verification

- `go build ./internal/...` — pass
- `go test ./internal/extension/... -count=1` — pass
- `go test ./internal/agent/... -count=1` — pass

## Cache impact

Cache-impact: none- extension protocol changes do not alter provider-visible request bytes
Cache-guard: none- not required
Documentation-impact: none- protocol docs update is follow-up
System-prompt-review: updated- @SivanCola - boot.go populates SessionContext provider/model; needs explicit system-prompt/approval review
