### PR TITLE
fix(desktop): prevent multi-line display math rows from overlapping / 修复多行公式（\substack+\underbrace）渲染重叠（#9225）

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -5167,6 +5167,19 @@ button.reasoning-summary:focus-visible {
 .md p {
   margin: 0 0 12px;
 }
+/* #9225: block (display) math must keep enough vertical line-height and not be
+   clipped by the container, so multi-line \substack / \underbrace rows do not
+   overlap. KaTeX itself renders the full structure (verified via
+   renderToString), so this is a container-style guard. */
+.md .katex-display {
+  line-height: 1.6;
+  overflow: visible;
+  margin: 12px 0;
+}
+.md .katex-display > .katex,
+.md .katex-display > .katex > .katex-html {
+  line-height: 1.6;
+}
 .md h1,
 .md h2,
 .md h3,


### PR DESCRIPTION
## Summary

Fixes block (display) LaTeX where multi-line `\substack` + `\underbrace` rows are rendered **on top of each other / overlapping** in Reasonix messages (fixes #9225).

### Root cause
- Rendering: `MarkdownRenderer.tsx` (react-markdown + remark-math + rehype-katex, `katex/dist/katex.min.css`, katex 0.18.1).
- Verified: `katex.renderToString(tex, { displayMode: true })` produces the **full multi-line structure correctly** — KaTeX itself is fine.
- Therefore the `.md` container's inherited style was compressing/clipping the display math's vertical spacing.

### Fix (frontend CSS only)
```css
.md .katex-display {
  line-height: 1.6;
  overflow: visible;
  margin: 12px 0;
}
.md .katex-display > .katex,
.md .katex-display > .katex > .katex-html {
  line-height: 1.6;
}
```
- Gives block math enough vertical line-height and prevents clipping of the multi-row `\underbrace`/`\substack` layers.

## Note
This is a container-style guard derived from the source + `renderToString` analysis. Please confirm against the 111.png reproduction in the desktop UI; if the overlap persists, the next step is to inspect the live DOM/CSS cascade for the specific `.md` variant (e.g. streaming `.md--stream-tail`).

## Verification
- `node scripts/check-css-syntax.mjs src/styles.css` — pass (CSS-only change; no TS).

## Cache impact
Cache-impact: none- frontend CSS only; no prompt/tool-schema/provider bytes change
Cache-guard: updated- node scripts/check-css-syntax.mjs src/styles.css && pnpm typecheck
Documentation-impact: none- no user-facing docs updated
System-prompt-review: none- @SivanCola - frontend CSS fix; no system-prompt/boot/config changes