### PR TITLE
test(desktop): sample copy viewport in place / 同位置采样复制视口

### DIFF
--- a/desktop/frontend/bench/transcript-selection.mjs
+++ b/desktop/frontend/bench/transcript-selection.mjs
@@ -374,8 +374,11 @@ try {
     transcript.dispatchEvent(new Event("scroll"));
   }, settled.scrollTop);
   await page.waitForTimeout(250);
-  const restoredRects = await page.locator(".transcript-selection-overlay__rect").count();
-  assert(restoredRects > 0, "logical overlay restores after selected rows scroll out and back in");
+  const beforeCopy = await page.evaluate(() => ({
+    overlayRects: document.querySelectorAll(".transcript-selection-overlay__rect").length,
+    scrollTop: document.querySelector(".transcript")?.scrollTop ?? 0,
+  }));
+  assert(beforeCopy.overlayRects > 0, "logical overlay restores after selected rows scroll out and back in");
 
   await page.evaluate(() => {
     window.__logicalClipboardText = null;
@@ -403,7 +406,10 @@ try {
   });
   assert(after.collapsed, "logical copy leaves no synthetic browser Range behind");
   assert(after.overlayRects === 0, "successful copy clears the logical overlay");
-  assert(Math.abs(after.scrollTop - settled.scrollTop) <= 1, "copy cleanup preserves the selection viewport");
+  assert(
+    Math.abs(after.scrollTop - beforeCopy.scrollTop) <= 1,
+    `copy cleanup preserves the selection viewport (${beforeCopy.scrollTop} -> ${after.scrollTop})`,
+  );
   assert(
     during.rows <= Math.ceil(after.rows * 1.1) + 2,
     `logical selection keeps the virtual DOM bounded (${after.rows} normal → ${during.rows} selecting)`,


### PR DESCRIPTION
## Summary

- sample the restored transcript viewport immediately before logical copy cleanup
- compare cleanup with the same-position control while preserving the existing 1px no-jump tolerance
- include the before/after scroll positions in future failure diagnostics

## Problem

The exact v1.31.0 candidate failed Linux Desktop CI at `copy cleanup preserves the selection viewport`. The same run had already passed logical promotion, 20+ turn copy resolution, overlay cleanup, and the bounded virtual-window checks.

## Root cause

The benchmark captured `settled.scrollTop` after pointerup, then deliberately scrolled the selected rows out of view and back in before copying. React Virtuoso can remeasure the restored window during that round trip, so the saved value was stale before copy cleanup began.

## Fix

Capture the control `scrollTop` immediately before the copy action, after the logical overlay has been restored, and compare the post-cleanup viewport with that same-position sample. The runtime behavior and tolerance are unchanged.

## Verification

- `transcript-selection.mjs`: 10 consecutive real Chromium passes
- `transcript-scroll-stability.mjs`
- `pnpm build`
- `go run ./tools/repolint`
- `git diff --check`

## Risk

Test-only change. No runtime, persisted-data, provider, prompt-cache, or release-workflow behavior changes.

Documentation-impact: none - the change only corrects an internal browser benchmark control measurement; existing user documentation remains accurate.
