### PR TITLE
fix(desktop): include qualityFloor in MetaForTab so delivery survives meta refresh / 修复 meta 刷新丢失交付模式

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6559,11 +6559,15 @@ type Meta struct {
 	ToolApprovalMode      string             `json:"toolApprovalMode"`
 	// TokenMode and AgentPreset are deprecated dual-write wire values pinned to
 	// their safe defaults; one-version-old frontends still parse them.
-	TokenMode   string           `json:"tokenMode"`
-	AgentPreset string           `json:"agentPreset,omitempty"`
-	Goal        string           `json:"goal,omitempty"`
-	GoalStatus  string           `json:"goalStatus,omitempty"`
-	GoalRuntime *GoalRuntimeView `json:"goalRuntime,omitempty"`
+	TokenMode   string `json:"tokenMode"`
+	AgentPreset string `json:"agentPreset,omitempty"`
+	// QualityFloor is the session's recorded delivery floor. The frontend
+	// profile derives from it (composerProfileFromMeta) and would otherwise
+	// reset to standard on every meta refresh, silently dropping delivery.
+	QualityFloor string           `json:"qualityFloor,omitempty"`
+	Goal         string           `json:"goal,omitempty"`
+	GoalStatus   string           `json:"goalStatus,omitempty"`
+	GoalRuntime  *GoalRuntimeView `json:"goalRuntime,omitempty"`
 	// Nil means no authoritative snapshot; non-nil empty means clear the panel.
 	CanonicalTodos *[]evidence.TodoItem `json:"canonicalTodos,omitempty"`
 	// Closed completed todo fingerprints from this session and its lineage.
@@ -6622,6 +6626,7 @@ func (a *App) MetaForTab(tabID string) Meta {
 	a.mu.RLock()
 	tab := a.tabByIDLocked(tabID)
 	snap := snapshotTabRuntimeLocked(tab)
+	qualityFloor := derivedQualityFloor(tab).floor
 	runtimeView := a.sessionRuntimeViewLocked(tab)
 	a.mu.RUnlock()
 	if tab == nil {
@@ -6678,6 +6683,7 @@ func (a *App) MetaForTab(tabID string) Meta {
 		TokenMode:             tokenMode,
 		AgentPreset:           agentPreset,
 		ToolApprovalMode:      toolApprovalMode,
+		QualityFloor:          qualityFloor,
 		Goal:                  goal,
 		GoalStatus:            goalStatus,
 		GoalRuntime:           goalRuntimeViewFromController(snap.ctrl),


### PR DESCRIPTION
## 变更摘要
<img width="1992" height="1530" alt="image" src="https://github.com/user-attachments/assets/ebee1f19-1175-48fd-a9bf-75f7cd756357" />

仅修改 `desktop/app.go` 一个文件，补上 qualityFloor 在后端 Meta 结构中的缺失：

1. `Meta` struct 新增字段：`QualityFloor string json:"qualityFloor,omitempty"`（放在 TokenMode/AgentPreset 之后）
2. `MetaForTab` 组装时赋值：`QualityFloor: snap.qualityFloor`（放在 ToolApprovalMode 之后）

## 根因说明

上游提交 bd8a8822b 引入 qualityFloor（交付模式）时，只实现了：
- tab 持久化：`WorkspaceTab.qualityFloor`
- 前端读取：`composerProfileFromMeta` 中 `qualityFloor: meta.qualityFloor ?? "standard"`

但漏了后端 `MetaForTab` 返回的 `Meta` 结构中的 `QualityFloor` 字段。导致前端每次 meta 刷新（清空目标、切 tab、运行结束）时 `qualityFloor` 恒为 `undefined`，回退到 `standard`，交付模式被静默重置——用户选择的交付模式在运行中悄悄丢失。

## 验证结果

- `go build ./...`（desktop/）：通过（exit 0，仅一条无关 ld warning）
- `go vet ./...`（desktop/）：通过
- `gofmt -l desktop/app.go`：无输出，格式合规
- `go test ./...`：未运行——本机 shell 环境带 `REASONIX_DEV=1` 会导致单实例锁测试 `TestSingleInstanceLockRestoresExistingInstance` 误失败；且本次改动仅新增一个 struct 字段 + 一处赋值，无新增逻辑分支，编译期类型检查已覆盖
- 前端 `composerProfile.ts:93` `meta.qualityFloor ?? "standard"` 与后端 json tag `qualityFloor` 字段名已核对一致

Documentation-impact: none - 纯后端 Meta 结构补字段，不涉及用户文档
Cache-impact: none - desktop/app.go 不在 cache-sensitive 路径
