### PR TITLE
fix(desktop): repair typecheck errors in transcript diagnostics tests / 修复会话诊断测试的类型检查错误

### DIFF
--- a/desktop/frontend/src/__tests__/frontend-diagnostics.test.ts
+++ b/desktop/frontend/src/__tests__/frontend-diagnostics.test.ts
@@ -101,7 +101,7 @@ assert.equal(active.markerCount, 0, "evicted markers are not counted as retained
 const payload = diagnostics.stop();
 assert.equal(payload.schemaVersion, 1);
 assert.equal(payload.manifest.platform, "windows");
-assert.equal(payload.events.at(-1)?.type, "stop");
+assert.equal(payload.events[payload.events.length - 1]?.type, "stop");
 const serialized = JSON.stringify(payload);
 assert.equal(serialized.includes("scrollToIndex"), true, "scroll writer details remain available for analysis");
 assert.equal(serialized.includes("targetIndex"), true, "scroll target remains available for analysis");

--- a/desktop/frontend/src/__tests__/transcript-row-geometry.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-row-geometry.test.ts
@@ -54,6 +54,7 @@ const markdownAnswer = {
     kind: "assistant" as const,
     id: "answer:markdown",
     streaming: false,
+    reasoning: "",
     text: "### Geometry block\n\n折叠布局检查完成，answer 保持内容感知估高。\n\n- 中文换行\n- English wrapping",
   },
   layoutVariant: "text-flow" as const,
@@ -89,6 +90,7 @@ assert.equal(resolveToolCardDefaultOpen({
     text: "",
     notice: "",
     lastActivityAt: 1,
+    truncated: false,
     startedAt: 1,
   },
 }, 0, "auto"), true, "auto mode follows live subagent reasoning");


### PR DESCRIPTION
## Problem
`pnpm test:typecheck` fails on 3 type errors in test files added by #9240 (frontend-diagnostics.test.ts, transcript-row-geometry.test.ts). Not caught by CI because the desktop frontend legs do not run `test:typecheck`.

## Root cause
- `Array.prototype.at` requires the ES2022 lib, which `tsconfig.test.json` does not enable.
- Test fixtures omitted required fields: `TranscriptRow.item.reasoning` and `SubagentProgress.truncated`.

`tsx` strips types at runtime, so the failing files still passed in CI's `test:transcript`.

## Fix
- Index the last event via `payload.events.length - 1`.
- Add the two missing fixture fields.

## Verification
- `pnpm test:typecheck` passes.
- Both test files pass under tsx.

Cache-impact: none - test files only, no provider-visible change.
Documentation-impact: none - no docs edited.