### PR TITLE
Desktop: harden streaming and Mermaid rendering / 桌面端：强化流式与 Mermaid 渲染

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -56,7 +56,6 @@
     "remark-math": "^6.0.0",
     "remark-parse": "11.0.0",
     "remark-rehype": "11.1.2",
-    "svg-pan-zoom": "^3.6.2",
     "unified": "11.0.5",
     "unist-util-visit": "^5.1.0",
     "vfile": "6.0.3",

--- a/desktop/frontend/pnpm-lock.yaml
+++ b/desktop/frontend/pnpm-lock.yaml
@@ -70,9 +70,6 @@ importers:
       remark-rehype:
         specifier: 11.1.2
         version: 11.1.2
-      svg-pan-zoom:
-        specifier: ^3.6.2
-        version: 3.6.2
       unified:
         specifier: 11.0.5
         version: 11.0.5
@@ -1873,9 +1870,6 @@ packages:
 
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
-
-  svg-pan-zoom@3.6.2:
-    resolution: {integrity: sha512-JwnvRWfVKw/Xzfe6jriFyfey/lWJLq4bUh2jwoR5ChWQuQoOH8FEh1l/bEp46iHHKHEJWIyFJETbazraxNWECg==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -4096,8 +4090,6 @@ snapshots:
       inline-style-parser: 0.2.7
 
   stylis@4.4.0: {}
-
-  svg-pan-zoom@3.6.2: {}
 
   symbol-tree@3.2.4: {}
 

--- a/desktop/frontend/src/__tests__/markdown-streaming-worker.test.tsx
+++ b/desktop/frontend/src/__tests__/markdown-streaming-worker.test.tsx
@@ -136,6 +136,51 @@ console.log("\nmarkdown streaming → worker final parse");
   delete (globalThis as { Worker?: unknown }).Worker;
 }
 
+console.log("\nstreaming code fence tail styling");
+
+// An unclosed fence stays in the streaming tail (never committed early) and
+// renders with code-block styling until the closing fence arrives (#8843).
+{
+  const root = createRoot(rootEl);
+
+  await act(async () => {
+    root.render(<Markdown text={"intro\n\n"} streaming />);
+    await flush();
+  });
+
+  await act(async () => {
+    root.render(<Markdown text={"intro\n\n```js\nconst a = 1;"} streaming />);
+    await flush();
+  });
+  const tail = rootEl.querySelector(".md--stream-tail");
+  ok(tail, "an open code fence keeps the uncommitted tail mounted");
+  const pre = tail?.querySelector("pre.code.md--stream-tail-code");
+  ok(pre, "an open code fence renders with code styling before the closing fence arrives");
+  eq(pre?.getAttribute("data-lang"), "js", "the streaming code block carries the fence language");
+  eq(pre?.textContent, "const a = 1;", "the streaming code block shows the fence body without the opener line");
+
+  await act(async () => {
+    root.render(<Markdown text={"intro\n\n```js\nconst a = 1;\nconst b = 2;"} streaming />);
+    await flush();
+  });
+  eq(rootEl.querySelector(".md--stream-tail pre code")?.textContent, "const a = 1;\nconst b = 2;", "the streaming code body grows in place");
+
+  await act(async () => {
+    root.render(<Markdown text={"intro\n\n```js\nconst a = 1;\nconst b = 2;\n```\ndone"} streaming />);
+    await new Promise((resolve) => setTimeout(resolve, 120));
+  });
+  // The closed fence commits on the next animation frame after the parse
+  // budget; let that frame run inside act before asserting.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 60));
+  });
+  const settledTail = rootEl.querySelector(".md--stream-tail");
+  ok(!settledTail?.querySelector("pre.md--stream-tail-code"), "a closed fence leaves the code styling to the parsed renderer");
+  eq(settledTail?.textContent, "done", "text after the closing fence rides the plain tail");
+
+  await act(async () => root.unmount());
+}
+
 await server.close();
 dom.window.close();
 

--- a/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
+++ b/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
@@ -140,6 +140,11 @@ function installDom() {
   const dom = installDom();
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   svg.setAttribute("viewBox", "0 0 160 80");
+  const defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
+  const marker = document.createElementNS("http://www.w3.org/2000/svg", "marker");
+  marker.setAttribute("id", "arrow");
+  defs.appendChild(marker);
+  svg.appendChild(defs);
   const content = document.createElementNS("http://www.w3.org/2000/svg", "g");
   content.setAttribute("id", "drawing");
   svg.appendChild(content);
@@ -153,6 +158,9 @@ function installDom() {
   const panZoom = createMermaidPanZoom(svg, { minZoom: 0.3, maxZoom: 8, zoomScaleSensitivity: 0.3 });
   const viewport = () => svg.querySelector("g[data-mermaid-pan-zoom-viewport]");
   ok(svg.querySelector("g[data-mermaid-pan-zoom-viewport] g#drawing"), "inline pan/zoom wraps the drawing in one viewport group");
+  ok(defs.parentNode === svg, "SVG definitions stay outside the transformed viewport");
+  ok(!viewport()?.querySelector("defs"), "the viewport does not transform SVG definitions");
+  ok(svg.querySelector("defs marker#arrow") === marker, "definition children remain available by ID");
 
   panZoom.fit();
   eq(viewport()?.getAttribute("transform"), "translate(0 0) scale(1)", "fit keeps the browser meet mapping at unit scale");

--- a/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
+++ b/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
@@ -9,7 +9,7 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import ReactMarkdown from "react-markdown";
-import { splitStableMarkdownSections, streamingCommitTarget, streamingMarkdownCommitInterval, useRenderedMarkdownText } from "../components/Markdown";
+import { splitStableMarkdownSections, splitStreamingTailFence, streamingCommitTarget, streamingMarkdownCommitInterval, useRenderedMarkdownText } from "../components/Markdown";
 import MermaidDiagram from "../components/MermaidDiagram";
 import {
   __setMermaidPanZoomFactoryForTest,
@@ -20,6 +20,7 @@ import {
   safelySyncPanZoom,
   sanitizeMermaidSvg,
 } from "../components/MermaidDiagram";
+import { createMermaidPanZoom } from "../components/mermaidPanZoom";
 import { LocaleProvider } from "../lib/i18n";
 import { REMOTE_MARKDOWN_IMAGE_PATH } from "../lib/markdownImage";
 
@@ -28,6 +29,7 @@ const styles = readFileSync(resolve(testDir, "../styles.css"), "utf8");
 const markdownRendererSource = readFileSync(resolve(testDir, "../components/MarkdownRenderer.tsx"), "utf8");
 const markdownComponentsSource = readFileSync(resolve(testDir, "../components/markdownComponents.tsx"), "utf8");
 const markdownSource = readFileSync(resolve(testDir, "../components/Markdown.tsx"), "utf8");
+const mermaidDiagramSource = readFileSync(resolve(testDir, "../components/MermaidDiagram.tsx"), "utf8");
 const messageSource = readFileSync(resolve(testDir, "../components/Message.tsx"), "utf8");
 
 let passed = 0;
@@ -132,6 +134,59 @@ function installDom() {
   dom.window.close();
 }
 
+// Inline pan/zoom (replaces svg-pan-zoom, #8068): transform math on one
+// viewport <g>, zoom clamped to 0.3–8, wheel/drag/dblclick interactions.
+{
+  const dom = installDom();
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 160 80");
+  const content = document.createElementNS("http://www.w3.org/2000/svg", "g");
+  content.setAttribute("id", "drawing");
+  svg.appendChild(content);
+  // 640x360 layout box: the meet mapping fits at scale 4, origin (0, 20).
+  Object.defineProperty(svg, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({ x: 0, y: 0, width: 640, height: 360, top: 0, right: 640, bottom: 360, left: 0, toJSON: () => ({}) }),
+  });
+  document.body.appendChild(svg);
+
+  const panZoom = createMermaidPanZoom(svg, { minZoom: 0.3, maxZoom: 8, zoomScaleSensitivity: 0.3 });
+  const viewport = () => svg.querySelector("g[data-mermaid-pan-zoom-viewport]");
+  ok(svg.querySelector("g[data-mermaid-pan-zoom-viewport] g#drawing"), "inline pan/zoom wraps the drawing in one viewport group");
+
+  panZoom.fit();
+  eq(viewport()?.getAttribute("transform"), "translate(0 0) scale(1)", "fit keeps the browser meet mapping at unit scale");
+
+  svg.dispatchEvent(new dom.window.WheelEvent("wheel", { clientX: 320, clientY: 180, deltaY: -120, bubbles: true, cancelable: true }));
+  eq(viewport()?.getAttribute("transform"), "translate(-24 -12) scale(1.3)", "wheel zooms in around the cursor");
+
+  for (let i = 0; i < 40; i += 1) {
+    svg.dispatchEvent(new dom.window.WheelEvent("wheel", { clientX: 320, clientY: 180, deltaY: 120, bubbles: true, cancelable: true }));
+  }
+  ok(viewport()?.getAttribute("transform")?.endsWith("scale(0.3)"), "wheel zoom-out clamps at the minimum zoom");
+
+  panZoom.reset();
+  eq(viewport()?.getAttribute("transform"), "translate(0 0) scale(1)", "reset restores the fitted unit transform");
+  for (let i = 0; i < 40; i += 1) {
+    svg.dispatchEvent(new dom.window.WheelEvent("wheel", { clientX: 320, clientY: 180, deltaY: -120, bubbles: true, cancelable: true }));
+  }
+  ok(viewport()?.getAttribute("transform")?.endsWith("scale(8)"), "wheel zoom-in clamps at the maximum zoom");
+
+  panZoom.reset();
+  svg.dispatchEvent(new dom.window.MouseEvent("pointerdown", { button: 0, clientX: 100, clientY: 100, bubbles: true }));
+  svg.dispatchEvent(new dom.window.MouseEvent("pointermove", { clientX: 130, clientY: 110, bubbles: true }));
+  eq(viewport()?.getAttribute("transform"), "translate(7.5 2.5) scale(1)", "pointer drag pans the drawing in screen pixels");
+  svg.dispatchEvent(new dom.window.MouseEvent("pointerup", { clientX: 130, clientY: 110, bubbles: true }));
+
+  panZoom.destroy();
+  svg.dispatchEvent(new dom.window.WheelEvent("wheel", { clientX: 320, clientY: 180, deltaY: -120, bubbles: true, cancelable: true }));
+  eq(viewport()?.getAttribute("transform"), "translate(7.5 2.5) scale(1)", "destroy detaches the interaction listeners");
+
+  ok(!mermaidDiagramSource.includes("svg-pan-zoom"), "MermaidDiagram no longer imports svg-pan-zoom");
+  ok(!styles.includes("svg-pan-zoom"), "styles no longer carry svg-pan-zoom hooks");
+  dom.window.close();
+}
+
 function parseSvg(svg: string): Document {
   return new DOMParser().parseFromString(svg, "image/svg+xml");
 }
@@ -199,7 +254,7 @@ console.log("\nmermaid rendering");
   eq(streamingCommitTarget("intro\n\npartial paragraph"), "intro\n\n", "commit target stops at the last completed block");
   eq(streamingCommitTarget("no blank line yet"), "", "no completed block means nothing to parse yet");
   eq(streamingCommitTarget("done\n\nalso done\n\n"), "done\n\nalso done\n\n", "trailing boundary commits everything");
-  eq(streamingCommitTarget("t\n\n```js\nstreaming code"), "t\n\n```js\nstreaming code", "an open fence keeps the whole text parsed for live highlighting");
+  eq(streamingCommitTarget("t\n\n```js\nstreaming code"), "t\n\n", "an open fence stays in the tail for code-styled streaming");
   eq(streamingCommitTarget("t\n\n$$\n\\int_0^1"), "t\n\n$$\n\\int_0^1", "open display math keeps the whole text parsed");
   eq(streamingCommitTarget("t\n\n```\nc\n```\nafter"), "t\n\n```\nc\n```\n", "a closed fence promotes immediately without waiting for a blank line");
   eq(streamingCommitTarget("t\n\n$$\nx\n$$\nafter"), "t\n\n$$\nx\n$$\n", "closed display math promotes immediately");
@@ -259,7 +314,7 @@ console.log("\nmermaid rendering");
   );
   eq(
     streamingCommitTarget("t\n\n```\n- not a list\n- also not\n"),
-    "t\n\n```\n- not a list\n- also not\n",
+    "t\n\n",
     "list markers inside an open fence do not create commit boundaries",
   );
   eq(
@@ -549,6 +604,16 @@ console.log("\nmermaid rendering");
   __setMermaidRenderAdapterForTest(null);
   __setMermaidPanZoomFactoryForTest(undefined);
   dom.window.close();
+}
+
+{
+  eq(splitStreamingTailFence("still typing"), null, "a plain tail has no code fence split");
+  eq(splitStreamingTailFence("```\nc\n```\nafter"), null, "a closed fence leaves no open code tail");
+  const split = splitStreamingTailFence("```js\nconst a = 1;\nconst b");
+  eq(split?.head, "", "an open fence at the tail start has no plain head");
+  eq(split?.lang, "js", "the open fence split keeps the info-string language");
+  eq(split?.code, "const a = 1;\nconst b", "the open fence split drops the opener line from the code body");
+  eq(splitStreamingTailFence("para\n\n```\nx")?.head, "para\n\n", "text before the open fence stays plain");
 }
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -145,9 +145,13 @@ function isStreamingListItemLine(line: string): boolean {
 
 // Live parse prefix: last completed block. A later list marker commits prior
 // items only — the new item stays in the tail so indented continuations can join.
+// An open code fence commits only up to the fence line: the tail renders the
+// growing code with code styling (splitStreamingTailFence), so streaming a
+// large block no longer re-parses the whole document on every commit.
 export function streamingCommitTarget(text: string): string {
   let lineStart = 0;
   let fence: { marker: string; length: number } | null = null;
+  let fenceStart = 0;
   let displayMath = false;
   let boundary = 0;
   while (lineStart < text.length) {
@@ -167,8 +171,10 @@ export function streamingCommitTarget(text: string): string {
       }
     } else {
       const fenceMatch = /^ {0,3}(`{3,}|~{3,})/.exec(line);
-      if (fenceMatch) fence = { marker: fenceMatch[1][0], length: fenceMatch[1].length };
-      else if (line.trim() === "$$") displayMath = true;
+      if (fenceMatch) {
+        fence = { marker: fenceMatch[1][0], length: fenceMatch[1].length };
+        fenceStart = lineStart;
+      } else if (line.trim() === "$$") displayMath = true;
       else if (terminated && line.trim() === "") boundary = lineEnd;
       // A heading interrupts a paragraph, so a partial heading line already
       // completes everything before it; a terminated one is itself complete.
@@ -177,7 +183,41 @@ export function streamingCommitTarget(text: string): string {
     }
     lineStart = lineEnd;
   }
-  return fence || displayMath ? text : text.slice(0, boundary);
+  return fence ? text.slice(0, fenceStart) : displayMath ? text : text.slice(0, boundary);
+}
+
+type StreamingTailFence = { head: string; lang: string; code: string };
+
+// Split a streaming tail around an unclosed code fence so the fence body can
+// render with code styling before the closing fence arrives. Bail out cheaply
+// when no fence marker exists; otherwise mirror the fence state machine from
+// streamingCommitTarget in one forward pass over the tail.
+export function splitStreamingTailFence(text: string): StreamingTailFence | null {
+  if (!text.includes("```") && !text.includes("~~~")) return null;
+  let lineStart = 0;
+  let fence: { marker: string; length: number } | null = null;
+  let fenceStart = 0;
+  let fenceBodyStart = 0;
+  let lang = "";
+  while (lineStart < text.length) {
+    const newline = text.indexOf("\n", lineStart);
+    const lineEnd = newline === -1 ? text.length : newline + 1;
+    const line = text.slice(lineStart, newline === -1 ? text.length : newline).replace(/\r$/, "");
+    if (fence) {
+      if (new RegExp(`^ {0,3}${fence.marker}{${fence.length},}[ \\t]*$`).test(line)) fence = null;
+    } else {
+      const fenceMatch = /^ {0,3}(`{3,}|~{3,})([^\n]*)$/.exec(line);
+      if (fenceMatch) {
+        fence = { marker: fenceMatch[1][0], length: fenceMatch[1].length };
+        fenceStart = lineStart;
+        fenceBodyStart = lineEnd;
+        lang = fenceMatch[2].trim();
+      }
+    }
+    lineStart = lineEnd;
+  }
+  if (!fence) return null;
+  return { head: text.slice(0, fenceStart), lang, code: text.slice(fenceBodyStart) };
 }
 
 export function useRenderedMarkdownText(text: string, streaming: boolean, holdIdleFinalization = false): string {
@@ -302,9 +342,35 @@ const StreamingMarkdownTail = memo(function StreamingMarkdownTail({ text }: { te
     const element = elementRef.current;
     if (!element) return;
     const previousText = previousTextRef.current;
-    const textNode = element.firstChild;
-    if (text.startsWith(previousText) && textNode?.nodeType === Node.TEXT_NODE) {
-      (textNode as Text).appendData(text.slice(previousText.length));
+    const previous = splitStreamingTailFence(previousText);
+    const next = splitStreamingTailFence(text);
+    // Append-only fast paths keep per-frame updates to one text-node append.
+    if (next && previous && next.head === previous.head && next.lang === previous.lang && next.code.startsWith(previous.code)) {
+      const textNode = element.querySelector("code")?.firstChild;
+      if (textNode?.nodeType === Node.TEXT_NODE) {
+        (textNode as Text).appendData(next.code.slice(previous.code.length));
+        previousTextRef.current = text;
+        return;
+      }
+    }
+    if (!next && !previous && text.startsWith(previousText)) {
+      const textNode = element.firstChild;
+      if (element.childNodes.length === 1 && textNode?.nodeType === Node.TEXT_NODE) {
+        (textNode as Text).appendData(text.slice(previousText.length));
+        previousTextRef.current = text;
+        return;
+      }
+    }
+    element.textContent = "";
+    if (next) {
+      if (next.head) element.appendChild(document.createTextNode(next.head));
+      const pre = document.createElement("pre");
+      pre.className = "code md--stream-tail-code";
+      if (next.lang) pre.setAttribute("data-lang", next.lang);
+      const code = document.createElement("code");
+      code.textContent = next.code;
+      pre.appendChild(code);
+      element.appendChild(pre);
     } else {
       element.textContent = text;
     }

--- a/desktop/frontend/src/components/MermaidDiagram.tsx
+++ b/desktop/frontend/src/components/MermaidDiagram.tsx
@@ -2,6 +2,7 @@ import { memo, type RefObject, useCallback, useEffect, useId, useLayoutEffect, u
 import { createPortal } from "react-dom";
 import { AlertCircle, Code2, Maximize2, Minimize2, Play, RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
 import { CopyButton } from "./CopyButton";
+import { createMermaidPanZoom, type MermaidPanZoomInstance, type MermaidPanZoomOptions } from "./mermaidPanZoom";
 import { openExternal } from "../lib/bridge";
 import { markdownImageSource } from "../lib/markdownImage";
 
@@ -25,17 +26,9 @@ type MermaidRenderAdapter = (
   signal: AbortSignal,
 ) => Promise<string>;
 
-type PanZoomInstance = {
-  destroy(): void;
-  resize(): unknown;
-  fit(): unknown;
-  center(): unknown;
-  zoomIn(): unknown;
-  zoomOut(): unknown;
-  reset(): unknown;
-};
+type PanZoomInstance = MermaidPanZoomInstance;
 
-type PanZoomFactory = (svg: SVGSVGElement, options?: Record<string, unknown>) => PanZoomInstance;
+type PanZoomFactory = (svg: SVGSVGElement, options?: MermaidPanZoomOptions) => PanZoomInstance;
 
 const MAX_TEXT_SIZE = 100000;
 const MIN_ZOOM = 0.3;
@@ -46,8 +39,6 @@ const XLINK_NS = "http://www.w3.org/1999/xlink";
 let mermaidApi: MermaidApi | null = null;
 let initPromise: Promise<MermaidApi> | null = null;
 let renderQueue: Promise<void> = Promise.resolve();
-let panZoomFactory: PanZoomFactory | null = null;
-let panZoomPromise: Promise<PanZoomFactory | null> | null = null;
 let renderAdapterForTest: MermaidRenderAdapter | null = null;
 let panZoomFactoryForTest: PanZoomFactory | null | undefined;
 
@@ -210,15 +201,7 @@ async function renderMermaid(
 
 async function ensurePanZoomFactory(): Promise<PanZoomFactory | null> {
   if (panZoomFactoryForTest !== undefined) return panZoomFactoryForTest;
-  if (panZoomFactory) return panZoomFactory;
-  if (!panZoomPromise) {
-    panZoomPromise = import("svg-pan-zoom").then((mod) => {
-      const factory = (("default" in mod ? mod.default : mod) as unknown) as PanZoomFactory;
-      panZoomFactory = factory;
-      return factory;
-    }).catch(() => null);
-  }
-  return panZoomPromise;
+  return createMermaidPanZoom;
 }
 
 export function isSafeMermaidHref(href: string | null | undefined): boolean {
@@ -317,7 +300,7 @@ function destroyPanZoom(instance: PanZoomInstance | null): void {
   try {
     instance.destroy();
   } catch {
-    /* svg-pan-zoom cleanup is best-effort across browser and test DOMs. */
+    /* pan/zoom listener cleanup is best-effort across browser and test DOMs. */
   }
 }
 
@@ -332,9 +315,8 @@ export function safelyRunPanZoom(instance: PanZoomInstance | null, action: () =>
     action();
     return true;
   } catch {
-    // svg-pan-zoom asks SVGMatrix.inverse() to invert the current transform.
-    // Hidden/zero-sized layouts can produce a singular matrix in WebKit and
-    // Chromium; keep that library detail out of the global crash surface.
+    // Pan/zoom math reads live layout (getBoundingClientRect); a detached or
+    // zero-sized surface must never reach the global crash surface (#8068).
     return false;
   }
 }
@@ -429,14 +411,6 @@ const MermaidDiagram = memo(function MermaidDiagram({ definition }: MermaidDiagr
         destroyPanZoom(panZoomRef.current);
         try {
           instance = factory(svg, {
-            zoomEnabled: true,
-            panEnabled: true,
-            controlIconsEnabled: false,
-            dblClickZoomEnabled: true,
-            // Fitting inside the constructor can run before the portal/layout has
-            // dimensions, which is the matrix-inverse crash seen in diagnostics.
-            fit: false,
-            center: false,
             minZoom: MIN_ZOOM,
             maxZoom: MAX_ZOOM,
             zoomScaleSensitivity: 0.3,

--- a/desktop/frontend/src/components/mermaidPanZoom.ts
+++ b/desktop/frontend/src/components/mermaidPanZoom.ts
@@ -42,7 +42,14 @@ function ensureViewport(svg: SVGSVGElement): SVGGElement {
   if (existing) return existing;
   const viewport = document.createElementNS(SVG_NS, "g");
   viewport.setAttribute(VIEWPORT_ATTR, "");
-  while (svg.firstChild) viewport.appendChild(svg.firstChild);
+  // Keep definitions in the SVG coordinate system. Mermaid commonly puts
+  // markers, clip paths, and gradients in <defs>; moving them under the
+  // transformed viewport changes their user coordinate system and can distort
+  // arrowheads or clipped/filled shapes.
+  for (const child of Array.from(svg.childNodes)) {
+    if (child.nodeType === 3 || (child.nodeType === 1 && (child as Element).tagName.toLowerCase() === "defs")) continue;
+    viewport.appendChild(child);
+  }
   svg.appendChild(viewport);
   return viewport;
 }

--- a/desktop/frontend/src/components/mermaidPanZoom.ts
+++ b/desktop/frontend/src/components/mermaidPanZoom.ts
@@ -1,0 +1,179 @@
+// Inline pan/zoom for the Mermaid preview, replacing svg-pan-zoom (#8068):
+// that library inverts the live SVG matrix on wheel/drag and crashes with a
+// singular matrix on hidden or zero-sized layouts. Everything here is a plain
+// translate/scale string applied to one viewport <g> — no matrix inversion.
+//
+// Scale is relative to the fit scale (1 = diagram fits the container); pan is
+// in screen pixels. The SVG keeps width/height 100% with the browser's own
+// viewBox "meet" mapping, which already fits and centers the drawing, so
+// fit/center simply reset the user transform.
+
+export interface MermaidPanZoomOptions {
+  minZoom?: number;
+  maxZoom?: number;
+  zoomScaleSensitivity?: number;
+}
+
+export interface MermaidPanZoomInstance {
+  destroy(): void;
+  resize(): void;
+  fit(): void;
+  center(): void;
+  zoomIn(): void;
+  zoomOut(): void;
+  reset(): void;
+}
+
+const VIEWPORT_ATTR = "data-mermaid-pan-zoom-viewport";
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+type ViewBox = { x: number; y: number; w: number; h: number };
+
+function readViewBox(svg: SVGSVGElement): ViewBox | null {
+  const raw = svg.getAttribute("viewBox");
+  if (!raw) return null;
+  const parts = raw.trim().split(/[\s,]+/).map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n)) || parts[2] <= 0 || parts[3] <= 0) return null;
+  return { x: parts[0], y: parts[1], w: parts[2], h: parts[3] };
+}
+
+function ensureViewport(svg: SVGSVGElement): SVGGElement {
+  const existing = svg.querySelector<SVGGElement>(`g[${VIEWPORT_ATTR}]`);
+  if (existing) return existing;
+  const viewport = document.createElementNS(SVG_NS, "g");
+  viewport.setAttribute(VIEWPORT_ATTR, "");
+  while (svg.firstChild) viewport.appendChild(svg.firstChild);
+  svg.appendChild(viewport);
+  return viewport;
+}
+
+// Geometry of the browser's meet mapping: drawing units → client pixels,
+// including the centering offset inside the SVG's layout box.
+function measure(svg: SVGSVGElement): { fitScale: number; originX: number; originY: number } | null {
+  const box = readViewBox(svg);
+  if (!box) return null;
+  const rect = svg.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return null;
+  const fitScale = Math.min(rect.width / box.w, rect.height / box.h);
+  return {
+    fitScale,
+    originX: rect.left + (rect.width - box.w * fitScale) / 2 - box.x * fitScale,
+    originY: rect.top + (rect.height - box.h * fitScale) / 2 - box.y * fitScale,
+  };
+}
+
+export function createMermaidPanZoom(svg: SVGSVGElement, options: MermaidPanZoomOptions = {}): MermaidPanZoomInstance {
+  const minZoom = options.minZoom ?? 0.3;
+  const maxZoom = options.maxZoom ?? 8;
+  const sensitivity = options.zoomScaleSensitivity ?? 0.3;
+  const clampZoom = (zoom: number) => Math.min(maxZoom, Math.max(minZoom, zoom));
+
+  const viewport = ensureViewport(svg);
+  let scale = 1;
+  let panX = 0;
+  let panY = 0;
+
+  // Rounded to 0.1px/0.01% precision so long zoom chains keep clean transforms.
+  const num = (n: number) => Math.round(n * 1e4) / 1e4;
+
+  const apply = () => {
+    const m = measure(svg);
+    if (!m) return;
+    viewport.setAttribute("transform", `translate(${num(panX / m.fitScale)} ${num(panY / m.fitScale)}) scale(${num(scale)})`);
+  };
+
+  // Keep the content point under (clientX, clientY) fixed while zooming.
+  const zoomAt = (clientX: number, clientY: number, nextZoom: number) => {
+    const next = clampZoom(nextZoom);
+    if (next === scale) return;
+    const m = measure(svg);
+    if (m) {
+      const ratio = next / scale;
+      panX = (clientX - m.originX) * (1 - ratio) + panX * ratio;
+      panY = (clientY - m.originY) * (1 - ratio) + panY * ratio;
+    }
+    scale = next;
+    apply();
+  };
+
+  const center = () => {
+    const rect = svg.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  };
+
+  const onWheel = (event: WheelEvent) => {
+    event.preventDefault();
+    zoomAt(event.clientX, event.clientY, scale * (event.deltaY < 0 ? 1 + sensitivity : 1 / (1 + sensitivity)));
+  };
+
+  let drag: { pointerId: number; x: number; y: number; panX: number; panY: number } | null = null;
+  const onPointerDown = (event: PointerEvent) => {
+    if (event.button !== 0) return;
+    drag = { pointerId: event.pointerId, x: event.clientX, y: event.clientY, panX, panY };
+    try {
+      svg.setPointerCapture(event.pointerId);
+    } catch {
+      /* pointer capture is unavailable in some test DOMs */
+    }
+  };
+  const onPointerMove = (event: PointerEvent) => {
+    if (!drag || event.pointerId !== drag.pointerId) return;
+    panX = drag.panX + event.clientX - drag.x;
+    panY = drag.panY + event.clientY - drag.y;
+    apply();
+  };
+  const onPointerEnd = (event: PointerEvent) => {
+    if (drag?.pointerId === event.pointerId) drag = null;
+  };
+  const onDblClick = (event: MouseEvent) => {
+    event.preventDefault();
+    zoomAt(event.clientX, event.clientY, scale * (1 + sensitivity));
+  };
+
+  svg.addEventListener("wheel", onWheel, { passive: false });
+  svg.addEventListener("pointerdown", onPointerDown);
+  svg.addEventListener("pointermove", onPointerMove);
+  svg.addEventListener("pointerup", onPointerEnd);
+  svg.addEventListener("pointercancel", onPointerEnd);
+  svg.addEventListener("dblclick", onDblClick);
+
+  return {
+    destroy() {
+      svg.removeEventListener("wheel", onWheel);
+      svg.removeEventListener("pointerdown", onPointerDown);
+      svg.removeEventListener("pointermove", onPointerMove);
+      svg.removeEventListener("pointerup", onPointerEnd);
+      svg.removeEventListener("pointercancel", onPointerEnd);
+      svg.removeEventListener("dblclick", onDblClick);
+      drag = null;
+    },
+    resize() {
+      apply();
+    },
+    fit() {
+      scale = clampZoom(1);
+      panX = 0;
+      panY = 0;
+      apply();
+    },
+    center() {
+      panX = 0;
+      panY = 0;
+      apply();
+    },
+    zoomIn() {
+      const c = center();
+      zoomAt(c.x, c.y, scale * (1 + sensitivity));
+    },
+    zoomOut() {
+      const c = center();
+      zoomAt(c.x, c.y, scale / (1 + sensitivity));
+    },
+    reset() {
+      scale = 1;
+      panX = 0;
+      panY = 0;
+      apply();
+    },
+  };
+}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -5796,8 +5796,7 @@ button.reasoning-summary:focus-visible {
 }
 
 .mermaid-diagram__preview:active,
-.mermaid-diagram__preview svg:active,
-.mermaid-diagram__preview .svg-pan-zoom_viewport:active {
+.mermaid-diagram__preview svg:active {
   cursor: grabbing;
 }
 
@@ -5807,6 +5806,7 @@ button.reasoning-summary:focus-visible {
   height: 100%;
   max-width: none;
   cursor: grab;
+  touch-action: none;
 }
 
 .mermaid-diagram__preview a {


### PR DESCRIPTION
Problem: streaming code fences could remain visually malformed, and Mermaid pan/zoom depended on a fragile SVG pan/zoom package.

Root cause: the streaming renderer did not establish a stable fence presentation early enough, while Mermaid interaction was coupled to the external SVG transform helper.

Fix: make streaming fence styling deterministic and replace the Mermaid interaction path with the local pointer-aware implementation.

Verification: focused Markdown/Mermaid tests; `pnpm --dir desktop/frontend build`.

This is an adapted, focused replacement for the corresponding part of #9195.

Documentation-impact: none - this changes rendering internals and dependency ownership without changing documented setup or configuration.
