### PR TITLE
test(desktop): compare selection windows in place / 同位置校验选区虚拟窗口

### DIFF
--- a/desktop/frontend/bench/transcript-selection.mjs
+++ b/desktop/frontend/bench/transcript-selection.mjs
@@ -203,9 +203,8 @@ try {
   }
   // Tool-dense fixtures often land the native tail on non-selectable tool
   // rows. Wheel off the pinned tail until a mounted "bench turn N" row is
-  // visible, then snapshot the virtual window for the later bound check.
+  // visible before beginning the logical selection gesture.
   const points = await waitForVisibleSelectionStart(page, { preferHighest: true });
-  const baselineRows = await page.locator(".transcript__row").count();
   assert(points != null, "bench transcript exposes a selectable visible message");
 
   await page.evaluate(() => {
@@ -345,7 +344,6 @@ try {
   }, logicalFocusPoint);
   assert(during.collapsed, `cross-row drag releases the browser Range after logical promotion (${JSON.stringify(during)})`);
   assert(during.mode === "selection", `cross-page drag remains owned by selection (${during.mode})`);
-  assert(during.rows <= Math.ceil(baselineRows * 1.1) + 2, `logical selection keeps the virtual DOM bounded (${baselineRows} → ${during.rows})`);
   assert(during.overlayRects > 0, `logical selection paints mounted-row overlay rectangles (${JSON.stringify(during)})`);
   if (during.writeOwners.some((owner) => owner !== "selection-edge-scroll")) {
     throw new Error(`logical gesture admitted non-selection scroll owners: ${JSON.stringify(during.writeOwners)}`);
@@ -400,11 +398,16 @@ try {
       collapsed: document.getSelection()?.isCollapsed ?? true,
       rows: document.querySelectorAll(".transcript__row").length,
       overlayRects: document.querySelectorAll(".transcript-selection-overlay__rect").length,
+      scrollTop: document.querySelector(".transcript")?.scrollTop ?? 0,
     };
   });
   assert(after.collapsed, "logical copy leaves no synthetic browser Range behind");
   assert(after.overlayRects === 0, "successful copy clears the logical overlay");
-  assert(after.rows <= Math.ceil(baselineRows * 1.1) + 2, "clearing logical selection preserves the normal virtual DOM window");
+  assert(Math.abs(after.scrollTop - settled.scrollTop) <= 1, "copy cleanup preserves the selection viewport");
+  assert(
+    during.rows <= Math.ceil(after.rows * 1.1) + 2,
+    `logical selection keeps the virtual DOM bounded (${after.rows} normal → ${during.rows} selecting)`,
+  );
   const selectionHeapBaseline = await retainedHeap();
 
   await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.scrollMode === "manual", undefined, { timeout: 10_000 });
@@ -462,7 +465,6 @@ try {
     owners: [...new Set((window.__transcriptProgrammaticWrites ?? []).map((write) => write.owner))],
   }));
   assert(forwardDuring.mode === "selection", "downward cross-page drag also promotes to logical selection");
-  assert(forwardDuring.rows <= Math.ceil(baselineRows * 1.1) + 2, "forward logical selection also keeps the virtual DOM bounded");
   assert(forwardDuring.owners.every((owner) => owner === "selection-edge-scroll"), "forward logical gesture preserves scroll ownership");
   await page.mouse.up();
   await page.keyboard.press(process.platform === "darwin" ? "Meta+C" : "Control+C");
@@ -470,6 +472,11 @@ try {
   const forwardCopiedTurns = await page.evaluate(() => (window.__logicalClipboardText.match(/bench turn /g) ?? []).length);
   assert(forwardCopiedTurns >= 20, `forward logical copy resolves a 20+ turn frozen snapshot (${forwardCopiedTurns} turns)`);
   await page.waitForFunction(() => document.querySelectorAll(".transcript-selection-overlay__rect").length === 0);
+  const forwardAfterRows = await page.locator(".transcript__row").count();
+  assert(
+    forwardDuring.rows <= Math.ceil(forwardAfterRows * 1.1) + 2,
+    `forward logical selection also keeps the virtual DOM bounded (${forwardAfterRows} normal → ${forwardDuring.rows} selecting)`,
+  );
   const retainedSelectionBytes = Math.max(0, (await retainedHeap()) - selectionHeapBaseline);
   assert(retainedSelectionBytes <= 2 * 1024 * 1024, `cleared logical selection retains at most 2MiB (${(retainedSelectionBytes / 1024 / 1024).toFixed(2)}MiB)`);
   await page.evaluate(() => { window.__REASONIX_TRANSCRIPT_SCROLL_WRITE__ = undefined; });


### PR DESCRIPTION
## Summary

- compare logical-selection and normal Virtuoso windows at the same scroll position
- preserve the bounded-window contract for both reverse and forward selection gestures
- assert copy cleanup preserves the selected viewport before using it as the control sample

## Problem

The exact v1.31.0 candidate failed the Linux Desktop browser gate twice at `logical selection keeps the virtual DOM bounded (45 → 55)`. The benchmark sampled 45 mounted rows near the tail, then compared that count with a different scroll region containing shorter variable-height rows.

React Virtuoso applies `increaseViewportBy` in pixels, so mounted item counts legitimately vary between regions. The old comparison did not measure whether logical selection enlarged the normal window.

## Fix

After copy clears each logical selection, measure the normal mounted window at the same viewport and compare it with the selection-time count. This keeps the existing 10% + 2 tolerance while binding it to the correct control state instead of raising a budget.

## Verification

- `transcript-selection.mjs`: 10 consecutive real Chromium passes
- `pnpm test:transcript-browser`
- `pnpm build`
- `go run ./tools/repolint`
- `git diff --check`

## Risk

Test-only change. No runtime, persisted-data, provider, prompt-cache, or release-workflow behavior changes.

Documentation-impact: none - the change only corrects an internal browser benchmark control measurement; existing user documentation remains accurate.