### PR TITLE
Fix: surface web search result deltas / 修复：展示 Web Search 增量结果

### DIFF
--- a/desktop/frontend/src/__tests__/search-sources.test.ts
+++ b/desktop/frontend/src/__tests__/search-sources.test.ts
@@ -32,6 +32,12 @@ eq(
 eq(formatSearchFootnotesMarkdown([{ title: "bad", url: "javascript:alert(1)" }]), "\n- **bad**\n", "unsafe URLs are dropped");
 eq(parseSearchSources("新闻本文\nhttps://example.com/a\nNo URL").length, 2, "output parser keeps title-only hits");
 eq(parseSearchSources("新闻本文\nhttps://example.com/a")[0]?.title, "新闻本文", "output parser keeps the title");
+eq(parseSearchSources("新闻本文\r\nhttps://example.com/a\r\n")[0]?.url, "https://example.com/a", "output parser tolerates CRLF line endings");
+const degraded = parseSearchSources("- **新闻本文**\n  <https://example.com/a>");
+eq(degraded.length, 1, "degraded footnote-markdown dump still resolves to one source");
+eq(degraded[0]?.title, "新闻本文", "degraded dump strips the bullet and bold markers from the title");
+eq(degraded[0]?.url, "https://example.com/a", "degraded dump unwraps the autolink URL");
+eq(parseSearchSources("<https://example.com/a>")[0]?.url, "https://example.com/a", "autolink-only lines parse as URL sources");
 eq(mergeSearchSources([{ title: "A", url: "https://a.example" }], [{ title: "A", url: "https://a.example" }]).length, 1, "duplicate hits collapse");
 
 const history = historyMessagesToItems([{

--- a/desktop/frontend/src/lib/searchSources.ts
+++ b/desktop/frontend/src/lib/searchSources.ts
@@ -49,13 +49,18 @@ export function parseSearchSources(output: string): SearchSource[] {
   const lines = output.split("\n").map((line) => line.trim()).filter(Boolean);
   const out: SearchSource[] = [];
   for (const line of lines) {
-    if (/^https?:\/\//i.test(line)) {
+    // Tolerate the footnote-markdown shape (`- **title**` / `<url>`) as well:
+    // if a degraded plain-text dump ever reaches this parser (#8900), sources
+    // still resolve into cards/footnotes instead of leaking raw markup.
+    const urlMatch = /^<?(https?:\/\/[^>\s]+)>?$/i.exec(line);
+    if (urlMatch) {
       const last = out[out.length - 1];
-      if (last && !last.url) last.url = line;
-      else out.push({ url: line });
+      if (last && !last.url) last.url = urlMatch[1];
+      else out.push({ url: urlMatch[1] });
       continue;
     }
-    out.push({ title: line });
+    const titleMatch = /^[-*]\s+\*\*(.+)\*\*$/.exec(line);
+    out.push({ title: titleMatch?.[1] ?? line });
   }
   return out;
 }

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -628,6 +628,15 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 						return
 					}
 				}
+			case "web_search_tool_result_delta":
+				// Some DeepSeek-compatible streams deliver the result array in a
+				// delta instead of the block-start content; without this the card
+				// stays empty and the model-written source list is all that shows.
+				if next := searches.resultsDelta(ev.Index, ev.Delta.WebSearchResults); next != nil {
+					if !send(provider.Chunk{Type: provider.ChunkServerSearch, ServerSearch: next}) {
+						return
+					}
+				}
 			}
 		case "content_block_stop":
 			if tc := tools[ev.Index]; tc != nil {

--- a/internal/provider/anthropic/web_search_stream.go
+++ b/internal/provider/anthropic/web_search_stream.go
@@ -64,6 +64,9 @@ func beginContentBlock(index int, block *streamContentBlock, tools map[int]*prov
 		}
 	case "web_search_tool_result":
 		if result := searches.result(block.ToolUseID, block.Content); result != nil {
+			// Register the result block's stream index too: streams that do not
+			// inline the content deliver it via web_search_tool_result_delta.
+			searches.byIndex[index] = searches.byID[block.ToolUseID]
 			return &provider.Chunk{Type: provider.ChunkServerSearch, ServerSearch: result}
 		}
 	}
@@ -92,6 +95,19 @@ func (s *searchStream) result(id string, raw json.RawMessage) *provider.ServerSe
 		block.call.Raw = append(json.RawMessage(nil), raw...)
 		block.call.Results = provider.ParseServerSearchHits(raw)
 	}
+	return cloneServerSearch(block.call)
+}
+
+// resultsDelta ingests a web_search_tool_result_delta payload: the result
+// array arrives after block start on streams that do not inline it in the
+// web_search_tool_result content_block_start content.
+func (s *searchStream) resultsDelta(index int, raw json.RawMessage) *provider.ServerSearchCall {
+	block := s.byIndex[index]
+	if block == nil || len(raw) == 0 {
+		return nil
+	}
+	block.call.Raw = append(json.RawMessage(nil), raw...)
+	block.call.Results = provider.ParseServerSearchHits(raw)
 	return cloneServerSearch(block.call)
 }
 

--- a/internal/provider/anthropic/web_search_test.go
+++ b/internal/provider/anthropic/web_search_test.go
@@ -157,6 +157,69 @@ func TestStreamSurfacesWebSearchResults(t *testing.T) {
 	}
 }
 
+// TestStreamSurfacesWebSearchResultDelta covers streams that deliver the
+// result array in a web_search_tool_result_delta after an empty block start
+// instead of inlining it in the block-start content.
+func TestStreamSurfacesWebSearchResultDelta(t *testing.T) {
+	sse := strings.Join([]string{
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`,
+		``,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"s1","name":"web_search"}}`,
+		``,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"latest\"}"}}`,
+		``,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"web_search_tool_result","tool_use_id":"s1","content":[]}}`,
+		``,
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"web_search_tool_result_delta","results":[{"title":"Change Log","url":"https://api-docs.deepseek.com/updates/"}]}}`,
+		``,
+		`data: {"type":"content_block_start","index":2,"content_block":{"type":"text"}}`,
+		``,
+		`data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"answer"}}`,
+		``,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`,
+		``,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(sse))
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4-flash", APIKey: "k", Extra: map[string]any{"web_search": true}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "search something"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var text strings.Builder
+	var searches []provider.ServerSearchCall
+	for chunk := range ch {
+		switch chunk.Type {
+		case provider.ChunkText:
+			text.WriteString(chunk.Text)
+		case provider.ChunkServerSearch:
+			if chunk.ServerSearch != nil {
+				searches = provider.MergeServerSearch(searches, *chunk.ServerSearch)
+			}
+		case provider.ChunkError:
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+	}
+	if text.String() != "answer" {
+		t.Fatalf("answer text = %q, want only the model reply", text.String())
+	}
+	if len(searches) != 1 || searches[0].ID != "s1" || searches[0].Query != "latest" || len(searches[0].Results) != 1 || searches[0].Results[0].Title != "Change Log" {
+		t.Fatalf("delta-delivered searches = %#v", searches)
+	}
+}
+
 func TestBuildRequestReplaysServerSearchBlocks(t *testing.T) {
 	c := &client{name: "deepseek", model: "deepseek-v4-flash", webSearch: true}
 	raw := json.RawMessage(`[{"title":"Change Log","url":"https://api-docs.deepseek.com/updates/","encrypted_content":"xxx"}]`)


### PR DESCRIPTION
Problem: Anthropic web-search result delta events were received but not surfaced to the provider/frontend stream.

Root cause: the result-delta event variant was missing from the stream decoder and source projection.

Fix: decode, normalize, and expose web-search result deltas without changing ordinary text/reasoning streaming.

Verification: `go test ./internal/provider/anthropic`; `pnpm exec tsx src/__tests__/search-sources.test.ts`.

This is an adapted, focused replacement for the corresponding part of #9195.

Documentation-impact: none - this restores existing web-search result rendering without changing documented setup or configuration.
Cache-impact: none - the change only decodes streamed results and normalizes display sources; provider request payloads, system prompts, and tool schemas are unchanged.
Cache-guard: no cache-visible request path changed; `scripts/check-cache-impact.sh` is the repository guard for this scope.
