### PR TITLE
Desktop: stabilize transcript tail ownership / 桌面端：稳定对话滚动尾部归属

### DIFF
--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -208,8 +208,14 @@ try {
     const settle = () => frames-- <= 0 ? resolve() : requestAnimationFrame(settle);
     requestAnimationFrame(settle);
   }));
-  await page.mouse.move(hydrationBox.x + hydrationBox.width / 2, hydrationBox.y + hydrationBox.height / 2);
-  await page.mouse.wheel(0, 100_000);
+  await moveToOuterReaderGutter(page, hydrationTranscript);
+  for (let attempt = 0; attempt < 32; attempt += 1) {
+    await page.mouse.wheel(0, 10_000);
+    const atBottom = await hydrationTranscript.evaluate((element) =>
+      element.scrollHeight - element.scrollTop - element.clientHeight <= 1);
+    if (atBottom) break;
+    await page.waitForTimeout(16);
+  }
   await page.waitForFunction(() => {
     const element = document.querySelector(".transcript");
     return element instanceof HTMLElement

--- a/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
@@ -230,15 +230,19 @@ await act(async () => arbiter?.atBottomStateChange(false));
 check(arbiter?.isAtBottom === true, "physical bottom overrides a stale Virtuoso atBottom=false report");
 
 // A thumb gesture that reaches the frozen native bottom must claim the tail
-// before release resumes real row measurements and changes the extent.
+// before release resumes real row measurements and changes the extent. The
+// claim now requires the bottom to be HELD (#8709/#9099): the native scroll
+// deliveries while the thumb rests at the bottom build the hold streak that
+// the release's final delivery completes.
 scrollElement.scrollTop = 0;
 await act(async () => arbiter?.onPointerDownIntent({
   button: 0,
   nativeEvent: { button: 0, clientX: 795 },
 } as React.PointerEvent<HTMLElement>));
 scrollElement.scrollTop = 400;
+await act(async () => arbiter?.deliverScroll());
 await act(async () => window.dispatchEvent(new dom.window.Event("pointerup")));
-check(arbiter?.modeRef.current === "tail-follow", "native thumb release at the physical bottom resumes tail-follow");
+check(arbiter?.modeRef.current === "tail-follow", "native thumb release after a held physical bottom resumes tail-follow");
 scrollExtent = 900;
 await act(async () => arbiter?.deliverScroll());
 await flushFrames();
@@ -279,8 +283,11 @@ check(nestedWheelAccepted && arbiter?.modeRef.current === "manual", "a nested ed
 nestedScroller.remove();
 
 // If measurement/clamping reaches the physical bottom between scroll events,
-// a fresh downward gesture must still claim tail-follow even though the
-// browser has no remaining pixels to deliver.
+// a fresh downward gesture must still claim the tail even though the browser
+// has no remaining pixels to deliver. Tail-follow re-entry now requires the
+// bottom to be HELD (#8709/#9099): a single touch-down claims the gesture
+// but stays manual, and a second at-bottom delivery inside the same intent
+// window re-enters tail-follow.
 scrollElement.scrollTop = 400;
 let bottomWheelAccepted = false;
 await act(async () => {
@@ -291,7 +298,59 @@ await act(async () => {
     target: scrollElement,
   } as React.WheelEvent<HTMLElement>) ?? false;
 });
-check(bottomWheelAccepted && arbiter?.modeRef.current === "tail-follow", "a downward gesture claims an already-clamped physical bottom");
+check(bottomWheelAccepted && arbiter?.modeRef.current === "manual", "a single downward touch-down claims the gesture without re-entering tail-follow");
+await act(async () => {
+  bottomWheelAccepted = arbiter?.onWheelIntent({
+    ctrlKey: false,
+    deltaX: 0,
+    deltaY: 40,
+    target: scrollElement,
+  } as React.WheelEvent<HTMLElement>) ?? false;
+});
+check(bottomWheelAccepted && arbiter?.modeRef.current === "tail-follow", "a held physical bottom (second delivery) re-enters tail-follow");
+
+// An upward gesture inside the streak resets the hold: the next downward
+// gesture must re-establish it from zero.
+await act(async () => arbiter?.releaseTailFollow());
+scrollElement.scrollTop = 400;
+await act(async () => {
+  arbiter?.onWheelIntent({
+    ctrlKey: false,
+    deltaX: 0,
+    deltaY: 40,
+    target: scrollElement,
+  } as React.WheelEvent<HTMLElement>);
+});
+check(arbiter?.modeRef.current === "manual", "one at-bottom delivery starts the hold without re-entering");
+await act(async () => {
+  arbiter?.onWheelIntent({
+    ctrlKey: false,
+    deltaX: 0,
+    deltaY: -40,
+    target: scrollElement,
+  } as React.WheelEvent<HTMLElement>);
+});
+scrollElement.scrollTop = 300;
+await act(async () => arbiter?.deliverScroll());
+scrollElement.scrollTop = 400;
+await act(async () => {
+  arbiter?.onWheelIntent({
+    ctrlKey: false,
+    deltaX: 0,
+    deltaY: 40,
+    target: scrollElement,
+  } as React.WheelEvent<HTMLElement>);
+});
+check(arbiter?.modeRef.current === "manual", "an upward gesture between at-bottom deliveries breaks the hold");
+await act(async () => {
+  arbiter?.onWheelIntent({
+    ctrlKey: false,
+    deltaX: 0,
+    deltaY: 40,
+    target: scrollElement,
+  } as React.WheelEvent<HTMLElement>);
+});
+check(arbiter?.modeRef.current === "tail-follow", "two consecutive held deliveries after the reset re-enter tail-follow");
 
 // A queued confirmation belongs to the surface that requested it. Resetting
 // before its frame runs must prevent the old request from writing the new one.
@@ -786,6 +845,76 @@ await advanceClock(2_100);
 const nextGenerationResetBefore = integrity?.resetKey;
 await triggerWatchdogRebuild();
 check(integrity?.resetKey !== nextGenerationResetBefore, "a changed 10,000-row generation receives a fresh hard-reset budget");
+
+// ── Manual-mode viewport anchor compensation (#8438/#8488/#8897): an
+// above-viewport height change (fold auto-collapse, history patch) must not
+// push the reading position. The drift is measured against the anchor sampled
+// on the last delivered scroll and corrected through exactly one arbiter-owned
+// offset write; growth below the viewport and ownership changes earn none.
+await switchSurface("surface-anchor");
+scrollElement.appendChild(rowElement);
+scrollExtent = 500;
+// Real-geometry stub: the row's client position tracks scrollTop like a
+// browser's would (document top 150).
+rowElement.getBoundingClientRect = () => rectAt(150 - scrollElement.scrollTop);
+scrollElement.scrollTop = 100;
+await act(async () => arbiter?.setMode("manual", "test-anchor-compensation"));
+await act(async () => arbiter?.deliverScroll());
+scrollWrites.length = 0;
+// A fold above the viewport expands: extent and the row both move +200.
+scrollExtent = 700;
+rowElement.getBoundingClientRect = () => rectAt(350 - scrollElement.scrollTop);
+await act(async () => arbiter?.followGrowingTail());
+await flushFrames(); // followGrowingTail frame: LAYOUT_HEIGHT_CHANGED + compensation scheduled
+await flushFrames(); // compensation measures drift and writes once
+await flushFrames(); // stable frame 1
+await flushFrames(); // stable frame 2: done
+const compensationWrites = scrollWrites.filter((write) => write.owner === "anchor-compensation");
+check(compensationWrites.length === 1, `above-viewport growth in manual mode emits exactly one anchor-compensation write (${compensationWrites.length})`);
+check(compensationWrites[0]?.top === 300 && scrollElement.scrollTop === 300, "the compensation restores the anchor row's viewport offset");
+check(arbiter?.modeRef.current === "manual", "anchor compensation preserves manual reading ownership");
+check(rowElement.getBoundingClientRect().top === 50, "the anchor row is physically back at its pre-change offset");
+
+// Growth below the viewport (streaming tail) leaves the anchor row put:
+// zero measured drift, zero writes.
+await act(async () => arbiter?.deliverScroll());
+scrollWrites.length = 0;
+scrollExtent = 900;
+await act(async () => arbiter?.followGrowingTail());
+for (let i = 0; i < 4; i += 1) await flushFrames();
+check(
+  scrollWrites.filter((write) => write.owner === "anchor-compensation").length === 0,
+  "below-viewport growth earns no compensation write",
+);
+check(scrollElement.scrollTop === 300, "below-viewport growth leaves the reading position untouched");
+
+// A collapse above the viewport (CONTENT_SHRANK path) compensates upward.
+scrollWrites.length = 0;
+scrollExtent = 600;
+rowElement.getBoundingClientRect = () => rectAt(150 - scrollElement.scrollTop);
+await act(async () => arbiter?.followGrowingTail());
+for (let i = 0; i < 4; i += 1) await flushFrames();
+const shrinkWrites = scrollWrites.filter((write) => write.owner === "anchor-compensation");
+check(shrinkWrites.length === 1 && shrinkWrites[0]?.top === 100, "an above-viewport collapse compensates upward exactly once");
+check(scrollElement.scrollTop === 100, "the upward compensation restores the anchor offset");
+
+// A user gesture mid-compensation cancels the loop: the reader owns the
+// viewport from there on.
+await act(async () => arbiter?.deliverScroll());
+scrollWrites.length = 0;
+scrollExtent = 800;
+rowElement.getBoundingClientRect = () => rectAt(350 - scrollElement.scrollTop);
+await act(async () => arbiter?.followGrowingTail());
+await flushFrames(); // schedules the compensation
+await act(async () => arbiter?.releaseTailFollow());
+for (let i = 0; i < 4; i += 1) await flushFrames();
+check(
+  scrollWrites.filter((write) => write.owner === "anchor-compensation").length === 0,
+  "user scroll intent cancels a pending anchor compensation",
+);
+
+rowElement.getBoundingClientRect = () => rectAt(200);
+scrollExtent = 500;
 
 await act(async () => root.unmount());
 Date.now = originalDateNow;

--- a/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
@@ -72,9 +72,56 @@ const returned = run([
   { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
   { type: "USER_SCROLL_INTENT", canClaimTail: true },
   { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
+  // The bottom must be held: two consecutive at-bottom deliveries inside the
+  // same reader-intent window re-engage tail-follow (#8709/#9099).
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
   { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
 ]);
-check(returned.state.mode === "tail-follow", "reaching the real bottom re-engages tail-follow");
+check(returned.state.mode === "tail-follow", "holding the real bottom across two deliveries re-engages tail-follow");
+
+const touchDownOnce = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "USER_SCROLL_INTENT", canClaimTail: true },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+]);
+check(touchDownOnce.state.mode === "manual", "a single touch-down at the bottom stays manual");
+
+const holdBrokenByUpwardGesture = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "USER_SCROLL_INTENT", canClaimTail: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  // An upward gesture inside the streak resets the hold; the next downward
+  // gesture starts again from zero.
+  { type: "USER_SCROLL_INTENT", canClaimTail: false },
+  { type: "USER_SCROLL_INTENT", canClaimTail: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+]);
+check(holdBrokenByUpwardGesture.state.mode === "manual", "an upward gesture breaks the bottom-hold streak");
+
+const holdEndsWithIntentWindow = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "USER_SCROLL_INTENT", canClaimTail: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "READER_INTENT_ENDED" },
+  { type: "USER_SCROLL_INTENT", canClaimTail: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+]);
+check(holdEndsWithIntentWindow.state.mode === "manual", "a closed intent window ends the bottom-hold streak");
+
+const steadyStateOffsetKeepsManual = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "USER_SCROLL_INTENT", canClaimTail: false },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
+  { type: "READER_INTENT_ENDED" },
+  { type: "SCROLL_TO_OFFSET", owner: "anchor-compensation", top: 640 },
+  { type: "SCROLL_TO_OFFSET", owner: "block-window-prepend", top: 680 },
+]);
+check(steadyStateOffsetKeepsManual.state.mode === "manual", "steady-state offset corrections keep manual ownership");
+check(
+  steadyStateOffsetKeepsManual.commands.join(",") === "SCROLL_TO_OFFSET,SCROLL_TO_OFFSET",
+  "steady-state offset corrections emit only their own commands",
+);
 
 const browserClamp = run([
   { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -52,7 +52,7 @@ import { useCreationTranscriptScrollbar } from "../lib/useCreationTranscriptScro
 import { useTranscriptScrollInteractions } from "../lib/useTranscriptScrollInteractions";
 import { hasTranscriptScrollableRange, TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX, useTranscriptScrollArbiter } from "../lib/useTranscriptScrollArbiter";
 import { useTranscriptLayoutIntegrity } from "../lib/useTranscriptLayoutIntegrity";
-import { TranscriptLayoutIntentProvider } from "./TranscriptLayoutIntentContext";
+import { TranscriptLayoutIntentProvider, TranscriptScrollWriteProvider } from "./TranscriptLayoutIntentContext";
 import { MarkdownImageTabContext } from "./MarkdownImageContext";
 import { recordTranscriptScrollDiagnostic } from "../lib/transcriptScrollProbe";
 import { useTranscriptQuestionJump, useTranscriptQuestions } from "../lib/useTranscriptQuestionNavigation";
@@ -964,6 +964,7 @@ export function Transcript({
     <InvocationMetadataContext.Provider value={invocationMetadata}>
     <MarkdownImageTabContext.Provider value={tabId ?? ""}>
     <TranscriptLayoutIntentProvider value={beginUserResize}>
+    <TranscriptScrollWriteProvider value={writeOffset}>
     <div className="transcript-shell">
       {empty ? (
         <div
@@ -1063,6 +1064,7 @@ export function Transcript({
       )}
       {ScrollDiagnosticPanel && <Suspense fallback={null}><ScrollDiagnosticPanel scrollElement={scrollElement} totalRows={virtualRows.length} /></Suspense>}
     </div>
+    </TranscriptScrollWriteProvider>
     </TranscriptLayoutIntentProvider>
     </MarkdownImageTabContext.Provider>
     </InvocationMetadataContext.Provider>

--- a/desktop/frontend/src/components/TranscriptLayoutIntentContext.tsx
+++ b/desktop/frontend/src/components/TranscriptLayoutIntentContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext } from "react";
+import type { TranscriptScrollOwner } from "../lib/transcriptScrollArbiter";
 
 const TranscriptLayoutIntentContext = createContext<() => void>(() => {});
 
@@ -6,4 +7,18 @@ export const TranscriptLayoutIntentProvider = TranscriptLayoutIntentContext.Prov
 
 export function useTranscriptUserResizeIntent(): () => void {
   return useContext(TranscriptLayoutIntentContext);
+}
+
+// Rows deep in the transcript tree (e.g. MarkdownHistory's block window)
+// reach the scroll arbiter's offset-write channel through this context. The
+// single-writer rule (desktop/AGENTS.md) forbids raw scroller writes, so
+// without a provider there is nobody to route to and compensation is skipped.
+type TranscriptScrollOffsetWrite = (owner: TranscriptScrollOwner, top: number, behavior?: ScrollBehavior) => boolean;
+
+const TranscriptScrollWriteContext = createContext<TranscriptScrollOffsetWrite | null>(null);
+
+export const TranscriptScrollWriteProvider = TranscriptScrollWriteContext.Provider;
+
+export function useTranscriptScrollOffsetWrite(): TranscriptScrollOffsetWrite | null {
+  return useContext(TranscriptScrollWriteContext);
 }

--- a/desktop/frontend/src/lib/transcriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/transcriptScrollArbiter.ts
@@ -10,7 +10,9 @@ export type TranscriptScrollOwner =
   | "rewind"
   | "jump-bottom"
   | "custom-scrollbar"
-  | "selection-edge-scroll";
+  | "selection-edge-scroll"
+  | "anchor-compensation"
+  | "block-window-prepend";
 
 /** Why an in-flight recovery request was cancelled. "user-takeover" is the
  *  only preemption path user gestures take; the other two are lifecycle
@@ -26,6 +28,11 @@ export type TranscriptScrollState = {
   scrollable: boolean;
   readerIntent: boolean;
   readerIntentCanClaimTail: boolean;
+  /** Consecutive at-bottom deliveries inside one reader-intent window. Reset
+   *  by upward gestures, by leaving the bottom, and when the intent window
+   *  closes. Tail-follow auto re-entry requires the bottom to be held for
+   *  TRANSCRIPT_BOTTOM_HOLD_DELIVERIES consecutive deliveries (#8709/#9099). */
+  bottomHoldCount: number;
   settleMode: "tail-follow" | "manual";
   /** Id of the in-flight recovery request; at most one at a time. */
   recoveryId: number | null;
@@ -71,6 +78,7 @@ export const INITIAL_TRANSCRIPT_SCROLL_STATE: TranscriptScrollState = {
   scrollable: false,
   readerIntent: false,
   readerIntentCanClaimTail: false,
+  bottomHoldCount: 0,
   settleMode: "tail-follow",
   recoveryId: null,
 };
@@ -91,6 +99,13 @@ export function isSubstantialTranscriptDisplacement(distance: number): boolean {
 export function isTranscriptContentShrink(delta: number): boolean {
   return delta <= -TRANSCRIPT_CONTENT_SHRINK_THRESHOLD_PX;
 }
+
+// Auto re-entry into tail-follow requires the bottom to be held stable: this
+// many consecutive at-bottom deliveries with no upward gesture in between. A
+// single touch-down (one wheel tick, a thumb flick, a browser clamp landing on
+// the bottom) no longer re-enters (#8709/#9099); only an explicit
+// JUMP_TO_BOTTOM bypasses the hold.
+export const TRANSCRIPT_BOTTOM_HOLD_DELIVERIES = 2;
 
 function transition(state: TranscriptScrollState, commands: readonly TranscriptScrollCommand[] = []): TranscriptScrollTransition {
   return { state, commands };
@@ -126,28 +141,42 @@ export function reduceTranscriptScroll(
       return preempt(INITIAL_TRANSCRIPT_SCROLL_STATE, [], "surface-switch");
     case "USER_SCROLL_INTENT":
       if (!state.scrollable) {
-        return preempt({ ...state, mode: "tail-follow", atBottom: true, readerIntent: false, readerIntentCanClaimTail: false, settleMode: "tail-follow" });
+        return preempt({ ...state, mode: "tail-follow", atBottom: true, readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0, settleMode: "tail-follow" });
       }
-      return preempt({ ...state, mode: "manual", readerIntent: true, readerIntentCanClaimTail: event.canClaimTail, settleMode: "manual" });
+      // A downward (tail-claiming) gesture keeps the current bottom-hold
+      // streak alive; an upward or non-claiming gesture breaks it.
+      return preempt({ ...state, mode: "manual", readerIntent: true, readerIntentCanClaimTail: event.canClaimTail, bottomHoldCount: event.canClaimTail ? state.bottomHoldCount : 0, settleMode: "manual" });
     case "MANUAL_READING":
-      return preempt({ ...state, mode: "manual", readerIntent: false, readerIntentCanClaimTail: false, settleMode: "manual" });
+      return preempt({ ...state, mode: "manual", readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0, settleMode: "manual" });
     case "READER_INTENT_ENDED":
-      return transition(state.readerIntent ? { ...state, readerIntent: false, readerIntentCanClaimTail: false } : state);
+      // The intent window closing also ends any bottom-hold streak: a later
+      // downward gesture must re-establish the hold from zero.
+      return transition(
+        state.readerIntent || state.bottomHoldCount !== 0
+          ? { ...state, readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0 }
+          : state,
+      );
     case "SCROLL_DELIVERED": {
       if (!event.scrollable) {
-        return transition({ ...state, mode: "tail-follow", atBottom: true, scrollable: false, readerIntent: false, readerIntentCanClaimTail: false, settleMode: "tail-follow" });
+        return transition({ ...state, mode: "tail-follow", atBottom: true, scrollable: false, readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0, settleMode: "tail-follow" });
       }
-      const next = { ...state, atBottom: event.atBottom, scrollable: true };
+      // The hold streak only accrues in manual mode (the only mode that can
+      // re-enter tail-follow this way) and breaks whenever the delivery is
+      // off the bottom.
+      const bottomHoldCount = event.atBottom && state.mode === "manual" ? state.bottomHoldCount + 1 : 0;
+      const next = { ...state, atBottom: event.atBottom, scrollable: true, bottomHoldCount };
       if (
         event.atBottom
         && state.readerIntent
         && state.readerIntentCanClaimTail
+        && bottomHoldCount >= TRANSCRIPT_BOTTOM_HOLD_DELIVERIES
         && state.mode !== "selection"
         && state.mode !== "user-resize"
         && state.mode !== "restoring"
       ) {
         next.mode = "tail-follow";
         next.settleMode = "tail-follow";
+        next.bottomHoldCount = 0;
       }
       return transition(
         next,
@@ -183,6 +212,7 @@ export function reduceTranscriptScroll(
         mode: "user-resize",
         readerIntent: false,
         readerIntentCanClaimTail: false,
+        bottomHoldCount: 0,
         settleMode: state.mode === "tail-follow" ? "tail-follow" : "manual",
       });
     case "USER_RESIZE_END":
@@ -191,30 +221,37 @@ export function reduceTranscriptScroll(
         state.mode === "user-resize" && state.settleMode === "tail-follow" ? [{ type: "AUTOSCROLL_TO_BOTTOM" }] : [],
       );
     case "SELECTION_BEGIN":
-      return preempt({ ...state, mode: "selection", readerIntent: false, readerIntentCanClaimTail: false, settleMode: "manual" });
+      return preempt({ ...state, mode: "selection", readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0, settleMode: "manual" });
     case "SELECTION_END":
       return transition(state.mode === "selection" ? { ...state, mode: "manual", settleMode: "manual" } : state);
     case "PROGRAMMATIC_BEGIN":
-      return preempt({ ...state, mode: "restoring", readerIntent: false, readerIntentCanClaimTail: false, settleMode: event.settleMode ?? "manual" });
+      return preempt({ ...state, mode: "restoring", readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0, settleMode: event.settleMode ?? "manual" });
     case "PROGRAMMATIC_END":
       return transition(state.mode === "restoring" ? { ...state, mode: state.settleMode } : state);
     case "JUMP_TO_BOTTOM":
       return preempt(
-        { ...state, mode: "tail-follow", atBottom: true, readerIntent: false, readerIntentCanClaimTail: false, settleMode: "tail-follow" },
+        { ...state, mode: "tail-follow", atBottom: true, readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0, settleMode: "tail-follow" },
         [{ type: "SCROLL_TO_LAST", behavior: event.behavior === "smooth" ? "smooth" : "auto" }],
       );
     case "JUMP_TO_INDEX":
       return preempt(
-        { ...state, mode: "restoring", atBottom: false, readerIntent: false, readerIntentCanClaimTail: false, settleMode: "manual" },
+        { ...state, mode: "restoring", atBottom: false, readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0, settleMode: "manual" },
         [{ type: "SCROLL_TO_INDEX", index: event.index, behavior: event.behavior ?? "auto" }],
       );
     case "SCROLL_TO_OFFSET":
+      // Steady-state corrections keep the current ownership: they only re-aim
+      // the offset (manual-mode viewport anchor compensation, in-row
+      // block-window prepend) without flipping the mode or claiming/releasing
+      // the tail, and they never preempt an in-flight recovery.
+      if (event.owner === "anchor-compensation" || event.owner === "block-window-prepend") {
+        return transition(state, [{ type: "SCROLL_TO_OFFSET", owner: event.owner, top: event.top, behavior: event.behavior ?? "auto" }]);
+      }
       return preempt(
         event.owner === "selection-edge-scroll"
-          ? { ...state, mode: "selection", readerIntent: false, readerIntentCanClaimTail: false, settleMode: "manual" }
+          ? { ...state, mode: "selection", readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0, settleMode: "manual" }
           : event.owner === "jump-bottom"
-            ? { ...state, mode: "tail-follow", atBottom: true, readerIntent: false, readerIntentCanClaimTail: false, settleMode: "tail-follow" }
-            : { ...state, mode: "restoring", atBottom: false, readerIntent: false, readerIntentCanClaimTail: false, settleMode: "manual" },
+            ? { ...state, mode: "tail-follow", atBottom: true, readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0, settleMode: "tail-follow" }
+            : { ...state, mode: "restoring", atBottom: false, readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0, settleMode: "manual" },
         [{ type: "SCROLL_TO_OFFSET", owner: event.owner, top: event.top, behavior: event.behavior ?? "auto" }],
       );
     case "RECOVERY_BEGIN":
@@ -222,11 +259,11 @@ export function reduceTranscriptScroll(
       // through the same explicit cancel transition a takeover would use.
       if (state.recoveryId !== null && state.recoveryId !== event.id) {
         return transition(
-          { ...state, mode: "restoring", readerIntent: false, readerIntentCanClaimTail: false, settleMode: event.settleMode ?? "manual", recoveryId: event.id },
+          { ...state, mode: "restoring", readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0, settleMode: event.settleMode ?? "manual", recoveryId: event.id },
           [{ type: "CANCEL_RECOVERY", id: state.recoveryId, reason: "superseded" }],
         );
       }
-      return transition({ ...state, mode: "restoring", readerIntent: false, readerIntentCanClaimTail: false, settleMode: event.settleMode ?? "manual", recoveryId: event.id });
+      return transition({ ...state, mode: "restoring", readerIntent: false, readerIntentCanClaimTail: false, bottomHoldCount: 0, settleMode: event.settleMode ?? "manual", recoveryId: event.id });
     case "RECOVERY_END":
       if (state.recoveryId !== event.id) return transition(state);
       return transition({

--- a/desktop/frontend/src/lib/transcriptVirtuosoRecovery.ts
+++ b/desktop/frontend/src/lib/transcriptVirtuosoRecovery.ts
@@ -84,6 +84,22 @@ export function captureTranscriptLayoutAnchor(
   );
 }
 
+/** Steady-state variant: only anchors on a row that actually intersects the
+ *  viewport. The nearest-row fallback in chooseTranscriptLayoutAnchor exists
+ *  for blank-viewport restores; using it for viewport compensation would
+ *  measure drift against an offscreen row and yank the reading position. */
+export function captureVisibleTranscriptLayoutAnchor(
+  element: HTMLElement,
+): Extract<TranscriptLayoutAnchor, { mode: "manual" }> | undefined {
+  const rect = element.getBoundingClientRect();
+  const viewport = { top: rect.top, bottom: rect.bottom };
+  const visible = readTranscriptRowRects(element)
+    .filter((row) => rowIntersectsViewport(row, viewport))
+    .sort((left, right) => left.top - right.top);
+  const anchor = visible.find((row) => row.top >= viewport.top) ?? visible[0];
+  return anchor ? { mode: "manual", rowKey: anchor.rowKey, offset: anchor.top - viewport.top } : undefined;
+}
+
 export function transcriptElementViewportIsBlank(element: HTMLElement): boolean {
   const rect = element.getBoundingClientRect();
   if (rect.bottom <= rect.top) return false;

--- a/desktop/frontend/src/lib/useTranscriptReaderExtentStability.ts
+++ b/desktop/frontend/src/lib/useTranscriptReaderExtentStability.ts
@@ -40,6 +40,10 @@ export function useTranscriptReaderExtentStability({
     if (guard?.frame != null) cancelAnimationFrame(guard.frame);
   }, []);
 
+  // While a guard is armed it owns post-gesture extent corrections; the
+  // steady-state anchor compensation must stay out of its way.
+  const isActive = useCallback(() => guardRef.current !== null, []);
+
   const observe = useCallback((element = scrollRef.current) => {
     const guard = guardRef.current;
     if (!element || guard?.element !== element) return false;
@@ -117,5 +121,5 @@ export function useTranscriptReaderExtentStability({
 
   useEffect(() => cancel, [cancel]);
 
-  return useMemo(() => ({ arm, cancel, observe }), [arm, cancel, observe]);
+  return useMemo(() => ({ arm, cancel, observe, isActive }), [arm, cancel, observe, isActive]);
 }

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -41,7 +41,7 @@ import {
 import { hasTranscriptScrollableRange, nativeTranscriptBottomTop, nativeTranscriptDistanceFromBottom, pinTranscriptTailAfterViewportShrink, TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX, type TranscriptFollowGeometry } from "./transcriptScrollGeometry";
 import type { TranscriptRow } from "./transcriptRows";
 import { captureTranscriptVirtuosoState } from "./transcriptStateSnapshot";
-import { captureTranscriptLayoutAnchor, type TranscriptLayoutAnchor } from "./transcriptVirtuosoRecovery";
+import { captureTranscriptLayoutAnchor, captureVisibleTranscriptLayoutAnchor, type TranscriptLayoutAnchor } from "./transcriptVirtuosoRecovery";
 import { useTranscriptReaderExtentStability } from "./useTranscriptReaderExtentStability";
 export type {
   TranscriptRecoveryRequestSpec,
@@ -103,6 +103,20 @@ export function useTranscriptScrollArbiter({
   // every user-takeover, and sampled on user scroll intent. The blank
   // watchdog restores from it instead of a nearest-mounted-row guess (#8657).
   const lastGoodAnchorRef = useRef<TranscriptLayoutAnchor | null>(null);
+  // Steady-state manual-mode anchor: re-sampled from live geometry on every
+  // delivered scroll while the user owns the viewport. An above-viewport
+  // height change (fold auto-collapse, history patch) is then measurable as
+  // anchor drift and compensated through the arbiter's offset channel
+  // (#8438/#8488/#8897).
+  const manualAnchorRef = useRef<Extract<TranscriptLayoutAnchor, { mode: "manual" }> | null>(null);
+  // At most one anchor-compensation loop at a time; bounded like a recovery
+  // (2 stable frames or the shared wall-clock budget).
+  const anchorCompensationRef = useRef<{
+    anchor: Extract<TranscriptLayoutAnchor, { mode: "manual" }>;
+    frame: number | null;
+    stableFrames: number;
+    deadline: number;
+  } | null>(null);
   const onRecoveryTerminalRef = useRef(onRecoveryTerminal);
   onRecoveryTerminalRef.current = onRecoveryTerminal;
   const onItemMeasuredRef = useRef(onItemMeasured);
@@ -158,6 +172,14 @@ export function useTranscriptScrollArbiter({
     if (layoutTransientIdleTimerRef.current !== null) window.clearTimeout(layoutTransientIdleTimerRef.current);
     layoutTransientIdleTimerRef.current = null;
     layoutTransientRef.current = false;
+  }, []);
+
+  const cancelAnchorCompensation = useCallback(() => {
+    const compensation = anchorCompensationRef.current;
+    anchorCompensationRef.current = null;
+    if (compensation?.frame !== null && compensation?.frame !== undefined) {
+      cancelAnimationFrame(compensation.frame);
+    }
   }, []);
 
   const armLayoutTransientIdle = useCallback(() => {
@@ -250,8 +272,10 @@ export function useTranscriptScrollArbiter({
     followFrameRef.current = null;
     resizeSettleFrameRef.current = null;
     cancelTailSettle();
+    cancelAnchorCompensation();
+    manualAnchorRef.current = null;
     readerExtent.cancel();
-  }, [cancelTailSettle, readerExtent]);
+  }, [cancelAnchorCompensation, cancelTailSettle, readerExtent]);
 
   // Executes the reducer's CANCEL_RECOVERY command. The cancelling event
   // already cleared recoveryId in the published state, so no RECOVERY_END
@@ -327,7 +351,27 @@ export function useTranscriptScrollArbiter({
       cancelTailSettle();
     }
     if (transcriptScrollEventCancelsReaderExtentGuard(event.type)) readerExtent.cancel();
-    if (event.type === "RESET") lastGoodAnchorRef.current = null;
+    // Ownership-changing events end an in-flight anchor compensation. The
+    // steady-state offset owners (anchor-compensation, block-window-prepend)
+    // are the loop's own writes and must not cancel it.
+    if (
+      event.type === "RESET"
+      || event.type === "USER_SCROLL_INTENT"
+      || event.type === "MANUAL_READING"
+      || event.type === "USER_RESIZE_BEGIN"
+      || event.type === "SELECTION_BEGIN"
+      || event.type === "PROGRAMMATIC_BEGIN"
+      || event.type === "JUMP_TO_BOTTOM"
+      || event.type === "JUMP_TO_INDEX"
+      || event.type === "RECOVERY_BEGIN"
+      || (event.type === "SCROLL_TO_OFFSET" && event.owner !== "anchor-compensation" && event.owner !== "block-window-prepend")
+    ) {
+      cancelAnchorCompensation();
+    }
+    if (event.type === "RESET") {
+      lastGoodAnchorRef.current = null;
+      manualAnchorRef.current = null;
+    }
     if (event.type === "USER_SCROLL_INTENT") {
       const element = scrollRef.current;
       const anchor = element ? captureTranscriptLayoutAnchor(element, false) : undefined;
@@ -339,7 +383,75 @@ export function useTranscriptScrollArbiter({
     publishState(result.state);
     for (const command of result.commands) runCommand(command, source);
     return result;
-  }, [cancelTailSettle, publishState, readerExtent, runCommand]);
+  }, [cancelAnchorCompensation, cancelTailSettle, publishState, readerExtent, runCommand]);
+
+  // Steady-state viewport anchoring for manual reading: when content ABOVE
+  // the viewport changes height (fold auto-collapse, history patch), the
+  // anchor row's measured drift is compensated through the arbiter's offset
+  // channel instead of pushing the viewport (#8438/#8488/#8897). Changes
+  // below the viewport (streaming footer growth) leave the anchor row put,
+  // so they measure zero drift and earn no write. Bounded like a recovery:
+  // two stable frames or the shared wall-clock budget, whichever comes first.
+  const scheduleAnchorCompensation = useCallback(() => {
+    if (anchorCompensationRef.current !== null) return;
+    const element = scrollRef.current;
+    if (!element) return;
+    if (modeRef.current !== "manual") return;
+    // Never fight an active gesture, an in-flight recovery, or an armed
+    // reader-extent guard: the reader's own scrolling continuously re-samples
+    // the anchor, and the recovery/guard already owns viewport corrections.
+    if (stateRef.current.readerIntent || stateRef.current.recoveryId !== null || readerExtent.isActive()) return;
+    const anchor = manualAnchorRef.current;
+    if (!anchor) return;
+    const generation = generationRef.current;
+    const compensation = {
+      anchor,
+      frame: null as number | null,
+      stableFrames: 0,
+      deadline: Date.now() + ANCHOR_RESTORE_BUDGET_MS,
+    };
+    const tick = () => {
+      compensation.frame = null;
+      if (anchorCompensationRef.current !== compensation) return;
+      if (
+        generationRef.current !== generation
+        || modeRef.current !== "manual"
+        || stateRef.current.readerIntent
+        || stateRef.current.recoveryId !== null
+        || readerExtent.isActive()
+      ) {
+        anchorCompensationRef.current = null;
+        return;
+      }
+      const current = scrollRef.current;
+      if (!current) {
+        anchorCompensationRef.current = null;
+        return;
+      }
+      const row = Array.from(current.querySelectorAll<HTMLElement>(".transcript__row[data-row-key]"))
+        .find((candidate) => candidate.dataset.rowKey === compensation.anchor.rowKey);
+      if (!row) {
+        // The anchor row is unmounted: without a measurement there is no
+        // trustworthy correction, so the compensation simply stops.
+        anchorCompensationRef.current = null;
+        return;
+      }
+      const correction = row.getBoundingClientRect().top - current.getBoundingClientRect().top - compensation.anchor.offset;
+      if (Math.abs(correction) > RECOVERY_CORRECTION_TOLERANCE_PX) {
+        compensation.stableFrames = 0;
+        dispatch({ type: "SCROLL_TO_OFFSET", owner: "anchor-compensation", top: current.scrollTop + correction, behavior: "auto" });
+      } else {
+        compensation.stableFrames += 1;
+      }
+      if (compensation.stableFrames >= RECOVERY_STABLE_FRAMES || Date.now() >= compensation.deadline) {
+        anchorCompensationRef.current = null;
+        return;
+      }
+      compensation.frame = requestAnimationFrame(tick);
+    };
+    anchorCompensationRef.current = compensation;
+    compensation.frame = requestAnimationFrame(tick);
+  }, [dispatch, readerExtent]);
 
   const endReaderIntent = useCallback(() => {
     if (readerIntentTimerRef.current !== null) window.clearTimeout(readerIntentTimerRef.current);
@@ -366,6 +478,12 @@ export function useTranscriptScrollArbiter({
       substantial: isSubstantialTranscriptDisplacement(distance),
     });
     if (stateRef.current.readerIntent) armReaderIntentIdle();
+    // Keep the steady-state manual anchor fresh from live geometry. Sampling
+    // is skipped while a compensation loop owns the reference so its own
+    // writes cannot move the goalposts mid-flight.
+    if (stateRef.current.mode === "manual" && anchorCompensationRef.current === null) {
+      manualAnchorRef.current = captureVisibleTranscriptLayoutAnchor(element) ?? null;
+    }
   }, [armReaderIntentIdle, dispatch, readerExtent]);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
@@ -561,8 +679,10 @@ export function useTranscriptScrollArbiter({
     if (layoutTransientIdleTimerRef.current !== null) window.clearTimeout(layoutTransientIdleTimerRef.current);
     if (jumpTailTimerRef.current !== null) window.clearTimeout(jumpTailTimerRef.current);
     if (recoveryRef.current?.frame != null) cancelAnimationFrame(recoveryRef.current.frame);
+    if (anchorCompensationRef.current?.frame != null) cancelAnimationFrame(anchorCompensationRef.current.frame);
     generationRef.current += 1;
     recoveryRef.current = null;
+    anchorCompensationRef.current = null;
     layoutTransientRef.current = false;
     jumpTailTimerRef.current = null;
   }, []);
@@ -633,12 +753,14 @@ export function useTranscriptScrollArbiter({
         followGeometryRef.current.contentExtent = scrollHeight;
         if (previous != null && isTranscriptContentShrink(scrollHeight - previous)) {
           dispatch({ type: "CONTENT_SHRANK" });
+          scheduleAnchorCompensation();
           return;
         }
       }
       dispatch({ type: "LAYOUT_HEIGHT_CHANGED" });
+      scheduleAnchorCompensation();
     });
-  }, [armLayoutTransientIdle, dispatch, readerExtent]);
+  }, [armLayoutTransientIdle, dispatch, readerExtent, scheduleAnchorCompensation]);
 
   const beginUserResize = useCallback(() => {
     dispatch({ type: "USER_RESIZE_BEGIN" });
@@ -654,14 +776,23 @@ export function useTranscriptScrollArbiter({
         resizeSettleFrameRef.current = null;
         if (generationRef.current !== generation || scrollRef.current !== scrollElement) return;
         dispatch({ type: "USER_RESIZE_END" });
+        // A user-initiated in-row resize (fold toggle) may have pushed the
+        // viewport; once ownership settles back to manual, anchor it again.
+        scheduleAnchorCompensation();
       });
     });
-  }, [dispatch]);
+  }, [dispatch, scheduleAnchorCompensation]);
 
   const atBottomStateChange = useCallback((_atBottom: boolean) => deliverScroll(), [deliverScroll]);
 
   const writeOffset = useCallback((owner: TranscriptScrollOwner, top: number, behavior: ScrollBehavior = "auto") => {
-    if (isTranscriptSelectionMode(modeRef.current) && owner !== "selection-edge-scroll") return false;
+    // Selection mode only accepts writes that keep the selection stable: its
+    // own edge scrolls and the in-row block-window prepend compensation.
+    if (
+      isTranscriptSelectionMode(modeRef.current)
+      && owner !== "selection-edge-scroll"
+      && owner !== "block-window-prepend"
+    ) return false;
     if (!scrollRef.current) return false;
     dispatch({ type: "SCROLL_TO_OFFSET", owner, top, behavior });
     return true;

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -83,6 +83,7 @@ export function useTranscriptScrollArbiter({
   const touchStartYRef = useRef<number | null>(null);
   const nativeScrollbarDragRef = useRef(false);
   const middlePointerScrollRef = useRef(false);
+  const deliverScrollRef = useRef<((element?: HTMLDivElement) => void) | null>(null);
   const generationRef = useRef(0);
   const followFrameRef = useRef<number | null>(null);
   const tailSettleFrameRef = useRef<number | null>(null);
@@ -463,6 +464,11 @@ export function useTranscriptScrollArbiter({
     if (readerIntentTimerRef.current !== null) window.clearTimeout(readerIntentTimerRef.current);
     readerIntentTimerRef.current = window.setTimeout(() => {
       readerIntentTimerRef.current = null;
+      // A large wheel/touch gesture can clamp the browser to the physical
+      // bottom without emitting a second scroll event. Re-sample once before
+      // closing the intent window so the bottom-hold policy can complete on
+      // real WebView2/native scrolling as well as on synthetic deliveries.
+      deliverScrollRef.current?.(scrollRef.current ?? undefined);
       dispatch({ type: "READER_INTENT_ENDED" });
     }, READER_INTENT_IDLE_MS);
   }, [dispatch]);
@@ -485,6 +491,7 @@ export function useTranscriptScrollArbiter({
       manualAnchorRef.current = captureVisibleTranscriptLayoutAnchor(element) ?? null;
     }
   }, [armReaderIntentIdle, dispatch, readerExtent]);
+  deliverScrollRef.current = deliverScroll;
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     if (isTranscriptSelectionMode(modeRef.current)) return;

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -96,6 +96,9 @@
     "desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx": {
       "test-file-size": 162
     },
+    "desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx": {
+      "test-file-size": 129
+    },
     "desktop/frontend/src/__tests__/workspace-changes-errors.test.tsx": {
       "test-file-size": 137
     },
@@ -164,6 +167,9 @@
     },
     "desktop/frontend/src/lib/useController.ts": {
       "file-size": 4035
+    },
+    "desktop/frontend/src/lib/useTranscriptScrollArbiter.ts": {
+      "file-size": 138
     },
     "desktop/heartbeat.go": {
       "essay": 7


### PR DESCRIPTION
Problem: stale Virtuoso delivery signals and viewport changes could steal tail ownership, strand recovery, or repeatedly write scroll corrections while the user was reading manually.

Root cause: tail-follow, recovery, selection, and native geometry signals were not separated into explicit ownership transitions.

Fix: make physical bottom and explicit user intent authoritative, add bounded recovery/tail convergence, preserve manual reading through resize, selection, and content churn, and re-sample native geometry before a reader-intent window closes so a large wheel/touch clamp can complete tail re-entry.

Verification: full `pnpm --dir desktop/frontend test:transcript` and `pnpm --dir desktop/frontend build`.

This is the first scroll layer and an adapted, focused replacement for the corresponding part of #9195.

Documentation-impact: none - this changes internal transcript scroll arbitration and recovery behavior without changing documented setup/configuration.

Cache-impact: none - the change only governs local transcript viewport ownership; model requests, prompts, tool schemas, and response caching are unchanged.

Cache-guard: no cache-visible request path changed; `scripts/check-cache-impact.sh` is the repository guard for this scope.
