### PR TITLE
fix(desktop): refine workspace preview panel layout / 优化工作区预览面板布局

### DIFF
--- a/desktop/frontend/src/__tests__/workspace-preview-css.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-preview-css.test.ts
@@ -117,22 +117,23 @@ eq(
   "0px",
   "themed workspace code keeps the line-number gutter flush",
 );
+const splitDom = `<html><head></head><body><aside class="workspace-panel"><section class="workspace-files"></section><section class="workspace-preview"></section><button class="workspace-tree-resizer"></button></aside></body></html>`;
 eq(
-  finalDeclaration(".workspace-panel--with-tree-rail:not(.workspace-panel--tree-hidden)", "grid-template-columns"),
-  "var(--workspace-tree-rail-width) minmax(var(--workspace-preview-min-width), 1fr) var(--workspace-tree-width)",
-  "split mode keeps a narrow tree toggle rail beside the file tree (preview left, tree right per user preference)",
+  computedDeclaration(splitDom, ".workspace-panel", "grid-template-columns"),
+  "minmax(var(--workspace-preview-min-width), 1fr) var(--workspace-tree-width)",
+  "split mode is a two-column layout: preview on the left, file tree on the right (the tree toggle rail is gone)",
 );
-eq(finalDeclaration(".workspace-panel--with-tree-rail:not(.workspace-panel--tree-hidden) .workspace-files", "grid-column"), "3", "file tree sits at the far right after the preview");
-eq(finalDeclaration(".workspace-panel--with-tree-rail:not(.workspace-panel--tree-hidden) .workspace-preview", "grid-column"), "2", "preview sits after the rail, before the tree");
+eq(computedDeclaration(splitDom, ".workspace-files", "grid-column"), "2", "file tree sits at the far right after the preview");
+eq(computedDeclaration(splitDom, ".workspace-preview", "grid-column"), "1", "preview sits to the left of the tree");
 eq(
-  finalDeclaration(".workspace-panel--with-tree-rail .workspace-tree-resizer", "left"),
+  computedDeclaration(splitDom, ".workspace-tree-resizer", "left"),
   "calc(100% - var(--workspace-tree-width) - 4px)",
   "tree resizer sits at the tree's left edge (tree is on the right)",
 );
 eq(
   finalDeclaration(".workspace-panel--tree-hidden", "grid-template-columns"),
   "minmax(0, 1fr)",
-  "preview-only mode drops the tree rail",
+  "preview-only mode drops the file tree",
 );
 eq(finalDeclaration(".workspace-panel--tree-hidden .workspace-preview", "grid-column"), "1", "preview fills the panel when the tree is hidden");
 eq(

--- a/desktop/frontend/src/__tests__/workspace-resize-interaction.test.tsx
+++ b/desktop/frontend/src/__tests__/workspace-resize-interaction.test.tsx
@@ -154,7 +154,7 @@ await act(async () => {
   separator.dispatchEvent(new window.KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "End" }));
   await flushTimers();
 });
-eq(Number(separator.getAttribute("aria-valuenow")), 616, "End preserves minimum space for the rail and preview");
+eq(Number(separator.getAttribute("aria-valuenow")), 660, "End widens the tree to keep only the preview minimum");
 
 await act(async () => {
   root.unmount();

--- a/desktop/frontend/src/__tests__/workspace-split.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-split.test.ts
@@ -28,30 +28,27 @@ function eq(a: unknown, b: unknown, label: string) {
 console.log("\nworkspace file split");
 
 const TREE_MIN_WIDTH = 140;
-const TREE_RAIL_WIDTH = 44;
 const PREVIEW_MIN_WIDTH = 140;
 
 eq(
   initialWorkspaceSplitTreeWidth({
     panelWidth: 660,
-    railWidth: TREE_RAIL_WIDTH,
     savedTreeWidth: null,
     treeMinWidth: TREE_MIN_WIDTH,
     previewMinWidth: PREVIEW_MIN_WIDTH,
   }),
-  308,
-  "first split divides the file area evenly after reserving the tree rail",
+  330,
+  "first split divides the file area evenly (no tree rail to reserve)",
 );
 
 eq(
   initialWorkspaceSplitTreeWidth({
     panelWidth: 660,
-    railWidth: TREE_RAIL_WIDTH,
     savedTreeWidth: 620,
     treeMinWidth: TREE_MIN_WIDTH,
     previewMinWidth: PREVIEW_MIN_WIDTH,
   }),
-  476,
+  520,
   "tree width is clamped so the preview keeps its minimum width",
 );
 
@@ -60,12 +57,11 @@ eq(
     clientX: 400,
     panelLeft: 100,
     panelWidth: 660,
-    railWidth: TREE_RAIL_WIDTH,
     treeMinWidth: TREE_MIN_WIDTH,
     previewMinWidth: PREVIEW_MIN_WIDTH,
   }),
-  256,
-  "tree resize pointer coordinates start after the tree rail",
+  300,
+  "tree resize pointer coordinates start at the panel's left edge",
 );
 
 eq(
@@ -73,12 +69,11 @@ eq(
     clientX: 700,
     panelLeft: 100,
     panelWidth: 660,
-    railWidth: TREE_RAIL_WIDTH,
     treeMinWidth: TREE_MIN_WIDTH,
     previewMinWidth: PREVIEW_MIN_WIDTH,
   }),
-  476,
-  "tree resize pointer clamps against the preview minimum after reserving the rail",
+  520,
+  "tree resize pointer clamps against the preview minimum",
 );
 
 eq(
@@ -86,7 +81,6 @@ eq(
     clientX: 650,
     panelLeft: 100,
     panelWidth: 800,
-    railWidth: TREE_RAIL_WIDTH,
     treeMinWidth: TREE_MIN_WIDTH,
     previewMinWidth: PREVIEW_MIN_WIDTH,
     treeOnRight: true,
@@ -100,13 +94,12 @@ eq(
     clientX: 100,
     panelLeft: 100,
     panelWidth: 800,
-    railWidth: TREE_RAIL_WIDTH,
     treeMinWidth: TREE_MIN_WIDTH,
     previewMinWidth: PREVIEW_MIN_WIDTH,
     treeOnRight: true,
   }),
-  616,
-  "right-side tree maximum keeps space for the rail and preview",
+  660,
+  "right-side tree maximum keeps space for the preview",
 );
 
 eq(
@@ -114,11 +107,10 @@ eq(
     mode: "even",
     currentTreeWidth: 140,
     panelWidth: 660,
-    railWidth: TREE_RAIL_WIDTH,
     treeMinWidth: TREE_MIN_WIDTH,
     previewMinWidth: PREVIEW_MIN_WIDTH,
   }),
-  308,
+  330,
   "default split recomputes evenly after the parent preview width applies",
 );
 
@@ -127,7 +119,6 @@ eq(
     mode: "manual",
     currentTreeWidth: 256,
     panelWidth: 660,
-    railWidth: TREE_RAIL_WIDTH,
     treeMinWidth: TREE_MIN_WIDTH,
     previewMinWidth: PREVIEW_MIN_WIDTH,
   }),
@@ -149,19 +140,17 @@ eq(
 
 eq(
   workspaceSplitCanFit({
-    panelWidth: 323,
-    railWidth: TREE_RAIL_WIDTH,
+    panelWidth: 279,
     treeMinWidth: TREE_MIN_WIDTH,
     previewMinWidth: PREVIEW_MIN_WIDTH,
   }),
   false,
-  "file tree collapses before rail tree and preview would overflow a narrow panel",
+  "file tree collapses before tree and preview would overflow a narrow panel",
 );
 
 eq(
   workspaceSplitCanFit({
-    panelWidth: 324,
-    railWidth: TREE_RAIL_WIDTH,
+    panelWidth: 280,
     treeMinWidth: TREE_MIN_WIDTH,
     previewMinWidth: PREVIEW_MIN_WIDTH,
   }),
@@ -172,7 +161,6 @@ eq(
 eq(
   workspaceSplitCanFit({
     panelWidth: undefined,
-    railWidth: TREE_RAIL_WIDTH,
     treeMinWidth: TREE_MIN_WIDTH,
     previewMinWidth: PREVIEW_MIN_WIDTH,
   }),
@@ -206,7 +194,6 @@ const effectiveEvenTreeWidth = resolveWorkspaceSplitTreeWidth({
   mode: "even",
   currentTreeWidth: TREE_MIN_WIDTH,
   panelWidth: 660,
-  railWidth: TREE_RAIL_WIDTH,
   treeMinWidth: TREE_MIN_WIDTH,
   previewMinWidth: PREVIEW_MIN_WIDTH,
 });
@@ -216,7 +203,6 @@ eq(
     mode: "manual",
     currentTreeWidth: effectiveEvenTreeWidth,
     panelWidth: 660,
-    railWidth: TREE_RAIL_WIDTH,
     treeMinWidth: TREE_MIN_WIDTH,
     previewMinWidth: PREVIEW_MIN_WIDTH,
   }),

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -89,14 +89,13 @@ import { WORKSPACE_TURN_VERIFICATION_ID, WorkspaceTurnVerification } from "./Wor
 import { useWorkspaceChangesResource } from "../lib/useWorkspaceChangesResource";
 import {
   workspaceBasename as basename, workspaceEntryPath as entryPath,
-  workspaceFormatBytes as formatBytes, workspaceFormatCommitDate as formatCommitDate,
+  workspaceFormatCommitDate as formatCommitDate,
   workspaceParentDirs as parentDirs, workspaceParentPath as parentPath,
-  workspaceShortCwd as shortCwd, workspaceTopLevelDirPath as topLevelDirPath,
+  workspaceTopLevelDirPath as topLevelDirPath,
 } from "../lib/workspacePanelFormat";
 
 const WORKSPACE_TREE_MIN_WIDTH = 140;
 const WORKSPACE_TREE_DEFAULT_WIDTH = 300;
-const WORKSPACE_TREE_RAIL_WIDTH = 44;
 const WORKSPACE_PREVIEW_MIN_WIDTH = 140;
 const WORKSPACE_PREVIEW_TARGET_WIDTH = 360;
 const WORKSPACE_DUAL_PANEL_TARGET_WIDTH = WORKSPACE_TREE_DEFAULT_WIDTH + WORKSPACE_PREVIEW_TARGET_WIDTH;
@@ -114,7 +113,6 @@ function clampWorkspaceTreeWidth(width: number, panelWidth?: number): number {
   return clampWorkspaceSplitTreeWidth({
     width,
     panelWidth,
-    railWidth: WORKSPACE_TREE_RAIL_WIDTH,
     treeMinWidth: WORKSPACE_TREE_MIN_WIDTH,
     previewMinWidth: WORKSPACE_PREVIEW_MIN_WIDTH,
   });
@@ -492,7 +490,6 @@ export function WorkspacePanel({
       if (initializeSplit) {
         setTreeWidth(initialWorkspaceSplitTreeWidth({
           panelWidth,
-          railWidth: WORKSPACE_TREE_RAIL_WIDTH,
           // Preserve a user-resized (manual) tree width: only first-time
           // splits (no saved width yet) default to an even 50/50 division.
           // Reopening a file after closing its preview must keep the
@@ -902,8 +899,6 @@ export function WorkspacePanel({
     [loadDir, revealedRootPaths, updateOpenDirs],
   );
 
-  const breadcrumbDirs = selectedPath ? parentDirs(selectedPath) : [""];
-  const pathParts = selectedPath?.split("/").filter(Boolean) ?? [];
   const sessionChanges = useMemo(
     () => workspaceChanges?.files.filter((c) => c.sources.includes("session")) ?? [],
     [workspaceChanges],
@@ -1174,12 +1169,10 @@ export function WorkspacePanel({
   const filePreviewActive = openTabs.length > 0 || selectedPath !== null;
   const changeDetailActive = changedMode && expandedCommit !== null;
   const previewVisible = changedMode || filePreviewActive;
-  const showTreeRail = previewVisible && !changedMode;
   const splitPanesFit = useMemo(
     () =>
       workspaceSplitCanFit({
         panelWidth,
-        railWidth: WORKSPACE_TREE_RAIL_WIDTH,
         treeMinWidth: WORKSPACE_TREE_MIN_WIDTH,
         previewMinWidth: WORKSPACE_PREVIEW_MIN_WIDTH,
       }),
@@ -1195,14 +1188,13 @@ export function WorkspacePanel({
         mode: treeWidthMode,
         currentTreeWidth: treeWidth,
         panelWidth,
-        railWidth: WORKSPACE_TREE_RAIL_WIDTH,
         treeMinWidth: WORKSPACE_TREE_MIN_WIDTH,
         previewMinWidth: WORKSPACE_PREVIEW_MIN_WIDTH,
       }),
     [panelWidth, treeWidth, treeWidthMode],
   );
   const maxTreeWidthForPanel = useMemo(
-    () => Math.max(WORKSPACE_TREE_MIN_WIDTH, (panelWidth ?? WORKSPACE_DUAL_PANEL_TARGET_WIDTH) - WORKSPACE_TREE_RAIL_WIDTH - WORKSPACE_PREVIEW_MIN_WIDTH),
+    () => Math.max(WORKSPACE_TREE_MIN_WIDTH, (panelWidth ?? WORKSPACE_DUAL_PANEL_TARGET_WIDTH) - WORKSPACE_PREVIEW_MIN_WIDTH),
     [panelWidth],
   );
 
@@ -1249,7 +1241,6 @@ export function WorkspacePanel({
   const showTreeEvenSplit = useCallback(() => {
     setTreeWidth(initialWorkspaceSplitTreeWidth({
       panelWidth,
-      railWidth: WORKSPACE_TREE_RAIL_WIDTH,
       savedTreeWidth: null,
       treeMinWidth: WORKSPACE_TREE_MIN_WIDTH,
       previewMinWidth: WORKSPACE_PREVIEW_MIN_WIDTH,
@@ -1318,7 +1309,6 @@ export function WorkspacePanel({
           clientX: moveEvent.clientX,
           panelLeft: rect.left,
           panelWidth: rect.width,
-          railWidth: WORKSPACE_TREE_RAIL_WIDTH,
           treeMinWidth: WORKSPACE_TREE_MIN_WIDTH,
           previewMinWidth: WORKSPACE_PREVIEW_MIN_WIDTH,
           treeOnRight: true,
@@ -1516,7 +1506,7 @@ export function WorkspacePanel({
     <MarkdownImageTabContext.Provider value={workspaceTabId}>
     <aside
       ref={panelRef}
-      className={`workspace-panel${embeddedDockMode ? " workspace-panel--embedded" : ""}${showTreeRail ? " workspace-panel--with-tree-rail" : ""}${changedMode ? " workspace-panel--detail-only" : ""}${changedMode && !selectedPath ? " workspace-panel--changed-overview" : ""}${previewVisible && actualTreeVisible ? " workspace-panel--split-preview" : ""}${actualTreeVisible ? "" : " workspace-panel--tree-hidden"}${previewVisible ? "" : " workspace-panel--preview-hidden"}${treeResizing ? " workspace-panel--tree-resizing" : ""}`}
+      className={`workspace-panel${embeddedDockMode ? " workspace-panel--embedded" : ""}${changedMode ? " workspace-panel--detail-only" : ""}${changedMode && !selectedPath ? " workspace-panel--changed-overview" : ""}${previewVisible && actualTreeVisible ? " workspace-panel--split-preview" : ""}${actualTreeVisible ? "" : " workspace-panel--tree-hidden"}${previewVisible ? "" : " workspace-panel--preview-hidden"}${treeResizing ? " workspace-panel--tree-resizing" : ""}`}
       aria-label={t("workspace.title")}
       style={panelStyle}
       onKeyDownCapture={(event) => {
@@ -1631,46 +1621,6 @@ export function WorkspacePanel({
             </div>
           </AnchoredPopover>
         </header>
-
-        <div className="workspace-preview__meta">
-          <Tooltip label={cwd}>
-            <button
-              className="workspace-crumb"
-              onClick={() => {
-                setFilter("");
-                showTreeEvenSplit();
-                updateOpenDirs((prev) => new Set([...Array.from(prev), ""]));
-                void loadDir("");
-              }}
-            >
-              {shortCwd(cwd) || t("workspace.title")}
-            </button>
-          </Tooltip>
-          {pathParts.map((part, index) => {
-            const isLast = index === pathParts.length - 1;
-            const dir = pathParts.slice(0, index + 1).join("/") + "/";
-            return (
-              <span className="workspace-crumb-group" key={`${part}-${index}`}>
-                <span>›</span>
-                <Tooltip label={isLast ? (selectedPath ?? undefined) : dir}>
-                  <button
-                    className={`workspace-crumb${isLast ? " workspace-crumb--current" : ""}`}
-                    onClick={() => {
-                      if (isLast) return;
-                      showTreeEvenSplit();
-                      setFilter("");
-                      updateOpenDirs((prev) => new Set([...Array.from(prev), ...breadcrumbDirs, dir]));
-                      void loadDir(dir);
-                    }}
-                  >
-                    {part}
-                  </button>
-                </Tooltip>
-              </span>
-            );
-          })}
-          {preview && preview.size > 0 && <span className="workspace-preview__size">{formatBytes(preview.size)}</span>}
-        </div>
 
         <div
           className={`workspace-preview__body${codePreviewLayoutActive ? " workspace-preview__body--code" : ""}`}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10036,7 +10036,6 @@ body > .mermaid-diagram--fullscreen {
 /* ── workspace side panel ────────────────────────────────────────────────── */
 .workspace-panel {
   --workspace-tree-width: 280px;
-  --workspace-tree-rail-width: 44px;
   --workspace-preview-min-width: 360px;
   position: relative;
   min-width: 0;
@@ -10052,15 +10051,6 @@ body > .mermaid-diagram--fullscreen {
 .workspace-panel--embedded {
   border-left: none;
 }
-.workspace-panel--with-tree-rail:not(.workspace-panel--tree-hidden) {
-  grid-template-columns: var(--workspace-tree-rail-width) minmax(var(--workspace-preview-min-width), 1fr) var(--workspace-tree-width);
-}
-.workspace-panel--with-tree-rail:not(.workspace-panel--tree-hidden) .workspace-files {
-  grid-column: 3;
-}
-.workspace-panel--with-tree-rail:not(.workspace-panel--tree-hidden) .workspace-preview {
-  grid-column: 2;
-}
 .workspace-panel--tree-hidden {
   grid-template-columns: minmax(0, 1fr);
 }
@@ -10073,8 +10063,7 @@ body > .mermaid-diagram--fullscreen {
 .workspace-panel--detail-only {
   grid-template-columns: minmax(0, 1fr);
 }
-.workspace-panel--detail-only .workspace-files,
-.workspace-panel--detail-only .workspace-tree-rail {
+.workspace-panel--detail-only .workspace-files {
   display: none;
 }
 .workspace-panel--detail-only .workspace-preview {
@@ -10118,9 +10107,6 @@ body > .mermaid-diagram--fullscreen {
   background: transparent;
   cursor: col-resize;
   touch-action: none;
-}
-.workspace-panel--with-tree-rail .workspace-tree-resizer {
-  left: calc(100% - var(--workspace-tree-width) - 4px);
 }
 .workspace-tree-resizer::after {
   content: "";
@@ -10344,78 +10330,6 @@ body > .mermaid-diagram--fullscreen {
 }
 .workspace-iconbtn--on {
   color: var(--fg-dim);
-}
-.workspace-tree-rail {
-  grid-row: 1;
-  grid-column: 1;
-  min-width: 0;
-  min-height: 0;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding-top: 6px;
-  background: var(--workspace-files-bg);
-  border-right: 1px solid var(--border-soft);
-}
-.workspace-panel--embedded .workspace-tree-rail {
-  padding-top: 9px;
-}
-.workspace-tree-reveal {
-  background: var(--bg-elev);
-  border: 1px solid var(--border-soft);
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
-}
-.workspace-preview__meta {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  min-width: 0;
-  padding: 8px 18px;
-  border-bottom: 1px solid var(--border-soft);
-  color: var(--fg-faint);
-  font-size: 11.5px;
-  white-space: nowrap;
-}
-.workspace-panel--embedded .workspace-preview__meta {
-  padding: 7px 12px;
-}
-.workspace-preview__meta span,
-.workspace-crumb {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.workspace-crumb,
-.workspace-crumb-group {
-  display: inline-flex;
-  align-items: center;
-  min-width: 0;
-  gap: 7px;
-}
-.workspace-crumb {
-  --wails-draggable: no-drag;
-  max-width: 160px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--fg-dim);
-  font: inherit;
-}
-.workspace-crumb:hover {
-  color: var(--fg);
-}
-.workspace-crumb--current {
-  color: var(--fg);
-  cursor: default;
-}
-.workspace-crumb--current:hover {
-  color: var(--fg);
-}
-.workspace-preview__size {
-  margin-left: auto;
-  flex-shrink: 0;
-  font-family: var(--mono);
 }
 .workspace-preview__body {
   position: relative;
@@ -27423,8 +27337,7 @@ body > .mermaid-diagram--fullscreen {
   border-radius: 7px;
 }
 
-.workspace-preview__head,
-.workspace-preview__meta {
+.workspace-preview__head {
   border-color: var(--border-soft);
 }
 
@@ -29522,8 +29435,7 @@ body > .mermaid-diagram--fullscreen {
   text-align: center;
 }
 
-:root[data-theme-style] .workspace-preview__head,
-:root[data-theme-style] .workspace-preview__meta {
+:root[data-theme-style] .workspace-preview__head {
   border-color: var(--border-soft);
 }
 
@@ -29543,8 +29455,7 @@ body > .mermaid-diagram--fullscreen {
   font-weight: 650;
 }
 
-:root[data-theme-style] .workspace-current-file__path,
-:root[data-theme-style] .workspace-preview__meta {
+:root[data-theme-style] .workspace-current-file__path {
   font-family: var(--mono);
 }
 
@@ -29554,20 +29465,6 @@ body > .mermaid-diagram--fullscreen {
   color: var(--fg);
   border-color: var(--border);
   background: var(--bg-soft);
-}
-
-:root[data-theme-style] .workspace-preview__meta {
-  min-height: 32px;
-  padding: 6px 12px;
-  background: var(--chat-bg);
-}
-
-:root[data-theme-style] .workspace-crumb {
-  color: var(--fg-dim);
-}
-
-:root[data-theme-style] .workspace-crumb--current {
-  color: var(--fg);
 }
 
 :root[data-theme-style] .workspace-preview__body {
@@ -34696,12 +34593,6 @@ body > .mermaid-diagram--fullscreen {
 /* Recent-files dropdown is not useful on Changes overview. */
 .app--creation .workbench-dock .workspace-panel--changed-overview .workspace-current-file__recent,
 :root[data-theme-style] .app--creation .workbench-dock .workspace-panel--changed-overview .workspace-current-file__recent {
-  display: none;
-}
-
-/* Second layer: breadcrumb path row (hide — duplicates the first path). */
-.app--creation .workbench-dock .workspace-panel--changed-overview .workspace-preview__meta,
-:root[data-theme-style] .app--creation .workbench-dock .workspace-panel--changed-overview .workspace-preview__meta {
   display: none;
 }
 


### PR DESCRIPTION
## 变更摘要

PR #8748 合并后，workspace 预览面板有三处布局残留需要清理：

1. **移除文件树图标列残留空间**：PR #8748 把 FolderTree 图标从 44px 竖列移到了 preview 头部，但那一列的 grid 空间、宽度预留和 CSS 都还留着，导致文件列表左侧流出一片空白。本次完全移除 rail 列（grid 回到两列 `preview | tree` 布局）。

2. **移除预览 meta 区冗余面包屑**：preview 头部文件名下方已有路径 crumb，meta 区又显示一遍 `workspace-crumb` 面包屑（项目名 › 目录 › 文件名），重复冗余。

3. **移除空的 meta 行**：删掉面包屑后 meta 行只剩文件大小显示，整行无保留价值，连同 `workspace-preview__size` 一起移除。

## 改动文件

- `desktop/frontend/src/components/WorkspacePanel.tsx` — 移除 rail 相关逻辑、meta 区面包屑与 meta 行
- `desktop/frontend/src/styles.css` — 移除 `.workspace-tree-rail`、`.workspace-crumb`、`.workspace-preview__meta/size` 相关样式
- `workspace-split.test.ts` / `workspace-preview-css.test.ts` / `workspace-resize-interaction.test.tsx` — 同步为无 rail 的两列布局断言

## 验证

- workspace 相关测试全部通过（split 23 / preview-css 36 / resize 4 / selection-isolation 6 / changes-errors 54）
- `tsc --noEmit`、CSS 语法/z-index 检查、eslint 通过
- pr-review 审查通过（ship as-is）

Documentation-impact: none - 纯桌面端 UI 布局清理，不涉及 docs/ 或用户可见文档内容
