### PR TITLE
fix(desktop): bound the transcript tail-settle convergence loop to stop end-of-transcript flicker

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
@@ -5,6 +5,8 @@ import {
   isSubstantialTranscriptDisplacement,
   isTranscriptContentShrink,
   reduceTranscriptScroll,
+  transcriptTailSettleBudgetExhausted,
+  TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS,
   type TranscriptScrollEvent,
   type TranscriptScrollState,
 } from "../lib/transcriptScrollArbiter";
@@ -254,6 +256,16 @@ check(
   strandedAfterMisreadShrink.commands.join(",") === "AUTOSCROLL_TO_BOTTOM,AUTOSCROLL_TO_BOTTOM,AUTOSCROLL_TO_BOTTOM",
   "substantial displacements keep reconverging after a misread shrink",
 );
+
+// The tail-settle convergence loop needs a bounded attempt budget: long
+// virtualized sessions whose bottom rows keep re-measuring can hold the native
+// distance-from-bottom just above the threshold forever, so without a cap the
+// settle rAF loop (and the flicker it drives) never ends (#9208).
+check(transcriptTailSettleBudgetExhausted(0) === false, "tail settle may re-aim from zero attempts");
+check(transcriptTailSettleBudgetExhausted(TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS - 1) === false, "tail settle keeps re-aiming before the budget fully spent");
+check(transcriptTailSettleBudgetExhausted(TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS) === true, "tail settle stops once the re-aim budget is exhausted");
+check(transcriptTailSettleBudgetExhausted(99) === true, "tail settle stops for any attempt count above the budget");
+check(TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS > 0, "the tail settle budget is positive");
 
 const wrapScroller = { scrollHeight: 500, scrollTop: 400, clientHeight: 80 };
 check(pinTranscriptScrollerToNativeTail(wrapScroller) === true, "a composer-wrap viewport shrink is off-bottom and gets pinned");

--- a/desktop/frontend/src/lib/transcriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/transcriptScrollArbiter.ts
@@ -107,6 +107,17 @@ export function isTranscriptContentShrink(delta: number): boolean {
 // JUMP_TO_BOTTOM bypasses the hold.
 export const TRANSCRIPT_BOTTOM_HOLD_DELIVERIES = 2;
 
+// Bounded budget for the tail-settle convergence loop. A virtualized bottom
+// whose rows keep re-measuring (long sessions, streaming output) can keep the
+// native distance-from-bottom just above the threshold forever; without a cap
+// the settle rAF loop — and the flicker it drives — never ends (#9208).
+export const TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS = 8;
+
+/** Whether the tail-settle loop has spent its bounded re-aim budget. */
+export function transcriptTailSettleBudgetExhausted(attempts: number): boolean {
+  return attempts >= TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS;
+}
+
 function transition(state: TranscriptScrollState, commands: readonly TranscriptScrollCommand[] = []): TranscriptScrollTransition {
   return { state, commands };
 }

--- a/desktop/frontend/src/lib/transcriptTailSettle.ts
+++ b/desktop/frontend/src/lib/transcriptTailSettle.ts
@@ -6,7 +6,7 @@ import {
   type TranscriptScrollDiagnosticSource,
   type TranscriptTailWriteDiagnostic,
 } from "./transcriptScrollDiagnosticProbe";
-import type { TranscriptScrollMode } from "./transcriptScrollArbiter";
+import { type TranscriptScrollMode, transcriptTailSettleBudgetExhausted } from "./transcriptScrollArbiter";
 import { nativeTranscriptDistanceFromBottom, TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX } from "./transcriptScrollGeometry";
 
 const TAIL_STAGNANT_FRAME_LIMIT = 2;
@@ -54,6 +54,7 @@ export function createTranscriptTailSettle({
     distance: number;
     stagnantFrames: number;
     offBottomFrames: number;
+    attempts: number;
   } | null = null;
   let jumpTailTimer: number | null = null;
   let layoutTransientIdleTimer: number | null = null;
@@ -169,17 +170,26 @@ export function createTranscriptTailSettle({
       const previous = tailSettleProgress;
       const offBottomFrames = (previous?.offBottomFrames ?? 0) + 1;
       if (offBottomFrames < TAIL_CONFIRM_OFF_BOTTOM_FRAMES) {
-        tailSettleProgress = { distance, stagnantFrames: 0, offBottomFrames };
+        tailSettleProgress = { distance, stagnantFrames: 0, offBottomFrames, attempts: previous?.attempts ?? 0 };
         tailSettleFrame = requestAnimationFrame(tick);
+        return;
+      }
+      const attempts = (previous?.attempts ?? 0) + 1;
+      if (transcriptTailSettleBudgetExhausted(attempts)) {
+        // Virtualization can keep the native distance off the bottom without
+        // real growth (long/unmeasured rows near the tail). Stop re-aiming so
+        // the settle loop cannot flash forever; a later layout change retries fresh.
+        tailSettleProgress = null;
+        armLayoutTransientIdle();
         return;
       }
       const stagnantFrames = previous && Math.abs(previous.distance - distance) <= 0.5
         ? previous.stagnantFrames + 1
         : 0;
       scrollToTail("auto", CAPTURE_TRANSCRIPT_SCROLL_DIAGNOSTICS && source
-        ? { source, phase: "settle", settle: { frame: offBottomFrames, offBottomFrames, stagnantFrames } }
+        ? { source, phase: "settle", settle: { frame: attempts, offBottomFrames, stagnantFrames } }
         : undefined);
-      tailSettleProgress = { distance, stagnantFrames, offBottomFrames };
+      tailSettleProgress = { distance, stagnantFrames, offBottomFrames, attempts };
       if (stagnantFrames < TAIL_STAGNANT_FRAME_LIMIT) tailSettleFrame = requestAnimationFrame(tick);
       else armLayoutTransientIdle();
     };


### PR DESCRIPTION
## Problem

In long, virtualized transcripts, the tail-follow ("stick to bottom on live
growth") convergence loop can never settle. The bottom rows are virtualized
and keep re-measuring, so the **native** distance-from-bottom stays slightly
above the at-bottom threshold even though the list is actually pinned. The
settle rAF loop kept re-aiming its scroll in response, and because layout
events from the re-measurement kept re-entering the loop, scrolling could
bounce off the bottom, loop indefinitely and flicker near the bottom of large
sessions.

## Root cause

`scheduleTailSettle` in `useTranscriptScrollArbiter.ts` had no upper bound:
the rAF convergence loop exited only when `distance <= threshold` OR the
distance was stagnant for N frames. For a virtualized bottom whose measured
height keeps oscillating, neither condition was ever met, so the loop (and the
flicker it drives) ran forever.

## Fix

Add a bounded attempt budget to the tail-settle loop
(`TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS = 8`). After a few confirmations with
no convergence the loop stops re-aiming and lets the layout quiet down; the
next real growth/layout change retries from scratch. Normal 1-2-frame
convergence is unaffected.

## Verification

- New unit checks in `transcript-scroll-release.test.ts` cover the budget.
- Regression tests unchanged and passing:
  - `transcript-scroll-release.test.ts`
  - `transcript-reader-extent-stability.test.ts`
  - `transcript-reader-extent-race.test.tsx`
  - `transcript-recovery-race.test.tsx`

Test run:
```
node --import tsx ../../scripts/run-ts-tests.mjs < ... >
```

Manually validated in a portable build on Windows 10: the transcript now
scrolls all the way to the bottom and the endless bounce/flicker loop no
longer occurs.

Cache-impact: none - no provider-visible prompt/tool surface changes; desktop frontend only.
Cache-guard: n/a - no cache-sensitive files changed (validated by scripts/check-cache-impact.sh).
Documentation-impact: none - behavior fix without user-facing docs; existing docs remain correct.
