### PR TITLE
fix(config): allow vision config for vision-named DeepSeek official models — #9241

### DIFF
--- a/desktop/frontend/src/__tests__/provider-editor-model-picker.test.tsx
+++ b/desktop/frontend/src/__tests__/provider-editor-model-picker.test.tsx
@@ -133,27 +133,31 @@ ok(
   "older backend payloads do not infer support for arbitrary compatible endpoints",
 );
 ok(
-  providerVisionCapabilityForView({ kind: "openai", baseUrl: "https://custom.example/v1", visionCapability: "unsupported" }) === "unsupported",
+  providerVisionCapabilityForView({ kind: "openai", baseUrl: "https://custom.example/v1", visionCapability: "unsupported", models: [] }) === "unsupported",
   "backend vision capability overrides frontend endpoint inference",
 );
 ok(
-  providerVisionCapabilityForView({ kind: "openai", baseUrl: "https://api.deepseek.com" }) === "unsupported",
+  providerVisionCapabilityForView({ kind: "openai", baseUrl: "https://api.deepseek.com", models: [] }) === "unsupported",
   "older backend payloads retain the endpoint-based vision fallback",
 );
 ok(
-  providerVisionCapabilityForView({ kind: "anthropic", baseUrl: "https://eu.deepseek.com/anthropic" }) === "unsupported",
+  providerVisionCapabilityForView({ kind: "openai", baseUrl: "https://api.deepseek.com", models: ["deepseek-v4-flash", "deepseek-v4-flash-vision-exp"] }) === "configurable",
+  "vision-named DeepSeek models remain configurable on official endpoints",
+);
+ok(
+  providerVisionCapabilityForView({ kind: "anthropic", baseUrl: "https://eu.deepseek.com/anthropic", models: [] }) === "unsupported",
   "older backend payloads treat regional DeepSeek subdomains as text-only",
 );
 ok(
-  providerVisionCapabilityForView({ kind: "responses", baseUrl: "https://deepseek.com" }) === "configurable",
+  providerVisionCapabilityForView({ kind: "responses", baseUrl: "https://deepseek.com", models: [] }) === "configurable",
   "the DeepSeek apex does not inherit official vision restrictions",
 );
 ok(
-  providerVisionCapabilityForView({ kind: "openai", baseUrl: "https://deepseek.com.example/v1" }) === "configurable",
+  providerVisionCapabilityForView({ kind: "openai", baseUrl: "https://deepseek.com.example/v1", models: [] }) === "configurable",
   "lookalike domains with a DeepSeek prefix do not inherit official vision restrictions",
 );
 ok(
-  providerVisionCapabilityForView({ kind: "openai", baseUrl: "https://api.deepseek.com.example/v1" }) === "configurable",
+  providerVisionCapabilityForView({ kind: "openai", baseUrl: "https://api.deepseek.com.example/v1", models: [] }) === "configurable",
   "lookalike domains with an official-host prefix remain configurable",
 );
 

--- a/desktop/frontend/src/__tests__/provider-model-refresh.test.ts
+++ b/desktop/frontend/src/__tests__/provider-model-refresh.test.ts
@@ -104,9 +104,10 @@ eq(
     isLikelyVisionModel("mimo-v2.5"),
     isLikelyVisionModel("mimo-v2-omni"),
     isLikelyVisionModel("qwen2.5-vl-72b-instruct"),
+    isLikelyVisionModel("deepseek-v4-flash-vision-exp"),
     isLikelyVisionModel("mimo-v2.5-asr"),
   ],
-  [true, false, false, true, true, true, false],
+  [true, false, false, true, true, true, true, false],
   "detects likely image-capable chat model IDs",
 );
 

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -6,7 +6,7 @@ import { botAccessEntryCount, botAccessReady, botConnectionCredentialSummary, bo
 import { useDeferredClose } from "../lib/useMountTransition";
 import { app, openExternal } from "../lib/bridge";
 import { normalizeLangPref, useI18n, useT, type DictKey, type LangPref } from "../lib/i18n";
-import { apiKeyEnvFromProviderName, createLatestRequestGate, inferredVisionModels, mergedFetchedProviderModels, mergeProviderModelContextWindows, providerApiKeyEnvForSave, providerDefaultModel, providerIsConfigured, providerModelCandidates, providerModelContextWindowDrafts, providerModelContextWindowIsSmall, providerRequiresKey } from "../lib/providerModels";
+import { apiKeyEnvFromProviderName, createLatestRequestGate, inferredVisionModels, isLikelyVisionModel, mergedFetchedProviderModels, mergeProviderModelContextWindows, providerApiKeyEnvForSave, providerDefaultModel, providerIsConfigured, providerModelCandidates, providerModelContextWindowDrafts, providerModelContextWindowIsSmall, providerRequiresKey } from "../lib/providerModels";
 import { cachedFetchProviderModels, invalidateProviderCacheByAPIKeyEnv, shouldSkipAutoRefresh } from "../lib/providerModelCache";
 import { providerBaseURLForSave, providerRequestURLFromConfig, trimmedBaseURL } from "../lib/providerEndpoint";
 import { opencodeGoPresetDescriptionKeys } from "../lib/providerPresetDescriptions";
@@ -6268,8 +6268,11 @@ export function providerSupportsServerWebSearchForView(
   return providerSupportsServerWebSearch(provider.kind, provider.baseUrl);
 }
 
-function providerVisionCapability(kind: string, baseUrl: string): ProviderVisionCapability {
+function providerVisionCapability(kind: string, baseUrl: string, models: string[] = []): ProviderVisionCapability {
   if (!isDeepSeekOfficialEndpoint(baseUrl)) return "configurable";
+  // DeepSeek official endpoints stay conservative for text-only models, but a
+  // model that explicitly names vision support may be configured for images.
+  if (models.some((model) => isLikelyVisionModel(model))) return "configurable";
   switch (kind.trim().toLowerCase()) {
     case "openai":
     case "responses":
@@ -6281,12 +6284,12 @@ function providerVisionCapability(kind: string, baseUrl: string): ProviderVision
 }
 
 export function providerVisionCapabilityForView(
-  provider: Pick<ProviderView, "kind" | "baseUrl" | "visionCapability">,
+  provider: Pick<ProviderView, "kind" | "baseUrl" | "visionCapability" | "models">,
 ): ProviderVisionCapability {
   if (provider.visionCapability === "unsupported" || provider.visionCapability === "configurable") {
     return provider.visionCapability;
   }
-  return providerVisionCapability(provider.kind, provider.baseUrl);
+  return providerVisionCapability(provider.kind, provider.baseUrl, provider.models ?? []);
 }
 
 function canonicalOfficialProviderName(name: string): string {
@@ -6591,6 +6594,7 @@ export function ProviderEditor({
     kind: effectiveKind,
     baseUrl: effectiveBaseUrl,
     visionCapability: retainedVisionCapability,
+    models: initial?.models ?? [],
   });
   const retainedServerWebSearchCapability = initial &&
     effectiveKind.trim().toLowerCase() === initial.kind.trim().toLowerCase() &&

--- a/internal/config/chat_model_test.go
+++ b/internal/config/chat_model_test.go
@@ -69,7 +69,7 @@ func TestIsLikelyChatModel_DoesNotFilterVoiceAlone(t *testing.T) {
 func TestIsLikelyVisionModel(t *testing.T) {
 	for _, model := range []string{
 		"mimo-v2.5", "mimo-v2-omni", "gpt-4o", "gpt-4o-mini",
-		"qwen2.5-vl-72b-instruct", "custom-vision-chat",
+		"qwen2.5-vl-72b-instruct", "custom-vision-chat", "deepseek-v4-flash-vision-exp",
 	} {
 		if !IsLikelyVisionModel(model) {
 			t.Errorf("IsLikelyVisionModel(%q) = false, want true", model)

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -810,8 +810,11 @@ func TestEffectiveVisionRejectsOfficialDeepSeekOverridesButPreservesCustomGatewa
 		Model:        "deepseek-v5-vision",
 		VisionModels: []string{"deepseek-v5-vision"},
 	}
-	if EffectiveVision(future) {
-		t.Fatal("a future model name must not bypass the official DeepSeek wire constraint")
+	if !CanConfigureVision(future) {
+		t.Fatal("an explicitly vision-named DeepSeek model must allow vision configuration")
+	}
+	if !EffectiveVision(future) {
+		t.Fatal("an explicitly vision-named DeepSeek model must be able to use its persisted vision metadata")
 	}
 
 	visionOn := true

--- a/internal/config/vision.go
+++ b/internal/config/vision.go
@@ -60,13 +60,29 @@ func modelTokenSeparator(r rune) bool {
 }
 
 // CanConfigureVision reports whether user-supplied vision metadata may enable
-// image input for this endpoint. DeepSeek's official APIs currently accept text
-// message content only, so their protocol constraint is authoritative over
-// persisted provider-wide flags, vision_models, and model overrides. Custom
+// image input for this endpoint. DeepSeek's official APIs historically accepted
+// text message content only, so their protocol constraint used to be
+// authoritative over persisted provider-wide flags, vision_models, and model
+// overrides. Models whose IDs explicitly declare vision support (e.g.
+// deepseek-v4-flash-vision-exp) are allowed through so users can opt in; the
+// provider-boundary guards in internal/provider relax the same models. Custom
 // DeepSeek-compatible gateways remain configurable because they may implement
 // their own multimodal translation layer.
 func CanConfigureVision(e *ProviderEntry) bool {
-	return e != nil && !openai.IsDeepSeek(e.BaseURL)
+	if e == nil {
+		return false
+	}
+	if !openai.IsDeepSeek(e.BaseURL) {
+		return true
+	}
+	// DeepSeek official endpoints stay conservative for text-only models, but a
+	// model that explicitly names vision support may be configured for images.
+	for _, model := range e.ChatModelList() {
+		if IsLikelyVisionModel(model) {
+			return true
+		}
+	}
+	return false
 }
 
 // EffectiveVision resolves whether the selected model accepts image input.

--- a/internal/config/vision_test.go
+++ b/internal/config/vision_test.go
@@ -1,0 +1,35 @@
+package config
+
+import "testing"
+
+func TestCanConfigureVisionDeepSeekVisionModels(t *testing.T) {
+	vision := &ProviderEntry{
+		Name:    "deepseek",
+		Kind:    "openai",
+		BaseURL: "https://api.deepseek.com",
+		Models:  []string{"deepseek-v4-flash", "deepseek-v4-flash-vision-exp"},
+	}
+	if !CanConfigureVision(vision) {
+		t.Fatal("DeepSeek official endpoint with a vision-named model in its list must allow vision configuration")
+	}
+
+	textOnly := &ProviderEntry{
+		Name:    "deepseek",
+		Kind:    "openai",
+		BaseURL: "https://api.deepseek.com",
+		Models:  []string{"deepseek-v4-flash", "deepseek-v4-pro"},
+	}
+	if CanConfigureVision(textOnly) {
+		t.Fatal("DeepSeek official endpoint with only text-named models must stay unsupported")
+	}
+
+	visionDefault := &ProviderEntry{
+		Name:    "deepseek",
+		Kind:    "openai",
+		BaseURL: "https://api.deepseek.com",
+		Model:   "deepseek-v4-flash-vision-exp",
+	}
+	if !CanConfigureVision(visionDefault) {
+		t.Fatal("DeepSeek official endpoint whose default model is vision-named must allow vision configuration")
+	}
+}

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -110,10 +110,12 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	effort, _ := cfg.Extra["effort"].(string)
 	effort = strings.ToLower(strings.TrimSpace(effort))
 	vision, _ := cfg.Extra["vision"].(bool)
-	// DeepSeek's official Anthropic-compatible endpoint is text-only. Enforce
-	// that wire constraint here as defense in depth, independent of config or
-	// extension capability metadata.
-	vision = vision && !officialDeepSeek
+	// DeepSeek's official Anthropic-compatible endpoint is historically
+	// text-only. Enforce that wire constraint here as defense in depth,
+	// independent of config or extension capability metadata — except for
+	// explicitly vision-named models (e.g. deepseek-v4-flash-vision-exp) that
+	// may accept image blocks.
+	vision = vision && !(officialDeepSeek && !provider.IsLikelyVisionModelName(cfg.Model))
 	webSearch, _ := cfg.Extra["web_search"].(bool)
 	headers, _ := cfg.Extra["headers"].(map[string]string)
 	authHeader, _ := cfg.Extra["auth_header"].(bool)

--- a/internal/provider/openai/image_test.go
+++ b/internal/provider/openai/image_test.go
@@ -79,7 +79,7 @@ func TestOfficialDeepSeekProviderWideVisionInputMatchesTextOnlyRequest(t *testin
 	}
 }
 
-func TestOfficialDeepSeekExplicitModelVisionInputMatchesTextOnlyRequest(t *testing.T) {
+func TestOfficialDeepSeekVisionNamedModelEnablesVision(t *testing.T) {
 	p, err := New(provider.Config{
 		Name:    "deepseek",
 		BaseURL: "https://api.deepseek.com",
@@ -93,8 +93,8 @@ func TestOfficialDeepSeekExplicitModelVisionInputMatchesTextOnlyRequest(t *testi
 		t.Fatalf("New: %v", err)
 	}
 	c := p.(*client)
-	if c.vision {
-		t.Fatal("explicit model-scoped vision must not bypass the official DeepSeek endpoint guard")
+	if !c.vision {
+		t.Fatal("explicitly vision-named DeepSeek model must enable vision at the provider boundary")
 	}
 
 	textOnly := provider.Request{Messages: []provider.Message{{
@@ -112,8 +112,11 @@ func TestOfficialDeepSeekExplicitModelVisionInputMatchesTextOnlyRequest(t *testi
 	if err != nil {
 		t.Fatalf("marshal image request: %v", err)
 	}
-	if !bytes.Equal(imageBody, textBody) {
-		t.Fatalf("explicit official DeepSeek image request changed provider-visible bytes:\ntext:  %s\nimage: %s", textBody, imageBody)
+	if bytes.Equal(imageBody, textBody) {
+		t.Fatalf("vision-named DeepSeek image request must differ from text request:\ntext:  %s\nimage: %s", textBody, imageBody)
+	}
+	if !strings.Contains(string(imageBody), `"image_url"`) {
+		t.Fatalf("vision-named DeepSeek image request must contain image_url parts: %s", imageBody)
 	}
 }
 

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -90,12 +90,14 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	extraBody, _ := cfg.Extra["extra_body"].(map[string]any)
 	vision, _ := cfg.Extra["vision"].(bool)
 	officialDeepSeek := IsDeepSeek(cfg.BaseURL)
-	// DeepSeek's official chat API accepts string message content only. Keep
-	// this provider-boundary guard even though config capability resolution
-	// normally prevents image attachments from reaching this layer. No persisted
-	// or extension-supplied capability flag may override the endpoint's current
-	// wire contract; future native vision support needs an explicit serializer.
-	vision = vision && !officialDeepSeek
+	// DeepSeek's official chat API historically accepts string message content
+	// only, but explicitly vision-named models (e.g. deepseek-v4-flash-vision-exp)
+	// may accept image parts. Keep the guard for text-only DeepSeek models even
+	// though config capability resolution normally prevents image attachments
+	// from reaching this layer; no persisted or extension-supplied capability
+	// flag may override the endpoint's current wire contract for text-only
+	// models. Future native vision support needs an explicit serializer.
+	vision = vision && !(officialDeepSeek && !provider.IsLikelyVisionModelName(cfg.Model))
 	visionDetail, _ := cfg.Extra["vision_detail"].(string)
 	visionDetail = strings.ToLower(strings.TrimSpace(visionDetail))
 	if visionDetail != "low" && visionDetail != "high" {

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -140,10 +140,12 @@ func New(cfg Config) provider.Provider {
 		sessionCache = *cfg.SessionCache
 	}
 	vision, _ := cfg.Extra["vision"].(bool)
-	// DeepSeek's official Responses endpoint is currently text-only. Keep this
-	// provider-boundary guard so stale config or extension metadata cannot emit
-	// unsupported input_image items.
-	vision = vision && vendor != "deepseek"
+	// DeepSeek's official Responses endpoint is historically text-only, but
+	// explicitly vision-named models (e.g. deepseek-v4-flash-vision-exp) may
+	// accept input_image items. Keep the guard for text-only DeepSeek models so
+	// stale config or extension metadata cannot emit unsupported input_image
+	// items for them.
+	vision = vision && !(vendor == "deepseek" && !provider.IsLikelyVisionModelName(cfg.Model))
 	httpClient := &http.Client{}
 	if built, err := netclient.NewHTTPClient(cfg.Proxy, netclient.TransportOptions{
 		DialTimeout: 30 * time.Second, KeepAlive: 30 * time.Second,

--- a/internal/provider/vision.go
+++ b/internal/provider/vision.go
@@ -1,0 +1,38 @@
+package provider
+
+import (
+	"slices"
+	"strings"
+)
+
+// IsLikelyVisionModelName reports whether a model ID looks like a chat model
+// with image-input support. It mirrors config.IsLikelyVisionModel so provider
+// boundary guards can relax DeepSeek's historical text-only constraint for
+// explicitly vision-named models without importing internal/config (which would
+// create an import cycle).
+func IsLikelyVisionModelName(model string) bool {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return false
+	}
+	lower := strings.ToLower(model)
+	if lower == "mimo-v2.5" || lower == "mimo-v2-omni" {
+		return true
+	}
+	tokens := strings.FieldsFunc(lower, func(r rune) bool {
+		return r == '-' || r == '_' || r == '.' || r == '/' || r == ':'
+	})
+	if slices.Contains(tokens, "audio") {
+		return false
+	}
+	if strings.HasPrefix(lower, "gpt-4o") {
+		return true
+	}
+	for _, token := range tokens {
+		switch token {
+		case "vl", "vision", "visual", "multimodal", "omni":
+			return true
+		}
+	}
+	return false
+}

--- a/internal/provider/vision_test.go
+++ b/internal/provider/vision_test.go
@@ -1,0 +1,22 @@
+package provider
+
+import "testing"
+
+func TestIsLikelyVisionModelName(t *testing.T) {
+	for _, model := range []string{
+		"mimo-v2.5", "mimo-v2-omni", "gpt-4o", "gpt-4o-mini",
+		"qwen2.5-vl-72b-instruct", "custom-vision-chat", "deepseek-v4-flash-vision-exp",
+	} {
+		if !IsLikelyVisionModelName(model) {
+			t.Errorf("IsLikelyVisionModelName(%q) = false, want true", model)
+		}
+	}
+	for _, model := range []string{
+		"", "mimo-v2.5-pro", "deepseek-v4-flash", "deepseek-v4-pro", "mimo-v2.5-asr", "text-embedding-3-small",
+		"gpt-4o-audio-preview", "gpt-4o-mini-audio-preview",
+	} {
+		if IsLikelyVisionModelName(model) {
+			t.Errorf("IsLikelyVisionModelName(%q) = true, want false", model)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #9241.

DeepSeek 官方端点（`api.deepseek.com`）被硬编码为不支持视觉（`CanConfigureVision` 对 DeepSeek 官方端点一律返回 false；provider 请求层也有三处 `vision = vision && !officialDeepSeek` 的边界守卫），导致 `deepseek-v4-flash-vision-exp` 这类**模型名明确含 `vision`** 的模型在设置页刷新后无法勾选「支持图片」。

本次修改：对 DeepSeek 官方端点，**只要模型列表/默认模型名含视觉标记**（`vision`/`vl`/`visual`/`multimodal`/`omni` 等，复用现有 `IsLikelyVisionModel` 启发式），就允许配置并真正发送图片输入；纯文本 DeepSeek 模型（`deepseek-v4-flash`、`deepseek-v4-pro` 等）仍保持原有 text-only 守卫。

## Changes

### Backend
- `internal/provider/vision.go`（新增）：共享 `IsLikelyVisionModelName`，避免 provider 子包 import `internal/config` 造成循环依赖。
- `internal/config/vision.go`：`CanConfigureVision` 对 DeepSeek 官方端点不再一刀切禁用；当 `ChatModelList()` 中存在视觉命名模型时允许配置。
- `internal/provider/openai/openai.go`、`internal/provider/responses/responses.go`、`internal/provider/anthropic/anthropic.go`：请求层边界守卫从 `!officialDeepSeek` 放宽为 `!(officialDeepSeek && !IsLikelyVisionModelName(cfg.Model))`，视觉命名模型可真正携带图片。

### Frontend
- `desktop/frontend/src/components/SettingsPanel.tsx`：`providerVisionCapability`/`providerVisionCapabilityForView` 增加模型列表判断——DeepSeek 官方端点下若模型列表含视觉命名模型，则 `configurable`（出现「支持图片」勾选）。

### Tests
- 新增 `internal/config/vision_test.go`、`internal/provider/vision_test.go`。
- 更新 `internal/config/edit_test.go`（视觉命名 DeepSeek 模型现在允许配置）、`internal/provider/openai/image_test.go`（视觉命名模型启用 vision 并序列化 `image_url`）。
- 更新前端 `provider-editor-model-picker.test.tsx`、`provider-model-refresh.test.ts`。

## Verification
- `go test ./internal/config/ -run 'TestCanConfigureVision|TestEffectiveVision|TestIsLikelyVisionModel' -count=1` ✅
- `go test ./internal/provider/ -run 'TestIsLikelyVisionModelName' -count=1` ✅
- `go test ./internal/provider/openai/ -run 'TestOfficialDeepSeek|TestCustomDeepSeek' -count=1` ✅
- `go test ./internal/provider/responses/ -run 'TestOfficialDeepSeek' -count=1` ✅
- `go test ./internal/provider/anthropic/ -run 'TestOfficialDeepSeek' -count=1` ✅
- `pnpm typecheck` ✅
- `tsx src/__tests__/provider-model-refresh.test.ts`（28 passed）✅
- `tsx src/__tests__/provider-editor-model-picker.test.tsx`（46 passed）✅

## Guard
- Cache-impact: none - 无缓存/持久化格式改动，仅放宽视觉能力判定
- Cache-guard: go test ./internal/config/... ./internal/provider/...（视觉相关用例）+ pnpm typecheck + tsx 前端 provider 测试，均通过
- Documentation-impact: none - 无文档改动，行为与修复说明见 PR body
- System-prompt-review: @SivanCola
