### PR TITLE
feat(desktop): attach external folder with read+write access / 支持附加外部目录到会话（读写权限）

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -11102,6 +11102,34 @@ func (a *App) AttachDropped(path string) (DroppedItem, error) {
 	return item, nil
 }
 
+// AttachExternalFolder opens a native folder picker and grants the selected
+// directory read+write access for the current session. Returns the display
+// path of the attached folder, or empty if the user cancelled.
+func (a *App) AttachExternalFolder() (string, error) {
+	tab, ctrl := a.tabAndCtrlByID("")
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return "", err
+	}
+	if tab != nil {
+		ctrl = a.controllerForTab(tab)
+	}
+	if ctrl == nil {
+		return "", fmt.Errorf("workspace is not ready")
+	}
+	dir, err := a.PickWorkspace()
+	if err != nil {
+		return "", err
+	}
+	if dir == "" {
+		return "", nil
+	}
+	_, displayPath, err := ctrl.RegisterExternalFolderRef(dir)
+	if err != nil {
+		return "", err
+	}
+	return displayPath, nil
+}
+
 func isImageExt(path string) bool {
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".png", ".jpg", ".jpeg", ".gif", ".webp":

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -453,6 +453,7 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   SaveExportFile(path: string, payload: string, base64Encoded: boolean): Promise<void>;
   SaveExportImageFiles(path: string, payloads: string[]): Promise<void>;
   AttachDropped(path: string): Promise<DroppedItem>;
+  AttachExternalFolder(): Promise<string>;
   AttachmentDataURL(path: string): Promise<string>;
   Models(): Promise<ModelInfo[]>;
   SetModel(name: string): Promise<void>;
@@ -4175,6 +4176,9 @@ function makeMockApp(): AppBindings {
       const attachmentPath = `.reasonix/attachments/mock-${name}`;
       mockAttachmentDataURLs.set(attachmentPath, mockPreviewImageDataURL);
       return { kind: "attachment" as const, path: attachmentPath };
+    },
+    async AttachExternalFolder() {
+      return "/mock/external-folder";
     },
     async AttachmentDataURL(path: string) {
       return mockAttachmentDataURLs.get(path) ?? mockPreviewImageDataURL;

--- a/internal/agent/agent_config.go
+++ b/internal/agent/agent_config.go
@@ -22,6 +22,10 @@ type agentConfig struct {
 	classifierTaskText string
 	// writeWorkspaceRoot scopes write reservations when writeScheduler is set.
 	writeWorkspaceRoot string
+	// externalWorkspaceRoots are user-attached directories outside the main
+	// workspace that the agent may write to. They extend the write scope
+	// without changing the primary workspace identity.
+	externalWorkspaceRoots []string
 	// subagentDepth caps delegation; at maxSubagentDepth the recursive
 	// agent/skill tools are excluded.
 	subagentDepth    int

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -218,6 +218,10 @@ func (c *Controller) RegisterExternalFolderRef(path string) (token, displayPath 
 	if c.externalFolderToolRefs != nil {
 		c.externalFolderToolRefs.RegisterReadRoot(token, abs)
 	}
+	// Also grant write access so the agent can edit files in the external folder.
+	if c.writeAccess.roots != nil {
+		c.writeAccess.roots.GrantVerifiedSession([]string{abs})
+	}
 	return token, filepath.ToSlash(abs), nil
 }
 


### PR DESCRIPTION
## Summary

When a user drops an external directory or uses the new `AttachExternalFolder` IPC (native folder picker), the directory now receives both **read and write** permissions for the session. Previously, external folders only got read access via `RegisterExternalFolderRef`.

## Changes

| File | Change |
|------|--------|
| `control/refs.go` | `RegisterExternalFolderRef` now also calls `writeAccess.roots.GrantVerifiedSession` |
| `control/write_access.go` | New `GrantExternalFolder` method |
| `agent/agent_config.go` | New `externalWorkspaceRoots` field |
| `desktop/app.go` | New `AttachExternalFolder()` IPC |
| `desktop/frontend/src/lib/bridge.ts` | Interface + mock binding |

## Usage

- **Drop a directory** onto the app → gets read+write access (previously read-only)
- **New IPC** `AttachExternalFolder()` → opens native folder picker, grants read+write

## Issues

Fixes #7085

## Cache impact

Cache-impact: none- sandbox write root changes do not alter provider-visible request bytes
Cache-guard: none- not required
Documentation-impact: none- sandbox write-root UI is internal; no user-facing docs update needed
System-prompt-review: none- no relevant changes.