### PR TITLE
feat: add model service search

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -111,7 +111,8 @@ if (initialCSS.length > 0) {
 // Navigation overlay styles add a bounded 0.1 KiB to the deferred shell.
 // The cleaned source panel adds 0.1 KiB gzip to the deferred shell on top of
 // the retained-transcript navigation allowance; keep the ratchet explicit.
-assertBudget("deferred app-shell CSS gzip", appShellCSSGzip, 114.3 * 1024);
+// The Other-providers search box and its empty state add 0.1 KiB gzip.
+assertBudget("deferred app-shell CSS gzip", appShellCSSGzip, 114.4 * 1024);
 if (localeChunks.length !== 2) {
   throw new Error(`expected 2 on-demand Chinese locale chunks, found ${localeChunks.length}`);
 }
@@ -137,8 +138,10 @@ for (const path of localeChunks) {
   // platform-dependent gate. The OpenCode one-key setup adds product-level
   // connection, fallback, and legacy-state copy while removing protocol
   // choices from the primary UI; keep that complete guidance with a bounded
-  // 0.4–0.5 KiB locale-only ratchet.
-  const budget = name.startsWith("zh-TW-") ? 57.2 * 1024 : 56.5 * 1024;
+  // 0.4–0.5 KiB locale-only ratchet. The Other-providers search placeholder
+  // and empty state add ~10 B gzip to zh and ~35 B to zh-TW; keep the 0.1 KiB
+  // headroom per chunk.
+  const budget = name.startsWith("zh-TW-") ? 57.3 * 1024 : 56.6 * 1024;
   assertBudget(`${name} gzip`, gzipBytes(path), budget);
 }
 
@@ -153,7 +156,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // More menu, completion summary) makes the latest-base merge 2353.1 KiB in
 // production and 2358.3 KiB in test: about 9.0 KiB (0.38%) over main-v2's
 // channel gates. Retain that attributable UI capacity with 0.1 KiB of build-SHA
-// headroom without widening the gzip or largest-chunk exceptions.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_358.4 : 2_353.2;
+// headroom without widening the gzip or largest-chunk exceptions. The
+// Other-providers search box adds ~0.3 KiB raw across both channels.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_358.7 : 2_353.5;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/__tests__/provider-other-search.test.tsx
+++ b/desktop/frontend/src/__tests__/provider-other-search.test.tsx
@@ -1,0 +1,228 @@
+// Run: tsx src/__tests__/provider-other-search.test.tsx
+// The "Other providers" section in the add-provider panel filters its preset
+// cards live as the user types. This suite covers default state, case-insensitive
+// fuzzy matching, clearing, the empty state, and the add flow regression.
+
+import { JSDOM } from "jsdom";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+console.log("\nother-provider search");
+
+const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+globalThis.Node = dom.window.Node;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Event = dom.window.Event;
+globalThis.CustomEvent = dom.window.CustomEvent;
+globalThis.MouseEvent = dom.window.MouseEvent;
+globalThis.localStorage = dom.window.localStorage;
+globalThis.sessionStorage = dom.window.sessionStorage;
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+Object.defineProperty(dom.window.HTMLElement.prototype, "attachEvent", { configurable: true, value: () => undefined });
+Object.defineProperty(dom.window.HTMLElement.prototype, "detachEvent", { configurable: true, value: () => undefined });
+window.scrollTo = () => {};
+window.matchMedia = () => ({
+  matches: true,
+  media: "",
+  onchange: null,
+  addListener: () => undefined,
+  removeListener: () => undefined,
+  addEventListener: () => undefined,
+  removeEventListener: () => undefined,
+  dispatchEvent: () => false,
+});
+
+// Import react-dom lazily so the attachEvent polyfill above is installed before
+// react-dom snapshots its input-event support (same pattern as blank-project-dialog).
+import React, { act } from "react";
+const [{ createRoot }, { AddProviderPanel }, { LocaleProvider }] = await Promise.all([
+  import("react-dom/client"),
+  import("../components/SettingsPanel"),
+  import("../lib/i18n"),
+]);
+const { ProviderPresetView } = await import("../lib/types").then((m) => m);
+
+function makePreset(id: string, label: string, description: string, keyEnv: string): ProviderPresetView {
+  return {
+    id,
+    label,
+    description,
+    keyEnv,
+    recommended: false,
+    displayGroup: "",
+    displaySection: "",
+    displayTier: "advanced",
+    routeKind: "openai",
+    providerNames: [id],
+    models: ["model"],
+    added: false,
+    status: "available",
+    statusProviderNames: [],
+    keySet: false,
+    requiresKey: true,
+    configured: false,
+  };
+}
+
+const presets = [
+  makePreset("deepseek-anthropic", "DeepSeek Official Anthropic", "Separate official Anthropic-compatible entry.", "DEEPSEEK_API_KEY"),
+  makePreset("longcat-openai", "LongCat OpenAI", "LongCat platform endpoint.", "LONGCAT_API_KEY"),
+  makePreset("kimi-cn", "Kimi CN API", "Moonshot Chinese mainland endpoint.", "KIMI_API_KEY"),
+];
+
+const addedPresetIDs: string[] = [];
+
+function panel() {
+  return (
+    <LocaleProvider>
+      <AddProviderPanel
+        mode="official"
+        kinds={["anthropic", "openai"]}
+        officialProviders={[]}
+        providerPresets={presets}
+        busy={false}
+        onMode={() => undefined}
+        onCancel={() => undefined}
+        onAddOfficial={async () => undefined}
+        onAddPreset={async (id) => {
+          addedPresetIDs.push(id);
+        }}
+        onViewPresetConflict={() => undefined}
+        onResetPreset={async () => undefined}
+        onAddCustom={() => undefined}
+      />
+    </LocaleProvider>
+  );
+}
+
+// The quick-setup screen shows by default; "Choose another provider" opens the
+// full catalog that contains the Other providers section with its search box.
+async function openFullCatalog(rootEl: HTMLElement) {
+  const chooseAnother = Array.from(rootEl.querySelectorAll("button"))
+    .find((button) => button.textContent?.trim() === "Choose another provider") as HTMLButtonElement | undefined;
+  await act(async () => {
+    chooseAnother?.click();
+    await flushPromises();
+  });
+}
+
+function setSearch(rootEl: HTMLElement, value: string) {
+  const input = rootEl.querySelector<HTMLInputElement>(".provider-other-search");
+  if (!input) throw new Error("search input missing");
+  const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+  input.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+}
+
+function visibleCards(rootEl: HTMLElement): string[] {
+  return Array.from(rootEl.querySelectorAll(".provider-template-grid .provider-template-card"))
+    .map((card) => card.textContent ?? "");
+}
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("missing root");
+const root = createRoot(rootEl);
+
+// Case 1: default state — search box present, all providers listed, no filtering.
+await act(async () => {
+  root.render(panel());
+  await flushPromises();
+});
+await openFullCatalog(rootEl);
+const searchInput = rootEl.querySelector<HTMLInputElement>(".provider-other-search");
+ok(searchInput !== null && searchInput.getAttribute("aria-label") === "Search model services...", "default state shows the search input next to the Other providers title");
+ok(searchInput?.value === "", "default state starts with an empty search query");
+const defaultCards = visibleCards(rootEl);
+ok(defaultCards.length === 3, "default state lists every other provider");
+ok(defaultCards.some((c) => c.includes("DeepSeek Official Anthropic")) && defaultCards.some((c) => c.includes("LongCat OpenAI")) && defaultCards.some((c) => c.includes("Kimi CN API")), "default state keeps all provider cards");
+const headRow = rootEl.querySelector(".provider-preset-group__head");
+ok(headRow?.querySelector("h4") !== null && headRow?.querySelector(".provider-other-search") !== null, "the search box sits beside the Other providers heading in the same row container");
+
+// Case 2: typing filters live to matching providers only.
+await act(async () => {
+  setSearch(rootEl, "deep");
+  await flushPromises();
+});
+const deepCards = visibleCards(rootEl);
+ok(deepCards.length === 1 && deepCards[0]?.includes("DeepSeek Official Anthropic"), "typing \"deep\" keeps only the DeepSeek preset");
+
+// Case 3: case-insensitive matching — all casings agree.
+for (const query of ["deepseek", "DeepSeek", "DEEPSEEK"]) {
+  await act(async () => {
+    setSearch(rootEl, query);
+    await flushPromises();
+  });
+  const cards = visibleCards(rootEl);
+  ok(cards.length === 1 && cards[0]?.includes("DeepSeek Official Anthropic"), `case-insensitive search "${query}" keeps the DeepSeek preset`);
+}
+
+// Case 4: clearing the query restores every provider.
+await act(async () => {
+  setSearch(rootEl, "");
+  await flushPromises();
+});
+ok(visibleCards(rootEl).length === 3, "clearing the query restores every other provider");
+ok(rootEl.querySelector(".provider-preset-group__empty") === null, "clearing the query removes the empty state");
+
+// Case 5: no matches shows the empty state without breaking the section.
+await act(async () => {
+  setSearch(rootEl, "this-model-does-not-exist");
+  await flushPromises();
+});
+const emptyState = rootEl.querySelector<HTMLElement>(".provider-preset-group__empty");
+ok(emptyState !== null && emptyState.textContent === "No matching model services", "an unmatched query shows the empty state");
+ok(rootEl.querySelector(".provider-preset-group__head") !== null, "the heading and search box remain visible in the empty state");
+ok(rootEl.querySelector(".provider-template-grid") === null, "the empty state removes the card grid");
+
+// Case 6: regression — selecting a card and confirming still runs the original add flow.
+await act(async () => {
+  setSearch(rootEl, "");
+  await flushPromises();
+});
+const kimiCard = Array.from(rootEl.querySelectorAll(".provider-template-grid .provider-template-card"))
+  .find((card) => card.textContent?.includes("Kimi CN API")) as HTMLButtonElement | undefined;
+ok(kimiCard !== undefined && !kimiCard.disabled, "provider cards stay clickable after filtering is cleared");
+await act(async () => {
+  kimiCard?.click();
+  await flushPromises();
+});
+const addButton = Array.from(rootEl.querySelectorAll(".prov-card__actions button"))
+  .find((button) => button.textContent?.trim() === "Add provider") as HTMLButtonElement | undefined;
+ok(addButton !== undefined && !addButton.disabled, "the confirm action enables after selecting a matching provider card");
+await act(async () => {
+  addButton?.click();
+  await flushPromises();
+});
+ok(addedPresetIDs.includes("kimi-cn"), "clicking a provider card still triggers the preset add flow");
+
+await act(async () => {
+  root.unmount();
+});
+dom.window.close();
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -5536,6 +5536,19 @@ function isFeaturedProviderChoice(choice: ProviderTemplateChoice): boolean {
     || (choice.source === "preset" && choice.presetID === "opencode-go-recommended");
 }
 
+// providerTemplateSearchText joins every user-facing or stable identifier of a
+// template choice into one case-normalized haystack so the other-provider search
+// box can match names, descriptions, preset IDs, and key env vars alike.
+function providerTemplateSearchText(choice: ProviderTemplateChoice): string {
+  return [
+    choice.label,
+    choice.description,
+    choice.id,
+    "presetID" in choice ? choice.presetID : "",
+    choice.keyEnv,
+  ].join(" ").toLowerCase();
+}
+
 function isHiddenOpenCodeRouteChoice(choice: ProviderTemplateChoice): boolean {
   return choice.source === "preset"
     && choice.displayGroup === "opencode"
@@ -5683,6 +5696,14 @@ export function AddProviderPanel({
 
   const featuredProviderChoices = visibleTemplateChoices.filter(isFeaturedProviderChoice);
   const otherChoices = visibleTemplateChoices.filter((choice) => !isFeaturedProviderChoice(choice));
+  const [otherQuery, setOtherQuery] = useState("");
+  const normalizedOtherQuery = otherQuery.trim().toLowerCase();
+  const filteredOtherChoices = useMemo(
+    () => normalizedOtherQuery
+      ? otherChoices.filter((choice) => providerTemplateSearchText(choice).includes(normalizedOtherQuery))
+      : otherChoices,
+    [otherChoices, normalizedOtherQuery],
+  );
   const focusedFeaturedProvider = selected && isFeaturedProviderChoice(selected) && !showProviderCatalog ? selected : null;
 
   const header = (
@@ -5797,8 +5818,22 @@ export function AddProviderPanel({
         ) : null}
         {otherChoices.length > 0 ? (
           <div className="provider-preset-group">
-            <h4>{t("settings.addProvider.otherProviders")}</h4>
-            <div className="provider-template-grid">{otherChoices.map(renderTemplateChoice)}</div>
+            <div className="provider-preset-group__head">
+              <h4>{t("settings.addProvider.otherProviders")}</h4>
+              <input
+                type="search"
+                className="mem-input provider-other-search"
+                placeholder={t("settings.addProvider.searchProviders")}
+                aria-label={t("settings.addProvider.searchProviders")}
+                value={otherQuery}
+                onChange={(event) => setOtherQuery(event.target.value)}
+              />
+            </div>
+            {filteredOtherChoices.length > 0 ? (
+              <div className="provider-template-grid">{filteredOtherChoices.map(renderTemplateChoice)}</div>
+            ) : (
+              <p className="provider-preset-group__empty">{t("settings.addProvider.noProviderMatches")}</p>
+            )}
           </div>
         ) : null}
         <label className="set-label">{t("settings.providerKeyOptional")}</label>

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2637,6 +2637,8 @@ export const en = {
   "settings.addProvider.connectAndStart": "Connect and start using",
   "settings.addProvider.chooseAnotherProvider": "Choose another provider",
   "settings.addProvider.otherProviders": "Other providers",
+  "settings.addProvider.searchProviders": "Search model services...",
+  "settings.addProvider.noProviderMatches": "No matching model services",
   "settings.addProvider.manageRoutes": "Advanced route settings",
   "settings.addProvider.opencodeGoCompatibilityLabel": "OpenCode Go Chat (Compatibility)",
   "settings.addProvider.zenCredentialHint": "Independent Zen product, key, and billing.",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1799,6 +1799,8 @@ export const zhTW: Record<DictKey, string> = {
   "settings.addProvider.connectAndStart": "連線並開始使用",
   "settings.addProvider.chooseAnotherProvider": "選擇其他模型服務",
   "settings.addProvider.otherProviders": "其他模型服務",
+  "settings.addProvider.searchProviders": "搜尋模型服務...",
+  "settings.addProvider.noProviderMatches": "未找到相符的模型服務",
   "settings.addProvider.manageRoutes": "進階線路設定",
   "settings.addProvider.opencodeGoCompatibilityLabel": "OpenCode Go Chat（相容入口）",
   "settings.addProvider.zenCredentialHint": "獨立的 Zen 產品、金鑰與計費體系。",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2640,6 +2640,8 @@ export const zh: Record<DictKey, string> = {
   "settings.addProvider.connectAndStart": "连接并开始使用",
   "settings.addProvider.chooseAnotherProvider": "选择其他模型服务",
   "settings.addProvider.otherProviders": "其他模型服务",
+  "settings.addProvider.searchProviders": "搜索模型服务...",
+  "settings.addProvider.noProviderMatches": "未找到匹配的模型服务",
   "settings.addProvider.manageRoutes": "高级线路设置",
   "settings.addProvider.opencodeGoCompatibilityLabel": "OpenCode Go Chat（兼容入口）",
   "settings.addProvider.zenCredentialHint": "独立的 Zen 产品、密钥和计费体系。",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -17531,6 +17531,31 @@ body > .mermaid-diagram--fullscreen {
 .provider-preset-group > h4 {
   font-size: var(--text-lg);
 }
+.provider-preset-group__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.provider-preset-group__head h4 {
+  margin: 0;
+}
+.provider-other-search {
+  flex: none;
+  width: min(230px, 100%);
+  padding: 4px 8px;
+  font-size: var(--font-control-small);
+}
+.provider-preset-group__empty {
+  margin: 0;
+  padding: 18px 12px;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  color: var(--fg-dim);
+  font-size: var(--font-control-small);
+  text-align: center;
+}
 .provider-preset-section {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- 为“其他模型”区域增加模型服务搜索框
- 支持实时模糊搜索（大小写不敏感，匹配名称/描述/preset ID/key env）
- 无匹配时显示空状态，保持现有页面布局和功能不变

## Tests

- [x] Search functionality
- [x] Clear search
- [x] Case-insensitive search
- [x] Empty result
- [x] Existing model service functionality
- [x] Layout regression
- [x] Full test suite
- [x] Lint
- [x] Type check
- [x] Build

### Budget ratchet（按项目惯例记录增量）

- deferred app-shell CSS gzip: 114.3 → 114.4 KiB（+0.1）
- zh/zh-TW locale chunk: 56.5/57.2 → 56.6/57.3 KiB（+0.1 headroom）
- initial raw JS+CSS: 2353.2/2358.4 → 2353.5/2358.7 KiB（+0.3）

Documentation-impact: none - 功能仅新增搜索 UI，不改变既有模型服务行为或概念，现有文档无需更新