### PR TITLE
fix: bound transcript tail-settle loop and stabilize near-bottom wheel / 修复流式输出与长会话底部滚动抖动、无法回落到底部

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
@@ -211,6 +211,31 @@ await flushFrames();
 check(scrollByCalls === 0 && scrollWrites.length === 0,
   "selection ownership cancels a pending reader transaction");
 
+// #9208 — a downward wheel near the physical bottom must not arm the
+// reader-extent guard: its correction would snap the viewport back up and
+// fight the scroll wheel, so the tail can never be reached.
+await act(async () => arbiter?.reset());
+scrollExtent = 2_000;
+Object.defineProperty(scrollElement, "clientHeight", { configurable: true, value: 725 });
+scrollElement.scrollTop = 1_275; // distance-from-bottom = 2_000-1_275-725 = 0 ⇒ at the physical tail
+await act(async () => arbiter?.deliverScroll());
+await act(async () => arbiter?.releaseTailFollow());
+scrollWrites.length = 0;
+scrollByCalls = 0;
+await act(async () => arbiter?.onWheelIntent({
+  ctrlKey: false,
+  deltaMode: 0,
+  deltaX: 0,
+  deltaY: 120,
+  target: scrollElement,
+} as React.WheelEvent<HTMLElement>));
+// A later extent rebound cannot snap the viewport because no guard was armed.
+scrollElement.scrollTop = 1_100;
+await act(async () => arbiter?.followGrowingTail());
+await flushFrames();
+check(scrollByCalls === 0 && scrollWrites.length === 0,
+  "near-bottom downward wheel does not arm the reader-extent guard");
+
 await act(async () => root.unmount());
 dom.window.close();
 

--- a/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
@@ -5,6 +5,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import type { StateSnapshot, VirtuosoHandle } from "react-virtuoso";
 import { useTranscriptScrollArbiter, type TranscriptRecoveryTerminal } from "../lib/useTranscriptScrollArbiter";
+import { TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS } from "../lib/transcriptScrollArbiter";
 import { useTranscriptLayoutIntegrity } from "../lib/useTranscriptLayoutIntegrity";
 import type { TranscriptScrollWriteRecord } from "../lib/transcriptScrollProbe";
 import type { TranscriptRow } from "../lib/transcriptRows";
@@ -752,6 +753,44 @@ await advanceClock(2_100);
 const nextGenerationResetBefore = integrity?.resetKey;
 await triggerWatchdogRebuild();
 check(integrity?.resetKey !== nextGenerationResetBefore, "a changed 10,000-row generation receives a fresh hard-reset budget");
+
+// ── #9208: the tail-settle loop is bounded. When virtualized bottom rows keep
+// the native distance just above the threshold (an extreme offsetTop/native
+// height mismatch) while the extent keeps growing, each real-growth re-aim can
+// only re-aim a bounded number of times before pausing, instead of flashing
+// forever. Once the height stops growing, re-aims stop entirely.
+await act(async () => arbiter?.reset());
+scrollExtent = 10_000;
+Object.defineProperty(scrollElement, "clientHeight", { configurable: true, value: 100 });
+scrollElement.scrollTop = 9_850; // distance-from-bottom = 50 ⇒ off-bottom
+await act(async () => arbiter?.scrollToBottom());
+// The jump transaction's 240ms confirmation must elapse before the settle
+// re-arms; otherwise its pending timer busies the schedule lane.
+await advanceClock(300);
+const originalTailScrollTo = virtuosoHandle.scrollTo;
+virtuosoHandle.scrollTo = (() => {
+  scrollToCalls += 1;
+  // Never move: simulates a bottom the tail writer cannot physically reach.
+}) as typeof virtuosoHandle.scrollTo;
+const budgetStart = scrollToCalls;
+for (let i = 0; i < 6; i += 1) {
+  scrollExtent += 200; // real growth past the re-aim threshold, every iteration
+  scrollElement.scrollTop = scrollExtent - 100 - 50; // keep the viewport displaced
+  await act(async () => arbiter?.followGrowingTail());
+  await flushFrames();
+  await flushFrames();
+}
+const budgetSpent = scrollToCalls - budgetStart;
+check(budgetSpent <= TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS,
+  `a hyper-native-mismatched tail spends no more than the settle budget (${budgetSpent} writes)`);
+// Drain the remaining settle budget while the height is frozen, then confirm
+// no writes continue: the tail must not flash once it is physically unable to
+// reach the bottom.
+for (let i = 0; i < 14; i += 1) await flushFrames();
+const drained = scrollToCalls;
+for (let i = 0; i < 8; i += 1) await flushFrames();
+check(scrollToCalls === drained, "a hyper-variance tail drains its budget and goes quiet");
+virtuosoHandle.scrollTo = originalTailScrollTo;
 
 await act(async () => root.unmount());
 Date.now = originalDateNow;

--- a/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
@@ -5,6 +5,10 @@ import {
   isSubstantialTranscriptDisplacement,
   isTranscriptContentShrink,
   reduceTranscriptScroll,
+  transcriptTailSettleBudgetExhausted,
+  transcriptTailShouldReaim,
+  TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS,
+  TRANSCRIPT_TAIL_REARM_MIN_HEIGHT_PX,
   type TranscriptScrollEvent,
   type TranscriptScrollState,
 } from "../lib/transcriptScrollArbiter";
@@ -270,6 +274,23 @@ check(
   pinTranscriptTailAfterViewportShrink(foldScroller, { contentExtent: 500, viewportExtent: 100 }, false) === null,
   "manual reading suppresses viewport-shrink pinning",
 );
+
+// #9208 — the tail-settle loop needs a bounded re-aim budget so virtualized
+// bottom rows that keep re-measuring cannot loop the convergence rAF forever.
+check(transcriptTailSettleBudgetExhausted(0) === false, "tail settle may re-aim from zero attempts");
+check(transcriptTailSettleBudgetExhausted(TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS - 1) === false, "tail settle keeps re-aiming before the budget is fully spent");
+check(transcriptTailSettleBudgetExhausted(TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS) === true, "tail settle stops once the re-aim budget is exhausted");
+check(transcriptTailSettleBudgetExhausted(99) === true, "tail settle stops for any attempt count above the budget");
+check(TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS > 0, "the tail settle budget is positive");
+
+// #9208 — a settled tail only re-aims on real growth, not on the small
+// measurement jitter that virtualized rows emit while drawing in.
+check(transcriptTailShouldReaim(null, 1_000) === true, "a fresh settle with no recorded bottom always re-aims");
+check(transcriptTailShouldReaim(1_000, 1_000) === false, "zero height growth does not re-aim a pinned tail");
+check(transcriptTailShouldReaim(1_000, 1_000 + TRANSCRIPT_TAIL_REARM_MIN_HEIGHT_PX - 1) === false, "sub-threshold re-measurement jitter does not re-aim");
+check(transcriptTailShouldReaim(1_000, 1_000 + TRANSCRIPT_TAIL_REARM_MIN_HEIGHT_PX) === true, "threshold-height growth re-aims the pinned tail");
+check(transcriptTailShouldReaim(1_000, 1_000 + TRANSCRIPT_TAIL_REARM_MIN_HEIGHT_PX + 1) === true, "supra-threshold growth re-aims the pinned tail");
+check(TRANSCRIPT_TAIL_REARM_MIN_HEIGHT_PX > 0, "the re-aim threshold is positive");
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/transcriptReaderExtentStability.ts
+++ b/desktop/frontend/src/lib/transcriptReaderExtentStability.ts
@@ -1,7 +1,7 @@
 import type { TranscriptLayoutAnchor } from "./transcriptVirtuosoRecovery";
 import type { TranscriptScrollEvent } from "./transcriptScrollArbiter";
 
-const MIN_REVERSE_JUMP_PX = 96;
+export const MIN_REVERSE_JUMP_PX = 96;
 const REVERSE_JUMP_VIEWPORT_RATIO = 0.5;
 const EXTENT_REBOUND_VIEWPORT_RATIO = 0.5;
 

--- a/desktop/frontend/src/lib/transcriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/transcriptScrollArbiter.ts
@@ -107,6 +107,29 @@ export function isTranscriptContentShrink(delta: number): boolean {
 // JUMP_TO_BOTTOM bypasses the hold.
 export const TRANSCRIPT_BOTTOM_HOLD_DELIVERIES = 2;
 
+// Bounded budget for the tail-settle convergence loop. A virtualized bottom
+// whose rows keep re-measuring (long sessions, streaming output) can keep the
+// native distance-from-bottom just above the threshold forever; without a cap
+// the settle rAF loop — and the flicker it drives — never ends (#9208).
+export const TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS = 8;
+
+/** Whether the tail-settle loop has spent its bounded re-aim budget. */
+export function transcriptTailSettleBudgetExhausted(attempts: number): boolean {
+  return attempts >= TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS;
+}
+
+// Minimum native scrollHeight growth before the tail-settle loop re-aims
+// against an already-pinned tail. Virtualized bottom rows emit many small
+// height deltas while being measured; re-aiming on every one is what makes the
+// pinned tail visibly jitter at the bottom of long sessions (#9208).
+export const TRANSCRIPT_TAIL_REARM_MIN_HEIGHT_PX = 24;
+
+/** Whether a settled tail should re-aim given the recorded bottom height. */
+export function transcriptTailShouldReaim(previousBottomHeight: number | null, currentHeight: number): boolean {
+  if (previousBottomHeight == null) return true;
+  return currentHeight - previousBottomHeight >= TRANSCRIPT_TAIL_REARM_MIN_HEIGHT_PX;
+}
+
 function transition(state: TranscriptScrollState, commands: readonly TranscriptScrollCommand[] = []): TranscriptScrollTransition {
   return { state, commands };
 }

--- a/desktop/frontend/src/lib/transcriptTailSettle.ts
+++ b/desktop/frontend/src/lib/transcriptTailSettle.ts
@@ -6,7 +6,11 @@ import {
   type TranscriptScrollDiagnosticSource,
   type TranscriptTailWriteDiagnostic,
 } from "./transcriptScrollDiagnosticProbe";
-import type { TranscriptScrollMode } from "./transcriptScrollArbiter";
+import {
+  type TranscriptScrollMode,
+  transcriptTailSettleBudgetExhausted,
+  transcriptTailShouldReaim,
+} from "./transcriptScrollArbiter";
 import { nativeTranscriptDistanceFromBottom, TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX } from "./transcriptScrollGeometry";
 
 const TAIL_STAGNANT_FRAME_LIMIT = 2;
@@ -54,9 +58,13 @@ export function createTranscriptTailSettle({
     distance: number;
     stagnantFrames: number;
     offBottomFrames: number;
+    attempts: number;
   } | null = null;
   let jumpTailTimer: number | null = null;
   let layoutTransientIdleTimer: number | null = null;
+  // Native scrollHeight recorded when the tail was last fully pinned. Guards
+  // the settle loop from re-aiming on every small bottom re-measurement.
+  let lastBottomHeight: number | null = null;
 
   const scrollToTail = (
     behavior: "auto" | "smooth",
@@ -65,6 +73,7 @@ export function createTranscriptTailSettle({
     const element = scrollRef.current;
     if (!element) return;
     const top = element.scrollHeight;
+    lastBottomHeight = top;
     if (CAPTURE_TRANSCRIPT_SCROLL_DIAGNOSTICS && diagnostic) {
       noteTranscriptScrollWrite({
         owner: "tail-follow",
@@ -91,6 +100,7 @@ export function createTranscriptTailSettle({
     if (tailSettleFrame !== null) cancelAnimationFrame(tailSettleFrame);
     tailSettleFrame = null;
     tailSettleProgress = null;
+    lastBottomHeight = null;
     if (jumpTailTimer !== null) window.clearTimeout(jumpTailTimer);
     jumpTailTimer = null;
     if (layoutTransientIdleTimer !== null) window.clearTimeout(layoutTransientIdleTimer);
@@ -146,6 +156,12 @@ export function createTranscriptTailSettle({
     }
     if (jumpTailTimer !== null) return;
     if (tailSettleFrame !== null) return;
+    // A layout event for bottom re-measurement (virtualized rows drawing in)
+    // does not need another settle if the tail is already pinned and the
+    // native height has barely grown — re-aiming here is the visible jitter.
+    if (!jump && !transcriptTailShouldReaim(lastBottomHeight, scrollElement.scrollHeight)) {
+      return;
+    }
     const generation = generationRef.current;
     const tick = () => {
       tailSettleFrame = null;
@@ -169,17 +185,26 @@ export function createTranscriptTailSettle({
       const previous = tailSettleProgress;
       const offBottomFrames = (previous?.offBottomFrames ?? 0) + 1;
       if (offBottomFrames < TAIL_CONFIRM_OFF_BOTTOM_FRAMES) {
-        tailSettleProgress = { distance, stagnantFrames: 0, offBottomFrames };
+        tailSettleProgress = { distance, stagnantFrames: 0, offBottomFrames, attempts: previous?.attempts ?? 0 };
         tailSettleFrame = requestAnimationFrame(tick);
+        return;
+      }
+      const attempts = (previous?.attempts ?? 0) + 1;
+      if (transcriptTailSettleBudgetExhausted(attempts)) {
+        // Virtualization can keep the native distance off the bottom without
+        // real growth (long/unmeasured rows near the tail). Stop re-aiming so
+        // the settle loop cannot flash forever; a later layout change retries fresh.
+        tailSettleProgress = null;
+        armLayoutTransientIdle();
         return;
       }
       const stagnantFrames = previous && Math.abs(previous.distance - distance) <= 0.5
         ? previous.stagnantFrames + 1
         : 0;
       scrollToTail("auto", CAPTURE_TRANSCRIPT_SCROLL_DIAGNOSTICS && source
-        ? { source, phase: "settle", settle: { frame: offBottomFrames, offBottomFrames, stagnantFrames } }
+        ? { source, phase: "settle", settle: { frame: attempts, offBottomFrames, stagnantFrames } }
         : undefined);
-      tailSettleProgress = { distance, stagnantFrames, offBottomFrames };
+      tailSettleProgress = { distance, stagnantFrames, offBottomFrames, attempts };
       if (stagnantFrames < TAIL_STAGNANT_FRAME_LIMIT) tailSettleFrame = requestAnimationFrame(tick);
       else armLayoutTransientIdle();
     };

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -34,6 +34,7 @@ import type {
   TranscriptRecoveryTerminal,
 } from "./transcriptScrollRecovery";
 import {
+  MIN_REVERSE_JUMP_PX,
   transcriptScrollEventCancelsReaderExtentGuard,
   transcriptKeyboardScrollDelta,
 } from "./transcriptReaderExtentStability";
@@ -569,7 +570,15 @@ export function useTranscriptScrollArbiter({
     ) {
       deliverScroll(element);
     }
-    if (readerDeltaY !== undefined) readerExtent.arm(readerDeltaY);
+    if (readerDeltaY !== undefined) {
+      // A downward reader gesture at (or close to) the physical bottom has no
+      // extent above it to reverse onto; arming the reader-extent guard there
+      // lets its correction snap the viewport back up and fights the scroll
+      // wheel. Only arm the guard when there is enough room to fall back.
+      const nearBottom = element
+        && nativeTranscriptDistanceFromBottom(element) < MIN_REVERSE_JUMP_PX;
+      if (readerDeltaY <= 0 || !nearBottom) readerExtent.arm(readerDeltaY);
+    }
     armReaderIntentIdle();
   }, [armReaderIntentIdle, deliverScroll, dispatch, readerExtent]);
   const followGrowingTail = useCallback(() => {


### PR DESCRIPTION
﻿## Summary

Binds the transcript tail-settle convergence loop to a bounded re-aim budget,
only re-aims an already-pinned tail on real height growth, and stops arming the
reader-extent guard for near-bottom downward wheel gestures. Together these
remove the scroll bounce/flicker that long virtualized sessions and streaming
output produce near the physical bottom, and let a downward wheel land on the
bottom instead of snapping back up.

## Issues

Fixes #9208
Related to #8688
Related to #8200
Related to #8399
Related to #8569

## Problem / 问题

- Long virtualized transcripts never settle at the bottom: the view bounces
  back and oscillates, the tail region flashes/flickers, and the physical
  bottom cannot be reached (#9208).
- A downward wheel at the bottom can be snapped back up by the reader-extent
  guard, fighting the user instead of landing on the tail.
- Small row re-measurements from virtualized bottom rows re-armed the settle
  loop on every frame, so the flicker was self-sustaining.

## Root Cause / 根因

`transcriptTailSettle.schedule` re-armed the settle rAF loop on every layout /
measurement notification while the tail was off the bottom, with no upper bound
on attempts. Virtualized bottom rows keep emitting small height deltas while
they are measured, so the native distance-from-bottom hovered just above the
4px threshold and the loop flashed forever. Meanwhile the reader-extent guard
armed by `releaseTailFollow` for a downward gesture at the physical bottom
could correct the viewport back up, exactly when it was trying to land.

## Solution / 解决方案

- **Bounded settle budget**: `TRANSCRIPT_TAIL_SETTLE_MAX_ATTEMPTS` stops a
  single settle loop once its re-aim budget is spent, so a hyper-native-mismatch
  tail pauses instead of flashing; real growth re-arms a fresh bounded loop.
- **Re-aim threshold**: `TRANSCRIPT_TAIL_REARM_MIN_HEIGHT_PX` suppresses
  re-aiming an already-pinned tail on sub-24px measurement jitter, while real
  growth still re-aims.
- **Reader-guard skip near bottom**: downward wheel gestures within the
  near-bottom margin no longer arm the reader-extent guard, so wheel-down
  passes through to the browser and lands on the tail.

## Test Coverage / 测试覆盖

- Unit (`transcript-scroll-release.test.ts`): budget boundary (0, max-1, max,
  max+1) and re-aim threshold boundary (distance = threshold-1 / threshold /
  threshold+1).
- Component/Race (`transcript-recovery-race.test.tsx`): a hyper-variance tail
  spends at most the settle budget and goes quiet once drained.
- Component/Race (`transcript-reader-extent-race.test.tsx`): a near-bottom
  downward wheel does not arm the reader-extent guard.
- Regression: full `pnpm test:transcript` suite, layout-recovery,
  selection-retention, virtualization, question navigation.
- Large history: `pnpm test:performance` (up to 10,000 turns / 30,000 items).

## Local Test Result / 本地测试结果

```
pnpm exec tsx src/__tests__/transcript-scroll-release.test.ts     54 passed
pnpm exec tsx src/__tests__/transcript-recovery-race.test.tsx     88 passed
pnpm exec tsx src/__tests__/transcript-reader-extent-race.test.tsx 11 passed
pnpm test:transcript   PASS (exit 0)
pnpm typecheck         PASS
pnpm lint:hooks        PASS
pnpm check:scroll-writer  OK
pnpm build             PASS (vite + bundle budgets)
pnpm test:performance  PASS (long-history performance contracts)
```

## Performance / 性能

Verified with the project's long-history synthetic benchmark
(`pnpm test:performance`), no per-message O(n) scroll/render regression:

```
1000 turns / 3000 items : transcriptCompute 1.20–1.43 ms
10000 turns / 30000 items: transcriptCompute 8.51 ms (below one 16ms frame)
```

Scroll behaviour: unit + race harnesses assert that tail-settle no longer loops
past its budget and near-bottom wheel passes through to the browser. A
real-browser visual benchmark (`bench/transcript-scroll-stability.mjs`) depends
on POSIX pnpm spawn + a dedicated mock fixture and could not run in this
Windows shell — recorded as not measured here.

## Risk / 风险

- Auto scroll: bounded budget + re-aim threshold only delay re-aim on tiny
  measurement jitter; real streaming growth still re-arms and follows.
- Streaming: the live region stays outside the virtual size tree; settle
  changes touch only tail-follow reconvergence.
- Manual reading / touch: reader-extent guard is skipped only within 96px of
  the bottom on downward gestures; upward and far-from-bottom gestures keep
  the guard.
- History loading: data prepends unaffected.

## Documentation impact

Documentation-impact: none - no user-facing UI/configuration/schema contract
changed; the fix only alters internal transcript scroll convergence.

## Cache impact

Cache-impact: none - the change is confined to `desktop/frontend/src/` UI
scroll logic; no provider-visible system prompt, tool schema, or memory prefix
is touched.
Cache-guard: not applicable - no cache-sensitive path changed
System-prompt-review: N/A
