### PR TITLE
fix(desktop): reset topic to idle on CompactionDone so /compact stops spinning / 修复手动 /compact 压缩完成后会话一直显示"处理中"转圈（#9230）

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1777,8 +1777,14 @@ func (e *asyncRuntimeEmitter) run() {
 
 func topicActivityStatusFromEvent(e event.Event) (string, bool) {
 	switch e.Kind {
-	case event.TurnStarted, event.Reasoning, event.ToolDispatch, event.ToolProgress, event.ToolResultPreview, event.ToolResult, event.CompactionStarted, event.CompactionDone, event.Retrying:
+	case event.TurnStarted, event.Reasoning, event.ToolDispatch, event.ToolProgress, event.ToolResultPreview, event.ToolResult, event.CompactionStarted, event.Retrying:
 		return topicStatusThinking, true
+	// CompactionDone is an ending state: the pass finished (successfully or was
+	// aborted). Reset the topic to idle instead of leaving it in "thinking",
+	// which would otherwise stay until a later TurnDone (manual /compact turns
+	// don't always fire one) — #9230.
+	case event.CompactionDone:
+		return "", true
 	case event.Text, event.Message:
 		return topicStatusStreaming, true
 	case event.ApprovalRequest, event.AskRequest:

--- a/desktop/tabs_runtime_status_test.go
+++ b/desktop/tabs_runtime_status_test.go
@@ -294,6 +294,15 @@ func TestTopicActivityStatusPresentsReadinessSeparatelyFromPause(t *testing.T) {
 	}
 }
 
+func TestTopicActivityStatusClearsOnCompactionDone(t *testing.T) {
+	if status, ok := topicActivityStatusFromEvent(event.Event{Kind: event.CompactionStarted}); !ok || status != topicStatusThinking {
+		t.Fatalf("compaction start = (%q, %v), want (%q, true)", status, ok, topicStatusThinking)
+	}
+	if status, ok := topicActivityStatusFromEvent(event.Event{Kind: event.CompactionDone}); !ok || status != "" {
+		t.Fatalf("compaction done = (%q, %v), want cleared status (no thinking spinner)", status, ok)
+	}
+}
+
 func TestCatalogRuntimeStatusPreservesDeliveryCheckWhenIdle(t *testing.T) {
 	got := catalogRuntimeStatus(topicStatusAwaitingDelivery, control.RuntimeStatus{})
 	if got != topicStatusAwaitingDelivery {


### PR DESCRIPTION
## Summary

Fixes the "session keeps showing the thinking spinner after a manual `/compact` completes" bug (fixes #9230).

### Root cause
- `desktop/tabs.go` `topicActivityStatusFromEvent` mapped **`CompactionDone` (an ending state) into `topicStatusThinking`** — same bucket as `CompactionStarted`/`TurnStarted`.
- Topic state reset only happens on `TurnDone` (`desktop/topic_status.go`); a manual `/compact` turn doesn't always fire the resetting `TurnDone`, so the session stayed "thinking" (spinner) forever.

### Fix
- `desktop/tabs.go`: remove `event.CompactionDone` from the `topicStatusThinking` case, and add a dedicated `CompactionDone` case that **resets the topic to idle** (`("", true)`), independent of `TurnDone`.

### Verification
- `go test -C desktop -run 'TestTopicActivityStatus|TestCatalogRuntimeStatus' -count=1` — pass
  - new `TestTopicActivityStatusClearsOnCompactionDone`: `CompactionStarted => thinking`, `CompactionDone => cleared`
  - existing readiness/pause/error/idle tests still pass
- `go build -C desktop .` — pass

## Cache impact

Cache-impact: none- desktop host-only; no provider/prompt/tool-schema change
Cache-guard: updated- go test -C desktop -run 'TestTopicActivityStatus|TestCatalogRuntimeStatus' -count=1
Documentation-impact: none- internal state fix; no docs updated
System-prompt-review: none- @SivanCola - desktop host change; no system-prompt/boot/config changes