### PR TITLE
History: bound search index growth / 历史记录：限制搜索索引增长

### DIFF
--- a/internal/config/history_search.go
+++ b/internal/config/history_search.go
@@ -1,0 +1,22 @@
+package config
+
+// HistorySearchMaxMB returns the user-global history_search.max_mb setting
+// (0 when unset or unreadable). It decodes only that table: adding a typed
+// field to Config would push ratcheted config.go/render.go over their
+// repolint budgets, and the setting is consumed by internal/historycatalog
+// only (#8717). A settings-UI save may drop the manually written section.
+func HistorySearchMaxMB() int {
+	path := userConfigLoadPath()
+	if path == "" {
+		return 0
+	}
+	var partial struct {
+		HistorySearch struct {
+			MaxMB int `toml:"max_mb"`
+		} `toml:"history_search"`
+	}
+	if _, err := decodeTOMLFile(path, &partial); err != nil {
+		return 0
+	}
+	return partial.HistorySearch.MaxMB
+}

--- a/internal/historycatalog/catalog.go
+++ b/internal/historycatalog/catalog.go
@@ -109,11 +109,9 @@ func Open(ctx context.Context, opts Options) (*Catalog, error) {
 	// blocks. Registered roots rescan afterwards and re-index truncated.
 	if !opts.InMemory && strings.TrimSpace(opts.Path) != "" &&
 		historyDBFileSize(opts.Path) > rebuildOversizeFactor*opts.MaxBytes {
-		c.wg.Add(1)
-		go func() {
-			defer c.wg.Done()
+		c.wg.Go(func() {
 			c.wipeForRebuild(c.ctx)
-		}()
+		})
 	}
 	return c, nil
 }

--- a/internal/historycatalog/catalog.go
+++ b/internal/historycatalog/catalog.go
@@ -72,6 +72,7 @@ func Open(ctx context.Context, opts Options) (*Catalog, error) {
 		// the interval longer so large installs are not re-walked every minute.
 		opts.ReconcileInterval = 5 * time.Minute
 	}
+	opts.MaxBytes = resolveMaxBytes(opts.MaxBytes, configuredMaxMB())
 	handle, err := projectiondb.Open(ctx, projectiondb.OpenOptions{
 		Path: opts.Path, MemoryName: "history-search", Migrations: migrations(), InMemory: opts.InMemory,
 		MaxOpenConns: 4, Now: opts.Now, SecureDelete: true, AutoVacuum: true,
@@ -103,6 +104,17 @@ func Open(ctx context.Context, opts Options) (*Catalog, error) {
 	c.refreshStatus(ctx)
 	c.wg.Add(1)
 	go c.worker()
+	// A far-over-cap index from before the cap existed (#8717) is cheaper to
+	// rebuild than to evict session-by-session; wipe async so startup never
+	// blocks. Registered roots rescan afterwards and re-index truncated.
+	if !opts.InMemory && strings.TrimSpace(opts.Path) != "" &&
+		historyDBFileSize(opts.Path) > rebuildOversizeFactor*opts.MaxBytes {
+		c.wg.Add(1)
+		go func() {
+			defer c.wg.Done()
+			c.wipeForRebuild(c.ctx)
+		}()
+	}
 	return c, nil
 }
 
@@ -118,12 +130,9 @@ func (c *Catalog) ensureTokenizerVersion(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	for _, statement := range []string{`DELETE FROM history_fts`, `DELETE FROM history_documents`,
-		`DELETE FROM history_sources`, `DELETE FROM history_roots`} {
-		if _, err := tx.ExecContext(ctx, statement); err != nil {
-			_ = tx.Rollback()
-			return err
-		}
+	if err := wipeProjectionRows(ctx, tx); err != nil {
+		_ = tx.Rollback()
+		return err
 	}
 	if _, err := tx.ExecContext(ctx, `UPDATE history_state SET tokenizer_version=?,revision=revision+1 WHERE id=1`, TokenizerVersion); err != nil {
 		_ = tx.Rollback()
@@ -239,6 +248,7 @@ func (c *Catalog) worker() {
 			return
 		case <-ticker.C:
 			c.markAllRootsDirty()
+			c.governSize(c.ctx)
 		case done := <-c.flushCh:
 			c.drainPending(c.ctx)
 			close(done)
@@ -471,22 +481,25 @@ func (c *Catalog) indexPath(ctx context.Context, root Root, path string, generat
 	if identityErr == nil && known {
 		digest, revision = state.DigestHex, state.Revision
 	}
-	var oldFingerprint, oldMetaFingerprint, oldDigest string
+	var oldFingerprint, oldMetaFingerprint, oldDigest, oldHealth string
 	var oldGeneration, oldRevision int64
 	var oldMessageCount int
 	err := c.db.QueryRowContext(ctx, `SELECT content_fingerprint,meta_fingerprint,content_digest,seen_generation,
-		content_revision,indexed_message_count FROM history_sources WHERE path=?`, path).Scan(
-		&oldFingerprint, &oldMetaFingerprint, &oldDigest, &oldGeneration, &oldRevision, &oldMessageCount)
+		content_revision,indexed_message_count,health FROM history_sources WHERE path=?`, path).Scan(
+		&oldFingerprint, &oldMetaFingerprint, &oldDigest, &oldGeneration, &oldRevision, &oldMessageCount, &oldHealth)
 	if sourceProjectionUnchanged(err, oldFingerprint, contentFingerprint, oldMetaFingerprint, metaFingerprint, oldDigest, digest) {
 		if generation != 0 && oldGeneration != generation {
-			_, _ = c.db.ExecContext(ctx, `UPDATE history_sources SET seen_generation=?,missing_since=0,health='ok' WHERE path=?`, generation, path)
+			// Keep evicted rows evicted: an unchanged file must not re-enter the index.
+			_, _ = c.db.ExecContext(ctx, `UPDATE history_sources SET seen_generation=?,missing_since=0,
+				health=CASE WHEN health='evicted' THEN 'evicted' ELSE 'ok' END WHERE path=?`, generation, path)
 		}
 		return nil
 	}
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
 	}
-	if err == nil && known && appendFrom >= 0 {
+	// An evicted projection has no prefix to append onto; fall through to a full reload.
+	if err == nil && known && appendFrom >= 0 && oldHealth != "evicted" {
 		handled, appendErr := c.tryAppendPath(ctx, root, path, generation, appendFrom, oldMessageCount, oldRevision,
 			revision, digest, contentFingerprint, metaFingerprint)
 		if appendErr != nil {

--- a/internal/historycatalog/documents.go
+++ b/internal/historycatalog/documents.go
@@ -2,10 +2,39 @@ package historycatalog
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"reasonix/internal/provider"
 	"reasonix/internal/retrieval"
 )
+
+const (
+	toolTextMaxBytes  = 8 * 1024
+	toolTextHeadBytes = 6 * 1024
+	toolTextTailBytes = 2 * 1024
+)
+
+// toolTextTruncationMarker makes elided middle bytes recognizable in search
+// hits, so truncation is not mistaken for source content.
+const toolTextTruncationMarker = "\n…[truncated]…\n"
+
+// truncateToolText bounds one tool payload's indexed text (#8717: tool output
+// is the index size driver). The tail survives because tool errors and
+// summaries typically sit at the end of the output.
+func truncateToolText(text string) string {
+	if len(text) <= toolTextMaxBytes {
+		return text
+	}
+	head := text[:toolTextHeadBytes]
+	for len(head) > 0 && !utf8.ValidString(head) {
+		head = head[:len(head)-1]
+	}
+	tail := text[len(text)-toolTextTailBytes:]
+	for len(tail) > 0 && !utf8.ValidString(tail) {
+		tail = tail[1:]
+	}
+	return head + toolTextTruncationMarker + tail
+}
 
 type indexedDocument struct {
 	message int
@@ -33,12 +62,12 @@ func documents(messages []provider.Message) []indexedDocument {
 		case provider.RoleAssistant:
 			appendDoc(i, 0, string(msg.Role), "assistant_text", "", msg.Content)
 			for part, call := range msg.ToolCalls {
-				appendDoc(i, part, string(msg.Role), "tool_input", call.Name, call.Name+" "+call.Arguments)
+				appendDoc(i, part, string(msg.Role), "tool_input", call.Name, truncateToolText(call.Name+" "+call.Arguments))
 			}
 		case provider.RoleTool:
 			// Index both tool_error and tool_output so explicit kind filters stay
 			// honest. Default search kinds still exclude tool_output.
-			text := msg.Name + " " + msg.Content
+			text := truncateToolText(msg.Name + " " + msg.Content)
 			lower := strings.ToLower(strings.TrimSpace(msg.Content))
 			if strings.HasPrefix(lower, "error:") || strings.HasPrefix(lower, "blocked:") || strings.Contains(lower, "permission denied") {
 				appendDoc(i, 0, string(msg.Role), "tool_error", msg.Name, text)

--- a/internal/historycatalog/documents_test.go
+++ b/internal/historycatalog/documents_test.go
@@ -1,0 +1,97 @@
+package historycatalog
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"reasonix/internal/provider"
+)
+
+func TestTruncateToolText(t *testing.T) {
+	t.Parallel()
+	patterned := strings.Repeat("0123456789", 10240) // 100KB, position-varying
+	tests := []struct {
+		name      string
+		text      string
+		truncated bool
+	}{
+		{"short unchanged", strings.Repeat("a", 100), false},
+		{"at limit unchanged", patterned[:toolTextMaxBytes], false},
+		{"one byte over truncated", patterned[:toolTextMaxBytes+1], true},
+		{"large truncated", patterned, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := truncateToolText(tt.text)
+			if !tt.truncated {
+				if got != tt.text {
+					t.Fatalf("text changed: got %d bytes, want unchanged %d", len(got), len(tt.text))
+				}
+				return
+			}
+			if !strings.Contains(got, toolTextTruncationMarker) {
+				t.Fatalf("missing truncation marker in %q…", got[:64])
+			}
+			if !strings.HasPrefix(got, tt.text[:toolTextHeadBytes]) {
+				t.Fatal("head bytes altered")
+			}
+			if !strings.HasSuffix(got, tt.text[len(tt.text)-toolTextTailBytes:]) {
+				t.Fatal("tail bytes altered")
+			}
+			if len(got) > toolTextMaxBytes+len(toolTextTruncationMarker) {
+				t.Fatalf("truncated text still %d bytes", len(got))
+			}
+		})
+	}
+}
+
+func TestTruncateToolTextKeepsRuneBoundary(t *testing.T) {
+	t.Parallel()
+	prefix := strings.Repeat("x", toolTextHeadBytes-1)
+	// Byte toolTextHeadBytes lands inside the multi-byte rune 世.
+	text := prefix + "世界" + strings.Repeat("y", 64*1024)
+	got := truncateToolText(text)
+	if !utf8.ValidString(got) {
+		t.Fatal("truncated text is not valid UTF-8")
+	}
+	if !strings.HasPrefix(got, prefix) {
+		t.Fatal("head lost bytes before the boundary rune")
+	}
+}
+
+func TestDocumentsTruncateToolPayloadsOnly(t *testing.T) {
+	t.Parallel()
+	filler := strings.Repeat("filler ", 4000) // 28KB
+	toolContent := filler[:10000] + " midmarkertoken " + filler[10000:] + " tailmarkertoken"
+	userContent := filler + " endusermarkertoken"
+	docs := documents([]provider.Message{
+		{Role: provider.RoleUser, Content: userContent},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "1", Name: "bash", Arguments: toolContent}}},
+		{Role: provider.RoleTool, ToolCallID: "1", Name: "bash", Content: toolContent},
+	})
+	byKind := map[string]indexedDocument{}
+	for _, doc := range docs {
+		byKind[doc.kind] = doc
+	}
+	user, ok := byKind["user_text"]
+	if !ok || !strings.Contains(user.terms, "endusermarkertoken") {
+		t.Fatalf("user_text must stay untruncated: %#v", user)
+	}
+	for _, kind := range []string{"tool_input", "tool_output"} {
+		doc, ok := byKind[kind]
+		if !ok {
+			t.Fatalf("missing %s document", kind)
+		}
+		if !strings.Contains(doc.terms, "tailmarkertoken") {
+			t.Fatalf("%s lost its tail token", kind)
+		}
+		if strings.Contains(doc.terms, "midmarkertoken") {
+			t.Fatalf("%s kept elided middle token", kind)
+		}
+		if !strings.Contains(doc.terms, "truncated") {
+			t.Fatalf("%s is missing the truncation marker", kind)
+		}
+	}
+}

--- a/internal/historycatalog/govern.go
+++ b/internal/historycatalog/govern.go
@@ -1,0 +1,216 @@
+package historycatalog
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strings"
+
+	"reasonix/internal/config"
+)
+
+const (
+	// DefaultMaxBytes caps the disposable index; session files stay authoritative.
+	DefaultMaxBytes = 256 << 20
+	// rebuildOversizeFactor: past this multiple of the cap a background
+	// wipe+rebuild beats evicting nearly every session, and applies tool-text
+	// truncation to legacy rows (#8717).
+	rebuildOversizeFactor = 2
+	// evictTargetPercent: reclaim down to this share of the cap so the next
+	// persist batch does not immediately re-trigger eviction.
+	evictTargetPercent = 80
+	maxEvictRounds     = 8
+)
+
+func resolveMaxBytes(option int64, configuredMB int) int64 {
+	if option > 0 {
+		return option
+	}
+	if configuredMB > 0 {
+		return int64(configuredMB) << 20
+	}
+	return DefaultMaxBytes
+}
+
+func configuredMaxMB() int {
+	return config.HistorySearchMaxMB()
+}
+
+func historyDBFileSize(path string) int64 {
+	var total int64
+	for _, candidate := range []string{path, path + "-wal"} {
+		if info, err := os.Stat(candidate); err == nil {
+			total += info.Size()
+		}
+	}
+	return total
+}
+
+// governSize enforces the on-disk size cap. Best-effort: failures surface via
+// status.LastError and the next reconcile tick retries.
+func (c *Catalog) governSize(ctx context.Context) {
+	if c.opts.MaxBytes <= 0 || c.opts.InMemory || strings.TrimSpace(c.opts.Path) == "" {
+		return
+	}
+	size := historyDBFileSize(c.opts.Path)
+	if size <= c.opts.MaxBytes {
+		return
+	}
+	// Live WAL bytes are not reclaimable; fold them before measuring again.
+	_, _ = c.db.ExecContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`)
+	size = historyDBFileSize(c.opts.Path)
+	if size <= c.opts.MaxBytes {
+		return
+	}
+	if size > rebuildOversizeFactor*c.opts.MaxBytes {
+		c.wipeForRebuild(ctx)
+		return
+	}
+	c.evictToTarget(ctx, size)
+}
+
+func wipeProjectionRows(ctx context.Context, tx *sql.Tx) error {
+	for _, statement := range []string{`DELETE FROM history_fts`, `DELETE FROM history_documents`,
+		`DELETE FROM history_sources`, `DELETE FROM history_roots`} {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// reclaimDiskSpace collapses FTS delete tombstones and returns freed pages to
+// the OS. auto_vacuum never stuck on these pooled handles, so
+// incremental_vacuum is a no-op here; VACUUM is the only working reclaim, and
+// in WAL mode its pages land in the WAL first, so the checkpoint follows it.
+func (c *Catalog) reclaimDiskSpace(ctx context.Context) {
+	_, _ = c.db.ExecContext(ctx, `INSERT INTO history_fts(history_fts) VALUES('optimize')`)
+	_, _ = c.db.ExecContext(ctx, `VACUUM`)
+	_, _ = c.db.ExecContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`)
+}
+
+// wipeForRebuild drops the whole projection so roots rescan under current
+// indexing rules; source session files are never touched.
+func (c *Catalog) wipeForRebuild(ctx context.Context) {
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		c.setError(err)
+		return
+	}
+	if err := wipeProjectionRows(ctx, tx); err != nil {
+		_ = tx.Rollback()
+		c.setError(err)
+		return
+	}
+	revision, err := bump(ctx, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		c.setError(err)
+		return
+	}
+	if err := tx.Commit(); err != nil {
+		c.setError(err)
+		return
+	}
+	c.reclaimDiskSpace(ctx)
+	c.markAllRootsDirty()
+	c.publish(revision, nil, "rebuild-oversize")
+}
+
+func (c *Catalog) evictToTarget(ctx context.Context, size int64) {
+	target := c.opts.MaxBytes * evictTargetPercent / 100
+	for range maxEvictRounds {
+		if size <= target {
+			return
+		}
+		evicted, err := c.evictOldestBatch(ctx, size, size-target)
+		if err != nil {
+			c.setError(err)
+			return
+		}
+		if evicted == 0 {
+			return
+		}
+		c.reclaimDiskSpace(ctx)
+		size = historyDBFileSize(c.opts.Path)
+	}
+}
+
+// evictOldestBatch drops index rows for the least-recently-active sessions
+// whose estimated footprint covers overage (always at least one). The
+// history_sources row survives as health='evicted' so an unchanged file is not
+// indexed back in on the next rescan; it fully re-indexes on its next content
+// change. Source session files are never touched.
+func (c *Catalog) evictOldestBatch(ctx context.Context, size, overage int64) (int, error) {
+	rows, err := c.db.QueryContext(ctx, `SELECT s.path,COALESCE(SUM(d.token_count),0)
+        FROM history_sources s JOIN history_documents d ON d.source_path=s.path
+        GROUP BY s.path ORDER BY s.last_activity_at ASC,s.path ASC`)
+	if err != nil {
+		return 0, err
+	}
+	type candidate struct {
+		path   string
+		tokens int64
+	}
+	candidates := []candidate{}
+	var totalTokens int64
+	for rows.Next() {
+		var cand candidate
+		if err := rows.Scan(&cand.path, &cand.tokens); err != nil {
+			_ = rows.Close()
+			return 0, err
+		}
+		candidates = append(candidates, cand)
+		totalTokens += cand.tokens
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return 0, err
+	}
+	_ = rows.Close()
+	if len(candidates) == 0 || totalTokens <= 0 {
+		return 0, nil
+	}
+	// Self-calibrating estimate of file bytes per indexed token (fixed overhead
+	// included), so the prefix errs towards evicting too few per round rather
+	// than too many; the round loop re-measures and converges.
+	bytesPerToken := float64(size) / float64(totalTokens)
+	batch := []string{}
+	covered := 0.0
+	for _, cand := range candidates {
+		batch = append(batch, cand.path)
+		covered += float64(cand.tokens) * bytesPerToken
+		if covered >= float64(overage) {
+			break
+		}
+	}
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	for _, path := range batch {
+		for _, statement := range []string{
+			`DELETE FROM history_fts WHERE rowid IN (SELECT id FROM history_documents WHERE source_path=?)`,
+			`DELETE FROM history_documents WHERE source_path=?`,
+		} {
+			if _, err := tx.ExecContext(ctx, statement, path); err != nil {
+				_ = tx.Rollback()
+				return 0, err
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE history_sources SET health='evicted' WHERE path=?`, path); err != nil {
+			_ = tx.Rollback()
+			return 0, err
+		}
+	}
+	revision, err := bump(ctx, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	c.publish(revision, nil, "evict")
+	return len(batch), nil
+}

--- a/internal/historycatalog/govern_test.go
+++ b/internal/historycatalog/govern_test.go
@@ -45,7 +45,7 @@ func TestResolveMaxBytes(t *testing.T) {
 func saveToolSession(t *testing.T, path, marker string, exchanges int) {
 	t.Helper()
 	messages := []provider.Message{{Role: provider.RoleUser, Content: "question about " + marker}}
-	for i := 0; i < exchanges; i++ {
+	for i := range exchanges {
 		id := fmt.Sprintf("call-%d", i)
 		content := id + " " + strings.Repeat("payload ", 4096)
 		if i == 0 {
@@ -226,7 +226,7 @@ func TestGovernSizeEvictsDownToTarget(t *testing.T) {
 		path := filepath.Join(root, marker+".jsonl")
 		if sourceHealth(t, catalog, path) == "evicted" {
 			// Eviction must be a prefix of the last-activity-ascending order.
-			for j := 0; j < i; j++ {
+			for j := range i {
 				prev := filepath.Join(root, markers[j]+".jsonl")
 				if sourceHealth(t, catalog, prev) != "evicted" {
 					t.Fatalf("%s evicted while older %s survived", marker, markers[j])

--- a/internal/historycatalog/govern_test.go
+++ b/internal/historycatalog/govern_test.go
@@ -1,0 +1,380 @@
+package historycatalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/provider"
+)
+
+func TestResolveMaxBytes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		option       int64
+		configuredMB int
+		want         int64
+	}{
+		{"explicit option wins", 12345, 512, 12345},
+		{"config max_mb", 0, 512, 512 << 20},
+		{"built-in default", 0, 0, DefaultMaxBytes},
+		{"negative config ignored", 0, -10, DefaultMaxBytes},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveMaxBytes(tt.option, tt.configuredMB); got != tt.want {
+				t.Fatalf("resolveMaxBytes(%d,%d)=%d, want %d", tt.option, tt.configuredMB, got, tt.want)
+			}
+		})
+	}
+	if DefaultMaxBytes != 256<<20 {
+		t.Fatalf("DefaultMaxBytes=%d, want 256MiB", DefaultMaxBytes)
+	}
+}
+
+// saveToolSession writes a session with exchanges tool calls, each carrying a
+// 32KB output, so one session's index footprint is meaningful next to the
+// database's fixed page overhead.
+func saveToolSession(t *testing.T, path, marker string, exchanges int) {
+	t.Helper()
+	messages := []provider.Message{{Role: provider.RoleUser, Content: "question about " + marker}}
+	for i := 0; i < exchanges; i++ {
+		id := fmt.Sprintf("call-%d", i)
+		content := id + " " + strings.Repeat("payload ", 4096)
+		if i == 0 {
+			// Keep the marker in exactly one document so search-hit counts are
+			// per-session, not per-exchange.
+			content = id + " " + marker + " " + strings.Repeat("payload ", 4096)
+		}
+		messages = append(messages,
+			provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: id, Name: "bash", Arguments: `{"cmd":"echo ` + id + `"}`}}},
+			provider.Message{Role: provider.RoleTool, ToolCallID: id, Name: "bash", Content: content})
+	}
+	saveMessages(t, path, messages...)
+}
+
+// setSessionModTime back-dates the session file and its sidecars so
+// last_activity_at ordering is deterministic.
+func setSessionModTime(t *testing.T, path string, mod time.Time) {
+	t.Helper()
+	stem := strings.TrimSuffix(path, filepath.Ext(path))
+	matches, err := filepath.Glob(stem + "*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, match := range matches {
+		if err := os.Chtimes(match, mod, mod); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func toolOutputHits(t *testing.T, catalog *Catalog, root, marker string) int {
+	t.Helper()
+	result, err := catalog.Search(context.Background(), SearchRequest{Query: marker, Kinds: []string{"tool_output"}, Roots: []string{root}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(result.Items)
+}
+
+func sourceHealth(t *testing.T, catalog *Catalog, path string) string {
+	t.Helper()
+	var health string
+	if err := catalog.db.QueryRow(`SELECT health FROM history_sources WHERE path=?`, path).Scan(&health); err != nil {
+		t.Fatal(err)
+	}
+	return health
+}
+
+func waitForCondition(t *testing.T, what string, ok func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if ok() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("%s: condition not met within 5s", what)
+}
+
+// checkpoint folds the WAL so file-size-based caps are measured post-fold.
+func checkpoint(t *testing.T, catalog *Catalog) {
+	t.Helper()
+	if _, err := catalog.db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// appendToSession grows an on-disk session so its content fingerprint changes.
+func appendToSession(t *testing.T, path, marker string) {
+	t.Helper()
+	session, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "more about " + marker})
+	if err := session.SaveSnapshot(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGovernSizeUnderCapIsNoOp(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	root := t.TempDir()
+	path := filepath.Join(root, "alpha.jsonl")
+	saveToolSession(t, path, "alphamarker", 4)
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "history.sqlite"), MaxBytes: 1 << 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	if err := catalog.ReconcileRoot(ctx, Root{Path: root, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+	catalog.governSize(ctx)
+	if hits := toolOutputHits(t, catalog, root, "alphamarker"); hits != 1 {
+		t.Fatalf("under-cap governSize dropped rows: hits=%d", hits)
+	}
+	if health := sourceHealth(t, catalog, path); health != "ok" {
+		t.Fatalf("health=%q, want ok", health)
+	}
+}
+
+func TestEvictOldestBatchEvictsLeastRecentlyActiveFirst(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	root := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "history.sqlite")
+	now := time.Now()
+	paths := map[string]string{}
+	for i, marker := range []string{"alpha", "beta", "gamma"} {
+		path := filepath.Join(root, marker+".jsonl")
+		saveToolSession(t, path, marker+"marker", 4)
+		setSessionModTime(t, path, now.Add(time.Duration(i-3)*time.Hour))
+		paths[marker] = path
+	}
+	catalog, err := Open(ctx, Options{Path: dbPath, MaxBytes: 1 << 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	if err := catalog.ReconcileRoot(ctx, Root{Path: root, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+	evicted, err := catalog.evictOldestBatch(ctx, historyDBFileSize(dbPath), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evicted != 1 {
+		t.Fatalf("evicted=%d, want exactly 1 for a 1-byte overage", evicted)
+	}
+	if hits := toolOutputHits(t, catalog, root, "alphamarker"); hits != 0 {
+		t.Fatalf("oldest session still searchable: hits=%d", hits)
+	}
+	for _, marker := range []string{"beta", "gamma"} {
+		if hits := toolOutputHits(t, catalog, root, marker+"marker"); hits != 1 {
+			t.Fatalf("%s wrongly evicted: hits=%d", marker, hits)
+		}
+	}
+	if health := sourceHealth(t, catalog, paths["alpha"]); health != "evicted" {
+		t.Fatalf("evicted source health=%q, want evicted", health)
+	}
+	if _, err := os.Stat(paths["alpha"]); err != nil {
+		t.Fatalf("eviction touched the source session file: %v", err)
+	}
+}
+
+func TestGovernSizeEvictsDownToTarget(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	root := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "history.sqlite")
+	now := time.Now()
+	markers := []string{"alpha", "beta", "gamma", "delta"}
+	for i, marker := range markers {
+		path := filepath.Join(root, marker+".jsonl")
+		saveToolSession(t, path, marker+"marker", 24)
+		setSessionModTime(t, path, now.Add(time.Duration(i-len(markers))*time.Hour))
+	}
+	catalog, err := Open(ctx, Options{Path: dbPath, MaxBytes: 1 << 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	if err := catalog.ReconcileRoot(ctx, Root{Path: root, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+	checkpoint(t, catalog)
+	size := historyDBFileSize(dbPath)
+	catalog.opts.MaxBytes = size / 2 // over cap, well under the 2x rebuild threshold
+	catalog.governSize(ctx)
+
+	target := (size / 2) * evictTargetPercent / 100
+	final := historyDBFileSize(dbPath)
+	evictedCount := 0
+	for i, marker := range markers {
+		path := filepath.Join(root, marker+".jsonl")
+		if sourceHealth(t, catalog, path) == "evicted" {
+			// Eviction must be a prefix of the last-activity-ascending order.
+			for j := 0; j < i; j++ {
+				prev := filepath.Join(root, markers[j]+".jsonl")
+				if sourceHealth(t, catalog, prev) != "evicted" {
+					t.Fatalf("%s evicted while older %s survived", marker, markers[j])
+				}
+			}
+			evictedCount++
+			if hits := toolOutputHits(t, catalog, root, marker+"marker"); hits != 0 {
+				t.Fatalf("evicted %s still searchable", marker)
+			}
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("eviction touched source file %s: %v", marker, err)
+			}
+		} else if hits := toolOutputHits(t, catalog, root, marker+"marker"); hits != 1 {
+			t.Fatalf("retained %s not searchable: hits=%d", marker, hits)
+		}
+	}
+	if evictedCount == 0 {
+		t.Fatal("over-cap governSize evicted nothing")
+	}
+	if final > target && evictedCount < len(markers) {
+		t.Fatalf("size=%d still above target=%d with sessions left", final, target)
+	}
+	if final >= size {
+		t.Fatalf("eviction reclaimed nothing: before=%d after=%d", size, final)
+	}
+}
+
+func TestGovernSizeFarOverCapWipesProjection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	root := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "history.sqlite")
+	alphaPath := filepath.Join(root, "alpha.jsonl")
+	saveToolSession(t, alphaPath, "alphamarker", 4)
+	catalog, err := Open(ctx, Options{Path: dbPath, MaxBytes: 1 << 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	if err := catalog.ReconcileRoot(ctx, Root{Path: root, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+	checkpoint(t, catalog)
+	size := historyDBFileSize(dbPath)
+	catalog.opts.MaxBytes = size / 4 // beyond the 2x rebuild threshold
+	catalog.governSize(ctx)
+	for _, table := range []string{"history_fts", "history_documents", "history_sources", "history_roots"} {
+		var count int
+		if err := catalog.db.QueryRow(`SELECT COUNT(*) FROM ` + table).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Fatalf("%s still has %d rows after oversize wipe", table, count)
+		}
+	}
+	if _, err := os.Stat(alphaPath); err != nil {
+		t.Fatalf("wipe touched the source session file: %v", err)
+	}
+}
+
+func TestOpenTriggersBackgroundWipeWhenFarOverCap(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	root := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "history.sqlite")
+	saveToolSession(t, filepath.Join(root, "alpha.jsonl"), "alphamarker", 4)
+	catalog, err := Open(ctx, Options{Path: dbPath, MaxBytes: 1 << 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.ReconcileRoot(ctx, Root{Path: root, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+	size := historyDBFileSize(dbPath)
+	reopened, err := Open(ctx, Options{Path: dbPath, MaxBytes: size / 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reopened.Close(context.Background()) })
+	waitForCondition(t, "background wipe", func() bool {
+		var count int
+		if err := reopened.db.QueryRow(`SELECT COUNT(*) FROM history_documents`).Scan(&count); err != nil {
+			return false
+		}
+		return count == 0
+	})
+	// The wipe must be followed by a rescan that rebuilds the index (now with
+	// truncated tool payloads) without blocking startup.
+	reopened.RegisterRoot(Root{Path: root, Scope: "global"})
+	waitForCondition(t, "rebuild rescan", func() bool {
+		result, err := reopened.Search(ctx, SearchRequest{Query: "alphamarker", Kinds: []string{"tool_output"}, Roots: []string{root}})
+		return err == nil && len(result.Items) == 1
+	})
+}
+
+func TestEvictedSessionStaysEvictedWhenUnchangedAndReindexesOnChange(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	root := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "history.sqlite")
+	now := time.Now()
+	alphaPath := filepath.Join(root, "alpha.jsonl")
+	betaPath := filepath.Join(root, "beta.jsonl")
+	saveToolSession(t, alphaPath, "alphamarker", 4)
+	saveToolSession(t, betaPath, "betamarker", 4)
+	setSessionModTime(t, alphaPath, now.Add(-2*time.Hour))
+	setSessionModTime(t, betaPath, now.Add(-time.Hour))
+	catalog, err := Open(ctx, Options{Path: dbPath, MaxBytes: 1 << 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	registered := Root{Path: root, Scope: "global"}
+	if err := catalog.ReconcileRoot(ctx, registered); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := catalog.evictOldestBatch(ctx, historyDBFileSize(dbPath), 1); err != nil {
+		t.Fatal(err)
+	}
+	if health := sourceHealth(t, catalog, alphaPath); health != "evicted" {
+		t.Fatalf("alpha health=%q, want evicted", health)
+	}
+
+	// Touch beta so the root signature changes and both paths are revisited;
+	// alpha is unchanged and must stay out of the index.
+	appendToSession(t, betaPath, "betamarker")
+	if err := catalog.ReconcileRoot(ctx, registered); err != nil {
+		t.Fatal(err)
+	}
+	if health := sourceHealth(t, catalog, alphaPath); health != "evicted" {
+		t.Fatalf("unchanged alpha resurrected: health=%q", health)
+	}
+	if hits := toolOutputHits(t, catalog, root, "alphamarker"); hits != 0 {
+		t.Fatalf("unchanged alpha re-indexed: hits=%d", hits)
+	}
+
+	// A content change fully re-indexes an evicted session.
+	appendToSession(t, alphaPath, "alphamarker")
+	if err := catalog.indexPath(ctx, registered, alphaPath, 0, -1); err != nil {
+		t.Fatal(err)
+	}
+	if health := sourceHealth(t, catalog, alphaPath); health != "ok" {
+		t.Fatalf("changed alpha health=%q, want ok", health)
+	}
+	if hits := toolOutputHits(t, catalog, root, "alphamarker"); hits != 1 {
+		t.Fatalf("changed alpha not re-indexed: hits=%d", hits)
+	}
+}

--- a/internal/historycatalog/types.go
+++ b/internal/historycatalog/types.go
@@ -37,6 +37,7 @@ type Options struct {
 	QueueCapacity     int
 	MissingGrace      time.Duration
 	ReconcileInterval time.Duration
+	MaxBytes          int64 // on-disk index cap; 0 = history_search.max_mb or DefaultMaxBytes
 	Now               func() time.Time
 	OnRevision        func(Status, []string, string)
 }


### PR DESCRIPTION
Problem: the history search index could grow without a bounded governance path as sessions and content revisions accumulated.

Root cause: catalog documents had no explicit cap/eviction policy for retained search material.

Fix: add bounded history-search configuration, document governance, and focused catalog tests while preserving resident projections and revision checks.

Verification: `go test ./internal/historycatalog ./internal/config`.

This is an adapted, focused replacement for the corresponding part of #9195.

Documentation-impact: none - this adds internal history-index governance and configuration handling without changing user-facing setup documentation.

Cache-impact: none - the change only bounds the disposable local history projection; model requests, prompts, tool schemas, and response caching are unchanged.

Cache-guard: no cache-visible request path changed; `scripts/check-cache-impact.sh` is the repository guard for this scope.
