### PR TITLE
fix(desktop): label the compaction-threshold pin so it is not read as context usage

### DIFF
--- a/desktop/frontend/src/__tests__/context-panel-capacity.test.tsx
+++ b/desktop/frontend/src/__tests__/context-panel-capacity.test.tsx
@@ -98,6 +98,7 @@ const capacity = document.querySelector(".context-panel__capacity-card");
 const meter = capacity?.querySelector(".context-panel__capacity-meter");
 const fill = meter?.querySelector(".context-panel__progress-fill") as HTMLElement | null;
 const usedPin = meter?.querySelector(".context-panel__capacity-pin--used");
+const compactPin = meter?.querySelector(".context-panel__capacity-pin--compact");
 const compactMarker = meter?.querySelector(".context-panel__compact-marker") as HTMLElement | null;
 
 eq(capacity?.querySelector(".context-panel__capacity-status")?.textContent, "Over context limit", "over-limit status is explicit");
@@ -106,6 +107,13 @@ eq(fill?.style.width, "100%", "capacity fill is capped at the physical track wid
 eq(meter?.querySelectorAll(".context-panel__progress-segment").length, 0, "capacity meter does not mix token composition into its fill");
 eq(compactMarker?.style.left, "80%", "compression threshold marker stays at the configured ratio");
 ok(meter?.getAttribute("aria-label")?.includes("101% used") === true, "accessible summary reports the over-limit ratio");
+
+// The compact pin must not read as a bare percentage: it carries the
+// compression-threshold label so users cannot mistake it for context usage.
+ok(compactPin?.textContent?.includes("80%") === true, "compact pin still shows the threshold ratio");
+ok((compactPin?.textContent?.trim().length ?? 0) > "80%".length, "compact pin is labeled, not a bare ratio");
+ok(compactPin?.getAttribute("title")?.includes("80%") === true, "compact pin tooltip includes the threshold ratio");
+ok(usedPin?.getAttribute("title") !== null, "used pin exposes a tooltip for assistive clarification");
 
 await act(async () => {
   root.unmount();

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -618,9 +618,22 @@ export function ContextPanel({
                 <strong>{usedLabel}/{windowLabel}</strong>
               </div>
               <div className="context-panel__usage-progress context-panel__capacity-meter" aria-label={`${t(windowStatus.key)}. ${usageSummary}. ${compactSummary}`}>
-                <div className="context-panel__capacity-scale" aria-hidden="true">
-                  <span className="context-panel__capacity-pin context-panel__capacity-pin--used" style={{ left: `${usageMarkerPct}%` }}>{rawUsagePct}%</span>
-                  <span className="context-panel__capacity-pin context-panel__capacity-pin--compact" style={{ left: `${compactLabelPct}%` }}>{compactPct}%</span>
+                <div className="context-panel__capacity-scale">
+                  <span
+                    className="context-panel__capacity-pin context-panel__capacity-pin--used"
+                    style={{ left: `${usageMarkerPct}%` }}
+                    title={`${t("context.windowUsedLabel")}: ${rawUsagePct}%`}
+                    aria-hidden="true"
+                  >
+                    {rawUsagePct}%
+                  </span>
+                  <span
+                    className="context-panel__capacity-pin context-panel__capacity-pin--compact"
+                    style={{ left: `${compactLabelPct}%` }}
+                    title={`${t("context.windowCompactThreshold")}: ${compactPct}%`}
+                  >
+                    {t("context.windowCompactThreshold")} {compactPct}%
+                  </span>
                 </div>
                 <div className="context-panel__progress-track" aria-hidden="true">
                   <span className="context-panel__progress-fill" style={{ width: `${usagePct}%` }} />

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -25919,7 +25919,7 @@ body > .mermaid-diagram--fullscreen {
   position: absolute;
   top: 0;
   z-index: var(--z-local-raised);
-  max-width: 58px;
+  max-width: 150px;
   overflow: hidden;
   padding: 3px 7px;
   border: 1px solid var(--border-soft);


### PR DESCRIPTION
## Summary

The context-window capacity meter shows two pins on the same scale: the used-context percentage and the auto-compaction threshold. The compact pin rendered as a bare percentage (e.g. `80%`), which can be misread as current context usage — especially confusing right after a session crosses the threshold and the usage pin reads `101%`.

This PR labels the compact pin with the localized "Compression threshold" text so the two pins are visually distinguishable, adds hover tooltips to both pins for assistive clarification, and widens the pin cap so the longer label is not truncated.

## Verification

- `desktop/frontend/src/__tests__/context-panel-capacity.test.tsx`: 10 passed with en-US locale. New assertions cover:
  - compact pin shows a label, not a bare ratio
  - compact pin tooltip includes the threshold ratio
  - used pin exposes a tooltip for assistive clarification
- `tsc --noEmit`: clean
- eslint: clean
- CSS syntax: valid

Note: 2 pre-existing failures occur only under zh-CN system locale because the test baseline renders Chinese; with en-US injected the suite is fully green. These are unrelated to this change.

## Documentation impact

Documentation-impact: none - the change is a self-explanatory UI label improvement; no docs reference the compact pin rendering.

## Cache impact

Cache-impact: none - frontend rendering only; no provider-visible system prompt, memory prefix, output style, skill index, tool schema, or request serialization touched.
Cache-guard: N/A - no cache-sensitive path modified.
System-prompt-review: N/A
