### PR TITLE
fix(desktop): prevent transcript flicker during session switches / 修复切换会话时 transcript 闪烁

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -87,7 +87,10 @@ console.log("\nbundle budgets");
 // main-v2 merge adds another 0.3 KiB of deterministic shared startup code.
 // Keep the increase explicit and bounded instead of hiding it in a broad
 // percentage ratchet.
-const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 430.9 : 430.9;
+// The retained-transcript surface adds a small, bounded navigation owner to
+// the startup path (overlay state + stale-completion guard). Keep the increase
+// explicit and narrow; the measured build is 431.1 KiB gzip.
+const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 431.3 : 431.3;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -101,7 +104,8 @@ if (initialCSS.length > 0) {
 // Extension surfaces, Task Monitor, and compact decision receipts share the
 // application stylesheet loaded before React mounts. Keep their combined
 // allowance bounded even though the file is no longer render-blocking.
-assertBudget("deferred app-shell CSS gzip", appShellCSSGzip, 114 * 1024);
+// Navigation overlay styles add a bounded 0.1 KiB to the deferred shell.
+assertBudget("deferred app-shell CSS gzip", appShellCSSGzip, 114.2 * 1024);
 if (localeChunks.length !== 2) {
   throw new Error(`expected 2 on-demand Chinese locale chunks, found ${localeChunks.length}`);
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1118,13 +1118,32 @@ export default function App() {
   const [tabMetas, setTabMetas] = useState<TabMeta[]>([]);
   const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
   const [navigationSurfaceIntent, setNavigationSurfaceIntent] = useState<number | null>(null);
+  type PreservedTranscriptSurface = {
+    tabId?: string;
+    items: Item[];
+    geometrySessionKey?: string;
+  };
+  const [preservedTranscriptSurface, setPreservedTranscriptSurface] = useState<PreservedTranscriptSurface | null>(null);
+  const renderedTranscriptSurfaceRef = useRef<PreservedTranscriptSurface | null>(null);
   const beginNavigationSurface = useCallback((intent: number) => {
     recordFrontendDiagnostic("navigation", "navigation.begin", { phase: "begin" });
-    flushSync(() => setNavigationSurfaceIntent(intent));
+    const rendered = renderedTranscriptSurfaceRef.current;
+    flushSync(() => {
+      if (rendered && rendered.items.length > 0) {
+        setPreservedTranscriptSurface(rendered);
+      } else {
+        setPreservedTranscriptSurface(null);
+      }
+      setNavigationSurfaceIntent(intent);
+    });
   }, []);
   const settleNavigationSurface = useCallback((intent: number) => {
     recordFrontendDiagnostic("navigation", "navigation.settle", { phase: "settle" });
-    setNavigationSurfaceIntent((current) => settleNavigationSurfaceIntent(current, intent));
+    setNavigationSurfaceIntent((current) => {
+      const next = settleNavigationSurfaceIntent(current, intent);
+      if (next === null) setPreservedTranscriptSurface(null);
+      return next;
+    });
   }, []);
   const [tabRevealSignal, setTabRevealSignal] = useState(0);
   const [transcriptRevealSignal, setTranscriptRevealSignal] = useState(0);
@@ -3473,6 +3492,23 @@ export default function App() {
   // Display items: backend history is authoritative after immediate commit.
   // rewindState only drives the undo banner, not optimistic truncation.
   const displayItems = transcriptItems;
+  // Keep a render-level snapshot of the last stable transcript. Navigation
+  // starts before the controller swaps activeTabId, so this ref gives the
+  // transition layer a synchronous, immutable surface to retain as its
+  // background instead of rendering the target tab's empty state.
+  if (!runtimeTransitioning) {
+    renderedTranscriptSurfaceRef.current = {
+      tabId: activeTabId,
+      items: displayItems,
+      geometrySessionKey: transcriptGeometrySessionKey,
+    };
+  }
+  const visibleTranscriptSurface = runtimeTransitioning && preservedTranscriptSurface
+    ? preservedTranscriptSurface
+    : null;
+  const visibleTranscriptItems = visibleTranscriptSurface?.items ?? displayItems;
+  const visibleTranscriptTabId = visibleTranscriptSurface?.tabId ?? activeTabId;
+  const visibleTranscriptGeometryKey = visibleTranscriptSurface?.geometrySessionKey ?? transcriptGeometrySessionKey;
   const latestGuidanceConsumed = useMemo(() => {
     for (let i = state.items.length - 1; i >= 0; i--) {
       const item = state.items[i];
@@ -4854,40 +4890,57 @@ export default function App() {
               <NoticePreviewPanel />
             ) : (
               <>
-                <Transcript
-                  items={runtimeTransitioning ? [] : displayItems}
-                  live={runtimeTransitioning ? undefined : state.live}
-                  liveStore={liveStore}
-                  tabId={activeTabId}
-                  geometrySessionKey={transcriptGeometrySessionKey}
-                  footerHeight={footerHeight}
-                  onPrompt={handleTranscriptPrompt}
-                  onDeliveryContinue={() => void handleDeliveryContinue()}
-                  onAcceptDelivery={() => void app.AcceptDeliveryToTab(activeTabIdRef.current ?? "")}
-                  onOpenChanges={() => openRightDockMode("changed")}
-                  onOpenVerification={openTurnVerification}
-                  onEditPrompt={handleEditPrompt}
-                  onRewind={handleMessageAction}
-                  checkpoints={state.checkpoints}
-                  actionPending={state.messageAction != null}
-                  rewindDisabled={Boolean(activeTab?.readOnly) || !controllerReady || hydratePlaceholderActive || rewindState != null || rewindCommitting || state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
-                  running={state.running || rewindCommitting}
-                  turnStartAt={state.turnStartAt}
-                  contentRevision={state.historyLayoutRevision}
-                  welcomeVariant={sidebarCreation ? "creation" : "default"}
-                  creationMode={sidebarCreation}
-                  actionHoverMenus={sidebarCreation && !hydratePlaceholderActive && !runtimeTransitioning}
-                  rewindSignal={rewindSignal}
-                  revealSignal={transcriptRevealSignal}
-                  hydrating={runtimeTransitioning || transcriptHydrating}
-                  hasOlderHistory={!runtimeTransitioning && state.historyHasOlder && !rewindState}
-                  historyStartTurn={state.historyStartTurn}
-                  historyTotalTurns={state.historyTotalTurns}
-                  loadingOlderHistory={state.historyOlderLoading}
-                  olderHistoryError={state.historyOlderError}
-                  onLoadOlderHistory={handleLoadOlderHistory}
-                  invocationMetadata={activeTabId ? invocationMetadataByTab[activeTabId] : undefined}
-                />
+                <div className="transcript-navigation-surface" aria-busy={runtimeTransitioning}>
+                  <div
+                    className="transcript-navigation-content"
+                    aria-hidden={runtimeTransitioning || undefined}
+                    ref={(node) => {
+                      if (!node) return;
+                      (node as HTMLElement & { inert?: boolean }).inert = runtimeTransitioning;
+                    }}
+                  >
+                    <Transcript
+                      items={visibleTranscriptItems}
+                      live={runtimeTransitioning ? undefined : state.live}
+                      liveStore={liveStore}
+                      tabId={visibleTranscriptTabId}
+                      geometrySessionKey={visibleTranscriptGeometryKey}
+                      footerHeight={footerHeight}
+                      onPrompt={handleTranscriptPrompt}
+                      onDeliveryContinue={() => void handleDeliveryContinue()}
+                      onAcceptDelivery={() => void app.AcceptDeliveryToTab(activeTabIdRef.current ?? "")}
+                      onOpenChanges={() => openRightDockMode("changed")}
+                      onOpenVerification={openTurnVerification}
+                      onEditPrompt={handleEditPrompt}
+                      onRewind={handleMessageAction}
+                      checkpoints={state.checkpoints}
+                      actionPending={state.messageAction != null}
+                      rewindDisabled={Boolean(activeTab?.readOnly) || !controllerReady || hydratePlaceholderActive || rewindState != null || rewindCommitting || state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending || runtimeTransitioning}
+                      running={state.running || rewindCommitting}
+                      turnStartAt={state.turnStartAt}
+                      contentRevision={state.historyLayoutRevision}
+                      welcomeVariant={sidebarCreation ? "creation" : "default"}
+                      creationMode={sidebarCreation}
+                      actionHoverMenus={sidebarCreation && !hydratePlaceholderActive && !runtimeTransitioning}
+                      rewindSignal={rewindSignal}
+                      revealSignal={transcriptRevealSignal}
+                      hydrating={runtimeTransitioning || transcriptHydrating}
+                      hasOlderHistory={!runtimeTransitioning && state.historyHasOlder && !rewindState}
+                      historyStartTurn={state.historyStartTurn}
+                      historyTotalTurns={state.historyTotalTurns}
+                      loadingOlderHistory={state.historyOlderLoading}
+                      olderHistoryError={state.historyOlderError}
+                      onLoadOlderHistory={handleLoadOlderHistory}
+                      invocationMetadata={visibleTranscriptTabId ? invocationMetadataByTab[visibleTranscriptTabId] : undefined}
+                    />
+                  </div>
+                  {runtimeTransitioning ? (
+                    <div className="transcript-navigation-overlay" role="status" aria-live="polite">
+                      <span className="transcript-navigation-overlay__spinner" aria-hidden="true" />
+                      <span>{t("common.loading")}</span>
+                    </div>
+                  ) : null}
+                </div>
                 {!runtimeTransitioning && state.hydrateError ? <div className="history-load-error" role="alert"><span>{state.hydrateError}</span><button type="button" className="btn btn--small" onClick={() => void retrySessionHistory(activeTabId)}>{t("common.retry")}</button></div> : null}
               </>
             )}

--- a/desktop/frontend/src/__tests__/navigation-surface-transition.test.ts
+++ b/desktop/frontend/src/__tests__/navigation-surface-transition.test.ts
@@ -56,8 +56,10 @@ ok(await staleAcceptedPromise === false, "a stale backend-activating result is r
 ok(reasserted === "tab.reveal-background:tab-stale", "stale reassertion receives the mutating target identity");
 
 const appSource = readFileSync(new URL("../App.tsx", import.meta.url), "utf8");
-ok(appSource.includes("flushSync(() => setNavigationSurfaceIntent(intent))"), "navigation masking commits synchronously before the Wails await");
-ok(appSource.includes("items={runtimeTransitioning ? [] : displayItems}"), "App removes source transcript rows during navigation");
+ok(appSource.includes("flushSync(() => {"), "navigation masking commits synchronously before the Wails await");
+ok(appSource.includes("setPreservedTranscriptSurface(rendered)"), "the last stable transcript is retained during navigation");
+ok(appSource.includes("items={visibleTranscriptItems}"), "the visible transcript is decoupled from the hydrating target");
+ok(appSource.includes("transcript-navigation-overlay"), "navigation renders a blocking transcript overlay");
 ok(appSource.includes("live={runtimeTransitioning ? undefined : state.live}"), "App removes source live output during navigation");
 ok(appSource.includes("hidden={composerSurfaceHidden || undefined}"), "App keeps the composer mounted but hidden during navigation");
 ok(appSource.includes("inert={composerSurfaceHidden ? true : undefined}"), "the hidden composer is inert during navigation");

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -307,9 +307,9 @@ export function Transcript({
 
   // Row measurement and footer resize share the same coalesced height path.
   useEffect(() => {
-    if (!virtuosoReadyRef.current || !stick.current) return;
+    if (hydrating || !virtuosoReadyRef.current || !stick.current) return;
     followGrowingTail();
-  }, [footerHeight, followGrowingTail, stick]);
+  }, [footerHeight, followGrowingTail, hydrating, stick]);
 
   const refreshGeometryEnvironment = useCallback((element: HTMLElement) => {
     const next = readTranscriptGeometryEnvironment(element);
@@ -340,12 +340,12 @@ export function Transcript({
       }
       if (height !== lastHeight) {
         lastHeight = height;
-        followGrowingTail();
+        if (!hydrating) followGrowingTail();
       }
     });
     observer.observe(element);
     return () => observer.disconnect();
-  }, [scrollElement, followGrowingTail, refreshGeometryEnvironment]);
+  }, [hydrating, scrollElement, followGrowingTail, refreshGeometryEnvironment]);
 
   // Typography settings update CSS variables synchronously. Re-read the
   // geometry signature without remounting Virtuoso; old exact samples then
@@ -634,6 +634,7 @@ export function Transcript({
     loadingOlderHistory,
     olderHistoryError,
     running,
+    suppressAutoComplete: hydrating,
     onLoadOlderHistory,
     clearTranscriptSelection,
     invalidateAnchors,
@@ -876,8 +877,9 @@ export function Transcript({
 
   const handleTotalListHeightChanged = useCallback((height: number) => {
     if (SHOW_SCROLL_DIAGNOSTICS) recordTranscriptScrollDiagnostic("list-height", { listHeight: height });
+    if (hydrating) return;
     followGrowingTail();
-  }, [followGrowingTail]);
+  }, [followGrowingTail, hydrating]);
 
   const virtuosoContext = useMemo<TranscriptVirtuosoContext>(() => ({
     tabId,

--- a/desktop/frontend/src/lib/transcriptScrollProbe.ts
+++ b/desktop/frontend/src/lib/transcriptScrollProbe.ts
@@ -103,7 +103,12 @@ function rowFoldState(element: HTMLElement): { foldState: "none" | "open" | "clo
 /** Records only geometry and fixed row classifications; text and row keys never leave the DOM. */
 export function noteTranscriptRowMeasurement(element: HTMLElement, field: "offsetHeight" | "offsetWidth", measuredSize: number): void {
   if (field !== "offsetHeight") return;
-  const previousSize = finiteDatasetNumber(element.dataset.knownSize);
+  // A physical Virtuoso row can be rebound to a different logical row before
+  // its known size is refreshed. Treat that size as recycled-node metadata,
+  // not as the current row's geometry contract.
+  const previousSize = element.dataset.transcriptRecycled === "true"
+    ? undefined
+    : finiteDatasetNumber(element.dataset.knownSize);
   const estimatedSize = finiteDatasetNumber(element.dataset.estimatedSize);
   const comparisonSize = previousSize ?? estimatedSize;
   if (comparisonSize !== undefined && Math.abs(measuredSize - comparisonSize) <= 0.5) return;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -4559,6 +4559,10 @@ export function useController() {
           // remain on screen while the user retries.
           if (previousTabId && activeTabIdRef.current === tabId && isNavigationIntentCurrent(navigationSeq)) {
             await app.SetActiveTab(previousTabId).catch(() => undefined);
+            // A newer click may arrive while the backend rebind is in flight.
+            // Do not let this stale failure restore the old frontend selection
+            // after that intent has already won.
+            if (!isNavigationIntentCurrent(navigationSeq) || activeTabIdRef.current !== tabId) return tabs;
             setActiveTabId(previousTabId);
             activeTabIdRef.current = previousTabId;
           }

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -4535,7 +4535,7 @@ export function useController() {
         }
         const tabs = await reconcileTabRuntime(tabId, { hydrateSessionData: false });
         if (!isNavigationIntentCurrent(navigationSeq)) return tabs;
-        void loadSessionDataForTab(tabId, false, "switch-tab", {
+        await loadSessionDataForTab(tabId, false, "switch-tab", {
           skipHistory: sameSession && hasCachedLiveTurn(statesRef.current.get(tabId)),
           placeholderItems,
           surfacePolicy: preserveTargetSurface ? "preserve-current" : "replace-surface",
@@ -4545,6 +4545,25 @@ export function useController() {
           sessionDigest: targetSessionDigest,
           sessionGeneration: targetSessionGeneration,
         });
+        // The navigation surface is committed by the caller only after the
+        // target history has been applied. This prevents the old surface from
+        // being replaced by an empty target state between SetActiveTab and
+        // the first history page.
+        if (!isNavigationIntentCurrent(navigationSeq)) return tabs;
+        const hydratedTargetState = statesRef.current.get(tabId);
+        if (hydratedTargetState?.hydrateError) {
+          noteActivationSettled(switchRequestId, "failed", hydratedTargetState.hydrateError);
+          // History loading errors are reported by loadSessionDataForTab as a
+          // state error rather than a rejected promise. Rebind the backend and
+          // visible tab to the previous session so the retained transcript can
+          // remain on screen while the user retries.
+          if (previousTabId && activeTabIdRef.current === tabId && isNavigationIntentCurrent(navigationSeq)) {
+            await app.SetActiveTab(previousTabId).catch(() => undefined);
+            setActiveTabId(previousTabId);
+            activeTabIdRef.current = previousTabId;
+          }
+          return tabs;
+        }
         noteActivationSettled(switchRequestId, "ready");
         return tabs;
       })

--- a/desktop/frontend/src/lib/useTranscriptQuestionNavigation.ts
+++ b/desktop/frontend/src/lib/useTranscriptQuestionNavigation.ts
@@ -109,6 +109,7 @@ export function useTranscriptQuestionJump({
   loadingOlderHistory,
   olderHistoryError,
   running,
+  suppressAutoComplete = false,
   onLoadOlderHistory,
   clearTranscriptSelection,
   invalidateAnchors,
@@ -124,6 +125,8 @@ export function useTranscriptQuestionJump({
   loadingOlderHistory: boolean;
   olderHistoryError?: string;
   running: boolean;
+  /** Avoid background history paging while a navigation surface is hidden. */
+  suppressAutoComplete?: boolean;
   onLoadOlderHistory?: (targetTurn?: number) => boolean | Promise<boolean>;
   clearTranscriptSelection: (reason?: string) => void;
   invalidateAnchors: () => void;
@@ -183,8 +186,9 @@ export function useTranscriptQuestionJump({
 
   const earlierTurnsRemaining = questions[0]?.turn ?? 0;
   useEffect(() => {
+    if (suppressAutoComplete) return;
     if (earlierTurnsRemaining > 0 && earlierTurnsRemaining < HISTORY_AUTO_COMPLETE_TURNS) void requestOlderHistory();
-  }, [earlierTurnsRemaining, requestOlderHistory]);
+  }, [earlierTurnsRemaining, requestOlderHistory, suppressAutoComplete]);
   const handleEarlierHistoryReached = useCallback(() => void requestOlderHistory(), [requestOlderHistory]);
   const retryOlderHistory = useCallback(() => {
     const targetTurn = pendingQuestion?.surfaceKey === layoutSurfaceKey ? pendingQuestion.turn + 1 : undefined;

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -91,6 +91,9 @@ export function useTranscriptScrollArbiter({
   const deliverScrollRef = useRef<((element?: HTMLDivElement) => void) | null>(null);
   const generationRef = useRef(0);
   const followFrameRef = useRef<number | null>(null);
+  // Virtuoso reuses physical row elements. A known size from the previous
+  // logical row must not be treated as the current row's geometry contract.
+  const measuredRowKeyRef = useRef(new WeakMap<HTMLElement, string>());
   const layoutTransientRef = useRef(false);
   const resizeSettleFrameRef = useRef<number | null>(null);
   const readerIntentTimerRef = useRef<number | null>(null);
@@ -508,6 +511,15 @@ export function useTranscriptScrollArbiter({
       element.style.removeProperty("height");
       delete element.dataset.transcriptGeometryFrozen;
     }
+    if (field === "offsetHeight") {
+      const currentRowKey = element.dataset.rowKey;
+      if (currentRowKey) {
+        const previousRowKey = measuredRowKeyRef.current.get(element);
+        if (previousRowKey !== undefined && previousRowKey !== currentRowKey) element.dataset.transcriptRecycled = "true";
+        else delete element.dataset.transcriptRecycled;
+        measuredRowKeyRef.current.set(element, currentRowKey);
+      }
+    }
     if (CAPTURE_TRANSCRIPT_SCROLL_DIAGNOSTICS) noteTranscriptRowMeasurement(element, field, measured);
     if (!frozen && !pendingGeometry && field === "offsetHeight") {
       const rowKey = element.dataset.rowKey;
@@ -522,16 +534,19 @@ export function useTranscriptScrollArbiter({
       const staticEstimate = Number.parseFloat(element.dataset.staticEstimate ?? "");
       const staticEstimateMatchesState = rawVariant === element.dataset.transcriptLayoutVariant;
       if (rowKey && kind && isTranscriptRowLayoutVariant(rawVariant) && measured > 0 && width > 0) {
-        onItemMeasuredRef.current?.(
-          rowKey,
-          kind,
-          rawVariant,
-          measured,
-          width,
-          element.dataset.layoutVersion,
-          estimateSource,
-          staticEstimateMatchesState && Number.isFinite(staticEstimate) ? staticEstimate : undefined,
-        );
+        const recycled = element.dataset.transcriptRecycled === "true";
+        if (!recycled) {
+          onItemMeasuredRef.current?.(
+            rowKey,
+            kind,
+            rawVariant,
+            measured,
+            width,
+            element.dataset.layoutVersion,
+            estimateSource,
+            staticEstimateMatchesState && Number.isFinite(staticEstimate) ? staticEstimate : undefined,
+          );
+        }
       }
     }
     return measured;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3432,6 +3432,48 @@ a[href] {
   min-height: 0;
   height: 100%;
 }
+.transcript-navigation-surface {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.transcript-navigation-content {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+}
+.transcript-navigation-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: var(--z-inline-sticky);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--fg);
+  background: color-mix(in srgb, var(--chat-bg, var(--bg)) 88%, transparent);
+  pointer-events: auto;
+  user-select: none;
+  cursor: progress;
+}
+.transcript-navigation-overlay__spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid color-mix(in srgb, var(--fg) 24%, transparent);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: transcript-navigation-spin 0.8s linear infinite;
+}
+@keyframes transcript-navigation-spin {
+  to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .transcript-navigation-overlay__spinner { animation: none; }
+}
 /* The active turn streams as the virtual list's in-flow Footer: inside the
    scroller, right after the last history row, but outside Virtuoso's
    measured size tree — unbounded growth never reaches the list's anchors or

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -4,7 +4,7 @@
     "commented-code": 0,
     "complexity": 1992,
     "essay": 1982,
-    "file-size": 107668,
+    "file-size": 107742,
     "function-size": 8617,
     "layering": 1,
     "marker": 0,
@@ -66,7 +66,7 @@
       "essay": 2
     },
     "desktop/frontend/src/App.tsx": {
-      "file-size": 4674
+      "file-size": 4727
     },
     "desktop/frontend/src/__tests__/app-chrome-tabs.test.ts": {
       "test-file-size": 27
@@ -135,7 +135,7 @@
       "file-size": 158
     },
     "desktop/frontend/src/components/Transcript.tsx": {
-      "file-size": 260
+      "file-size": 262
     },
     "desktop/frontend/src/components/UsageStatsPanel.tsx": {
       "file-size": 276
@@ -159,7 +159,7 @@
       "file-size": 1611
     },
     "desktop/frontend/src/lib/useController.ts": {
-      "file-size": 4034
+      "file-size": 4053
     },
     "desktop/heartbeat.go": {
       "essay": 7

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -4,7 +4,7 @@
     "commented-code": 0,
     "complexity": 1992,
     "essay": 1982,
-    "file-size": 107742,
+    "file-size": 107746,
     "function-size": 8617,
     "layering": 1,
     "marker": 0,
@@ -159,7 +159,7 @@
       "file-size": 1611
     },
     "desktop/frontend/src/lib/useController.ts": {
-      "file-size": 4053
+      "file-size": 4057
     },
     "desktop/heartbeat.go": {
       "essay": 7


### PR DESCRIPTION
## Summary

Switching between desktop sessions no longer exposes the target tab's empty transcript while history hydration is still in flight. The last stable transcript remains visible behind an inert loading overlay and is replaced only after the target surface is ready.

## Problem

The frontend cleared the visible transcript as soon as navigation started. Long sessions then loaded history in multiple batches, repeatedly triggered tail-follow writes, and reused stale Virtuoso row sizes. Users could see a flash during session switching even though the blank watchdog never observed a recoverable blank viewport.

## Root cause

- `App` rendered an empty `items` array while `runtimeTransitioning` was active.
- `switchTab` released the navigation mask before target history hydration completed.
- Initial question navigation could auto-request older history during the first paint.
- Recycled physical Virtuoso rows treated the previous logical row size as the current geometry contract.

## Fix

- Retain the last stable transcript surface and show a transcript-only loading overlay.
- Make the retained surface inert and disable transcript actions while navigation is pending.
- Await target hydration before committing the target surface; stale navigation completions remain ignored.
- Restore the previous session when target history hydration fails.
- Suppress initial history auto-completion and hydration-time tail-follow writes.
- Ignore recycled-row known sizes for geometry diagnostics and cache updates.
- Keep the change memory-only; no persisted/API/provider/cache contract changes.

## Verification

- `pnpm typecheck`
- `pnpm test:transcript`
- `pnpm exec tsx src/__tests__/navigation-surface-transition.test.ts`
- `pnpm build`
- ESLint, CSS syntax/z-index, WAAPI, scroll-writer, and bundle-budget checks

## Related work

This follow-up complements the merged #9240 geometry fix and is intentionally scoped to the navigation/hydration owner. It may overlap with open tail-settle work in #9248 and #9209; those PRs should be integrated with the latest-base three-dot diff rather than treated as duplicates.

Documentation-impact: none - this is an internal desktop implementation fix; existing user and developer documentation remains correct.

## Acknowledgements

Co-author: [FuchaZ](https://github.com/FuchaZ) — thank you for providing the test data used to diagnose and validate this fix.

## Merge attribution

Please preserve FuchaZ's contribution in the squash merge commit with:

```
Co-authored-by: FuchaZ <296198446+FuchaZ@users.noreply.github.com>
```