### PR TITLE
Desktop: harden catalog-only topic UX / 桌面端：强化仅目录主题交互

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-rename-optimistic.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-rename-optimistic.test.ts
@@ -1,0 +1,81 @@
+// Run: tsx src/__tests__/project-tree-rename-optimistic.test.ts
+
+import { projectTreeWithTopicTitle } from "../lib/projectTreeTopic";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+let passed = 0;
+let failed = 0;
+
+function eq(a: unknown, b: unknown, label: string) {
+  if (JSON.stringify(a) === JSON.stringify(b)) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+console.log("\nproject tree optimistic rename");
+
+eq(
+  projectTreeWithTopicTitle(
+    [
+      {
+        key: "p",
+        kind: "project",
+        label: "P",
+        children: [
+          { key: "topic_rename", kind: "topic", label: "Old name", topicId: "topic_rename" },
+          { key: "topic_keep", kind: "topic", label: "Keep me", topicId: "topic_keep" },
+        ],
+      },
+    ],
+    "topic_rename",
+    "New name",
+  ).map((node) => (node.children ?? []).map((child) => child.label)),
+  [["New name", "Keep me"]],
+  "a committed rename repaints the topic row label before the catalog event arrives",
+);
+
+eq(
+  projectTreeWithTopicTitle(
+    [{ key: "p", kind: "project", label: "P", children: [{ key: "t", kind: "topic", label: "Same", topicId: "t" }] }],
+    "t",
+    "Same",
+  )[0].children?.[0].label,
+  "Same",
+  "an unchanged rename label leaves the tree identity stable",
+);
+
+eq(
+  projectTreeWithTopicTitle(
+    [{ key: "p", kind: "project", label: "P", children: [{ key: "t", kind: "topic", label: "T", topicId: "t" }] }],
+    "topic_missing",
+    "New name",
+  )[0].children?.[0].label,
+  "T",
+  "a rename for a topic outside the loaded tree changes nothing",
+);
+
+const projectTreeSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "../components/ProjectTree.tsx"), "utf8");
+eq(
+  projectTreeSource.includes("projectTreeWithTopicTitle(current, topicId, title)"),
+  true,
+  "commitRenameTopic paints the new label optimistically before the refresh round-trip",
+);
+eq(
+  projectTreeSource.includes("project-tree__skeleton"),
+  true,
+  "an expanded folder with a loading first topic page renders skeleton rows",
+);
+eq(
+  /projectTreeRevisionIsFresh\(latestRevisionRef\.current, event\.revision\)\) \{\s*void refresh\(\)/.test(projectTreeSource),
+  true,
+  "a stale project-tree revision falls back to a full snapshot refetch instead of dropping the event",
+);
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -10,7 +10,7 @@ import { asArray } from "../lib/array";
 import { useToast } from "../lib/toast";
 import { app } from "../lib/bridge";
 import { onProjectTreeChangedV2 } from "../lib/sessionCatalogBridge";
-import { isRuntimeSessionNode, isTopicNode, loadWorkbenchOrganizeMode, loadWorkbenchSortMode, mergeIncompleteProjectTopicPage, mergeProjectTopicPage, projectTreeDedupedExactTime, projectTreeEventAffectsFolder, projectTreeFolderDisclosure, projectTreeReadActivityKey, projectTreeRevisionIsFresh, projectTreeShellChildren, projectTreeShellSignature, projectTreeShouldApplyShellSnapshot, projectTreeShouldRenderTopicActions, projectTreeShouldSuppressOpenForRename, projectTreeTopicArchiveBlocked, projectTreeTopicHasUnreadActivity, projectTreeTopicHoverCardModel, projectTreeTopicMenuOffersPin, projectTreeTopicMetaLine, projectTreeTopicOpenRequest, projectTreeTopicPageIsFresh, projectTreeTopicPageSignature, projectTreeWithoutTopic, topicActivityAt, topicActivityDateLabel, topicActivityLabel, topicIsActive, topicStatus, topicStatusLabel, topicUnknownTimeLabel, WORKBENCH_ORGANIZE_KEY, WORKBENCH_SORT_KEY, type ProjectTreePendingTopicOpen, type ProjectTreeReadActivity, type ProjectTreeTopicHoverCard, type ProjectTreeVariant, type WorkbenchOrganizeMode, type WorkbenchSortMode } from "../lib/projectTreeTopic";
+import { isRuntimeSessionNode, isTopicNode, loadWorkbenchOrganizeMode, loadWorkbenchSortMode, mergeIncompleteProjectTopicPage, mergeProjectTopicPage, projectTreeDedupedExactTime, projectTreeEventAffectsFolder, projectTreeFolderDisclosure, projectTreeReadActivityKey, projectTreeRevisionIsFresh, projectTreeShellChildren, projectTreeShellSignature, projectTreeShouldApplyShellSnapshot, projectTreeShouldRenderTopicActions, projectTreeShouldSuppressOpenForRename, projectTreeTopicArchiveBlocked, projectTreeTopicHasUnreadActivity, projectTreeTopicHoverCardModel, projectTreeTopicMenuOffersPin, projectTreeTopicMetaLine, projectTreeTopicOpenRequest, projectTreeTopicPageIsFresh, projectTreeTopicPageSignature, projectTreeWithoutTopic, projectTreeWithTopicTitle, topicActivityAt, topicActivityDateLabel, topicActivityLabel, topicIsActive, topicStatus, topicStatusLabel, topicUnknownTimeLabel, WORKBENCH_ORGANIZE_KEY, WORKBENCH_SORT_KEY, type ProjectTreePendingTopicOpen, type ProjectTreeReadActivity, type ProjectTreeTopicHoverCard, type ProjectTreeVariant, type WorkbenchOrganizeMode, type WorkbenchSortMode } from "../lib/projectTreeTopic";
 export * from "../lib/projectTreeTopic";
 import { arrangeClassicProjectTree, arrangeWorkbenchTree, classicTopicWindow, CLASSIC_TOPIC_PREVIEW_LIMIT, splitPinnedProjectTree, type PinnedTreeSections } from "../lib/projectTreePresentation";
 export * from "../lib/projectTreePresentation";
@@ -485,7 +485,12 @@ export function ProjectTree({
   }, [refresh, refreshSignal]);
 
   useEffect(() => onProjectTreeChangedV2((event) => {
-    if (!projectTreeRevisionIsFresh(latestRevisionRef.current, event.revision)) return;
+    // A stale or missed revision means the tree may have drifted from the
+    // catalog; refetch the full snapshot instead of dropping the event.
+    if (!projectTreeRevisionIsFresh(latestRevisionRef.current, event.revision)) {
+      void refresh();
+      return;
+    }
     latestRevisionRef.current = Math.max(latestRevisionRef.current, event.revision);
     if (event.reason === "metadata") setOrganizationRevision((current) => Math.max(current, event.revision));
     void app.GetSessionCatalogStatus().then(setCatalogStatus).catch(() => {});
@@ -769,6 +774,8 @@ export function ProjectTree({
     try {
       if (onRenameTopic) await onRenameTopic(topicId, title);
       else await app.RenameTopic(topicId, title);
+      // Paint the new label immediately; the catalog event round-trip can lag.
+      setTree((current) => applyRuntimeProjection(projectTreeWithTopicTitle(current, topicId, title)));
       await refresh();
       if (!onRenameTopic) await onTopicsChanged?.();
     } catch (err) {
@@ -1050,7 +1057,6 @@ export function ProjectTree({
       const accentStyle = projectAccentStyle(node.projectColor, scope === "global" ? "var(--project-tree-global-accent)" : undefined);
       const active = topicIsActive(node, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath);
       const label = (node.label || node.topicId || "Untitled").replace(/^●\s*/, "");
-      // Ordinary list never advertises recovery copies; History owns that view.
       const activityAt = node.lastActivityAt || node.createdAt || 0;
       // Every variant is a single-line row with the activity time on the right;
       // classic moved there too so turns and the exact date live in the hover
@@ -1551,6 +1557,23 @@ export function ProjectTree({
     const backendPage = topicPageState[key];
     const renderFolderChildren = () => {
       if (!hasChildren) {
+        // While the first topic page is still loading (cold start, catalog
+        // reconcile in flight), show a skeleton instead of a blank folder or
+        // a premature "no topics" placeholder.
+        if (backendPage?.loading) {
+          return (
+            <div className={`project-tree__children${isExpanded ? " project-tree__children--expanded" : ""}`}>
+              <div className="project-tree__children-inner">
+                <div className="project-tree__skeleton" style={{ paddingLeft: 14 + (depth + 1) * 16 }} aria-hidden="true">
+                  <span className="project-tree__skeleton-bar" />
+                  <span className="project-tree__skeleton-bar project-tree__skeleton-bar--short" />
+                  <span className="project-tree__skeleton-bar" />
+                  <span className="project-tree__skeleton-bar project-tree__skeleton-bar--short" />
+                </div>
+              </div>
+            </div>
+          );
+        }
         if (!classicTopics) return null;
         return (
           <div className={`project-tree__children${isExpanded ? " project-tree__children--expanded" : ""}`}>

--- a/desktop/frontend/src/lib/projectTreeTopic.ts
+++ b/desktop/frontend/src/lib/projectTreeTopic.ts
@@ -143,6 +143,35 @@ export function projectTreeWithoutTopics(tree: ProjectNode[], topicIds: Readonly
   return changed ? next : tree;
 }
 
+// After a successful rename, paint the new label immediately instead of
+// waiting for the catalog event round-trip.
+export function projectTreeWithTopicTitle(tree: ProjectNode[], topicId: string, title: string): ProjectNode[] {
+  const id = topicId.trim();
+  if (!id) return tree;
+  let changed = false;
+  const next: ProjectNode[] = [];
+  for (const node of tree) {
+    if (node.topicId === id && (isTopicNode(node) || isRuntimeSessionNode(node))) {
+      if (node.label !== title) {
+        changed = true;
+        next.push({ ...node, label: title });
+      } else {
+        next.push(node);
+      }
+      continue;
+    }
+    const children = asArray(node.children);
+    const renamedChildren = projectTreeWithTopicTitle(children, id, title);
+    if (renamedChildren !== children) {
+      changed = true;
+      next.push({ ...node, children: renamedChildren });
+    } else {
+      next.push(node);
+    }
+  }
+  return changed ? next : tree;
+}
+
 export function projectTreeFolderKeyForTopic(tree: ProjectNode[], topicId: string): string {
   const id = topicId.trim();
   if (!id) return "";

--- a/desktop/project_tree_activity_ttl_test.go
+++ b/desktop/project_tree_activity_ttl_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+func TestReapStaleTopicActivityStatus(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	now := time.Now()
+	cases := []struct {
+		name       string
+		status     string
+		age        time.Duration
+		wantStatus string
+	}{
+		{"fresh thinking kept", topicStatusThinking, time.Minute, topicStatusThinking},
+		{"fresh streaming kept", topicStatusStreaming, 5 * time.Minute, topicStatusStreaming},
+		{"stale thinking reaped", topicStatusThinking, topicActivityStatusTTL + time.Minute, ""},
+		{"stale streaming reaped", topicStatusStreaming, topicActivityStatusTTL + time.Minute, ""},
+		{"waiting confirmation never reaped", topicStatusWaitingConfirmation, topicActivityStatusTTL + time.Minute, topicStatusWaitingConfirmation},
+		{"error status never reaped", topicStatusError, topicActivityStatusTTL + time.Minute, topicStatusError},
+		{"zero timestamp never reaped", topicStatusThinking, 0, topicStatusThinking},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := NewApp()
+			tab := &WorkspaceTab{
+				ID:             "tab",
+				Scope:          "global",
+				TopicID:        "topic_ttl",
+				Ready:          true,
+				ActivityStatus: tc.status,
+				disabledMCP:    map[string]ServerView{},
+			}
+			if tc.age > 0 {
+				app.projectTreeRuntime.setActivityAt(tab.ID, now.Add(-tc.age))
+			}
+			app.tabs[tab.ID] = tab
+			app.reapStaleTopicActivityStatus(now)
+			if tab.ActivityStatus != tc.wantStatus {
+				t.Fatalf("status after reap = %q, want %q", tab.ActivityStatus, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestReconcileTabActivityStatus(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := desktopSessionDir(globalTabWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := writeTopicSessionWithPrompt(t, dir, "reconcile.jsonl", "topic_reconcile", "Reconcile", "", "prompt", time.Now())
+
+	newTab := func(ctrl control.SessionAPI) *WorkspaceTab {
+		return &WorkspaceTab{
+			ID:             "tab",
+			Scope:          "global",
+			WorkspaceRoot:  globalTabWorkspaceRoot(),
+			TopicID:        "topic_reconcile",
+			SessionPath:    path,
+			Ctrl:           ctrl,
+			Ready:          true,
+			ActivityStatus: topicStatusThinking,
+			disabledMCP:    map[string]ServerView{},
+		}
+	}
+
+	t.Run("clears status the idle controller does not corroborate", func(t *testing.T) {
+		app := NewApp()
+		ctrl := control.New(control.Options{SessionDir: dir, SessionPath: path, Label: "idle", Sink: event.Discard})
+		defer ctrl.Close()
+		tab := newTab(ctrl)
+		app.tabs[tab.ID] = tab
+		if !app.reconcileTabActivityStatus(tab) {
+			t.Fatal("reconcile should clear the stale status")
+		}
+		if tab.ActivityStatus != "" {
+			t.Fatalf("status after reconcile = %q, want cleared", tab.ActivityStatus)
+		}
+	})
+
+	t.Run("keeps status while the controller is running", func(t *testing.T) {
+		app := NewApp()
+		runner := &blockingRunner{started: make(chan struct{}), release: make(chan struct{})}
+		ctrl := control.New(control.Options{Runner: runner, SessionDir: dir, SessionPath: path, Label: "running", Sink: event.Discard})
+		defer ctrl.Close()
+		tab := newTab(ctrl)
+		app.tabs[tab.ID] = tab
+		ctrl.Submit("keep running")
+		<-runner.started
+		if app.reconcileTabActivityStatus(tab) {
+			t.Fatal("reconcile must not clear the status of a running turn")
+		}
+		if tab.ActivityStatus != topicStatusThinking {
+			t.Fatalf("status after reconcile = %q, want %q", tab.ActivityStatus, topicStatusThinking)
+		}
+		close(runner.release)
+		waitNotRunning(t, ctrl)
+	})
+
+	t.Run("ignores non-live statuses", func(t *testing.T) {
+		app := NewApp()
+		ctrl := control.New(control.Options{SessionDir: dir, SessionPath: path, Label: "idle", Sink: event.Discard})
+		defer ctrl.Close()
+		tab := newTab(ctrl)
+		tab.ActivityStatus = topicStatusWaitingConfirmation
+		app.tabs[tab.ID] = tab
+		if app.reconcileTabActivityStatus(tab) {
+			t.Fatal("reconcile must not touch waiting_confirmation")
+		}
+	})
+}

--- a/desktop/project_tree_runtime.go
+++ b/desktop/project_tree_runtime.go
@@ -2,13 +2,51 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"time"
 )
 
 type projectTreeRuntimeState struct {
 	revision atomic.Uint64
+	// activityAt records the last activity-status event per tab ID. The TTL
+	// watchdog reaps a live status that sees no terminating event; the state
+	// lives here (not on WorkspaceTab) to keep tabs.go within budget.
+	watchdogOnce sync.Once
+	activityMu   sync.Mutex
+	activityAt   map[string]time.Time
+}
+
+// noteActivityStatus refreshes a tab's activity timestamp on every status
+// event, even an unchanged one: the TTL watchdog measures silence, not how
+// long a status has been displayed, so a long but active turn is never reaped.
+func (s *projectTreeRuntimeState) noteActivityStatus(a *App, tabID string) {
+	s.setActivityAt(tabID, time.Now())
+	// The watchdog starts lazily with the first status event — before that
+	// there is nothing to reap.
+	s.watchdogOnce.Do(func() { a.watchTopicActivityStatus() })
+}
+
+func (s *projectTreeRuntimeState) setActivityAt(tabID string, at time.Time) {
+	s.activityMu.Lock()
+	defer s.activityMu.Unlock()
+	if s.activityAt == nil {
+		s.activityAt = map[string]time.Time{}
+	}
+	s.activityAt[tabID] = at
+}
+
+func (s *projectTreeRuntimeState) activityAtSnapshot() map[string]time.Time {
+	s.activityMu.Lock()
+	defer s.activityMu.Unlock()
+	out := make(map[string]time.Time, len(s.activityAt))
+	for id, at := range s.activityAt {
+		out[id] = at
+	}
+	return out
 }
 
 func syncRuntimeWorkspaceRootSpelling(tab *WorkspaceTab, projects []desktopProject) bool {
@@ -140,4 +178,110 @@ func (a *App) emitRuntimeEvent(name string, payload ...any) {
 	if a != nil && a.ctx != nil {
 		a.runtimeEvents.Emit(a.ctx, name, payload...)
 	}
+}
+
+const (
+	// topicActivityStatusTTL bounds how long a live spinner status may go
+	// without any turn event before it is treated as orphaned. A flat TTL is
+	// used instead of a per-session P99: turn durations are not tracked
+	// per session in this package, and simplicity wins (#8528/#8555/#8859).
+	topicActivityStatusTTL = 10 * time.Minute
+	// topicActivityReapInterval is how often the watchdog scans for orphans.
+	topicActivityReapInterval = 30 * time.Second
+)
+
+// liveTopicActivityStatus reports statuses that must be terminated by a
+// TurnDone event; if that event is lost the spinner would run forever.
+// waiting_confirmation is excluded: it waits on the user, not on turn events.
+func liveTopicActivityStatus(status string) bool {
+	switch status {
+	case topicStatusThinking, topicStatusStreaming:
+		return true
+	}
+	return false
+}
+
+// watchTopicActivityStatus reaps live activity statuses that have seen no
+// turn event for longer than the TTL — the missed-TurnDone safety net.
+func (a *App) watchTopicActivityStatus() {
+	a.goSafe("topicActivityWatchdog", func() {
+		ticker := time.NewTicker(topicActivityReapInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-a.bootContext().Done():
+				return
+			case now := <-ticker.C:
+				a.reapStaleTopicActivityStatus(now)
+			}
+		}
+	})
+}
+
+func (a *App) reapStaleTopicActivityStatus(now time.Time) {
+	activityAt := a.projectTreeRuntime.activityAtSnapshot()
+	a.mu.Lock()
+	var reaped []string
+	for _, tab := range a.runtimeTabsLocked() {
+		if tab == nil || !liveTopicActivityStatus(tab.ActivityStatus) {
+			continue
+		}
+		if at := activityAt[tab.ID]; at.IsZero() || now.Sub(at) < topicActivityStatusTTL {
+			continue
+		}
+		reaped = append(reaped, tab.ID+":"+tab.ActivityStatus)
+		tab.ActivityStatus = ""
+	}
+	a.mu.Unlock()
+	if len(reaped) == 0 {
+		return
+	}
+	slog.Warn("desktop: cleared stale topic activity status (no turn event within TTL)",
+		"tabs", reaped, "ttl", topicActivityStatusTTL.String())
+	a.emitProjectTreeRuntimeChangedWithLegacy()
+}
+
+// reconcileTabActivityStatus clears a live spinner status the session's
+// controller does not corroborate — a TurnDone missed while the session was
+// detached would otherwise spin forever after reopen. The controller query
+// takes the controller's own lock, so it runs outside App.mu (the same lock
+// order rule as catalogRuntimeSnapshots).
+func (a *App) reconcileTabActivityStatus(tab *WorkspaceTab) bool {
+	if a == nil || tab == nil {
+		return false
+	}
+	a.mu.RLock()
+	status := tab.ActivityStatus
+	ctrl := tab.Ctrl
+	a.mu.RUnlock()
+	if ctrl == nil || !liveTopicActivityStatus(status) || ctrl.Running() {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if tab.ActivityStatus != status {
+		// A new turn (or its TurnDone) landed while the locks were dropped.
+		return false
+	}
+	tab.ActivityStatus = ""
+	slog.Warn("desktop: cleared stale topic activity status on session open", "tab", tab.ID, "status", status)
+	return true
+}
+
+// setTabActivityStatus records the project-tree status for a tab's in-flight
+// turn and notes the event time for the TTL watchdog.
+func (a *App) setTabActivityStatus(tabID, status string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	tab := a.tabByEventSinkIDLocked(tabID)
+	if tab == nil {
+		return false
+	}
+	a.projectTreeRuntime.noteActivityStatus(a, tab.ID)
+	status = normalizeTopicStatus(status)
+	if tab.ActivityStatus == status {
+		return false
+	}
+	tab.ActivityStatus = status
+	return true
 }

--- a/desktop/project_tree_runtime.go
+++ b/desktop/project_tree_runtime.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log/slog"
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -43,9 +44,7 @@ func (s *projectTreeRuntimeState) activityAtSnapshot() map[string]time.Time {
 	s.activityMu.Lock()
 	defer s.activityMu.Unlock()
 	out := make(map[string]time.Time, len(s.activityAt))
-	for id, at := range s.activityAt {
-		out[id] = at
-	}
+	maps.Copy(out, s.activityAt)
 	return out
 }
 

--- a/desktop/rename_topic_catalog_test.go
+++ b/desktop/rename_topic_catalog_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+)
+
+func TestRenameTopicCatalogOnlyProjectTopic(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := robustTempDir(t)
+	if err := addProject(root, "Catalog Only Project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	topicID := "topic_catalog_only"
+	// The session exists in the project session dir with branch metadata, but
+	// no topic title index entry and no open tab: the catalog is the only
+	// place that knows the topic.
+	writeTopicSessionWithPrompt(t, dir, "catalog-only.jsonl", topicID, "旧标题", root, "catalog only prompt", time.Now())
+
+	app := NewApp()
+	installSessionCatalogForTest(t, app, dir, "project", root)
+
+	if err := app.RenameTopic(topicID, "新标题"); err != nil {
+		t.Fatalf("rename catalog-only topic: %v", err)
+	}
+	if got := loadTopicTitle(root, topicID); got != "新标题" {
+		t.Fatalf("catalog-only topic title = %q, want 新标题", got)
+	}
+	if meta, ok, err := agent.LoadBranchMeta(filepath.Join(dir, "catalog-only.jsonl")); err != nil || !ok || meta.TopicTitle != "新标题" {
+		t.Fatalf("branch meta title = %q ok=%v err=%v, want 新标题", meta.TopicTitle, ok, err)
+	}
+}
+
+func TestRenameTopicUnknownTopicStillFails(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	if err := app.RenameTopic("topic_does_not_exist", "标题"); err == nil {
+		t.Fatal("rename of an unknown topic should fail")
+	}
+}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6452,35 +6452,39 @@ func loadTelemetry(path string) tabTelemetrySnapshot {
 // ProjectNode is one node in the sidebar project tree (a project folder or a
 // topic leaf).
 type ProjectNode struct {
-	Key                          string        `json:"key"`  // stable key for React
-	Kind                         string        `json:"kind"` // "project" | "topic" | "session" | "global_folder" | "global_topic" | "global_session"
-	Label                        string        `json:"label"`
-	Root                         string        `json:"root,omitempty"` // project workspace root
-	TopicID                      string        `json:"topicId,omitempty"`
-	SessionPath                  string        `json:"sessionPath,omitempty"`
-	Preview                      string        `json:"preview,omitempty"`
-	ProjectColor                 string        `json:"projectColor,omitempty"`
-	Turns                        int           `json:"turns,omitempty"`
-	TurnsState                   string        `json:"turnsState,omitempty"`
-	Health                       string        `json:"health,omitempty"`
-	CreatedAt                    int64         `json:"createdAt,omitempty"`
-	LastActivityAt               int64         `json:"lastActivityAt,omitempty"`
-	Open                         bool          `json:"open,omitempty"`
-	Running                      bool          `json:"running,omitempty"`
-	Status                       string        `json:"status,omitempty"`
-	Pinned                       bool          `json:"pinned,omitempty"`
-	SortOrder                    int           `json:"sortOrder"` // manual topic order index (0-based); -1 when unknown
-	Recovered                    bool          `json:"recovered,omitempty"`
-	RecoveryReason               string        `json:"recoveryReason,omitempty"`
-	RecoveryDigest               string        `json:"recoveryDigest,omitempty"`
-	RecoveryParentID             string        `json:"recoveryParentId,omitempty"`
-	RecoveryState                string        `json:"recoveryState,omitempty"`
-	RecoveryBranchCount          int           `json:"recoveryBranchCount,omitempty"`
-	RecoveryUnresolvedCount      int           `json:"recoveryUnresolvedCount,omitempty"`
-	RecoveryCleanupEligibleCount int           `json:"recoveryCleanupEligibleCount,omitempty"`
-	IsolatedWorktree             bool          `json:"isolatedWorktree,omitempty"`
-	RuntimeOnly                  bool          `json:"runtimeOnly,omitempty"`
-	Children                     []ProjectNode `json:"children,omitempty"`
+	Key                          string `json:"key"`  // stable key for React
+	Kind                         string `json:"kind"` // "project" | "topic" | "session" | "global_folder" | "global_topic" | "global_session"
+	Label                        string `json:"label"`
+	Root                         string `json:"root,omitempty"` // project workspace root
+	TopicID                      string `json:"topicId,omitempty"`
+	SessionPath                  string `json:"sessionPath,omitempty"`
+	Preview                      string `json:"preview,omitempty"`
+	ProjectColor                 string `json:"projectColor,omitempty"`
+	Turns                        int    `json:"turns,omitempty"`
+	TurnsState                   string `json:"turnsState,omitempty"`
+	Health                       string `json:"health,omitempty"`
+	CreatedAt                    int64  `json:"createdAt,omitempty"`
+	LastActivityAt               int64  `json:"lastActivityAt,omitempty"`
+	Open                         bool   `json:"open,omitempty"`
+	Running                      bool   `json:"running,omitempty"`
+	Status                       string `json:"status,omitempty"`
+	Pinned                       bool   `json:"pinned,omitempty"`
+	SortOrder                    int    `json:"sortOrder"` // manual topic order index (0-based); -1 when unknown
+	Recovered                    bool   `json:"recovered,omitempty"`
+	RecoveryReason               string `json:"recoveryReason,omitempty"`
+	RecoveryDigest               string `json:"recoveryDigest,omitempty"`
+	RecoveryParentID             string `json:"recoveryParentId,omitempty"`
+	RecoveryState                string `json:"recoveryState,omitempty"`
+	RecoveryBranchCount          int    `json:"recoveryBranchCount,omitempty"`
+	RecoveryUnresolvedCount      int    `json:"recoveryUnresolvedCount,omitempty"`
+	RecoveryCleanupEligibleCount int    `json:"recoveryCleanupEligibleCount,omitempty"`
+	// RecoveryCopyCount is the number of recovery copies folded behind this
+	// logical row (covered or diverged). The ordinary tree renders it as a
+	// muted "恢复副本" count badge; History still owns the full copy list.
+	RecoveryCopyCount int           `json:"recoveryCopyCount,omitempty"`
+	IsolatedWorktree  bool          `json:"isolatedWorktree,omitempty"`
+	RuntimeOnly       bool          `json:"runtimeOnly,omitempty"`
+	Children          []ProjectNode `json:"children,omitempty"`
 }
 
 func normalizeTopicStatus(status string) string {
@@ -6873,7 +6877,9 @@ func (a *App) RenameTopic(topicID, title string) error {
 		}
 		return nil
 	}
-	return fmt.Errorf("topic %q not found", topicID)
+	// Catalog-only topics (no title map entry, no open tab) persist through
+	// renameCatalogOnlyTopic instead of failing (#9090).
+	return a.renameCatalogOnlyTopic(topicID, trimmed)
 }
 
 func (a *App) findTopicLocation(topicID string) (string, string, bool) {
@@ -6963,21 +6969,6 @@ func (a *App) updateTopicSessionTitles(topicID, title string) []string {
 		}
 	}
 	return changedDirs
-}
-
-func (a *App) setTabActivityStatus(tabID, status string) bool {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	tab := a.tabByEventSinkIDLocked(tabID)
-	if tab == nil {
-		return false
-	}
-	status = normalizeTopicStatus(status)
-	if tab.ActivityStatus == status {
-		return false
-	}
-	tab.ActivityStatus = status
-	return true
 }
 
 func (a *App) emitProjectTreeChanged() {

--- a/desktop/topic_live_runtime.go
+++ b/desktop/topic_live_runtime.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 
 	"reasonix/internal/sessioncatalog"
@@ -125,6 +126,9 @@ func (a *App) openTopicTabPreferLiveActivation(scope, workspaceRoot, topicID, se
 		meta := a.tabMeta(promoted, promoted.ID == a.activeTabID)
 		a.saveTabsLocked()
 		a.mu.Unlock()
+		// A TurnDone missed while the runtime was detached leaves a permanent
+		// spinner; reconcile against the controller's real turn state on open.
+		a.reconcileTabActivityStatus(promoted)
 		a.emitProjectTreeRuntimeChangedWithLegacy()
 		return enrichTabMeta(meta), nil
 	}
@@ -150,4 +154,57 @@ func (a *App) promoteDetachedRuntimeLocked(sessionPath string, activate bool) *W
 		a.activeTabID = tab.ID
 	}
 	return tab
+}
+
+// renameCatalogOnlyTopic persists a rename for a topic known only to the
+// session catalog (metadata shell, no title map entry, no open tab) through
+// the same title metadata path as an indexed topic, instead of failing the
+// rename (#9090). It returns the usual "not found" error when the catalog
+// does not list the topic either.
+func (a *App) renameCatalogOnlyTopic(topicID, title string) error {
+	scope, workspaceRoot, ok := a.findCatalogTopicLocation(topicID)
+	if !ok {
+		return fmt.Errorf("topic %q not found", topicID)
+	}
+	if scope == "global" {
+		workspaceRoot = ""
+	}
+	if err := setTopicTitle(workspaceRoot, topicID, title); err != nil {
+		return err
+	}
+	changedDirs := a.updateTopicSessionTitles(topicID, title)
+	if len(changedDirs) > 0 {
+		a.emitProjectTreeChangedForSessionDirs(changedDirs...)
+	} else {
+		a.emitProjectTreeMetadataChanged()
+	}
+	return nil
+}
+
+// findCatalogTopicLocation resolves a topic that exists only in the session
+// catalog to its scope and workspace root.
+func (a *App) findCatalogTopicLocation(topicID string) (string, string, bool) {
+	topicID = strings.TrimSpace(topicID)
+	if topicID == "" {
+		return "", "", false
+	}
+	catalog := a.sessionCatalog.Load()
+	if catalog == nil {
+		return "", "", false
+	}
+	ctx, cancel := a.catalogReadContext()
+	defer cancel()
+	if _, ok, err := catalog.GetTopic(ctx, sessioncatalog.TopicKey{Scope: "global", TopicID: topicID}); err == nil && ok {
+		return "global", "", true
+	}
+	for _, p := range loadProjectsFile().Projects {
+		root := normalizeProjectRoot(p.Root)
+		if root == "" {
+			continue
+		}
+		if _, ok, err := catalog.GetTopic(ctx, sessioncatalog.TopicKey{Scope: "project", WorkspaceRoot: root, TopicID: topicID}); err == nil && ok {
+			return "project", root, true
+		}
+	}
+	return "", "", false
 }


### PR DESCRIPTION
Problem: catalog-only topics could not be renamed reliably, stale activity indicators could remain indefinitely, and asynchronous tree refreshes could leave labels stale.

Root cause: metadata-only topics were routed through live-tab rename logic, activity status had no missed-event watchdog, and the tree dropped stale revisions instead of refetching.

Fix: persist catalog-only renames, add TTL/reopen reconciliation for live status, paint successful renames optimistically, and refetch after revision gaps.

Verification: `cd desktop && go test ./...`; focused project-tree rename contract test.

This is an adapted, focused replacement for the corresponding part of #9195.


Documentation-impact: none - this changes internal catalog refresh, rename projection, and status reconciliation without changing documented setup or configuration.
