### PR TITLE
Performance: fuse session digest into decode / 性能：融合会话摘要解码

### DIFF
--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -1130,6 +1131,59 @@ func digestAndSizeSessionMessages(msgs []provider.Message) ([sha256.Size]byte, i
 	return out, size, nil
 }
 
+// sessionTranscriptHasher accumulates the transcript digest one message at a
+// time, exactly like digestAndSizeSessionMessages, so load paths hash during
+// decode instead of re-serializing. A nil receiver disables hashing.
+type sessionTranscriptHasher struct {
+	h   hash.Hash
+	err error
+}
+
+func newSessionTranscriptHasher() *sessionTranscriptHasher {
+	return &sessionTranscriptHasher{h: sha256.New()}
+}
+
+// rehash restarts accumulation over msgs (event-log replace records).
+func (s *sessionTranscriptHasher) rehash(msgs []provider.Message) {
+	if s == nil {
+		return
+	}
+	s.h.Reset()
+	s.err = nil
+	s.addAll(msgs)
+}
+
+func (s *sessionTranscriptHasher) addAll(msgs []provider.Message) {
+	for _, m := range msgs {
+		s.add(m)
+	}
+}
+
+// add hashes one message and returns it for append chaining.
+func (s *sessionTranscriptHasher) add(m provider.Message) provider.Message {
+	if s == nil || s.err != nil {
+		return m
+	}
+	b, err := json.Marshal(messageForSessionIdentity(m))
+	if err != nil {
+		s.err = err
+		return m
+	}
+	_, _ = s.h.Write(b)
+	_, _ = s.h.Write([]byte{'\n'})
+	return m
+}
+
+// sum reports the accumulated digest; ok is false when hashing was disabled
+// or a message failed to encode, and callers fall back to digestSessionMessages.
+func (s *sessionTranscriptHasher) sum() (digest [sha256.Size]byte, ok bool) {
+	if s == nil || s.err != nil {
+		return digest, false
+	}
+	copy(digest[:], s.h.Sum(nil))
+	return digest, true
+}
+
 func messagesHavePrefix(full, prefix []provider.Message) bool {
 	if len(prefix) > len(full) {
 		return false
@@ -1392,7 +1446,8 @@ func LoadSession(path string) (*Session, error) {
 }
 
 func loadSessionUnlocked(path string) (*Session, error) {
-	msgs, _, damaged, err := loadSessionMessages(path)
+	hasher := newSessionTranscriptHasher()
+	msgs, _, damaged, err := loadSessionMessagesWithLimits(path, defaultSessionReplayLimits, hasher)
 	if err != nil {
 		return nil, err
 	}
@@ -1418,7 +1473,17 @@ func loadSessionUnlocked(path string) (*Session, error) {
 		s.rawMessages = msgs
 	}
 	s.Messages = normalized
-	if digest, err := digestSessionMessages(s.Messages); err == nil {
+	// Decode already hashed the transcript; when the repairs above returned it
+	// unchanged (the common case) reuse that digest, else re-hash the repair.
+	digest, digestOK := hasher.sum()
+	if s.normalizedDirty || !digestOK {
+		if d, derr := digestSessionMessages(s.Messages); derr == nil {
+			digest, digestOK = d, true
+		} else {
+			digestOK = false
+		}
+	}
+	if digestOK {
 		// Pair the raw pre-repair transcript when normalization changed it.
 		diskView := s.Messages
 		if s.normalizedDirty {

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -1046,7 +1046,7 @@ func TestSaveSnapshotAppendsEventLogAndDisplayReadModel(t *testing.T) {
 	if !os.SameFile(checkpointBefore, checkpointAfter) {
 		t.Fatal("append-only snapshot replaced the display read model")
 	}
-	checkpoint, err := loadSessionMessagesFromJSONL(path)
+	checkpoint, err := loadSessionMessagesFromJSONL(path, nil)
 	if err != nil {
 		t.Fatalf("read display read model: %v", err)
 	}
@@ -1105,7 +1105,7 @@ func TestSaveRewriteAppendsReplaceEventAndRefreshesCheckpoint(t *testing.T) {
 	}
 	// Rewrites refresh the compatibility checkpoint so direct .jsonl readers
 	// and older binaries stay bounded-stale instead of frozen at first save.
-	anchor, err := loadSessionMessagesFromJSONL(path)
+	anchor, err := loadSessionMessagesFromJSONL(path, nil)
 	if err != nil {
 		t.Fatalf("read checkpoint after rewrite: %v", err)
 	}

--- a/internal/agent/session_content.go
+++ b/internal/agent/session_content.go
@@ -80,7 +80,7 @@ func loadSessionUserMessagesWithLimits(path string, limits sessionReplayLimits) 
 		return nil, fmt.Errorf("session event log for %s uses schema %d; this build supports up to %d", path, probe.schemaVersion, sessionEventSchemaVersion)
 	}
 	if probe.native && probe.size > 0 {
-		replay, err := replaySessionEventLogWithLimits(store.SessionEventLog(path), limits)
+		replay, err := replaySessionEventLogWithLimits(store.SessionEventLog(path), limits, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -102,7 +102,7 @@ func loadSessionUserMessagesWithLimits(path string, limits sessionReplayLimits) 
 			return out, nil
 		}
 	}
-	msgs, err := loadSessionMessagesFromJSONL(path)
+	msgs, err := loadSessionMessagesFromJSONL(path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/session_display_index_test.go
+++ b/internal/agent/session_display_index_test.go
@@ -375,7 +375,7 @@ func TestRepairSessionDisplayReadModelFromAuthoritativeEventLog(t *testing.T) {
 	if err := RepairSessionDisplayReadModel(path); err != nil {
 		t.Fatalf("RepairSessionDisplayReadModel: %v", err)
 	}
-	repaired, err := loadSessionMessagesFromJSONL(path)
+	repaired, err := loadSessionMessagesFromJSONL(path, nil)
 	if err != nil || !reflect.DeepEqual(repaired, msgs) {
 		t.Fatalf("repaired model = %+v, err %v; want %+v", repaired, err, msgs)
 	}

--- a/internal/agent/session_display_read_model.go
+++ b/internal/agent/session_display_read_model.go
@@ -26,13 +26,17 @@ func LoadSessionDisplayMessages(path string) ([]provider.Message, PersistedState
 }
 
 func loadSessionDisplayMessagesUnlocked(path string) ([]provider.Message, PersistedState, bool, error) {
-	msgs, _, damaged, err := loadSessionMessages(path)
+	hasher := newSessionTranscriptHasher()
+	msgs, _, damaged, err := loadSessionMessagesWithLimits(path, defaultSessionReplayLimits, hasher)
 	if err != nil {
 		return nil, PersistedState{}, false, err
 	}
-	digest, err := digestSessionMessages(msgs)
-	if err != nil {
-		return nil, PersistedState{}, false, err
+	digest, digestOK := hasher.sum()
+	if !digestOK {
+		digest, err = digestSessionMessages(msgs)
+		if err != nil {
+			return nil, PersistedState{}, false, err
+		}
 	}
 	revision, ledgerDigest, err := sessionContentRevision(path)
 	if err != nil {

--- a/internal/agent/session_events.go
+++ b/internal/agent/session_events.go
@@ -332,10 +332,10 @@ func probeSessionEventHeader(r io.Reader) (schemaVersion int, eventType string, 
 // versions and unknown event types stay hard errors — they mean a newer writer
 // owns this log, and truncating it would discard that writer's data.
 func replaySessionEventLog(path string) (sessionEventReplay, error) {
-	return replaySessionEventLogWithLimits(path, defaultSessionReplayLimits)
+	return replaySessionEventLogWithLimits(path, defaultSessionReplayLimits, nil)
 }
 
-func replaySessionEventLogWithLimits(path string, limits sessionReplayLimits) (sessionEventReplay, error) {
+func replaySessionEventLogWithLimits(path string, limits sessionReplayLimits, hasher *sessionTranscriptHasher) (sessionEventReplay, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return sessionEventReplay{}, err
@@ -384,14 +384,13 @@ func replaySessionEventLogWithLimits(path string, limits sessionReplayLimits) (s
 			replay.msgs = msgs
 			replay.collectionItems = collectionItems
 			replay.times = make([]time.Time, len(replay.msgs))
+			hasher.rehash(msgs)
 		case sessionEventTypeAppend:
 			if rec.MessageIndex != len(replay.msgs) {
 				replay.damaged = true
 				return replay, nil
 			}
-			msgs, collectionItems, err := decodeSessionEventMessages(
-				path, rec.Messages, len(replay.msgs), replay.collectionItems, limits,
-			)
+			msgs, collectionItems, err := decodeSessionEventMessages(path, rec.Messages, len(replay.msgs), replay.collectionItems, limits)
 			if err != nil {
 				if errors.Is(err, ErrSessionReplayLimitExceeded) {
 					return replay, err
@@ -404,6 +403,7 @@ func replaySessionEventLogWithLimits(path string, limits sessionReplayLimits) (s
 			for range msgs {
 				replay.times = append(replay.times, rec.CreatedAt)
 			}
+			hasher.addAll(msgs)
 		default:
 			return replay, fmt.Errorf("decode session event log %s: unsupported event type %q", path, rec.Type)
 		}
@@ -555,10 +555,10 @@ func preflightSessionEventValue(path string, dec *json.Decoder, collectionItems 
 // not be replayed to its end (torn tail or corrupt record); callers that write
 // should rewrite-and-compact to heal it.
 func loadSessionMessages(sessionPath string) (msgs []provider.Message, fromEvents, damaged bool, err error) {
-	return loadSessionMessagesWithLimits(sessionPath, defaultSessionReplayLimits)
+	return loadSessionMessagesWithLimits(sessionPath, defaultSessionReplayLimits, nil)
 }
 
-func loadSessionMessagesWithLimits(sessionPath string, limits sessionReplayLimits) (msgs []provider.Message, fromEvents, damaged bool, err error) {
+func loadSessionMessagesWithLimits(sessionPath string, limits sessionReplayLimits, hasher *sessionTranscriptHasher) (msgs []provider.Message, fromEvents, damaged bool, err error) {
 	probe, err := probeSessionEventLogWithLimits(sessionPath, limits)
 	if err != nil {
 		return nil, false, false, err
@@ -567,7 +567,7 @@ func loadSessionMessagesWithLimits(sessionPath string, limits sessionReplayLimit
 		return nil, true, false, fmt.Errorf("session event log for %s uses schema %d; this build supports up to %d", sessionPath, probe.schemaVersion, sessionEventSchemaVersion)
 	}
 	if probe.native && probe.size > 0 {
-		replay, replayErr := replaySessionEventLogWithLimits(store.SessionEventLog(sessionPath), limits)
+		replay, replayErr := replaySessionEventLogWithLimits(store.SessionEventLog(sessionPath), limits, hasher)
 		if replayErr != nil {
 			return nil, true, false, replayErr
 		}
@@ -576,14 +576,14 @@ func loadSessionMessagesWithLimits(sessionPath string, limits sessionReplayLimit
 		}
 		// Defensive: the probe saw a native head but nothing replayed; fall
 		// back to the checkpoint and let the next save rebuild the log.
-		msgs, err = loadSessionMessagesFromJSONL(sessionPath)
+		msgs, err = loadSessionMessagesFromJSONL(sessionPath, hasher)
 		return msgs, false, true, err
 	}
-	msgs, err = loadSessionMessagesFromJSONL(sessionPath)
+	msgs, err = loadSessionMessagesFromJSONL(sessionPath, hasher)
 	return msgs, false, false, err
 }
 
-func loadSessionMessagesFromJSONL(path string) ([]provider.Message, error) {
+func loadSessionMessagesFromJSONL(path string, hasher *sessionTranscriptHasher) ([]provider.Message, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -600,7 +600,7 @@ func loadSessionMessagesFromJSONL(path string) ([]provider.Message, error) {
 			}
 			return nil, fmt.Errorf("decode %s: %w", path, err)
 		}
-		msgs = append(msgs, m)
+		msgs = append(msgs, hasher.add(m))
 	}
 	return msgs, nil
 }

--- a/internal/agent/session_events_test.go
+++ b/internal/agent/session_events_test.go
@@ -343,7 +343,7 @@ func TestReplaySessionEventLogEnforcesResourceBudgetsWithoutMutation(t *testing.
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := replaySessionEventLogWithLimits(logPath, tc.limits); !errors.Is(err, ErrSessionReplayLimitExceeded) {
+			if _, err := replaySessionEventLogWithLimits(logPath, tc.limits, nil); !errors.Is(err, ErrSessionReplayLimitExceeded) {
 				t.Fatalf("replay error = %v, want ErrSessionReplayLimitExceeded", err)
 			} else {
 				var limitErr *SessionReplayLimitError
@@ -376,7 +376,7 @@ func TestReplayChecksMessageBudgetBeforeDecodingOverLimitElement(t *testing.T) {
 
 	replay, err := replaySessionEventLogWithLimits(logPath, sessionReplayLimits{
 		maxBytes: int64(len(events) + 1), maxRecords: 10, maxMessages: 2,
-	})
+	}, nil)
 	if !errors.Is(err, ErrSessionReplayLimitExceeded) {
 		t.Fatalf("replay error = %v, want message replay limit", err)
 	}
@@ -400,7 +400,7 @@ func TestReplayChecksCollectionBudgetBeforeDecodingOverLimitElement(t *testing.T
 
 	replay, err := replaySessionEventLogWithLimits(logPath, sessionReplayLimits{
 		maxBytes: int64(len(events) + 1), maxRecords: 10, maxMessages: 10, maxCollectionItems: 2,
-	})
+	}, nil)
 	if !errors.Is(err, ErrSessionReplayLimitExceeded) {
 		t.Fatalf("replay error = %v, want collection replay limit", err)
 	}
@@ -427,7 +427,7 @@ func TestReplayCollectionBudgetAggregatesAcrossRecords(t *testing.T) {
 
 	replay, err := replaySessionEventLogWithLimits(logPath, sessionReplayLimits{
 		maxBytes: int64(len(events) + 1), maxRecords: 10, maxMessages: 10, maxCollectionItems: 2,
-	})
+	}, nil)
 	if !errors.Is(err, ErrSessionReplayLimitExceeded) {
 		t.Fatalf("replay error = %v, want aggregate collection replay limit", err)
 	}
@@ -455,7 +455,7 @@ func TestLoadSessionMessagesDoesNotFallbackAfterEventReplayBudget(t *testing.T) 
 
 	msgs, fromEvents, damaged, err := loadSessionMessagesWithLimits(path, sessionReplayLimits{
 		maxBytes: int64(len(events) + 1), maxRecords: 10, maxMessages: 1,
-	})
+	}, nil)
 	if !errors.Is(err, ErrSessionReplayLimitExceeded) {
 		t.Fatalf("load error = %v, want ErrSessionReplayLimitExceeded", err)
 	}
@@ -585,7 +585,7 @@ func TestEventLogCompactionBoundsGrowth(t *testing.T) {
 	if got := loaded.Messages[len(loaded.Messages)-1].Content; got != strings.Repeat("z", 60) {
 		t.Fatalf("compacted transcript tail wrong: %q", got[:min(8, len(got))])
 	}
-	anchor, err := loadSessionMessagesFromJSONL(path)
+	anchor, err := loadSessionMessagesFromJSONL(path, nil)
 	if err != nil {
 		t.Fatalf("read anchor: %v", err)
 	}

--- a/internal/agent/session_load_digest_test.go
+++ b/internal/agent/session_load_digest_test.go
@@ -1,0 +1,313 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// legacyDigestSessionMessages is the pre-fusion reference implementation: a
+// full re-serialize pass over the final message slice. The incremental hasher
+// fed during decode must reproduce it byte-for-byte.
+func legacyDigestSessionMessages(msgs []provider.Message) ([sha256.Size]byte, error) {
+	h := sha256.New()
+	for _, m := range msgs {
+		m = messageForSessionIdentity(m)
+		b, err := json.Marshal(m)
+		if err != nil {
+			return [sha256.Size]byte{}, err
+		}
+		if _, err := h.Write(b); err != nil {
+			return [sha256.Size]byte{}, err
+		}
+		if _, err := h.Write([]byte{'\n'}); err != nil {
+			return [sha256.Size]byte{}, err
+		}
+	}
+	var out [sha256.Size]byte
+	copy(out[:], h.Sum(nil))
+	return out, nil
+}
+
+// representativeSessionMessages mixes the message shapes a long real session
+// carries: system prompt, plain text, multimodal user input, reasoning with
+// provider signatures, tool calls and their results, and display timestamps
+// (which the digest must keep ignoring).
+func representativeSessionMessages() []provider.Message {
+	return []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "prompt one", CreatedAt: 1720000000000},
+		{Role: provider.RoleAssistant, Content: "thinking about it", ReasoningContent: "chain of thought", ReasoningID: "rs_1", ReasoningStatus: "completed", ReasoningSignature: "sig"},
+		{Role: provider.RoleUser, Content: "with image", Images: []string{"data:image/png;base64,aGVsbG8="}, CreatedAt: 1720000001000},
+		{Role: provider.RoleAssistant, Content: "", ToolCalls: []provider.ToolCall{
+			{ID: "call_1", Name: "read_file", Arguments: `{"path":"a.go"}`},
+		}},
+		{Role: provider.RoleTool, ToolCallID: "call_1", Name: "read_file", Content: "package main"},
+		{Role: provider.RoleAssistant, Content: "final answer", WorkDurationMs: 42},
+	}
+}
+
+func writeLegacyJSONLSession(t *testing.T, path string, msgs []provider.Message) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("open jsonl: %v", err)
+	}
+	enc := json.NewEncoder(f)
+	for _, m := range msgs {
+		if err := enc.Encode(m); err != nil {
+			f.Close()
+			t.Fatalf("encode jsonl: %v", err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close jsonl: %v", err)
+	}
+}
+
+// loadAndDigestSessionMessages loads like LoadSession does and returns the
+// decode-fused digest alongside the messages.
+func loadAndDigestSessionMessages(path string) (msgs []provider.Message, fromEvents, damaged bool, digest [sha256.Size]byte, digestOK bool, err error) {
+	hasher := newSessionTranscriptHasher()
+	msgs, fromEvents, damaged, err = loadSessionMessagesWithLimits(path, defaultSessionReplayLimits, hasher)
+	digest, digestOK = hasher.sum()
+	return msgs, fromEvents, damaged, digest, digestOK, err
+}
+
+func TestLoadSessionMessagesWithDigestMatchesLegacyEventLog(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	for _, m := range representativeSessionMessages()[1:] {
+		s.Add(m)
+		// One save per message forces a replace record plus a chain of append
+		// records, exercising the hasher across both event types.
+		if err := s.SaveSnapshot(path); err != nil {
+			t.Fatalf("SaveSnapshot: %v", err)
+		}
+	}
+
+	msgs, fromEvents, damaged, digest, digestOK, err := loadAndDigestSessionMessages(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !fromEvents || damaged {
+		t.Fatalf("fromEvents=%v damaged=%v, want event-log replay without damage", fromEvents, damaged)
+	}
+	if !digestOK {
+		t.Fatal("digestOK = false, want true")
+	}
+	want, err := legacyDigestSessionMessages(msgs)
+	if err != nil {
+		t.Fatalf("legacy digest: %v", err)
+	}
+	if digest != want {
+		t.Fatalf("incremental digest %x != legacy digest %x", digest, want)
+	}
+}
+
+func TestLoadSessionMessagesWithDigestMatchesLegacyJSONL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	writeLegacyJSONLSession(t, path, representativeSessionMessages())
+
+	msgs, fromEvents, damaged, digest, digestOK, err := loadAndDigestSessionMessages(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if fromEvents || damaged {
+		t.Fatalf("fromEvents=%v damaged=%v, want plain jsonl load", fromEvents, damaged)
+	}
+	if !digestOK {
+		t.Fatal("digestOK = false, want true")
+	}
+	want, err := legacyDigestSessionMessages(msgs)
+	if err != nil {
+		t.Fatalf("legacy digest: %v", err)
+	}
+	if digest != want {
+		t.Fatalf("incremental digest %x != legacy digest %x", digest, want)
+	}
+}
+
+func TestLoadSessionMessagesWithDigestCoversOnlyCleanPrefix(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	sessionWithTurns(t, path, 2)
+
+	logPath := SessionEventLogPath(path)
+	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	if _, err := f.Write([]byte(`{"schema_version":1,"type":"append","message_index":5,"mess`)); err != nil {
+		t.Fatalf("write torn tail: %v", err)
+	}
+	f.Close()
+
+	msgs, _, damaged, digest, digestOK, err := loadAndDigestSessionMessages(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !damaged {
+		t.Fatal("damaged = false, want true for torn tail")
+	}
+	if !digestOK {
+		t.Fatal("digestOK = false, want true")
+	}
+	// The digest must cover exactly the replayable prefix the caller received,
+	// never bytes from the torn record.
+	want, err := legacyDigestSessionMessages(msgs)
+	if err != nil {
+		t.Fatalf("legacy digest: %v", err)
+	}
+	if digest != want {
+		t.Fatalf("incremental digest %x != legacy digest %x", digest, want)
+	}
+}
+
+func TestLoadSessionDigestFastPathKeepsPersistedBaseline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	for _, m := range representativeSessionMessages()[1:] {
+		s.Add(m)
+	}
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if loaded.normalizedDirty {
+		t.Fatal("normalizedDirty = true for a well-formed session, want false")
+	}
+	// The baseline anchored during load must equal the legacy digest of the
+	// loaded transcript; otherwise change detection (HasUnsavedChanges) would
+	// report phantom writes or miss real ones.
+	want, err := legacyDigestSessionMessages(loaded.Snapshot())
+	if err != nil {
+		t.Fatalf("legacy digest: %v", err)
+	}
+	if !loaded.persisted.ok || loaded.persisted.digest != want {
+		t.Fatalf("persisted baseline digest %x (ok=%v) != legacy digest %x", loaded.persisted.digest, loaded.persisted.ok, want)
+	}
+	if loaded.HasUnsavedChanges(path) {
+		t.Fatal("HasUnsavedChanges = true right after a clean load, want false")
+	}
+}
+
+func TestLoadSessionDigestRecomputedAfterNormalizationRepair(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	// Dangling tool call: normalization fabricates a placeholder tool result,
+	// so the persisted baseline must be the digest of the repaired transcript.
+	writeLegacyJSONLSession(t, path, []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "run it"},
+		{Role: provider.RoleAssistant, Content: "", ToolCalls: []provider.ToolCall{
+			{ID: "call_1", Name: "read_file", Arguments: `{"path":"a.go"}`},
+		}},
+	})
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if !loaded.normalizedDirty {
+		t.Fatal("normalizedDirty = false, want true for a dangling tool call")
+	}
+	want, err := legacyDigestSessionMessages(loaded.Snapshot())
+	if err != nil {
+		t.Fatalf("legacy digest: %v", err)
+	}
+	if !loaded.persisted.ok || loaded.persisted.digest != want {
+		t.Fatalf("persisted baseline digest %x (ok=%v) != legacy digest of repaired transcript %x", loaded.persisted.digest, loaded.persisted.ok, want)
+	}
+	rawWant, err := legacyDigestSessionMessages(loaded.rawMessages)
+	if err != nil {
+		t.Fatalf("legacy raw digest: %v", err)
+	}
+	if loaded.persisted.digest == rawWant {
+		t.Fatal("persisted baseline still hashes the pre-repair transcript")
+	}
+}
+
+func TestLoadSessionDisplayMessagesDigestMatchesLegacy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	for _, m := range representativeSessionMessages()[1:] {
+		s.Add(m)
+	}
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	msgs, state, clean, err := LoadSessionDisplayMessages(path)
+	if err != nil {
+		t.Fatalf("LoadSessionDisplayMessages: %v", err)
+	}
+	if !clean {
+		t.Fatal("clean = false, want true")
+	}
+	want, err := legacyDigestSessionMessages(msgs)
+	if err != nil {
+		t.Fatalf("legacy digest: %v", err)
+	}
+	if state.Digest != want || state.DigestHex != digestString(want) {
+		t.Fatalf("display digest %s != legacy digest %s", state.DigestHex, digestString(want))
+	}
+}
+
+// BenchmarkLoadSessionDigestFusion contrasts the old load shape (decode pass +
+// separate full re-serialize digest pass) with the fused decode-time digest on
+// a synthetic long session with realistic tool-output sizes.
+func BenchmarkLoadSessionDigestFusion(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	bigResult := strings.Repeat("package main // line of tool output\n", 128) // ~4KB
+	for range 400 {
+		for _, m := range representativeSessionMessages()[1:] {
+			if m.Role == provider.RoleTool {
+				m.Content = bigResult
+			}
+			s.Add(m)
+		}
+	}
+	if err := s.SaveSnapshot(path); err != nil {
+		b.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	b.Run("digest_pass_only", func(b *testing.B) {
+		msgs, _, _, err := loadSessionMessages(path)
+		if err != nil {
+			b.Fatalf("loadSessionMessages: %v", err)
+		}
+		b.ResetTimer()
+		for b.Loop() {
+			if _, err := digestSessionMessages(msgs); err != nil {
+				b.Fatalf("digestSessionMessages: %v", err)
+			}
+		}
+	})
+	b.Run("separate_digest_pass", func(b *testing.B) {
+		for b.Loop() {
+			msgs, _, _, err := loadSessionMessages(path)
+			if err != nil {
+				b.Fatalf("loadSessionMessages: %v", err)
+			}
+			if _, err := digestSessionMessages(msgs); err != nil {
+				b.Fatalf("digestSessionMessages: %v", err)
+			}
+		}
+	})
+	b.Run("fused_decode_digest", func(b *testing.B) {
+		for b.Loop() {
+			if _, _, _, _, ok, err := loadAndDigestSessionMessages(path); err != nil || !ok {
+				b.Fatalf("fused load: ok=%v err=%v", ok, err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Problem: session loading decoded the same persisted content through multiple paths, increasing startup work and making the display projection depend on repeated parsing.

Root cause: the decode result was not shared across the load and display projections.

Fix: fuse the session digest into the decode path and reuse the canonical content identity while preserving existing fallback behavior.

Verification: `go test ./internal/agent`.

Documentation-impact: none - this is an internal session persistence and digest consistency optimization; it adds no user-facing configuration, workflow, or documented behavior.

This is an adapted, focused replacement for the corresponding part of #9195.
