### PR TITLE
Refresh v1.31.0 release candidate links / 刷新 v1.31.0 发布候选链接

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -26,7 +26,7 @@
             "en": "For details on supported version lines and reporting methods, see the migration guide.",
             "zh": "有关支持的版本线和报告方式的详细信息，请参阅迁移指南。"
           },
-          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/d619d3fc7541f74a4da734b8412c0657bdcb589c/docs/MIGRATING.md"
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ec4b3f61e8fe18bc6ca0b4fbd974b24a26e282e6/docs/MIGRATING.md"
         },
         {
           "title": {
@@ -37,7 +37,7 @@
             "en": "For details on supported version lines and reporting methods, see the migration guide.",
             "zh": "有关支持的版本线和报告方式的详细信息，请参阅迁移指南。"
           },
-          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/d619d3fc7541f74a4da734b8412c0657bdcb589c/docs/MIGRATING.zh-CN.md"
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ec4b3f61e8fe18bc6ca0b4fbd974b24a26e282e6/docs/MIGRATING.zh-CN.md"
         }
       ],
       "highlights": [


### PR DESCRIPTION
## Summary

- Rebind the reviewed v1.31.0 migration guide links to the current `main-v2` candidate after the desktop benchmark gate repair.
- Keep the reviewed English and Chinese user-visible release content unchanged.
- Refresh only the two immutable source-revision URLs required to bind the release record to the new candidate.

## Context

The original v1.31.0 Notes PR was merged before the candidate-only desktop benchmark repair. That repair moved `main-v2` to `ec4b3f61e8fe18bc6ca0b4fbd974b24a26e282e6`, so the reviewed record must be changed again by the final candidate commit before Stable tagging.

The automated same-version prepare workflow cannot perform this refresh because it queries the GitHub API for a local merge commit before that commit exists remotely and receives HTTP 422. This focused refresh preserves the reviewed release text and changes only the guide source revisions.

## Issues

Refs #9183
Refs #9186

## Verification

- `node scripts/release-notes.mjs validate`
- `node --test scripts/release-notes.test.mjs`
- Rendered and reviewed v1.31.0 release notes in English and Chinese.
- `git diff --check`

## Documentation impact

Documentation-impact: none - this is a release metadata refresh; the existing embedded English and Chinese release documentation remains correct and no `docs/*.md` content changes.

## Cache impact

Cache-impact: none - release catalog URLs do not affect provider-visible prompts, tool schemas, serialization, or ordering.
Cache-guard: N/A - no cache-sensitive code or content changed.
System-prompt-review: N/A
