### PR TITLE
fix(desktop): hide the dock toggle while the automation panel is open / 自动化面板打开时隐藏右上角侧边栏折叠按钮

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4325,7 +4325,7 @@ export default function App() {
       ].filter(Boolean).join(" ")}
     >
       <ThemeBackground />
-      {sidebarWorkbench && <div className="app__dock-toggle">{dockToggleButton}</div>}
+      {sidebarWorkbench && !automationView && <div className="app__dock-toggle">{dockToggleButton}</div>}
       <div
         ref={layoutRef}
         className={[


### PR DESCRIPTION
## 变更摘要

自动化面板（heartbeat 调度页，`mainView === "automation"`）打开时，右上角固定的 dock 折叠/展开按钮（`.app__dock-toggle`，仅 workbench 布局渲染）不再展示。

## 问题背景

automation 视图会把右侧 dock 面板强制隐藏（`effectiveWorkspacePanelRenderable = false`），但右上角固定按钮仍渲染，点击会展开一个无法出现的面板，与自动化面板布局冲突。本次在渲染条件上增加 `!automationView` 门控，chat 视图行为不变。

## 变更范围

- `desktop/frontend/src/App.tsx`：1 行条件渲染改动

Documentation-impact: none - 纯 UI 条件渲染改动，不涉及内嵌文档，现有文档仍准确