### PR TITLE
feat(desktop): allow model switch while a turn is running, applied from the next turn / 允许回答运行中切换模型，切换在下一轮生效

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -9469,6 +9469,62 @@ func rebuildControllerActiveWorkErrorFor(ctrl control.SessionAPI, setting string
 	return &rebuildBusyError{setting: setting, work: work}
 }
 
+// modelSwitchDeferredError reports a model switch accepted while the tab was
+// busy. The selection updates immediately but the controller rebuild is queued
+// behind the running turn, so the new model applies from the next turn; the
+// frontend surfaces it as a notice rather than a failure.
+type modelSwitchDeferredError struct{}
+
+func (e *modelSwitchDeferredError) Error() string {
+	return "model switch accepted; the new model will apply from the next turn"
+}
+
+// deferModelSwitch accepts a model switch while the tab has active runtime
+// work: it updates the tab's model identity and persisted session metadata now
+// (so the UI and a restart see the new selection), queues a deferred rebuild
+// that swaps the controller once the turn finishes, and reports the switch as
+// accepted-but-not-yet-applied. busy must be the rejection from the active-work
+// guard; any other error is returned untouched.
+func (a *App) deferModelSwitch(tab *WorkspaceTab, name string, busy error) error {
+	var work *rebuildBusyError
+	if !errors.As(busy, &work) {
+		return busy
+	}
+	resolved, effortOverride, err := a.resolveModelSwitchTarget(tab, a.tabRuntimeSnapshot(tab), name)
+	if err != nil {
+		return err
+	}
+	a.mu.Lock()
+	if tab.removed || a.tabs[tab.ID] != tab {
+		a.mu.Unlock()
+		return fmt.Errorf("tab %q changed while switching model; retry", tab.ID)
+	}
+	prevModel := tab.model
+	tab.model = resolved
+	// Carry the normalized effort alongside the model, exactly like the
+	// immediate switch path, so the deferred generic rebuild does not run the
+	// new model with a stale or invalid effort.
+	tab.effort = cloneStringPtr(effortOverride)
+	a.saveTabsLocked()
+	a.mu.Unlock()
+	if path := a.currentSessionPathFor(tab); path != "" {
+		if err := agent.SetBranchModelPreserveUpdated(path, resolved); err != nil {
+			// Roll back the tab identity: the old controller is still running
+			// under the previous model, and keeping the new model here would
+			// both mislead the UI and make a retry a no-op via the
+			// currentModel match in SetModelForTab.
+			a.mu.Lock()
+			tab.model = prevModel
+			tab.effort = nil
+			a.saveTabsLocked()
+			a.mu.Unlock()
+			return fmt.Errorf("persist selected model: %w", err)
+		}
+	}
+	a.scheduleDeferredRebuild(tab.ID, "model")
+	return &modelSwitchDeferredError{}
+}
+
 type sessionLeaseBusyError struct {
 	setting string
 	err     error
@@ -9673,6 +9729,47 @@ type modelSwitchTiming struct {
 	Outcome        string
 }
 
+// resolveModelSwitchTarget resolves a user-facing model name into the wire
+// name a controller build consumes, applying the provider-access check and the
+// tab's effort override. Shared by the immediate rebuild path and the deferred
+// switch so a busy tab validates the target before queueing it.
+func (a *App) resolveModelSwitchTarget(tab *WorkspaceTab, snap tabRuntimeSnapshot, name string) (resolved string, effort *string, err error) {
+	cfg, err := config.LoadForRoot(snap.workspaceRoot)
+	if err != nil {
+		return "", nil, err
+	}
+	entry, ok := cfg.ResolveModel(name)
+	pluginRef := false
+	if !ok {
+		// Plugin-namespaced refs belong to extension sidecars: validate them
+		// against the tab controller's merged catalog instead of the config.
+		if d, found := extensionModelDescriptor(a.providerCatalogForTab(tab), name); found {
+			pluginRef = true
+			ok = true
+			name = d.Ref
+		}
+	}
+	if !ok {
+		return "", nil, fmt.Errorf("unknown model %q", name)
+	}
+	if !pluginRef {
+		if !modelProviderAccessAllowed(cfg.Desktop.ProviderAccess, entry.Name) {
+			return "", nil, fmt.Errorf("model %q is not available because provider %q is not added", name, entry.Name)
+		}
+		name = entry.Name + "/" + entry.Model
+	}
+	effortOverride := cloneStringPtr(snap.effort)
+	if effortOverride != nil && !pluginRef {
+		normalized, err := config.NormalizeEffort(entry, config.EffortDisplay(&config.ProviderEntry{Effort: *effortOverride}))
+		if err != nil {
+			effortOverride = nil
+		} else {
+			effortOverride = &normalized
+		}
+	}
+	return name, effortOverride, nil
+}
+
 func (a *App) SetModelForTab(tabID, name string) (retErr error) {
 	if a.ctx == nil || name == "" {
 		return nil
@@ -9731,7 +9828,7 @@ func (a *App) SetModelForTab(tabID, name string) (retErr error) {
 		a.attachExistingSessionRuntime(tab, prevPath, a.ctx)
 	}
 	if err := rebuildControllerActiveWorkErrorFor(a.controllerForTab(tab), "model"); err != nil {
-		return err
+		return a.deferModelSwitch(tab, name, err)
 	}
 	if err := a.ensureTabControllerWorkspace(tab); err != nil {
 		return err
@@ -9746,7 +9843,7 @@ func (a *App) SetModelForTab(tabID, name string) (retErr error) {
 			prevPath = a.currentSessionPathFor(tab)
 		}
 		if err := rebuildControllerActiveWorkErrorFor(a.controllerForTab(tab), "model"); err != nil {
-			return err
+			return a.deferModelSwitch(tab, name, err)
 		}
 	}
 	timing.Prepare = time.Since(stageStarted)
@@ -9756,38 +9853,9 @@ func (a *App) SetModelForTab(tabID, name string) (retErr error) {
 	stageStarted = time.Now()
 	snap := a.tabRuntimeSnapshot(tab)
 	runtime := snap.normalizedRuntime()
-	cfg, err := config.LoadForRoot(snap.workspaceRoot)
+	name, effortOverride, err := a.resolveModelSwitchTarget(tab, snap, name)
 	if err != nil {
 		return err
-	}
-	entry, ok := cfg.ResolveModel(name)
-	pluginRef := false
-	if !ok {
-		// Plugin-namespaced refs belong to extension sidecars: validate them
-		// against the tab controller's merged catalog instead of the config.
-		if d, found := extensionModelDescriptor(a.providerCatalogForTab(tab), name); found {
-			pluginRef = true
-			ok = true
-			name = d.Ref
-		}
-	}
-	if !ok {
-		return fmt.Errorf("unknown model %q", name)
-	}
-	if !pluginRef {
-		if !modelProviderAccessAllowed(cfg.Desktop.ProviderAccess, entry.Name) {
-			return fmt.Errorf("model %q is not available because provider %q is not added", name, entry.Name)
-		}
-		name = entry.Name + "/" + entry.Model
-	}
-	effortOverride := cloneStringPtr(snap.effort)
-	if effortOverride != nil && !pluginRef {
-		normalized, err := config.NormalizeEffort(entry, config.EffortDisplay(&config.ProviderEntry{Effort: *effortOverride}))
-		if err != nil {
-			effortOverride = nil
-		} else {
-			effortOverride = &normalized
-		}
 	}
 	timing.Config = time.Since(stageStarted)
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -3286,6 +3286,89 @@ func TestSetModelForTabRejectsProviderOutsideAccess(t *testing.T) {
 	}
 }
 
+func TestSetModelForTabDefersWhileRunning(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "REASONIX_TEST_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "prov-a/model-a1"
+	cfg.Desktop.ProviderAccess = []string{"prov-a", "prov-b"}
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "prov-a", Kind: "openai", BaseURL: "https://a.example.com", Model: "model-a1", APIKeyEnv: "REASONIX_TEST_KEY"},
+		{Name: "prov-b", Kind: "openai", BaseURL: "https://b.example.com", Model: "model-b1", APIKeyEnv: "REASONIX_TEST_KEY"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+
+	runner := &blockingRunner{started: make(chan struct{}), release: make(chan struct{})}
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	app.enableDeferredRebuildRetry()
+	t.Cleanup(app.stopDeferredRebuildRetry)
+	tab := &WorkspaceTab{
+		ID:          "tab_deferred_model",
+		Scope:       "global",
+		Ready:       true,
+		model:       "prov-a/model-a1",
+		sink:        &tabEventSink{tabID: "tab_deferred_model", app: app},
+		disabledMCP: map[string]ServerView{},
+	}
+	installNoopRuntimeEvents(app, tab.sink)
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	sessionPath := filepath.Join(dir, "deferred-model-switch.jsonl")
+	oldCtrl := control.New(control.Options{Runner: runner, SessionDir: dir, SessionPath: sessionPath, Label: "old"})
+	tab.Ctrl = oldCtrl
+	app.bindControllerDisplayRecorder(oldCtrl)
+	t.Cleanup(func() {
+		if c := app.controllerForTab(tab); c != nil && c != oldCtrl {
+			c.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	oldCtrl.Submit("work")
+	<-runner.started
+
+	err := app.SetModelForTab(tab.ID, "prov-b/model-b1")
+	if err == nil || !strings.Contains(err.Error(), "will apply from the next turn") {
+		t.Fatalf("SetModelForTab while running err = %v, want deferred-accept error", err)
+	}
+	if got := tab.model; got != "prov-b/model-b1" {
+		t.Fatalf("tab.model after deferred switch = %q, want prov-b/model-b1", got)
+	}
+	if !app.deferredRebuildPending(tab.ID) {
+		t.Fatal("deferred rebuild was not scheduled while the turn is running")
+	}
+	if app.controllerForTab(tab) != oldCtrl {
+		t.Fatal("controller changed while the turn is still running")
+	}
+
+	close(runner.release)
+	waitNotRunning(t, oldCtrl)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !app.deferredRebuildPending(tab.ID) && app.controllerForTab(tab) != oldCtrl {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if app.deferredRebuildPending(tab.ID) {
+		t.Fatal("deferred rebuild is still pending after the turn finished")
+	}
+	if c := app.controllerForTab(tab); c == nil || c == oldCtrl {
+		t.Fatalf("controller was not rebuilt with the new model after the turn finished: got %p", c)
+	}
+}
+
 func TestSetModelForTabRefreshesCarriedSystemPromptWithoutChangingDefaults(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")

--- a/desktop/deferred_rebuild.go
+++ b/desktop/deferred_rebuild.go
@@ -113,6 +113,16 @@ func (a *App) deferredRebuildPending(tabID string) bool {
 	return ok
 }
 
+// deferredRebuildSetting returns the pending rebuild label for a tab, or
+// ok=false when the tab has no queued rebuild.
+func (a *App) deferredRebuildSetting(tabID string) (string, bool) {
+	d := &a.deferredRebuild
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	setting, ok := d.pending[tabID]
+	return setting, ok
+}
+
 // stopDeferredRebuildRetry permanently stops the retry loop; used on shutdown
 // and by tests.
 func (a *App) stopDeferredRebuildRetry() {

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -133,6 +133,16 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // production and 2358.3 KiB in test: about 9.0 KiB (0.38%) over main-v2's
 // channel gates. Retain that attributable UI capacity with 0.1 KiB of build-SHA
 // headroom without widening the gzip or largest-chunk exceptions.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_358.4 : 2_353.2;
+// Deferred model switching (busy turns accept a model change that applies from
+// the next turn) adds ~0.4 KiB raw to the startup path; raise the raw gate by
+// that amount while keeping the gzip and largest-chunk exceptions unchanged.
+// The next-turn notice's dedicated variant style and direct transcript
+// placement add another ~0.2 KiB raw, absorbed in the same gate. Keeping the
+// notice in history (instead of the live footer) adds the live-split filter,
+// another ~0.4 KiB raw, widening the gate once more. Rendering the notice next
+// to its user message in the settled rows (so it never jumps to the bottom
+// after the turn) adds ~0.2 KiB more.
+// Preserving the notice across history replaces (merge helper) adds ~0.2 KiB.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_359.8 : 2_354.6;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/__tests__/model-switch-notice-persistence.test.ts
+++ b/desktop/frontend/src/__tests__/model-switch-notice-persistence.test.ts
@@ -1,0 +1,96 @@
+// Run: tsx src/__tests__/model-switch-notice-persistence.test.ts
+
+import { initialState, reducer } from "../lib/useController";
+import { getLocale } from "../lib/i18n";
+
+getLocale();
+
+let passed = 0;
+let failed = 0;
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (actual === expected) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}\n`);
+    failed += 1;
+  }
+}
+
+function noticeIds(items: readonly { kind: string; id: string }[]): string[] {
+  return items.filter((item) => item.kind === "notice").map((item) => item.id);
+}
+
+const replace = (items: readonly { kind: string; id: string }[]) =>
+  reducer(initialState, {
+    type: "history_replace",
+    items: [...items] as never,
+    startTurn: 0,
+    totalTurns: 1,
+    hasOlder: false,
+  } as never);
+
+console.log("\nmodel-switch notice survives history replaces");
+
+{
+  let s = initialState;
+  s = reducer(s, { type: "user", text: "hello", submissionId: "s1" });
+  s = reducer(s, {
+    type: "local_notice",
+    level: "info",
+    text: "已切换模型，将在下一轮对话中生效。",
+    variant: "model-switch",
+    preserveRuntime: true,
+  });
+  // The turn settles, then the backend history (which never stores local
+  // notices) replaces the transcript — the confirmation must not vanish.
+  s = reducer(s, { type: "event", e: { kind: "turn_done", tabId: "t", err: false } as never });
+  const backendHistory = [{ kind: "user", id: "u0", text: "hello" }];
+  s = reducer(s, { type: "history_replace", items: backendHistory as never, startTurn: 0, totalTurns: 1, hasOlder: false } as never);
+  eq(noticeIds(s.items).length, 1, "history replace keeps the session's model-switch notice");
+  const userIndex = s.items.findIndex((item) => item.kind === "user");
+  const noticeIndex = s.items.findIndex((item) => item.kind === "notice");
+  eq(noticeIndex > userIndex, true, "model-switch notice sits after the newest user message");
+  // A second replace must not duplicate the notice.
+  s = reducer(s, { type: "history_replace", items: backendHistory as never, startTurn: 0, totalTurns: 1, hasOlder: false } as never);
+  eq(noticeIds(s.items).length, 1, "repeated history replaces do not duplicate the notice");
+}
+
+{
+  // Without a notice, history replace is unchanged.
+  const s = replace([{ kind: "user", id: "u0", text: "hello" }]);
+  eq(noticeIds(s.items).length, 0, "history replace without a local notice stays clean");
+}
+
+{
+  // Notices carry the originating user id and stay with that turn instead of
+  // migrating to the newest message.
+  let s = initialState;
+  s = reducer(s, { type: "user", text: "first", submissionId: "s1" });
+  s = reducer(s, { type: "local_notice", level: "info", text: "notice A", variant: "model-switch", turnUserID: "u0" });
+  s = reducer(s, { type: "user", text: "second", submissionId: "s2" });
+  s = reducer(s, { type: "local_notice", level: "info", text: "notice B", variant: "model-switch", turnUserID: "u1" });
+  s = reducer(s, {
+    type: "history_replace",
+    items: [
+      { kind: "user", id: "u0", text: "first" },
+      { kind: "user", id: "u1", text: "second" },
+    ] as never,
+    startTurn: 0,
+    totalTurns: 2,
+    hasOlder: false,
+  } as never);
+  const order = s.items.map((item) => (item.kind === "notice" ? `notice:${item.text}` : `${item.kind}:${item.text}`));
+  eq(
+    order.join(","),
+    "user:first,notice:notice A,user:second,notice:notice B",
+    "each model-switch notice stays with its originating turn",
+  );
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} model-switch notice persistence test(s) failed; ${passed} passed.`);
+  process.exit(1);
+}
+console.log(`\n${passed} model-switch notice persistence tests passed.`);

--- a/desktop/frontend/src/__tests__/transcript-live-split.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-live-split.test.ts
@@ -127,6 +127,44 @@ const keys = (rows: readonly { key: string }[]) => rows.map((row) => row.key).jo
   check(keys(split.liveRows) === keys(rows), "a prelude turn's rows all render in the live region");
 }
 
+// ── Model-switch notice stays in history while the turn streams ──────────────
+{
+  const notice: Item = {
+    kind: "notice",
+    id: "n1",
+    level: "info",
+    text: "Model switched. It will take effect from your next message.",
+    variant: "model-switch",
+  };
+  const { models, rows } = rowsFor(
+    [user("u1"), notice, assistant("a1", { text: "answering", streaming: true })],
+    { id: "a1", hasAnswerText: true, hasReasoning: false },
+    true,
+  );
+  const split = splitTranscriptLiveRows(models, rows, "a1", true);
+  check(split.liveActive, "a streaming turn with a model-switch notice stays live");
+  check(keys(split.historyRows).includes("n:n1"), "model-switch notice scrolls with history");
+  check(!keys(split.liveRows).includes("n:n1"), "model-switch notice is not pinned to the live region");
+  check(keys(split.liveRows).includes("a:a1"), "the streaming answer still renders in the live region");
+}
+
+// ── Settled turn: model-switch notice keeps its position next to the user ─────
+{
+  const notice: Item = {
+    kind: "notice",
+    id: "n1",
+    level: "info",
+    text: "Model switched. It will take effect from your next message.",
+    variant: "model-switch",
+  };
+  const { rows } = rowsFor([user("u1"), notice, assistant("a1", { text: "done", reasoningComplete: true })]);
+  const ordered = rows.map((row) => row.key);
+  check(
+    ordered[0] === userRowKey("u1") && ordered[1] === "n:n1",
+    "settled turn keeps the model-switch notice right after the user message",
+  );
+}
+
 if (failed > 0) {
   console.error(`\n${failed} transcript live-split test(s) failed; ${passed} passed.`);
   process.exit(1);

--- a/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
@@ -787,6 +787,34 @@ const nextGenerationResetBefore = integrity?.resetKey;
 await triggerWatchdogRebuild();
 check(integrity?.resetKey !== nextGenerationResetBefore, "a changed 10,000-row generation receives a fresh hard-reset budget");
 
+// ── Model-switch notice live→history transition keeps a manual viewport ─────
+// The first streaming update carrying the notice moves it out of the live
+// surface into history (splitTranscriptLiveRows), growing history by one row
+// while the live surface shrinks. That geometry change must not drag a
+// manually positioned viewport (AGENTS.md race-test mandate).
+{
+  const noticeRow: TranscriptRow = {
+    kind: "notice",
+    key: "n:model-switch",
+    item: { kind: "notice", id: "model-switch", level: "info", text: "Model switched. It will take effect from your next message.", variant: "model-switch" },
+  };
+  await switchSurface("surface-model-switch", baseRows);
+  // User manually scrolls away from the tail before the notice lands.
+  scrollElement.scrollTop = 300;
+  scrollToCalls = 0;
+  scrollByCalls = 0;
+  scrollToIndexCalls = 0;
+  await act(async () => arbiter?.releaseTailFollow());
+  // The transition lands: the notice row joins history on the same surface.
+  await act(async () => root.render(<Probe surfaceKey="surface-model-switch" rows={[noticeRow, ...baseRows]} />));
+  await flushFrames();
+  await advanceClock(240);
+  await flushFrames();
+  check(scrollElement.scrollTop === 300, "model-switch notice history transition keeps the manual viewport");
+  check(scrollToCalls === 0 && scrollToIndexCalls === 0 && scrollByCalls === 0,
+    "no recovery write drags the viewport during the notice transition");
+}
+
 await act(async () => root.unmount());
 Date.now = originalDateNow;
 dom.window.setTimeout = originalSetTimeout;

--- a/desktop/frontend/src/__tests__/use-controller-live-context.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-live-context.test.tsx
@@ -626,6 +626,38 @@ ok(
   "failed close preserves model balance reconciliation",
 );
 
+const deferredSwitchGate = deferred<void>();
+modelSwitchSteps.push({
+  gate: deferredSwitchGate,
+  error: new Error("model switch accepted; the new model will apply from the next turn"),
+});
+let deferredSwitch: Promise<boolean> | undefined;
+await act(async () => {
+  deferredSwitch = controller?.setModel("provider-j/model-j");
+  await flushPromises();
+});
+deferredSwitchGate.resolve();
+let deferredSwitchResult: boolean | undefined;
+await act(async () => {
+  deferredSwitchResult = await deferredSwitch;
+  await flushPromises();
+});
+eq(deferredSwitchResult, true, "deferred model switch reports success to its caller");
+ok(
+  (controller?.state.items ?? []).some(
+    (item) =>
+      (item as { kind: string }).kind === "notice" &&
+      (item as { level?: string }).level === "info" &&
+      (item as { text?: string }).text === "Model switched. It will take effect from your next message.",
+  ),
+  "deferred model switch surfaces the next-turn notice",
+);
+eq(
+  controller?.state.meta?.label,
+  backendModel,
+  "deferred model switch reconciles metadata to the backend model",
+);
+
 await act(async () => {
   root.unmount();
 });

--- a/desktop/frontend/src/lib/transcriptRows.ts
+++ b/desktop/frontend/src/lib/transcriptRows.ts
@@ -87,7 +87,7 @@ export function partitionTurnItems(items: readonly Item[], live: TranscriptLiveF
       if (isSteerNoticeText(item.text)) {
         current.outsideItems.push(item);
         currentHasConversation = true;
-      } else if (item.level === "warn" || item.variant === "delivery") {
+      } else if (item.level === "warn" || item.variant === "delivery" || item.variant === "model-switch") {
         current.outsideItems.push(item);
       } else {
         pushProcess(item);
@@ -554,6 +554,17 @@ export function buildTranscriptRows(models: readonly TurnModel[], options: Build
     if (user) {
       rows.push({ kind: "user", key: userRowKey(user.id), item: user, turn });
     }
+    // Model-switch notices render right after their user message: they confirm
+    // an accepted switch, and keeping that position in the settled rows (not
+    // after the answer body) stops the notice from jumping to the bottom when
+    // the live split hands the turn over to history.
+    for (const segment of model.segments) {
+      for (const item of segment.outsideItems) {
+        if (item.kind === "notice" && item.variant === "model-switch") {
+          rows.push({ kind: "notice", key: `n:${item.id}`, item });
+        }
+      }
+    }
     for (const segment of model.segments) {
       if (segment.displayItems.length > 0) {
         const open = options.folds.get(segment.key)?.open ?? defaultFoldOpen(segment, options.foldPreference);
@@ -564,6 +575,7 @@ export function buildTranscriptRows(models: readonly TurnModel[], options: Build
         if (item.kind === "extension") {
           rows.push({ kind: "extension", key: `x:${item.id}`, item });
         } else if (item.kind === "notice") {
+          if (item.variant === "model-switch") continue; // already rendered after the user row
           rows.push({ kind: "notice", key: `n:${item.id}`, item });
         } else {
           rows.push({ kind: "answer", key: `a:${item.id}`, item });
@@ -630,15 +642,31 @@ export function splitTranscriptLiveRows(
     const firstKey = firstRowKeyForModel(active);
     const firstIndex = firstKey ? rows.findIndex((row) => row.key === firstKey) : -1;
     if (!firstKey || firstIndex < 0) return { historyRows: [...rows], liveRows: [], liveActive: true };
-    return { historyRows: rows.slice(0, firstIndex), liveRows: rows.slice(firstIndex), liveActive: true };
+    const liveRows = rows.slice(firstIndex);
+    return {
+      historyRows: [...rows.slice(0, firstIndex), ...pullLiveModelSwitchNotices(liveRows)],
+      liveRows: withoutLiveModelSwitchNotices(liveRows),
+      liveActive: true,
+    };
   }
   const userIndex = rows.findIndex((row) => row.key === userRowKey(active.user!.id));
   if (userIndex < 0) return { historyRows: [...rows], liveRows: [], liveActive: false };
+  const liveRows = rows.slice(userIndex + 1);
   return {
-    historyRows: rows.slice(0, userIndex + 1),
-    liveRows: rows.slice(userIndex + 1),
+    historyRows: [...rows.slice(0, userIndex + 1), ...pullLiveModelSwitchNotices(liveRows)],
+    liveRows: withoutLiveModelSwitchNotices(liveRows),
     liveActive: true,
   };
+}
+
+// Model-switch notices confirm an accepted switch and must scroll with history
+// even while the turn streams: pinning them to the live footer makes them
+// flash on every stream update. Pull them into the history tail instead.
+function pullLiveModelSwitchNotices(rows: readonly TranscriptRow[]): TranscriptRow[] {
+  return rows.filter((row) => row.kind === "notice" && (row.item as NoticeItem).variant === "model-switch");
+}
+function withoutLiveModelSwitchNotices(rows: readonly TranscriptRow[]): TranscriptRow[] {
+  return rows.filter((row) => !(row.kind === "notice" && (row.item as NoticeItem).variant === "model-switch"));
 }
 
 // ── Measurement / identity helpers ────────────────────────────────────────────

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -239,7 +239,7 @@ export type Item =
   | { kind: "user"; id: string; submissionId?: string; text: string; submitText?: string; failed?: boolean; createdAt?: number; checkpointTurn?: number; historyTurn?: number }
   | { kind: "assistant"; id: string; text: string; reasoning: string; streaming: boolean; reasoningComplete?: boolean; reasoningDurationMs?: number; workDurationMs?: number; memoryCitations?: MemoryCitation[]; searchSources?: SearchSource[] }
   | { kind: "phase"; id: string; text: string }
-  | { kind: "notice"; id: string; level: "info" | "warn"; text: string; detail?: string; title?: string; variant?: "delivery" | "completion"; action?: "continue_delivery" | "open_changes"; completionSummary?: WireCompletionSummary; decisionReceipt?: WireDecisionReceipt; missing?: string[]; inboxItemId?: string }
+  | { kind: "notice"; id: string; level: "info" | "warn"; text: string; detail?: string; title?: string; variant?: "delivery" | "completion" | "model-switch"; turnUserID?: string; action?: "continue_delivery" | "open_changes"; completionSummary?: WireCompletionSummary; decisionReceipt?: WireDecisionReceipt; missing?: string[]; inboxItemId?: string }
   | {
       kind: "compaction";
       id: string;
@@ -759,6 +759,48 @@ function compactArchivedToolItems(items: Item[]): Item[] {
   });
 }
 
+// Model-switch notices are session-local UI state: the backend history never
+// stores them, so a live-turn history replace would otherwise drop the
+// "applies from the next turn" confirmation the moment the turn settles.
+// Re-insert the current session's notices after the user message they belong
+// to (turnUserID), so a notice does not migrate to a later unrelated turn.
+function mergeModelSwitchNotices(prev: readonly Item[], next: readonly Item[]): Item[] {
+  const notices = prev.filter((item): item is Extract<Item, { kind: "notice" }> =>
+    item.kind === "notice" && item.variant === "model-switch");
+  if (notices.length === 0) return [...next];
+  const byUser = new Map<string, Item[]>();
+  const orphaned: Item[] = [];
+  for (const notice of notices) {
+    const uid = notice.turnUserID;
+    if (uid) {
+      const list = byUser.get(uid) ?? [];
+      list.push(notice);
+      byUser.set(uid, list);
+    } else {
+      orphaned.push(notice);
+    }
+  }
+  const out: Item[] = [];
+  for (const item of next) {
+    out.push(item);
+    if (item.kind === "user") {
+      const attached = byUser.get(item.id);
+      if (attached) out.push(...attached);
+    }
+  }
+  // Notices whose originating user message is not in the new history (e.g.
+  // a rewind or compaction) fall back to the tail of the current turn.
+  if (orphaned.length > 0) {
+    let lastUser = -1;
+    for (let i = 0; i < out.length; i += 1) {
+      if (out[i].kind === "user") lastUser = i;
+    }
+    if (lastUser < 0) return [...orphaned, ...out];
+    return [...out.slice(0, lastUser + 1), ...orphaned, ...out.slice(lastUser + 1)];
+  }
+  return out;
+}
+
 type Action =
   | { type: "event"; e: WireEvent }
   | { type: "stream_batch"; segments: StreamSegment[] }
@@ -792,7 +834,7 @@ type Action =
   | { type: "history_items_patch"; patches: Record<string, Item> }
   | { type: "history_older_start" }
   | { type: "history_older_error"; error?: string }
-  | { type: "local_notice"; level: "info" | "warn"; text: string; preserveRuntime?: boolean }
+  | { type: "local_notice"; level: "info" | "warn"; text: string; variant?: "model-switch"; turnUserID?: string; preserveRuntime?: boolean }
   | { type: "clearApproval" }
   | { type: "clearAsk" }
   | { type: "clearExtensionForm" }
@@ -2086,7 +2128,7 @@ export function reducer(s: State, a: Action): State {
     case "history_replace":
       return {
         ...s,
-        items: compactArchivedToolItems(a.items),
+        items: compactArchivedToolItems(mergeModelSwitchNotices(s.items, a.items)),
         pendingSubmissionId: undefined,
         hydrateHistoryLoaded: true,
         hydratePlaceholderItems: undefined,
@@ -2128,7 +2170,7 @@ export function reducer(s: State, a: Action): State {
       });
       return changed ? { ...s, items: next, historyLayoutRevision: s.historyLayoutRevision + 1 } : s;
     }
-    case "local_notice": return { ...s, running: a.preserveRuntime ? s.running : false, turnActive: a.preserveRuntime ? s.turnActive : false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
+    case "local_notice": return { ...s, running: a.preserveRuntime ? s.running : false, turnActive: a.preserveRuntime ? s.turnActive : false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text, ...(a.variant ? { variant: a.variant } : {}), ...(a.turnUserID ? { turnUserID: a.turnUserID } : {}) }] };
     case "clearApproval": {
       const next = { ...s, approval: undefined, pendingPrompt: Boolean(s.ask), resolvedPromptId: s.approval?.id ?? s.resolvedPromptId };
       return endPromptWaitIfIdle(next);
@@ -2224,6 +2266,13 @@ function errorMessage(err: unknown): string {
   return String(err || "");
 }
 
+// isModelSwitchDeferred reports the backend's deferred-accept error: the model
+// selection changed immediately and the controller rebuild is queued until the
+// running turn finishes, so the switch takes effect from the next turn.
+function isModelSwitchDeferred(err: unknown): boolean {
+  return /model switch accepted; the new model will apply from the next turn/i.test(errorMessage(err));
+}
+
 export function effortSwitchNoticeText(err: unknown): string {
   return settingSwitchNoticeText(err, "effort", {
     busy: "status.effortSwitchBusy",
@@ -2240,6 +2289,9 @@ export function effortSwitchNoticeText(err: unknown): string {
 
 export function modelSwitchNoticeText(err: unknown): string {
   const msg = errorMessage(err).trim() || "unknown error";
+  if (isModelSwitchDeferred(err)) {
+    return t("status.modelSwitchDeferred");
+  }
   const unknownModel = /^unknown model (.+)$/i.exec(msg);
   if (unknownModel) {
     return t("status.modelSwitchUnknown", { model: unknownModel[1] });
@@ -2586,6 +2638,11 @@ export function useController() {
   const modelSwitchSeqByTab = useRef(new Map<string, number>());
   const modelSwitchSuccessVersionByTab = useRef(new Map<string, number>());
   const modelSwitchQueueByTab = useRef(new Map<string, ModelSwitchQueueState>());
+  // Tabs with an accepted-but-not-yet-applied deferred model switch: the
+  // runtime-rebuilt event for that tab must refresh balance/meta against the
+  // selected provider, which the deferred-success branch cannot do yet (the
+  // outgoing controller is still installed at that point).
+  const deferredModelSwitchByTabRef = useRef(new Map<string, string>());
   const lastTurnActivityAtByTab = useRef(new Map<string, number>());
   const runtimeEpochByTabRef = useRef(new Map<string, string>());
   const listedSessionIdentityByTabRef = useRef(new Map<string, { sessionPath?: string; sessionGeneration?: number }>());
@@ -3475,6 +3532,13 @@ export function useController() {
         invalidateSharedQuery("MetaForTab", [rebuiltTabId]);
         if (runtimeEpoch) runtimeEpochByTabRef.current.set(rebuiltTabId, runtimeEpoch);
         dispatchTo(rebuiltTabId, { type: "controller_rebuilt" });
+        // A deferred model switch lands here: the outgoing controller's
+        // balance/meta were refreshed too early, so re-fetch against the
+        // selected provider now that the swap completed.
+        if (deferredModelSwitchByTabRef.current.delete(rebuiltTabId)) {
+          void refreshBalanceForTab(rebuiltTabId);
+          void refreshMetaForTab(rebuiltTabId);
+        }
       } else {
         if (runtimeEpoch) {
           for (const id of Array.from(statesRef.current.keys())) runtimeEpochByTabRef.current.set(id, runtimeEpoch);
@@ -4292,21 +4356,52 @@ export function useController() {
       );
     } catch (err) {
       if (modelSwitchSeqByTab.current.get(tabId) !== switchSeq) return false;
-      dispatchTo(tabId, { type: "local_notice", level: "warn", text: modelSwitchNoticeText(err) });
-      const olderSwitchSucceeded =
-        (modelSwitchSuccessVersionByTab.current.get(tabId) ?? 0) !== successVersion;
-      // Restore the known balance only when no older overlapping switch
-      // completed after this attempt began. Otherwise the backend now owns a
-      // different provider and the refresh below must establish its balance.
-      if (fallbackBalance && !olderSwitchSucceeded) {
-        dispatchTo(tabId, { type: "balance", balance: fallbackBalance });
+      if (isModelSwitchDeferred(err)) {
+        // The backend accepted the switch and will swap the controller when
+        // the current turn finishes; the selection already changed, so treat
+        // it as a success instead of a failure.
+        modelSwitchSuccessVersionByTab.current.set(
+          tabId,
+          (modelSwitchSuccessVersionByTab.current.get(tabId) ?? 0) + 1,
+        );
+        // preserveRuntime: the switch is accepted while the turn is still
+        // running — the notice must not flip the UI out of the streaming state.
+        // variant "model-switch" gives it the same visual weight as a warning
+        // while staying semantically informational. turnUserID pins the notice
+        // to the turn it was accepted on.
+        let turnUserID: string | undefined;
+        const items = statesRef.current.get(tabId)?.items ?? [];
+        for (let i = items.length - 1; i >= 0; i -= 1) {
+          if (items[i].kind === "user") {
+            turnUserID = items[i].id;
+            break;
+          }
+        }
+        dispatchTo(tabId, { type: "local_notice", level: "info", text: modelSwitchNoticeText(err), variant: "model-switch", turnUserID, preserveRuntime: true });
+        // The backend swap arrives as a runtime-rebuilt event later; mark the
+        // expected provider so that handler can refresh balance/meta with the
+        // selected model instead of the outgoing one.
+        deferredModelSwitchByTabRef.current.set(tabId, name);
+      } else {
+        dispatchTo(tabId, { type: "local_notice", level: "warn", text: modelSwitchNoticeText(err) });
+        const olderSwitchSucceeded =
+          (modelSwitchSuccessVersionByTab.current.get(tabId) ?? 0) !== successVersion;
+        // Restore the known balance only when no older overlapping switch
+        // completed after this attempt began. Otherwise the backend now owns a
+        // different provider and the refresh below must establish its balance.
+        if (fallbackBalance && !olderSwitchSucceeded) {
+          dispatchTo(tabId, { type: "balance", balance: fallbackBalance });
+        }
+        void refreshBalanceForTab(tabId);
+        // A superseded success deliberately skips its own UI reconciliation.
+        // If this latest queued switch then fails, reconcile the model metadata
+        // to the provider that actually became active in the backend.
+        if (olderSwitchSucceeded) await refreshMetaForTab(tabId);
+        return false;
       }
       void refreshBalanceForTab(tabId);
-      // A superseded success deliberately skips its own UI reconciliation.
-      // If this latest queued switch then fails, reconcile the model metadata
-      // to the provider that actually became active in the backend.
-      if (olderSwitchSucceeded) await refreshMetaForTab(tabId);
-      return false;
+      await refreshMetaForTab(tabId);
+      return modelSwitchSeqByTab.current.get(tabId) === switchSeq;
     }
     if (modelSwitchSeqByTab.current.get(tabId) !== switchSeq) return false;
     void refreshBalanceForTab(tabId);

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -865,6 +865,7 @@ export const en = {
   "modelSwitcher.noMatches": "No matching models",
   "status.noModels": "no switchable models",
   "status.modelSwitchBusy": "The model cannot change yet. Stop the current answer, handle pending prompts, or wait for background jobs to finish.",
+  "status.modelSwitchDeferred": "Model switched. It will take effect from your next message.",
   "status.modelSwitchBusyRunning": "The model cannot change while the current answer is running. Stop it first.",
   "status.modelSwitchBusyPrompt": "The model cannot change while a prompt is waiting for your response. Handle it first.",
   "status.modelSwitchBusyJobs": "The model cannot change while background work is active. Active jobs: {n}. Open Background jobs in the status bar to stop them.",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -635,6 +635,7 @@ export const zhTW: Record<DictKey, string> = {
   "modelSwitcher.noMatches": "沒有匹配的模型",
   "status.noModels": "沒有可切換模型",
   "status.modelSwitchBusy": "暫時不能切換模型。請先停止目前回答、處理待確認問題，或等待背景任務結束。",
+  "status.modelSwitchDeferred": "已切換模型，將在下一輪對話中生效。",
   "status.modelSwitchBusyRunning": "目前回答仍在執行，暫時不能切換模型。請先停止回答。",
   "status.modelSwitchBusyPrompt": "有待處理的確認問題，暫時不能切換模型。請先完成處理。",
   "status.modelSwitchBusyJobs": "仍有 {n} 個背景任務在執行，暫時不能切換模型。請從狀態列的「背景作業」中停止它們。",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -866,6 +866,7 @@ export const zh: Record<DictKey, string> = {
   "modelSwitcher.noMatches": "没有匹配的模型",
   "status.noModels": "没有可切换模型",
   "status.modelSwitchBusy": "暂时不能切换模型。请先停止当前回答、处理待确认问题，或等待后台任务结束。",
+  "status.modelSwitchDeferred": "已切换模型，将在下一轮对话中生效。",
   "status.modelSwitchBusyRunning": "当前回答仍在运行，暂时不能切换模型。请先停止回答。",
   "status.modelSwitchBusyPrompt": "有待处理的确认问题，暂时不能切换模型。请先完成处理。",
   "status.modelSwitchBusyJobs": "仍有 {n} 个后台任务在运行，暂时不能切换模型。请从状态栏的“后台作业”中停止它们。",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3673,9 +3673,15 @@ a[href] {
   color: var(--fg-faint);
   border-radius: 6px;
 }
-.notice-line--warn {
+.notice-line--warn,
+.notice-line--model-switch {
   color: var(--accent);
   background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+.notice-line--model-switch {
+  /* The notice sits between its user message and the streaming content that
+     follows; keep that transition airy instead of cramped. */
+  margin-bottom: 10px;
 }
 .notice-line--delivery {
   gap: 9px;

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1974,6 +1974,18 @@ func (a *App) rebuildSettingTurnLockedWithModel(setting string, tab *WorkspaceTa
 		oldCtrl.Close()
 	}
 	a.persistTabSessionPath(tab, path)
+	// The rebuild snapshots the old controller, whose autosave writes its own
+	// modelRef back into the session sidecar; a deferred model switch must not
+	// lose the new selection that way. Re-persist the final model after the
+	// swap — a no-op for rebuilds that did not change the model.
+	a.mu.RLock()
+	rebuiltModel := tab.model
+	a.mu.RUnlock()
+	if path != "" && rebuiltModel != "" {
+		if err := agent.SetBranchModelPreserveUpdated(path, rebuiltModel); err != nil {
+			return fmt.Errorf("persist selected model: %w", err)
+		}
+	}
 	a.clearDeferredRebuild(tab.ID)
 	a.notifyTabRuntimeRebuilt(tab)
 	a.emitReady(a.ctx)

--- a/desktop/turn_admission.go
+++ b/desktop/turn_admission.go
@@ -37,6 +37,7 @@ func (admission *tabTurnAdmission) abort() {
 
 // beginTabTurn reserves one tab until its TurnDone fan-out completes.
 func (a *App) beginTabTurn(tabID string, reclaim bool, submissionID ...string) (*tabTurnAdmission, control.SessionAPI, error) {
+	flushedDeferredModel := false
 	for {
 		tab, ctrl := a.tabAndCtrlByID(tabID)
 		if a.tabIsReadOnly(tab) {
@@ -91,6 +92,20 @@ func (a *App) beginTabTurn(tabID string, reclaim bool, submissionID ...string) (
 			}
 			abort()
 			return nil, nil, control.ErrTurnRunning
+		}
+		// A deferred model switch must land before the next turn starts — the
+		// notice promises the new model applies from the next turn. Flush the
+		// pending rebuild synchronously here (the 2s retry loop could
+		// otherwise let a fast resubmit run on the old model); a failed flush
+		// falls through to the current controller once instead of blocking or
+		// looping forever.
+		if !flushedDeferredModel {
+			if setting, ok := a.deferredRebuildSetting(tab.ID); ok && setting == "model" {
+				flushedDeferredModel = true
+				abort()
+				a.retryDeferredRebuild(tab.ID, setting)
+				continue
+			}
 		}
 		if tab.sink != nil && !tab.sink.tryBeginTurn(submissionID...) {
 			abort()

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -25,14 +25,14 @@
     },
     "desktop/app.go": {
       "complexity": 58,
-      "essay": 64,
-      "file-size": 11122,
+      "essay": 65,
+      "file-size": 11190,
       "function-size": 365,
       "struct-state": 15
     },
     "desktop/app_test.go": {
       "essay": 2,
-      "test-file-size": 10263
+      "test-file-size": 10345
     },
     "desktop/bot_bridge.go": {
       "essay": 3
@@ -163,7 +163,7 @@
       "file-size": 1601
     },
     "desktop/frontend/src/lib/useController.ts": {
-      "file-size": 4035
+      "file-size": 4120
     },
     "desktop/heartbeat.go": {
       "essay": 7
@@ -249,7 +249,7 @@
     },
     "desktop/settings_app.go": {
       "complexity": 29,
-      "essay": 6,
+      "essay": 7,
       "file-size": 2828
     },
     "desktop/settings_app_test.go": {
@@ -1532,6 +1532,12 @@
     },
     "internal/botruntime/runtime.go": {
       "file-size": 38
+    },
+    "desktop/turn_admission.go": {
+      "essay": 3
+    },
+    "desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx": {
+      "test-file-size": 28
     }
   }
 }


### PR DESCRIPTION
## 变更摘要

回答运行中切换模型不再被拒绝：模型选择立即更新并持久化，controller 重建排队到当前轮结束后执行，切换从下一轮回答生效。前端以醒目提示「已切换模型，将在下一轮对话中生效」告知，且提示随对话历史保留。

### 后端（desktop/app.go）
- `SetModelForTab` 检测到 active runtime work（running / pending prompt / background jobs）时，不再返回 busy 错误，改走 `deferModelSwitch`：
  - 立即更新 `tab.model` + 持久化 session 元数据（UI 与重启均看到新选择）
  - 通过既有 deferred-rebuild 队列排队，当前轮结束后自动重建 controller 生效
  - 返回专用 `modelSwitchDeferredError` 供前端识别
- 提取 `resolveModelSwitchTarget` 共用模型解析（provider access 校验 + effort override）

### 前端（useController.ts / transcriptRows.ts）
- `isModelSwitchDeferred` 识别 deferred 错误，走成功路径刷新 balance/meta，显示 info 提示（`preserveRuntime` 保持生成状态）
- 提示以 `variant: "model-switch"` 渲染在 user 消息之后、回答之前：streaming 期间归入历史区随流上滚（不钉底部、不闪动），对话结束后位置保持
- `history_replace` 合并保留本会话的 model-switch 提示，不被后端历史覆盖

### 测试
- `TestSetModelForTabDefersWhileRunning`：busy → deferred → idle 后自动重建全流程
- 前端：deferred notice 显示、live-split 归历史、history_replace 保留，共 86 个断言
- 三语 locale 新增 `status.modelSwitchDeferred`

### 验证
- 后端：gofmt / go vet / desktop 全量测试通过
- 前端：tsc / eslint / 全部单测 / vite build + bundle budget 通过
- repolint clean

Documentation-impact: none - 纯桌面端交互功能改动（模型切换 deferred 语义），不涉及任何文档内容，现有文档仍然准确
