### PR TITLE
feat(config): add dir field and ${WORKSPACE_ROOT} expansion for MCP plugins

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -121,6 +121,7 @@ auth_mode = "none"             # none|token|password; use auth before binding be
 [[plugins]]
 name    = "example"
 command = "reasonix-plugin-example"
+# dir = "${WORKSPACE_ROOT}"   # subprocess CWD; empty inherits Reasonix CWD
 startup_timeout_seconds = 60   # optional initialize + tools/list cap
 call_timeout_seconds = 600   # optional per-server MCP call timeout
 tool_timeout_seconds = { "generate_video" = 1800 }   # optional raw MCP tool names
@@ -843,6 +844,15 @@ Reasonix is an MCP client. A `[[plugins]]` entry's `type` selects the transport:
 (`${VAR}` / `${VAR:-default}` expanded from the environment, so tokens stay out
 of the file); `sse` connects to servers that still use the legacy persistent
 GET + announced POST endpoint transport.
+
+Stdio subprocesses inherit Reasonix's working directory, not the user's
+project root. Servers that detect their workspace from CWD (file finders,
+indexers, linters) need an explicit `dir` — use
+`dir = "${WORKSPACE_ROOT}"` (or `${REASONIX_WORKSPACE}`) to pin them to the
+active session workspace. Servers that implement the MCP `roots` capability
+receive the project root automatically and need no `dir` override. The
+substitution variables resolve from the session root first, then from the
+process environment.
 
 For a remote HTTP server without a static `Authorization` header, an
 authentication challenge is shown as **Sign in**. Run

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -115,6 +115,7 @@ auth_mode = "none"             # none|token|password；绑定到非 localhost �
 [[plugins]]
 name    = "example"
 command = "reasonix-plugin-example"
+# dir = "${WORKSPACE_ROOT}"   # 子进程工作目录；留空继承 Reasonix CWD
 startup_timeout_seconds = 60   # 可选：initialize + tools/list 上限
 call_timeout_seconds = 600   # 可选：单个 MCP server 的调用超时
 tool_timeout_seconds = { "generate_video" = 1800 }   # 可选：raw MCP tool 名称
@@ -668,6 +669,12 @@ Reasonix 是一个 MCP 客户端。`[[plugins]]` 的 `type` 选择传输：`stdi
 程（`command`/`args`/`env`）；`http`（Streamable HTTP）连接远程 `url`，可带静态
 `headers`（`${VAR}` / `${VAR:-default}` 从环境展开，密钥不入文件）。
 `sse` 则兼容仍使用持久 GET 与 server 公布 POST endpoint 的旧版远程 server。
+
+Stdio 子进程继承 Reasonix 的工作目录，而非用户的项目根目录。CWD 敏感的 server（文件查找器、
+索引器、linter）需要显式 `dir` — 用 `dir = "${WORKSPACE_ROOT}"`（或
+`${REASONIX_WORKSPACE}`）将它们指向当前会话的工作区根目录。实现了 MCP `roots` 能力的
+server 会自动收到项目根目录，无需 `dir` 覆盖。替换变量先从会话根目录取值，再从进程环境变量
+回退。
 
 远程 HTTP server 未配置静态 `Authorization` header 时，认证要求会显示为 **登录**。
 CLI 可运行 `reasonix mcp auth <name>`，桌面端则在 MCP 面板点击该 server 的 **登录**。

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -2614,7 +2614,7 @@ func PluginSpecsForRootWithOptions(entries []config.PluginEntry, workspaceRoot s
 }
 
 func pluginSpecFromEntryWithOptions(e config.PluginEntry, workspaceRoot string, opts PluginSpecOptions) plugin.Spec {
-	e = e.ExpandedPlugin() // resolve ${VAR} / ${VAR:-default} from the environment
+	e = e.ExpandedPluginForWorkspace(workspaceRoot)
 	configSource := strings.TrimSpace(string(e.Source))
 	if configSource == "" {
 		configSource = opts.ConfigSource
@@ -2624,6 +2624,7 @@ func pluginSpecFromEntryWithOptions(e config.PluginEntry, workspaceRoot string, 
 		Package:               strings.TrimSpace(opts.PackageOwners[e.Name]),
 		Type:                  e.Type,
 		Command:               e.Command,
+		Dir:                   e.Dir,
 		Args:                  e.Args,
 		Env:                   e.Env,
 		URL:                   e.URL,

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -3979,6 +3979,54 @@ func TestPluginSpecsForRootDoesNotPinHTTPCodeGraph(t *testing.T) {
 	}
 }
 
+func TestPluginSpecsForRootExpandsWorkspaceRootInArgsAndDir(t *testing.T) {
+	specs := PluginSpecsForRoot([]config.PluginEntry{{
+		Name:    "fff",
+		Command: "fff-mcp",
+		Dir:     "${WORKSPACE_ROOT}",
+		Args:    []string{"--root", "${WORKSPACE_ROOT}"},
+	}}, "/work")
+	if len(specs) != 1 {
+		t.Fatalf("got %d specs, want 1", len(specs))
+	}
+	if specs[0].Dir != "/work" {
+		t.Errorf("Dir = %q, want /work", specs[0].Dir)
+	}
+	if len(specs[0].Args) != 2 || specs[0].Args[1] != "/work" {
+		t.Errorf("Args = %v, want [--root /work]", specs[0].Args)
+	}
+}
+
+func TestPluginSpecsForRootExplicitDirBeatsCodeGraphOverride(t *testing.T) {
+	specs := PluginSpecsForRoot([]config.PluginEntry{{
+		Name: "codegraph",
+		Dir:  "${REASONIX_WORKSPACE}",
+	}}, "/workspace")
+	if len(specs) != 1 {
+		t.Fatalf("got %d specs, want 1", len(specs))
+	}
+	if specs[0].Dir != "/workspace" {
+		t.Errorf("Dir = %q, want /workspace (explicit dir takes precedence)", specs[0].Dir)
+	}
+}
+
+func TestPluginSpecsNoRootDoesNotExpandWorkspaceVars(t *testing.T) {
+	specs := PluginSpecs([]config.PluginEntry{{
+		Name: "server",
+		Dir:  "${WORKSPACE_ROOT}",
+		Args: []string{"--root", "${WORKSPACE_ROOT:-fallback}"},
+	}})
+	if len(specs) != 1 {
+		t.Fatalf("got %d specs, want 1", len(specs))
+	}
+	if specs[0].Dir != "" {
+		t.Errorf("Dir = %q, want empty (no workspace root)", specs[0].Dir)
+	}
+	if specs[0].Args[1] != "fallback" {
+		t.Errorf("Args[1] = %q, want fallback (:-default)", specs[0].Args[1])
+	}
+}
+
 func TestBuildMigratesLegacyEagerTierToBackground(t *testing.T) {
 	isolateConfigHome(t)
 	dir := robustTempDir(t)

--- a/internal/config/expand.go
+++ b/internal/config/expand.go
@@ -60,12 +60,34 @@ func (c *Config) expandVars(s string) string {
 }
 
 // ExpandedPlugin returns a copy of e with ${VAR} references expanded across the
-// command, args, env values, url, and header values — the fields Claude Code
-// also expands. The entry itself is left untouched.
+// command, dir, args, env, url, and header values — the fields Claude Code also
+// expands. The entry itself is left untouched.
 func (e PluginEntry) ExpandedPlugin() PluginEntry {
-	lookup := scopedEnvLookup(e.expansionEnv)
+	return e.expandedPlugin(scopedEnvLookup(e.expansionEnv))
+}
+
+// ExpandedPluginForWorkspace returns a copy of e with ${VAR} references
+// expanded; WORKSPACE_ROOT and REASONIX_WORKSPACE resolve to the session root
+// before the environment is consulted.
+func (e PluginEntry) ExpandedPluginForWorkspace(root string) PluginEntry {
+	base := scopedEnvLookup(e.expansionEnv)
+	lookup := func(name string) (string, bool) {
+		if workspaceRootVar(name) && strings.TrimSpace(root) != "" {
+			return root, true
+		}
+		return base(name)
+	}
+	return e.expandedPlugin(lookup)
+}
+
+func workspaceRootVar(name string) bool {
+	return name == "WORKSPACE_ROOT" || name == "REASONIX_WORKSPACE"
+}
+
+func (e PluginEntry) expandedPlugin(lookup envLookup) PluginEntry {
 	out := e
 	out.Command = expandVarsWithLookup(e.Command, lookup)
+	out.Dir = expandVarsWithLookup(e.Dir, lookup)
 	out.URL = expandVarsWithLookup(e.URL, lookup)
 	if len(e.Args) > 0 {
 		out.Args = make([]string, len(e.Args))

--- a/internal/config/expand_test.go
+++ b/internal/config/expand_test.go
@@ -34,6 +34,7 @@ func TestExpandedPlugin(t *testing.T) {
 		Args:    []string{"--token", "${REASONIX_TEST_KEY}"},
 		Env:     map[string]string{"K": "${REASONIX_TEST_KEY}"},
 		Headers: map[string]string{"Authorization": "Bearer ${REASONIX_TEST_KEY}"},
+		Dir:     "${REASONIX_TEST_KEY}/sub",
 	}
 	out := e.ExpandedPlugin()
 	if out.URL != "https://api/v1" {
@@ -45,9 +46,67 @@ func TestExpandedPlugin(t *testing.T) {
 	if out.Env["K"] != "secret" || out.Headers["Authorization"] != "Bearer secret" {
 		t.Errorf("env/headers not expanded: %v %v", out.Env, out.Headers)
 	}
+	if out.Dir != "secret/sub" {
+		t.Errorf("Dir = %q, want %q", out.Dir, "secret/sub")
+	}
 	// The original entry must be untouched (we returned a copy).
 	if e.Headers["Authorization"] != "Bearer ${REASONIX_TEST_KEY}" {
 		t.Error("ExpandedPlugin mutated the original entry")
+	}
+	if e.Dir != "${REASONIX_TEST_KEY}/sub" {
+		t.Error("ExpandedPlugin mutated the original Dir")
+	}
+}
+
+func TestExpandedPluginForWorkspace(t *testing.T) {
+	e := PluginEntry{
+		Name: "server",
+		Args: []string{"--root", "${WORKSPACE_ROOT}"},
+		Dir:  "${REASONIX_WORKSPACE}/sub",
+		Env:  map[string]string{"CWD": "${WORKSPACE_ROOT}"},
+	}
+	out := e.ExpandedPluginForWorkspace("/work")
+	if out.Args[1] != "/work" {
+		t.Errorf("Args[1] = %q, want /work", out.Args[1])
+	}
+	if out.Dir != "/work/sub" {
+		t.Errorf("Dir = %q, want /work/sub", out.Dir)
+	}
+	if out.Env["CWD"] != "/work" {
+		t.Errorf("Env[CWD] = %q, want /work", out.Env["CWD"])
+	}
+}
+
+func TestExpandedPluginForWorkspacePrecedence(t *testing.T) {
+	t.Setenv("WORKSPACE_ROOT", "/env-root")
+	e := PluginEntry{
+		Name: "server",
+		Args: []string{"--root", "${WORKSPACE_ROOT}"},
+	}
+	// Workspace root wins over the env var.
+	out := e.ExpandedPluginForWorkspace("/session-root")
+	if out.Args[1] != "/session-root" {
+		t.Errorf("Args[1] = %q, want /session-root (session root should beat env)", out.Args[1])
+	}
+}
+
+func TestExpandedPluginForWorkspaceEmptyRoot(t *testing.T) {
+	t.Setenv("REASONIX_TEST_KEY", "env-val")
+	e := PluginEntry{
+		Name: "server",
+		Args: []string{"${WORKSPACE_ROOT}", "${REASONIX_TEST_KEY}"},
+		Dir:  "${WORKSPACE_ROOT:-fallback}",
+	}
+	// Empty root: WORKSPACE_ROOT falls back to env (unset → ""), :-default kicks in.
+	out := e.ExpandedPluginForWorkspace("")
+	if out.Args[0] != "" {
+		t.Errorf("Args[0] = %q, want \"\" (empty root)", out.Args[0])
+	}
+	if out.Args[1] != "env-val" {
+		t.Errorf("Args[1] = %q, want env-val (env fallback)", out.Args[1])
+	}
+	if out.Dir != "fallback" {
+		t.Errorf("Dir = %q, want fallback (:-default)", out.Dir)
 	}
 }
 

--- a/internal/config/plugin_entry.go
+++ b/internal/config/plugin_entry.go
@@ -8,9 +8,11 @@ package config
 // fields mirror Claude Code's mcpServers spec, so entries can come from either
 // reasonix.toml's [[plugins]] or a project-root .mcp.json (see loadMCPJSON).
 type PluginEntry struct {
-	Name    string            `toml:"name"`
-	Type    string            `toml:"type"` // "stdio" (default) | "http" | "sse"
-	Command string            `toml:"command"`
+	Name    string `toml:"name"`
+	Type    string `toml:"type"` // "stdio" (default) | "http" | "sse"
+	Command string `toml:"command"`
+	// Dir is the stdio subprocess working directory; empty inherits Reasonix's CWD.
+	Dir     string            `toml:"dir"`
 	Args    []string          `toml:"args"`
 	Env     map[string]string `toml:"env"`
 	URL     string            `toml:"url"`

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -184,6 +184,10 @@ stalled_warning_seconds = 900   # warn once per background job after this many q
 # [[plugins]]
 # name    = "example"
 # command = "reasonix-plugin-example"
+# # Working directory for stdio subprocesses; empty inherits Reasonix's CWD.
+# # Use ${WORKSPACE_ROOT} (or ${REASONIX_WORKSPACE}) to pin cwd-sensitive
+# # servers to the active project root.
+# # dir = "${WORKSPACE_ROOT}"
 # # Startup may continue in the background after the first caller stops waiting.
 # # startup_timeout_seconds = 60
 # # Per-server MCP call timeout; 0 keeps the global/default cap.


### PR DESCRIPTION
## Summary

Adds a `dir` field to `[[plugins]]` and `${WORKSPACE_ROOT}` / `${REASONIX_WORKSPACE}` expansion so MCP servers that detect their workspace from CWD (file finders, indexers, linters) can be pinned to the active project root.

Stdio subprocesses currently inherit Reasonix's CWD, not the user's workspace — this breaks cwd-sensitive servers like fff-mcp.

## Changes

- **`internal/config/plugin_entry.go`** — Added `Dir string \"toml:\"dir\"` field to `PluginEntry`
- **`internal/config/expand.go`** — Extracted shared `expandedPlugin(lookup)`; added `ExpandedPluginForWorkspace(root)` that resolves `WORKSPACE_ROOT` / `REASONIX_WORKSPACE` from the session root before env fallback; expanded `Dir` in both paths
- **`internal/config/expand_test.go`** — 3 new tests: workspace root expansion, session-root beats env precedence, empty root falls back to `:-default`
- **`internal/boot/boot.go`** — `pluginSpecFromEntryWithOptions` calls `ExpandedPluginForWorkspace(workspaceRoot)` and passes `Dir` to `plugin.Spec`
- **`internal/boot/boot_test.go`** — 3 new tests: Dir+Args expansion, explicit Dir beats CodeGraph override, no-root path leaves vars unexpanded
- **`reasonix.example.toml`** + **`docs/GUIDE.md`** + **`docs/GUIDE.zh-CN.md`** — Documented `dir = \"${WORKSPACE_ROOT}\"` and the CWD inheritance issue

## Backward compatibility

Fully backward compatible. Entries without `dir` keep inheriting Reasonix's CWD. When the workspace root is empty, `${WORKSPACE_ROOT}` falls back to the env var (or `${VAR:-default}`), matching the existing expansion convention.

## PR metadata

Cache-impact: none - Dir field and ExpandedPluginForWorkspace do not change the provider-visible prefix
Cache-guard: new PluginEntry.Dir and ExpandedPluginForWorkspace do not touch system-prompt bytes; existing prefix guard tests unchanged
Documentation-impact: updated - stdio CWD paragraph added to GUIDE.md + GUIDE.zh-CN.md §Plugins, dir example in reasonix.example.toml
System-prompt-review: nk34player - plugin expansion is config-layer only; provider-visible prefix bytes are unchanged