### PR TITLE
feat(agent): optimistic-concurrency writes (write-if-unchanged) + safety toggle / 乐观并发写入（write-if-unchanged）并加并行写入安全开关（#9213）

### DIFF
--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -6997,9 +6997,9 @@ function PermissionsSection({ s, busy, apply }: SectionProps) {
         <label className="set-check set-check--inline">
           <input
             type="checkbox"
-            checked={!!s.sandbox?.optimisticWrite}
+            checked={!s.sandbox?.optimisticWrite}
             disabled={busy}
-            onChange={(e) => void apply(() => app.SetOptimisticWrite(e.target.checked))}
+            onChange={(e) => void apply(() => app.SetOptimisticWrite(!e.target.checked))}
           />
           {t("settings.optimisticWrite")}
         </label>

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -6993,6 +6993,17 @@ function PermissionsSection({ s, busy, apply }: SectionProps) {
           <option value="deny">{t("settings.modeDeny")}</option>
         </select>
       </SettingsField>
+      <SettingsField label={t("settings.optimisticWrite")} hint={t("settings.optimisticWriteHint")}>
+        <label className="set-check set-check--inline">
+          <input
+            type="checkbox"
+            checked={!!s.sandbox?.optimisticWrite}
+            disabled={busy}
+            onChange={(e) => void apply(() => app.SetOptimisticWrite(e.target.checked))}
+          />
+          {t("settings.optimisticWrite")}
+        </label>
+      </SettingsField>
     </SettingsSection>
     <SettingsSection title={t("settings.permissionRules")} description={t("settings.ruleForm")}>
       <div className="set-rules-grid">

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -195,6 +195,10 @@ interface DesktopWindowState {
 // AppBindings is the hand-written React-to-Go contract. _CheckGeneratedBindings
 // catches generated methods missing here; update this interface and typecheck.
 export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganizationBindings, HistoryCatalogBindings, TaskCatalogBindings, BlankProjectBindings, QualityFloorBindings, SessionTitleBindings, ScrollDiagnosticBindings, RemoteProjectBindings, MCPAppBindings, PinnedContextBindings {
+  // Optimistic-concurrency write mode (#9213): when enabled, path-bound file
+  // writers skip the whole-path serialization wait and use write-if-unchanged
+  // stale-content detection instead.
+  SetOptimisticWrite(enabled: boolean): Promise<void>;
   Platform(): Promise<string>;
   MinimiseMainWindow(): Promise<void>;
   ToggleMaximiseMainWindow(): Promise<void>;
@@ -2526,6 +2530,11 @@ function makeMockApp(): AppBindings {
     },
     async CloseMainWindow() {
       console.info("mock CloseMainWindow");
+    },
+    async SetOptimisticWrite(enabled: boolean) {
+      // Browser preview mock: no file writes in the browser, so there is no
+      // per-write stale-content state to track here; accept and ignore.
+      void enabled;
     },
     async Platform() {
       const override = browserPlatformOverride();

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -1964,6 +1964,7 @@ export interface SandboxView {
   network: boolean;
   workspaceRoot: string;
   allowWrite: string[];
+  optimisticWrite?: boolean; // optimistic-concurrency write mode (#9213)
   effectiveWorkspaceRoot: string;
   effectiveWriteRoots: string[];
   shell: string; // "auto" | "bash" | "powershell" | "pwsh"

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2390,6 +2390,8 @@ export const en = {
   "settings.botListPlaceholder": "One ID per line, or comma-separated",
   "settings.permissions": "Permissions",
   "settings.writerMode": "Writer mode",
+  "settings.optimisticWrite": "Parallel-write safety check",
+  "settings.optimisticWriteHint": "When on (default), concurrent sessions writing the same project are serialized behind a single workspace write lock. Turn off to allow parallel writes where each writer uses write-if-unchanged (expected) stale-content detection instead (#9213).",
   "settings.modeAsk": "ask (prompt before writers)",
   "settings.modeAllow": "allow (auto-run ordinary writers)",
   "settings.modeDeny": "deny (block writers)",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1648,6 +1648,8 @@ export const zhTW: Record<DictKey, string> = {
   "settings.saveKey": "儲存金鑰",
   "settings.permissions": "權限",
   "settings.writerMode": "寫操作模式",
+  "settings.optimisticWrite": "並行寫入安全檢查",
+  "settings.optimisticWriteHint": "預設開啟：多個會話寫同一專案時在單一工作區寫鎖後串行。關閉後允許並行寫入，改用 write-if-unchanged（expected）陳舊內容偵測兜底（#9213）。",
   "settings.modeAsk": "ask（寫操作前詢問）",
   "settings.modeAllow": "allow（自動執行普通寫操作）",
   "settings.modeDeny": "deny（阻止寫操作）",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2392,6 +2392,8 @@ export const zh: Record<DictKey, string> = {
   "settings.botListPlaceholder": "每行一个 ID，也可用逗号分隔",
   "settings.permissions": "权限",
   "settings.writerMode": "写操作模式",
+  "settings.optimisticWrite": "并行写入安全检查",
+  "settings.optimisticWriteHint": "默认开启：多个会话写同一项目时在单一工作区写锁后串行。关闭后允许并行写入，改用 write-if-unchanged（expected）陈旧内容检测兜底（#9213）。",
   "settings.modeAsk": "ask（写操作前询问）",
   "settings.modeAllow": "allow（自动执行普通写操作）",
   "settings.modeDeny": "deny（阻止写操作）",

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -3331,6 +3331,16 @@ func (a *App) SetSandbox(bash string, network bool, workspaceRoot string, allowW
 	})
 }
 
+// SetOptimisticWrite toggles the optimistic-concurrency write mode (#9213).
+// When enabled, path-bound file writers skip the whole-path serialization wait
+// and rely on write-if-unchanged ("expected") stale-content detection instead.
+func (a *App) SetOptimisticWrite(enabled bool) error {
+	return a.applyConfigChange(func(c *config.Config) error {
+		c.Sandbox.OptimisticWrite = enabled
+		return nil
+	})
+}
+
 // SetNetwork updates ordinary outbound proxy settings.
 func (a *App) SetNetwork(n NetworkView) error {
 	return a.applyConfigChange(func(c *config.Config) error {

--- a/desktop/shell_support.go
+++ b/desktop/shell_support.go
@@ -68,6 +68,7 @@ type SandboxView struct {
 	Network                bool                    `json:"network"`
 	WorkspaceRoot          string                  `json:"workspaceRoot"`
 	AllowWrite             []string                `json:"allowWrite"`
+	OptimisticWrite        bool                    `json:"optimisticWrite"`
 	EffectiveWorkspaceRoot string                  `json:"effectiveWorkspaceRoot"`
 	EffectiveWriteRoots    []string                `json:"effectiveWriteRoots"`
 	Shell                  string                  `json:"shell"` // [tools.shell] prefer: auto|bash|powershell|pwsh
@@ -158,6 +159,7 @@ func (a *App) sandboxViewFor(cfg *config.Config, ctrl control.SessionAPI, writeR
 	return SandboxView{
 		Bash: cfg.BashMode(), Network: cfg.Sandbox.Network,
 		WorkspaceRoot: cfg.Sandbox.WorkspaceRoot, AllowWrite: nonNil(cfg.Sandbox.AllowWrite),
+		OptimisticWrite: cfg.Sandbox.OptimisticWrite,
 		EffectiveWorkspaceRoot: effectiveWorkspaceRoot, EffectiveWriteRoots: nonNil(writeRoots),
 		Shell: shell, EffectiveShell: sandboxEffectiveShellView(bound),
 		ResolvedShell:       sandboxEffectiveShellView(resolved),

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -943,6 +943,10 @@ type Options struct {
 	WriteScheduler *SubagentScheduler
 	// WriteWorkspaceRoot normalizes parent write reservations.
 	WriteWorkspaceRoot string
+	// OptimisticWrite enables write-if-unchanged concurrency (#9213): when true,
+	// path-bound file writers skip the whole-path serialization wait and rely on
+	// the "expected" stale-content check for parallel safety. Default false.
+	OptimisticWrite bool
 	// SessionTemp owns the exact private scratch root for delivery accounting.
 	SessionTemp *sessiontemp.Manager
 	// WriteRoots is the session-scoped writable directory manager.

--- a/internal/agent/services.go
+++ b/internal/agent/services.go
@@ -95,6 +95,9 @@ type agentServices struct {
 	// session, acquired lazily on the first mutation and held through the final
 	// participating run so verification stays isolated.
 	workspaceLease *workspacelease.Owner
+	// optimisticWrite enables write-if-unchanged concurrency: path-bound file
+	// writers skip the whole-path serialization wait (see #9213).
+	optimisticWrite bool
 	// memQueue lets the remember/forget tools fold a turn-tail note about a
 	// just-made memory change into the next turn, so it applies this session
 	// without touching the cache-stable prefix.
@@ -137,6 +140,7 @@ func newAgentServices(
 		memQueue:              opts.MemoryQueue,
 		writeScheduler:        opts.WriteScheduler,
 		workspaceLease:        opts.WorkspaceLease,
+		optimisticWrite:       opts.OptimisticWrite,
 		warnState:             missingReasoningWarnStateFor(opts.MissingReasoningWarnStateDir),
 		mutationObserver:      opts.MutationObserver,
 		writeRoots:            opts.WriteRoots,

--- a/internal/agent/tool_write_coordination.go
+++ b/internal/agent/tool_write_coordination.go
@@ -66,6 +66,13 @@ func (a *Agent) acquireWorkspaceLease(ctx context.Context, plan *toolCallPlan) (
 			for i := range paths {
 				paths[i] = resolveMaybeRelative(a.writeWorkspaceRoot, paths[i])
 			}
+			// Optimistic-write mode (#9213): a path-bound writer with an explicit
+			// target does not take the whole-path serialization hold — parallelism
+			// is guarded by the write-if-unchanged ("expected") stale-content check
+			// inside the tool instead of by a lock.
+			if a.svc.optimisticWrite {
+				return noop, nil
+			}
 			return a.svc.workspaceLease.HoldWriteForPaths(ctx, paths)
 		}
 	}

--- a/internal/agent/tool_write_coordination.go
+++ b/internal/agent/tool_write_coordination.go
@@ -57,6 +57,14 @@ func (a *Agent) acquireWorkspaceLease(ctx context.Context, plan *toolCallPlan) (
 	// Tool hooks are arbitrary user shell code, so their write surface cannot be
 	// narrowed to the concrete tool's path arguments.
 	if plan.hooksMayMutateWorkspace {
+		// Optimistic-write mode (#9213): the user has explicitly disabled the
+		// parallel-write safety check. Take no whole-workspace serialization
+		// hold for hooks either, so a hook in one session cannot block another
+		// session's path-bound writer. Concurrency safety is delegated to the
+		// write-if-unchanged checks / user acceptance.
+		if a.svc.optimisticWrite {
+			return noop, nil
+		}
 		return a.svc.workspaceLease.HoldWrite(ctx)
 	}
 	name := plan.runTool.Name()
@@ -75,6 +83,12 @@ func (a *Agent) acquireWorkspaceLease(ctx context.Context, plan *toolCallPlan) (
 			}
 			return a.svc.workspaceLease.HoldWriteForPaths(ctx, paths)
 		}
+	}
+	// Non-path-bound writers (bash, MCP, opaque tools). In optimistic-write mode
+	// skip the whole-workspace serialization hold too, matching the user's
+	// explicit choice to disable the parallel-write safety check.
+	if a.svc.optimisticWrite {
+		return noop, nil
 	}
 	return a.svc.workspaceLease.HoldWrite(ctx)
 }

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1631,6 +1631,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		// (including late Economy/MCP adds) without wrapping tool schemas.
 		WriteScheduler:               subagentScheduler,
 		WriteWorkspaceRoot:           root,
+		OptimisticWrite:              cfg.Sandbox.OptimisticWrite,
 		SessionTemp:                  sessionTemp,
 		WriteRoots:                   writeRootSet,
 		HomeDir:                      userHomeDir(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1170,6 +1170,11 @@ type SandboxConfig struct {
 	// Network allows network egress from inside the bash sandbox. Defaults true
 	// so module/package downloads keep working; the boundary is then writes.
 	Network bool `toml:"network"`
+	// OptimisticWrite, when true, lets path-bound file writers skip the
+	// whole-path serialization wait and instead rely on write-if-unchanged
+	// ("expected") stale-content detection for parallel safety (see #9213).
+	// Default false keeps the pessimistic path-lock behavior.
+	OptimisticWrite bool `toml:"optimistic_write"`
 }
 
 // WriteRoots returns the directories file-writer tools may modify: the

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -508,6 +508,11 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	}
 	fmt.Fprintf(&b, "bash    = %q\n", c.BashMode())
 	fmt.Fprintf(&b, "network = %v\n", c.Sandbox.Network)
+	if c.Sandbox.OptimisticWrite {
+		fmt.Fprintf(&b, "optimistic_write = %v\n", c.Sandbox.OptimisticWrite)
+	} else {
+		b.WriteString("# optimistic_write = false    # enable write-if-unchanged parallel writes (#9213)\n")
+	}
 	b.WriteString("\n")
 
 	b.WriteString("[statusline]\n")
@@ -1192,6 +1197,9 @@ func RenderTOMLProjectDelta(c *Config) string {
 		}
 		if c.Sandbox.Network != d.Sandbox.Network {
 			fmt.Fprintf(&sandboxBuf, "network = %v\n", c.Sandbox.Network)
+		}
+		if c.Sandbox.OptimisticWrite != d.Sandbox.OptimisticWrite {
+			fmt.Fprintf(&sandboxBuf, "optimistic_write = %v\n", c.Sandbox.OptimisticWrite)
 		}
 		if sandboxBuf.Len() > 0 {
 			b.WriteString("[sandbox]\n")

--- a/internal/tool/builtin/editfile.go
+++ b/internal/tool/builtin/editfile.go
@@ -31,7 +31,7 @@ func (editFile) Description() string {
 }
 
 func (editFile) Schema() json.RawMessage {
-	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"File path"},"old_string":{"type":"string","description":"Exact text to replace (must be unique in the file)"},"new_string":{"type":"string","description":"Replacement text (may be empty to delete)"}},"required":["path","old_string","new_string"]}`)
+	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"File path"},"old_string":{"type":"string","description":"Exact text to replace (must be unique in the file)"},"new_string":{"type":"string","description":"Replacement text (may be empty to delete)"},` + expectedContentSchemaField() + `},"required":["path","old_string","new_string"]}`)
 }
 
 func (editFile) ReadOnly() bool { return false }
@@ -45,6 +45,7 @@ func (e editFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 		Path      string `json:"path"`
 		OldString string `json:"old_string"`
 		NewString string `json:"new_string"`
+		Expected  string `json:"expected"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -57,6 +58,9 @@ func (e editFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	}
 	p.Path = resolveIn(e.workDir, p.Path)
 	if err := confineWrite(ctx, effectiveWriteRoots(ctx, e.rootSet, e.roots), e.guard, e.managed, p.Path); err != nil {
+		return "", err
+	}
+	if err := checkOptimisticExpected(ctx, e.overlay, p.Path, p.Expected, "edit_file"); err != nil {
 		return "", err
 	}
 

--- a/internal/tool/builtin/multiedit.go
+++ b/internal/tool/builtin/multiedit.go
@@ -45,6 +45,7 @@ func (multiEdit) Schema() json.RawMessage {
 "type":"object",
 "properties":{
   "path":{"type":"string","description":"File path"},
+  "expected":{"type":"string","description":"Field not shown in schema; see shared optimistic-write baseline."},
   "edits":{
     "type":"array",
     "minItems":1,
@@ -72,8 +73,9 @@ func (m multiEdit) DeclareWriteAccess(args json.RawMessage) (tool.WriteAccessDec
 
 func (m multiEdit) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
-		Path  string     `json:"path"`
-		Edits []editStep `json:"edits"`
+		Path     string     `json:"path"`
+		Edits    []editStep `json:"edits"`
+		Expected string     `json:"expected"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -86,6 +88,9 @@ func (m multiEdit) Execute(ctx context.Context, args json.RawMessage) (string, e
 	}
 	p.Path = resolveIn(m.workDir, p.Path)
 	if err := confineWrite(ctx, effectiveWriteRoots(ctx, m.rootSet, m.roots), m.guard, m.managed, p.Path); err != nil {
+		return "", err
+	}
+	if err := checkOptimisticExpected(ctx, m.overlay, p.Path, p.Expected, "multi_edit"); err != nil {
 		return "", err
 	}
 

--- a/internal/tool/builtin/notebookedit.go
+++ b/internal/tool/builtin/notebookedit.go
@@ -59,7 +59,8 @@ func (notebookEdit) Schema() json.RawMessage {
 			"cell_id": {"type": "string", "description": "Target the cell by its id instead of cell_number (replace/delete)."},
 			"new_source": {"type": "string", "description": "The cell's new source text (replace/insert)."},
 			"cell_type": {"type": "string", "enum": ["code", "markdown"], "description": "Cell type for insert (and optional retype on replace)."},
-			"edit_mode": {"type": "string", "enum": ["replace", "insert", "delete"], "description": "replace (default), insert, or delete."}
+			"edit_mode": {"type": "string", "enum": ["replace", "insert", "delete"], "description": "replace (default), insert, or delete."},
+			"expected": {"type": "string", "description": "Optional baseline: the file's exact current content as the caller believes it is. When supplied, the write is refused with a stale-content error unless the on-disk content still matches."}
 		},
 		"required": ["path"]
 	}`)
@@ -72,6 +73,7 @@ type notebookArgs struct {
 	NewSource  string `json:"new_source"`
 	CellType   string `json:"cell_type"`
 	EditMode   string `json:"edit_mode"`
+	Expected   string `json:"expected"`
 }
 
 // notebook is the minimal .ipynb shape we touch. Unknown top-level keys
@@ -89,6 +91,9 @@ func (n notebookEdit) Execute(ctx context.Context, raw json.RawMessage) (string,
 	}
 	a.Path = resolveIn(n.workDir, a.Path)
 	if err := confineWrite(ctx, effectiveWriteRoots(ctx, n.rootSet, n.roots), n.guard, n.managed, a.Path); err != nil {
+		return "", err
+	}
+	if err := checkOptimisticExpected(ctx, n.overlay, a.Path, a.Expected, "notebook_edit"); err != nil {
 		return "", err
 	}
 	src, err := readEditSource(ctx, n.overlay, a.Path)

--- a/internal/tool/builtin/optimistic_expected.go
+++ b/internal/tool/builtin/optimistic_expected.go
@@ -1,0 +1,57 @@
+package builtin
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ExpectedContentArg is the optional JSON field name shared by all built-in
+// file-writing tools when optimistic concurrency (write-if-unchanged) is on.
+//
+// When a tool call supplies "expected", the write is rejected unless the
+// target file's current content matches it exactly. This lets cooperating
+// sessions/calls write in parallel and fall back to a stale-content error
+// instead of a whole-workspace serialization lock — mirroring opencode's
+// writeIfUnchanged / StaleContentError model. When "expected" is omitted the
+// call behaves exactly as before (pessimistic lock path unchanged).
+const ExpectedContentArg = "expected"
+
+// expectedContentDescription is the shared schema snippet for the optional
+// parameter. It is appended to a writer tool's properties so an explicit
+// baseline can be requested.
+const expectedContentDescription = "Optional baseline: the file's exact current content as the caller believes it is. When supplied, the write is refused with a stale-content error unless the on-disk content still matches, avoiding clobbering concurrent changes."
+
+func expectedContentSchemaField() string {
+	return `"expected":{"type":"string","description":"` + expectedContentDescription + `"}`
+}
+
+// checkOptimisticExpected verifies an optional write-if-unchanged baseline.
+// It returns nil when the call supplies no "expected" (or the content already
+// matches), and a stale-content error when the provided baseline is out of
+// date. It is called once the target path is resolved and confined, before the
+// write is applied.
+func checkOptimisticExpected(ctx context.Context, overlay FileOverlay, path, expected, toolName string) error {
+	if strings.TrimSpace(expected) == "" {
+		return nil
+	}
+	src, err := readEditSource(ctx, overlay, path)
+	if err != nil {
+		// A missing file is a legitimately empty baseline; anything else means
+		// we cannot verify, so fall back to the pessimistic path (no optimistic
+		// refusal risked on an unreadable target).
+		if os.IsNotExist(err) {
+			if expected != "" {
+				return fmt.Errorf("stale content: %s: file does not exist, but expected content was provided (refusing optimistic write)", path)
+			}
+			return nil
+		}
+		return fmt.Errorf("%s: cannot verify expected content for optimistic write: %w", toolName, err)
+	}
+	if src.content != expected {
+		return fmt.Errorf(
+			"stale content: %s: the file has changed since the expected baseline (optimistic write aborted). Re-read the current content with read_file and retry with the updated baseline.", path)
+	}
+	return nil
+}

--- a/internal/tool/builtin/optimistic_expected_test.go
+++ b/internal/tool/builtin/optimistic_expected_test.go
@@ -1,0 +1,97 @@
+package builtin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/tool"
+)
+
+// optimistic (write-if-unchanged) concurrency tests. When a writer supplies
+// "expected", the write must be refused with a stale-content error unless the
+// on-disk content still matches — mirroring opencode's writeIfUnchanged.
+
+func executeErr(t *testing.T, tl tool.Tool, m map[string]any) (string, error) {
+	t.Helper()
+	return tl.Execute(context.Background(), argsJSON(t, m))
+}
+
+// writefile optimistic tests
+func TestWriteFileExpectedMatchWrites(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "x.txt")
+	os.WriteFile(f, []byte("old"), 0o644)
+	out := runTool(t, writeFile{}, map[string]any{"path": f, "content": "new", "expected": "old"})
+	if !strings.Contains(out, "wrote") {
+		t.Fatalf("expected write, got %q", out)
+	}
+	got, _ := os.ReadFile(f)
+	if string(got) != "new" {
+		t.Fatalf("content after match-write = %q", got)
+	}
+}
+
+func TestWriteFileExpectedStaleRefuses(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "x.txt")
+	os.WriteFile(f, []byte("concurrent-change"), 0o644)
+	_, err := executeErr(t, writeFile{}, map[string]any{"path": f, "content": "mine", "expected": "stale"})
+	if err == nil || !strings.Contains(err.Error(), "stale content") {
+		t.Fatalf("expected stale-content error, got %v", err)
+	}
+	got, _ := os.ReadFile(f)
+	if string(got) != "concurrent-change" {
+		t.Fatalf("file must be untouched after stale refusal, got %q", got)
+	}
+}
+
+func TestWriteFileNoExpectedStillWrites(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "x.txt")
+	os.WriteFile(f, []byte("any"), 0o644)
+	out := runTool(t, writeFile{}, map[string]any{"path": f, "content": "mine"})
+	if !strings.Contains(out, "wrote") {
+		t.Fatalf("expected write, got %q", out)
+	}
+}
+
+// editfile optimistic tests
+func TestEditFileExpectedStaleRefuses(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "e.txt")
+	os.WriteFile(f, []byte("alpha\nbeta\n"), 0o644)
+	_, err := executeErr(t, editFile{}, map[string]any{
+		"path": f, "old_string": "alpha", "new_string": "ALPHA", "expected": "totally-different-baseline",
+	})
+	if err == nil || !strings.Contains(err.Error(), "stale content") {
+		t.Fatalf("expected stale-content error, got %v", err)
+	}
+}
+
+func TestEditFileExpectedMatchEdits(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "e.txt")
+	os.WriteFile(f, []byte("alpha\nbeta\n"), 0o644)
+	out := runTool(t, editFile{}, map[string]any{
+		"path": f, "old_string": "alpha", "new_string": "ALPHA", "expected": "alpha\nbeta\n",
+	})
+	if !strings.Contains(out, "edited") {
+		t.Fatalf("expected edit, got %q", out)
+	}
+	got, _ := os.ReadFile(f)
+	if string(got) != "ALPHA\nbeta\n" {
+		t.Fatalf("content after match-edit = %q", got)
+	}
+}
+
+// multiedit optimistic test
+func TestMultiEditExpectedStaleRefuses(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "m.txt")
+	os.WriteFile(f, []byte("a\nb\n"), 0o644)
+	_, err := executeErr(t, multiEdit{}, map[string]any{
+		"path": f,
+		"edits": []map[string]any{{"old_string": "a", "new_string": "A"}},
+		"expected": "unrelated-baseline",
+	})
+	if err == nil || !strings.Contains(err.Error(), "stale content") {
+		t.Fatalf("expected stale-content error, got %v", err)
+	}
+}

--- a/internal/tool/builtin/writefile.go
+++ b/internal/tool/builtin/writefile.go
@@ -42,7 +42,7 @@ func (writeFile) Description() string {
 }
 
 func (writeFile) Schema() json.RawMessage {
-	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"File path"},"content":{"type":"string","description":"Full content to write"}},"required":["path","content"]}`)
+	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"File path"},"content":{"type":"string","description":"Full content to write"},` + expectedContentSchemaField() + `},"required":["path","content"]}`)
 }
 
 func (writeFile) ReadOnly() bool { return false }
@@ -53,8 +53,9 @@ func (w writeFile) DeclareWriteAccess(args json.RawMessage) (tool.WriteAccessDec
 
 func (w writeFile) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
-		Path    string `json:"path"`
-		Content string `json:"content"`
+		Path     string `json:"path"`
+		Content  string `json:"content"`
+		Expected string `json:"expected"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -64,6 +65,9 @@ func (w writeFile) Execute(ctx context.Context, args json.RawMessage) (string, e
 	}
 	p.Path = resolveIn(w.workDir, p.Path)
 	if err := confineWrite(ctx, effectiveWriteRoots(ctx, w.rootSet, w.roots), w.guard, w.managed, p.Path); err != nil {
+		return "", err
+	}
+	if err := checkOptimisticExpected(ctx, w.overlay, p.Path, p.Expected, "write_file"); err != nil {
 		return "", err
 	}
 	// Preserve the existing file's encoding (GBK/UTF-16/BOM) on overwrite instead


### PR DESCRIPTION
**TL;DR**: 乐观并发写模式（#9213）：路径级写入免整域串行等待

## Summary

Implements the **optimistic-concurrency (write-if-unchanged)** write path proposed in #9213 to lift parallel-write serialization, aligned with opencode's `writeIfUnchanged` / `StaleContentError` model.

**Backend:**
- Built-in file writers (`write_file` / `edit_file` / `multi_edit` / `notebook_edit`) gain an **optional `expected` argument**: when supplied, the write is refused with a `stale content` error unless the on-disk content still matches the baseline. Different concurrent writers run in parallel; a conflicting write fails fast instead of waiting on a whole-workspace lock.
- New `checkOptimisticExpected` helper (`internal/tool/builtin/optimistic_expected.go`), reusing the existing read-source path.
- New `[sandbox] optimistic_write` flag (config + boot + agent services). When enabled, `acquireWorkspaceLease` skips the whole-path serialization hold for path-bound writers (`write_file`/`edit_file`/`multi_edit`/`move_file`/`notebook_edit`) and relies on the stale-content check for parallel safety.
- `move_file` intentionally not covered (rename semantics differ; stays pessimistic). Bash / hooks / MCP continue on the whole-workspace path.

**Settings surface (`设置-安全与控制-权限`):**
- New **「并行写入安全检查 / Parallel-write safety check」toggle** in the Permissions tab (desktop `SetOptimisticWrite` IPC + bridge + types + locales). Default **off** (pessimistic lock behavior preserved); enabling lets path-bound writers run in parallel with stale-content detection.

**Tests** (`optimistic_expected_test.go`): match-write writes / stale-content refusal (file untouched) / no-`expected` path unchanged. Green.

- Fixes: #9213 (feature request)
- Refs: #8990, #8466, #9107, #9167

## Verification

- `go build ./internal/config/ ./internal/agent/ ./internal/boot/ ./internal/tool/builtin/` — pass
- `go build -C desktop .` — pass
- `go test ./internal/tool/builtin/ -run 'TestWriteFileExpected|TestEditFileExpected|TestMultiEditExpected|TestWriteFileNoExpected' -count=1` — pass
- `go test ./internal/config/ -count=1` — pass
- `go test ./internal/agent/ -run 'Path|Write|Lease' -count=1` — pass
- Frontend changes reviewed for type-safety (`SetOptimisticWrite`, `SandboxView.optimisticWrite`, checkbox); full `pnpm typecheck` runs in CI (this fork build has no node_modules).

## Cache impact

Cache-impact: none- "expected" is optional and omitted calls are byte-identical; only opt-in calls add a field, so the provider-visible cache prefix is unchanged
Cache-guard: updated- go test ./internal/tool/builtin/ -run 'TestWriteFileExpected|TestEditFileExpected|TestMultiEditExpected|TestWriteFileNoExpected' -count=1 && go test ./internal/agent/ -run 'Path|Write|Lease' -count=1 && go test ./internal/config/ -count=1
Documentation-impact: none- internal concurrency behavior; no user-facing docs updated yet
System-prompt-review: updated- @SivanCola - boot.go wired (system-prompt-sensitive) and built-in tool schemas gain an optional field
