### PR TITLE
fix(desktop): hide load-more while sidebar filter is active / 侧边栏筛选生效时隐藏加载更多

### DIFF
--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1548,6 +1548,9 @@ export function ProjectTree({
       ? classicTopicWindow(children, folderShowAll)
       : { visible: children, hiddenCount: 0 };
     const windowToggleVisible = classicTruncationActive && (hiddenCount > 0 || (folderShowAll && children.length > CLASSIC_TOPIC_PREVIEW_LIMIT));
+    // Filtering (search query or time range) narrows the page to a closed view;
+    // paging through a filtered result adds little value, so hide load-more.
+    const filtering = query.trim() !== "" || timeFilter !== "all";
     const backendPage = topicPageState[key];
     const renderFolderChildren = () => {
       if (!hasChildren) {
@@ -1576,7 +1579,7 @@ export function ProjectTree({
                 {hiddenCount > 0 ? t("projectTree.showMoreTopics", { n: hiddenCount }) : t("projectTree.showFewerTopics")}
               </button>
             )}
-            {backendPage?.nextCursor && (
+            {backendPage?.nextCursor && !filtering && (
               <button
                 type="button"
                 className="project-tree__topic-window-toggle"


### PR DESCRIPTION
## 变更摘要

左侧边栏（会话列表）顶部做筛选（搜索关键词或时间范围）后，列表是收敛后的窄视图，此时继续分页价值不大——筛选生效时隐藏每个项目文件夹底部的「加载更多」按钮，清空筛选后恢复。

## 改动文件

- `desktop/frontend/src/components/ProjectTree.tsx`（5 行）

## 实现方式

复用既有的 `filtering = query.trim() !== "" || timeFilter !== "all"` 判断（与 `loadProjectTopics` 的加载逻辑同源），渲染「加载更多」按钮时追加 `!filtering` 条件。经典截断（`classicTruncationActive`）本身只在无筛选时激活，与后端分页按钮互斥，无逻辑冲突。

## 验证

- `npx tsc --noEmit` 通过
- `npx eslint src/components/ProjectTree.tsx` 通过
- project-tree 相关契约测试（catalog-completeness / archive-race / organization / pinned-header / pinned-shell-runtime）全部通过
- 本地 `wails build` 打包后实际验收：筛选生效时不显示加载更多，清空后恢复

Documentation-impact: none - 纯前端交互逻辑改动，不涉及文档内容