### PR TITLE
feat(desktop): add up/down arrows to the question navigator rail

### DIFF
--- a/desktop/frontend/src/__tests__/question-jump-bar.test.tsx
+++ b/desktop/frontend/src/__tests__/question-jump-bar.test.tsx
@@ -142,6 +142,95 @@ await act(async () => {
 eq(jumps.at(-1)?.turn, unloadedTurn, "a long aggregated rail still targets the exact unloaded question");
 eq(jumps.at(-1)?.loaded, false, "an unloaded aggregate target keeps the lazy-load contract");
 
+// ── Arrow stepping ──────────────────────────────────────────────────────────
+// The rail now exposes up/down chevron arrows that step one question at a time
+// and stay disabled at the first/last section.
+{
+  const arrowJumps: QuestionAnchor[] = [];
+  let arrowKey = 0;
+  function ArrowController({ total, initialActive }: { total: number; initialActive: number | null }) {
+    const [activeTurn, setActiveTurn] = React.useState<number | null>(initialActive);
+    return (
+      <QuestionJumpBar
+        loadedQuestions={questions}
+        totalQuestions={total}
+        activeTurn={activeTurn}
+        onJump={(question) => {
+          arrowJumps.push(question);
+          setActiveTurn(question.turn);
+        }}
+      />
+    );
+  }
+  const renderArrows = async (total: number, active: number | null) => {
+    arrowKey += 1;
+    await act(async () => {
+      root.render(
+        <LocaleProvider>
+          <ArrowController key={arrowKey} total={total} initialActive={active} />
+        </LocaleProvider>,
+      );
+      await flushTimers();
+    });
+  };
+  const arrowState = () => {
+    const up = document.querySelector(".jump-arrow--up") as HTMLButtonElement | null;
+    const down = document.querySelector(".jump-arrow--down") as HTMLButtonElement | null;
+    return { up: up?.disabled, down: down?.disabled };
+  };
+  const setArrowBar = () => {
+    const arrowBar = document.querySelector(".jump-bar") as HTMLElement;
+    arrowBar.getBoundingClientRect = () => rect(0, 240, 56);
+    return arrowBar;
+  };
+
+  await renderArrows(3, 2); // tail active
+  setArrowBar();
+  eq(arrowState().up, false, "up arrow enabled from the tail");
+  eq(arrowState().down, true, "down arrow disabled at the last section");
+  await act(async () => {
+    (document.querySelector(".jump-arrow--up") as HTMLButtonElement).click();
+    await flushTimers();
+  });
+  eq(arrowJumps.at(-1)?.turn, 1, "up arrow steps to the previous question");
+  eq(arrowJumps.at(-1)?.id, "u2", "up arrow emits the loaded previous question");
+
+  await renderArrows(3, 0); // first active
+  setArrowBar();
+  eq(arrowState().up, true, "up arrow disabled at the first section");
+  eq(arrowState().down, false, "down arrow enabled from the first section");
+  await act(async () => {
+    (document.querySelector(".jump-arrow--down") as HTMLButtonElement).click();
+    await flushTimers();
+  });
+  eq(arrowJumps.at(-1)?.turn, 1, "down arrow steps to the next question");
+
+  // Single question: both arrows disabled, no jump on click.
+  await renderArrows(1, 0);
+  setArrowBar();
+  eq(arrowState().up, true, "single section disables the up arrow");
+  eq(arrowState().down, true, "single section disables the down arrow");
+  const beforeSingle = arrowJumps.length;
+  await act(async () => {
+    (document.querySelector(".jump-arrow--up") as HTMLButtonElement).click();
+    (document.querySelector(".jump-arrow--down") as HTMLButtonElement).click();
+    await flushTimers();
+  });
+  eq(arrowJumps.length, beforeSingle, "disabled arrows at a single section emit no jump");
+
+  // Unknown active (null) treats the position as the tail: up enabled, down not.
+  await renderArrows(4, null);
+  setArrowBar();
+  eq(arrowState().up, false, "null active (treated as tail) enables up");
+  eq(arrowState().down, true, "null active (treated as tail) disables down");
+  const beforeNull = arrowJumps.length;
+  await act(async () => {
+    (document.querySelector(".jump-arrow--up") as HTMLButtonElement).click();
+    await flushTimers();
+  });
+  eq(arrowJumps.at(-1)?.turn, 2, "null active (treated as tail) + up steps to the previous question");
+  eq(arrowJumps.length, beforeNull + 1, "null active + up emits exactly one jump");
+}
 await act(async () => root.unmount());
 dom.window.close();
 

--- a/desktop/frontend/src/components/QuestionJumpBar.tsx
+++ b/desktop/frontend/src/components/QuestionJumpBar.tsx
@@ -1,6 +1,7 @@
 // QuestionJumpBar: the question navigator rail along the transcript edge.
 
 import { useMemo, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { useT } from "../lib/i18n";
 import type { QuestionAnchor } from "../lib/transcriptGrouping";
 
@@ -99,6 +100,20 @@ export function QuestionJumpBar({
     onJump(question);
   };
 
+  // Arrow stepping around the current active question. When active is null
+  // (nothing tracked yet) the rail treats the tail as the current position.
+  // The arrows stay disabled at either end instead of wrapping around.
+  const activeIndex = active != null && active >= 0 && active < total ? active : null;
+  const step = (direction: -1 | 1) => {
+    if (total === 0) return;
+    const from = activeIndex ?? (total - 1);
+    const next = from + direction;
+    if (next < 0 || next >= total) return;
+    scrollTo(questionAt(next));
+  };
+  const canStepUp = activeIndex != null ? activeIndex > 0 : total > 1;
+  const canStepDown = activeIndex != null ? activeIndex < total - 1 : false;
+
   const onMove = (event: ReactMouseEvent<HTMLDivElement>) => {
     const target = questionFromY(event.clientY);
     if (!target) return;
@@ -167,6 +182,19 @@ export function QuestionJumpBar({
         setShowPreview(false);
       }}
     >
+      <button
+        type="button"
+        className="jump-arrow jump-arrow--up"
+        disabled={!canStepUp}
+        aria-label={t("questionNav.up")}
+        title={t("questionNav.up")}
+        onClick={(event) => {
+          event.stopPropagation();
+          step(-1);
+        }}
+      >
+        <ChevronUp size={14} strokeWidth={2.2} aria-hidden="true" />
+      </button>
       <div
         className="jump-scroll"
         ref={railRef}
@@ -196,6 +224,19 @@ export function QuestionJumpBar({
           </span>
         ))}
       </div>
+      <button
+        type="button"
+        className="jump-arrow jump-arrow--down"
+        disabled={!canStepDown}
+        aria-label={t("questionNav.down")}
+        title={t("questionNav.down")}
+        onClick={(event) => {
+          event.stopPropagation();
+          step(1);
+        }}
+      >
+        <ChevronDown size={14} strokeWidth={2.2} aria-hidden="true" />
+      </button>
       {showPreview && hoveredQuestion && (
         <div className="jump-preview" style={{ top: previewTop.current }} role="tooltip">
           <span className="jump-text">{hoveredQuestion.text}</span>

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -3012,6 +3012,8 @@ export const en = {
   "questionNav.jump": "Jump to question {n}",
   "questionNav.hint": "Click to jump to this question",
   "questionNav.notLoaded": "Question {n} (click to load)",
+  "questionNav.up": "Previous question",
+  "questionNav.down": "Next question",
   "compaction.working": "Compacting conversation…",
   "compaction.title": "Context compacted",
   "compaction.messages": "{n} messages",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2112,6 +2112,8 @@ export const zhTW: Record<DictKey, string> = {
   "questionNav.jump": "跳轉到問題 {n}",
   "questionNav.hint": "點擊跳轉到這次提問",
   "questionNav.notLoaded": "第 {n} 個問題（點擊載入）",
+  "questionNav.up": "上一個問題",
+  "questionNav.down": "下一個問題",
   "compaction.working": "正在壓縮對話…",
   "compaction.title": "上下文已壓縮",
   "compaction.messages": "{n} 條訊息",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -3015,6 +3015,8 @@ export const zh: Record<DictKey, string> = {
   "questionNav.jump": "跳转到问题 {n}",
   "questionNav.hint": "点击跳转到这次提问",
   "questionNav.notLoaded": "第 {n} 个问题（点击加载）",
+  "questionNav.up": "上一个问题",
+  "questionNav.down": "下一个问题",
   "compaction.working": "正在压缩对话…",
   "compaction.title": "上下文已压缩",
   "compaction.messages": "{n} 条消息",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3920,18 +3920,46 @@ a[href] {
   z-index: var(--z-inline-sticky);
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  width: 56px;
+  align-items: center;
+  width: 48px;
   height: 240px;
-  padding: 0 12px;
+  max-height: min(240px, calc(100vh - 120px));
+  padding: 0;
   opacity: 0;
   pointer-events: none;
   animation: jump-bar-in 0.18s ease-out 0.08s forwards;
 }
+.jump-arrow {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--fg-faint);
+  cursor: pointer;
+  pointer-events: auto;
+  opacity: 0.8;
+  transition:
+    color 120ms ease,
+    opacity 120ms ease;
+}
+.jump-arrow:hover:not(:disabled) {
+  color: var(--fg);
+  opacity: 1;
+}
+.jump-arrow:disabled {
+  cursor: default;
+  opacity: 0.25;
+}
 .jump-scroll {
   position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
   width: 32px;
-  height: 100%;
   cursor: pointer;
   pointer-events: auto;
   outline: none;


### PR DESCRIPTION
��## Summary

Add up/down chevron arrows to the **question navigator rail** (`QuestionJumpBar`) so users can step one question at a time, in addition to clicking a rail marker.

- **`QuestionJumpBar.tsx`**   adds configurable up/down arrow buttons around the rail:
  - `step(direction)` moves to `active � 1`.
  - Arrows are **disabled** at the first/last section (and when only one question exists) so they cannot wrap.
  - An untracked `activeTurn` (null) treats the tail as the current section, matching the rail's default.
- **`styles.css`**   the rail is now a flex column with a shrinking scroll track, a lighter 48px bar, and compact arrow buttons (no background, subtle hover). Indicators stay proportionally positioned.
- **`locales` (zh / en / zh-TW)**   new `questionNav.up` / `questionNav.down` labels.
- **`question-jump-bar.test.tsx`**   adds arrow tests.

## Test cases

Added to `question-jump-bar.test.tsx` (jsdom, run via `npx tsx src/__tests__/question-jump-bar.test.tsx`, also chained in `test:transcript`):

| # | Case | Expected |
|---|------|----------|
| T1 | Up arrow from the tail | enabled; clicking jumps to `turn - 1` and emits the loaded question |
| T2 | Down arrow at the last section | disabled; clicking emits no jump |
| T3 | Up arrow at the first section | disabled |
| T4 | Down arrow from the first section | enabled; clicking jumps to `turn + 1` |
| T5 | Single-question session | both arrows disabled; clicking emits no jump |
| T6 | Untracked (null) active, 4 questions | treated as tail: up enabled, down disabled; up jumps to the previous section (`3` �! `2`) |

## Test results

```
$ npx tsx src/__tests__/question-jump-bar.test.tsx
27 passed, 0 failed

$ npm run test:transcript   # full transcript chain incl. the new arrow tests
&  all files pass (0 failed) & 

$ npm run typecheck
passed

$ npm run check:css
CSS syntax check passed
z-index token check passed
```

## Commits
- `feat(desktop): add up/down arrows to the question navigator rail`


---

Documentation-impact: none - no docs/*.md changed in this PR; it only adjusts the desktop QuestionJumpBar UI (arrows), its styles/labels, and adds tests. Existing docs remain correct.
