### PR TITLE
feat: open local file path links in sidebar preview

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -157,6 +157,6 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // channel gates. Retain that attributable UI capacity with 0.1 KiB of build-SHA
 // headroom without widening the gzip or largest-chunk exceptions.
 // Local-path sidebar preview + Unix path patterns add ~0.5 KiB raw.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_358.9 : 2_353.7;
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_359.0 : 2_353.8;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -156,8 +156,7 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // production and 2358.3 KiB in test: about 9.0 KiB (0.38%) over main-v2's
 // channel gates. Retain that attributable UI capacity with 0.1 KiB of build-SHA
 // headroom without widening the gzip or largest-chunk exceptions.
-// Local-path sidebar preview adds a small lucide-react icon (Eye) and the
-// reveal-path event wiring — 0.2 KiB raw over the previous gate.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_358.7 : 2_353.5;
+// Local-path sidebar preview + Unix path patterns add ~0.5 KiB raw.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_358.9 : 2_353.7;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -154,6 +154,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // production and 2358.3 KiB in test: about 9.0 KiB (0.38%) over main-v2's
 // channel gates. Retain that attributable UI capacity with 0.1 KiB of build-SHA
 // headroom without widening the gzip or largest-chunk exceptions.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_358.4 : 2_353.2;
+// Local-path sidebar preview adds a small lucide-react icon (Eye) and the
+// reveal-path event wiring — 0.2 KiB raw over the previous gate.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_358.6 : 2_353.4;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -156,6 +156,6 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // headroom without widening the gzip or largest-chunk exceptions.
 // Local-path sidebar preview adds a small lucide-react icon (Eye) and the
 // reveal-path event wiring — 0.2 KiB raw over the previous gate.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_358.6 : 2_353.4;
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_358.7 : 2_353.5;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -111,7 +111,9 @@ if (initialCSS.length > 0) {
 // Navigation overlay styles add a bounded 0.1 KiB to the deferred shell.
 // The cleaned source panel adds 0.1 KiB gzip to the deferred shell on top of
 // the retained-transcript navigation allowance; keep the ratchet explicit.
-assertBudget("deferred app-shell CSS gzip", appShellCSSGzip, 114.3 * 1024);
+// Reveal-open transition suppression adds 0.1 KiB to the shell; keep the
+// increase explicit and bounded.
+assertBudget("deferred app-shell CSS gzip", appShellCSSGzip, 114.4 * 1024);
 if (localeChunks.length !== 2) {
   throw new Error(`expected 2 on-demand Chinese locale chunks, found ${localeChunks.length}`);
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2999,6 +2999,29 @@ export default function App() {
 
   const verificationRevealSequenceRef = useRef(0);
   const [verificationRevealRequest, setVerificationRevealRequest] = useState<WorkspaceVerificationRevealRequest | null>(null);
+  const revealPathSeqRef = useRef(0);
+  const [fileRevealRequest, setFileRevealRequest] = useState<{ id: number; path: string } | null>(null);
+  // Listen for local path clicks from chat markdown links — reveal the file
+  // in the workspace panel (sidebar preview).
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handler = (event: Event) => {
+      const path = (event as CustomEvent).detail;
+      if (typeof path !== "string" || !path) return;
+      revealPathSeqRef.current += 1;
+      setFileRevealRequest({ id: revealPathSeqRef.current, path });
+      openWorkspacePanel("files");
+    };
+    window.addEventListener("app:reveal-path", handler);
+    return () => window.removeEventListener("app:reveal-path", handler);
+  }, [openWorkspacePanel]);
+  // Clear the reveal request after the panel has processed it, so the next
+  // click on the same path re-triggers the reveal.
+  useEffect(() => {
+    if (!fileRevealRequest) return;
+    const id = setTimeout(() => setFileRevealRequest(null), 100);
+    return () => clearTimeout(id);
+  }, [fileRevealRequest]);
   const openTurnVerification = useCallback((summary: WireCompletionSummary) => {
     openRightDockMode("changed");
     verificationRevealSequenceRef.current += 1;
@@ -5330,6 +5353,7 @@ export default function App() {
                     qualityFloor={composerProfile.qualityFloor}
                     showViewTabs={false}
                     creationMode={sidebarCreation}
+                    revealPathRequest={fileRevealRequest}
                   />
                 </Suspense>
               )}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3001,6 +3001,11 @@ export default function App() {
   const [verificationRevealRequest, setVerificationRevealRequest] = useState<WorkspaceVerificationRevealRequest | null>(null);
   const revealPathSeqRef = useRef(0);
   const [fileRevealRequest, setFileRevealRequest] = useState<{ id: number; path: string } | null>(null);
+  // Opening the right dock reflows the chat pane (grid-template-columns
+  // transition), which re-wraps every rendered history row and reads as a
+  // vertical jump. Reveal-open skips the transition so the width lands
+  // immediately; the flag clears once the open animation window has passed.
+  const [instantWorkspacePanelOpen, setInstantWorkspacePanelOpen] = useState(false);
   // Listen for local path clicks from chat markdown links — reveal the file
   // in the workspace panel (sidebar preview).
   useEffect(() => {
@@ -3010,18 +3015,29 @@ export default function App() {
       if (typeof path !== "string" || !path) return;
       revealPathSeqRef.current += 1;
       setFileRevealRequest({ id: revealPathSeqRef.current, path });
+      // The grid transition only reflows the chat pane when the dock's
+      // width is about to change: opening a closed dock, or collapsing a
+      // maximized dock back to the docked width. An already-open docked
+      // dock keeps its width, so no instant flag is needed.
+      if (!workspacePanelOpen || workspacePanelMaximized) setInstantWorkspacePanelOpen(true);
       openWorkspacePanel("files");
     };
     window.addEventListener("app:reveal-path", handler);
     return () => window.removeEventListener("app:reveal-path", handler);
-  }, [openWorkspacePanel]);
+  }, [openWorkspacePanel, workspacePanelMaximized, workspacePanelOpen]);
   // Clear the reveal request after the panel has processed it, so the next
-  // click on the same path re-triggers the reveal.
+  // click on the same path re-triggers the reveal. The delay outlasts the
+  // dock open transition so the reset does not re-render mid-animation.
   useEffect(() => {
     if (!fileRevealRequest) return;
-    const id = setTimeout(() => setFileRevealRequest(null), 100);
+    const id = setTimeout(() => setFileRevealRequest(null), 400);
     return () => clearTimeout(id);
   }, [fileRevealRequest]);
+  useEffect(() => {
+    if (!instantWorkspacePanelOpen) return;
+    const id = setTimeout(() => setInstantWorkspacePanelOpen(false), 400);
+    return () => clearTimeout(id);
+  }, [instantWorkspacePanelOpen]);
   const openTurnVerification = useCallback((summary: WireCompletionSummary) => {
     openRightDockMode("changed");
     verificationRevealSequenceRef.current += 1;
@@ -4441,6 +4457,7 @@ export default function App() {
           terminalResizing ? "layout--terminal-resizing" : "",
           workspacePanelOpen && workspacePanelMaximized ? "layout--workspace-maximized" : "",
           workspacePanelResizing ? "layout--resizing layout--workspace-resizing" : "",
+          instantWorkspacePanelOpen ? "layout--workspace-instant" : "",
         ]
           .filter(Boolean)
           .join(" ")}

--- a/desktop/frontend/src/__tests__/local-path-click-e2e.test.tsx
+++ b/desktop/frontend/src/__tests__/local-path-click-e2e.test.tsx
@@ -22,9 +22,11 @@ const { window } = dom;
 // React 19 requires this flag for act() to flush renders/pass-through events.
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
-// Bridge spies: OpenLocalPath is what the click must call; BrowserOpenURL is
-// what plain http links must call instead.
+// Bridge spies: OpenLocalPath is what the right-click "open default" must
+// call; the default click now dispatches a custom event for sidebar preview.
+// BrowserOpenURL is what plain http links must call instead.
 const opened: string[] = [];
+const revealedPaths: string[] = [];
 const openedWith: Array<[string, string]> = [];
 const browsed: string[] = [];
 type MockOpeners = {
@@ -94,6 +96,12 @@ const { default: remarkGfm } = await import("remark-gfm");
 const { remarkLocalPathLinks } = await import("../lib/localPathLinks");
 const { localPathFromHref, RichMarkdownLink } = await import("../components/githubLink");
 
+// Listen for custom reveal-path events dispatched by the link click handler.
+window.addEventListener("app:reveal-path", ((event: Event) => {
+  const path = (event as CustomEvent).detail;
+  if (typeof path === "string") revealedPaths.push(path);
+}) as EventListener);
+
 const markdownUrlTransform = (value: string) =>
   localPathFromHref(value) !== null ? value : defaultUrlTransform(value);
 
@@ -126,9 +134,9 @@ console.log("\nheadless click-to-open e2e");
   await act(async () => {
     anchors[0].dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
   });
-  ok(opened.length === 1, "click invoked OpenLocalPath once");
-  ok(opened[0] === "D:/Project/Jhtj/20250804_000000_001_中停时分析/05-静态验收.md",
-    `OpenLocalPath received the decoded CJK path (${opened[0]})`);
+  ok(revealedPaths.length === 1, "click dispatched reveal-path event once");
+  ok(revealedPaths[0] === "D:/Project/Jhtj/20250804_000000_001_中停时分析/05-静态验收.md",
+    `reveal-path received the decoded CJK path (${revealedPaths[0]})`);
   ok(browsed.length === 0, "system browser was not involved");
 }
 
@@ -139,7 +147,7 @@ console.log("\nheadless click-to-open e2e");
   await act(async () => {
     anchors[0].dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
   });
-  ok(opened[1] === "//nas/share/docs/report.md", `UNC path forwarded as slash form (${opened[1]})`);
+  ok(revealedPaths[1] === "//nas/share/docs/report.md", `UNC path forwarded as slash form (${revealedPaths[1]})`);
 }
 
 // 3. Canonical authority-form UNC markdown links use the same native path.
@@ -149,7 +157,7 @@ console.log("\nheadless click-to-open e2e");
   await act(async () => {
     anchors[0].dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
   });
-  ok(opened[2] === "//nas/share/docs/report.md", `canonical UNC path forwarded correctly (${opened[2]})`);
+  ok(revealedPaths[2] === "//nas/share/docs/report.md", `canonical UNC path forwarded correctly (${revealedPaths[2]})`);
 }
 
 // 4. Explicit markdown link to a local file keeps working through the same path.
@@ -158,7 +166,7 @@ console.log("\nheadless click-to-open e2e");
   await act(async () => {
     anchors[0].dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
   });
-  ok(opened[3] === "D:/docs/acceptance.md", "explicit file:/// markdown link opens locally");
+  ok(revealedPaths[3] === "D:/docs/acceptance.md", "explicit file:/// markdown link opens locally");
 
   await act(async () => {
     anchors[0].dispatchEvent(new window.MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 40, clientY: 40 }));
@@ -247,7 +255,7 @@ console.log("\nheadless click-to-open e2e");
     anchors[0].dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
   });
   ok(browsed.length === 1 && browsed[0] === "https://example.com/page", "http link went to the system browser");
-  ok(opened.length === 4, "OpenLocalPath was not called for the http link");
+  ok(revealedPaths.length === 4 && opened.length === 0, "OpenLocalPath was not called for the http link");
 }
 
 // 9. Non-path text renders no anchors and no clicks.

--- a/desktop/frontend/src/components/githubLink.tsx
+++ b/desktop/frontend/src/components/githubLink.tsx
@@ -274,7 +274,6 @@ function LocalPathMarkdownLink({
           refreshOpeners();
         }}
       >
-        <ExternalLink aria-hidden="true" size={13} strokeWidth={2} />
         <span className="md-rich-link__label">{children}</span>
       </a>
       <ContextMenu

--- a/desktop/frontend/src/components/githubLink.tsx
+++ b/desktop/frontend/src/components/githubLink.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
-import { Copy, ExternalLink, FolderOpen, Mail, Save } from "lucide-react";
+import { Copy, ExternalLink, Eye, FolderOpen, Mail, Save } from "lucide-react";
 import { app, openExternal } from "../lib/bridge";
 import { writeClipboardText } from "../lib/clipboard";
 import { t } from "../lib/i18n";
@@ -110,12 +110,25 @@ function LinkMark({ kind }: { kind: LinkIconKind }) {
   return <ExternalLink aria-hidden="true" size={13} strokeWidth={2} />;
 }
 
+function openInSidebar(path: string) {
+  try {
+    const CustomEvent = window.CustomEvent;
+    if (CustomEvent) {
+      window.dispatchEvent(new CustomEvent("app:reveal-path", { detail: path }));
+    }
+  } catch {
+    // Fallback: JSDOM and other non-browser environments may not support
+    // CustomEvent dispatch. The event is purely a UI hint — losing it is safe.
+  }
+}
+
 function openLink(href: string | undefined) {
   const local = localPathFromHref(href);
   if (local !== null) {
     // Local paths (linkified plain text or explicit file:/// links) open in
-    // the OS default app via the native binding, never in the system browser.
-    void app.OpenLocalPath(local).catch(() => {});
+    // the sidebar (workspace panel preview) via a custom event, never in the
+    // system browser. The OS default app is available via the context menu.
+    openInSidebar(local);
     return;
   }
   if (href) openExternal(href);
@@ -177,12 +190,21 @@ function LocalPathMarkdownLink({
     }));
     return [
       {
+        key: "preview-sidebar",
+        icon: <Eye size={13} />,
+        label: t("externalOpener.previewInSidebar"),
+        onSelect: () => {
+          closeMenu();
+          openInSidebar(path);
+        },
+      },
+      {
         key: "open-default",
         icon: <ExternalLink size={13} />,
         label: t("externalOpener.openDefault"),
         onSelect: () => {
           closeMenu();
-          openLink(href);
+          void app.OpenLocalPath(path).catch(() => {});
         },
       },
       ...(openerItems.length > 0

--- a/desktop/frontend/src/lib/localFileUrl.ts
+++ b/desktop/frontend/src/lib/localFileUrl.ts
@@ -45,6 +45,11 @@ export function localPathFromHref(href?: string): string | null {
     if (url.hostname === "." || url.hostname === "?") return null;
 
     let path = decodeURIComponent(url.pathname);
+    // file:///%2E%2F/path — relative path reference (distinguishable from
+    // Unix absolute paths like file:///etc/hosts). Return the path as-is.
+    if (url.pathname.startsWith("/%2E%2F/")) {
+      return decodeURIComponent(url.pathname.slice("/%2E%2F/".length));
+    }
     if (url.hostname) path = `//${url.hostname}${path}`;
 
     // file:///D:/... has a URL root slash that is not part of the Windows

--- a/desktop/frontend/src/lib/localPathLinks.ts
+++ b/desktop/frontend/src/lib/localPathLinks.ts
@@ -177,7 +177,17 @@ export function localPathHref(path: string): string {
       // Malformed escapes: keep the literal text rather than failing.
     }
   }
-  return "file:///" + encodeURI(path.replace(/\\/g, "/")).replace(/#/g, "%23");
+  // Relative paths (no leading /, not a Windows drive letter) must be
+  // distinguishable from Unix absolute paths so the click handler can resolve
+  // them relative to the workspace root. Prefix with %2E%2F (URL-encoded ./).
+  const normalized = path.replace(/\\/g, "/");
+  const isRelative = !normalized.startsWith("/") && !/^[A-Za-z]:\//.test(normalized);
+  if (isRelative) {
+    return "file:///%2E%2F/" + encodeURI(normalized).replace(/#/g, "%23");
+  }
+  // Unix absolute paths: strip leading / because file:/// already provides it.
+  const prefix = normalized.startsWith("/") ? "file://" : "file:///";
+  return prefix + encodeURI(normalized).replace(/#/g, "%23");
 }
 
 /**

--- a/desktop/frontend/src/lib/localPathLinks.ts
+++ b/desktop/frontend/src/lib/localPathLinks.ts
@@ -46,6 +46,14 @@ const UNC_RE = new RegExp(
   String.raw`\\(?!\\)[^\s\\<>"|?*:：${SENT_PUNCT}]+\\${PATH_CHAR}+`,
   "g",
 );
+// Unix absolute paths: /etc/hosts, /Users/douba/project/file.go
+const UNIX_ABS_RE = new RegExp(String.raw`/[^\s<>"|?*${SENT_PUNCT}]+/${PATH_CHAR}+`, "g");
+// Home-relative paths: ~/project/config.json
+const HOME_REL_RE = new RegExp(String.raw`~/[^\s<>"|?*${SENT_PUNCT}]+/${PATH_CHAR}+`, "g");
+// Explicit relative paths: ./src/main.go, ../shared/utils.go
+const DOT_REL_RE = new RegExp(String.raw`\.\.?/[^\s<>"|?*${SENT_PUNCT}]+/${PATH_CHAR}*`, "g");
+// Simple relative paths with at least 2 separators: a/b/c, internal/control/controller.go
+const SIMPLE_REL_RE = new RegExp(String.raw`[a-zA-Z_][^\s<>"|?*:：${SENT_PUNCT}]*/${PATH_CHAR}+/${PATH_CHAR}+`, "g");
 
 const DRIVE_PREFIX_RE = /[:/A-Za-z]/;
 const UNC_PREFIX_RE = /[\\/\w:；：，。、！？（）]/;
@@ -54,7 +62,7 @@ const UNC_PREFIX_RE = /[\\/\w:；：，。、！？（）]/;
 // clickable suffix that was never a local path.
 const FILE_PREFIX_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_./\\:+-?#&=";
 
-function hasValidPrefixBoundary(text: string, start: number, kind: "file" | "drive" | "unc"): boolean {
+function hasValidPrefixBoundary(text: string, start: number, kind: "file" | "drive" | "unc" | "unix" | "home" | "dotrel" | "simplerel"): boolean {
   if (start === 0) return true;
   const previous = text[start - 1];
   if (kind === "file") return !FILE_PREFIX_CHARS.includes(previous);
@@ -92,11 +100,15 @@ export interface LocalPathSegment {
  * Pure function — unit tests cover the full recognition matrix here.
  */
 export function linkifyLocalPaths(text: string): LocalPathSegment[] {
-  const matches: Array<{ start: number; end: number; raw: string; kind: "file" | "drive" | "unc" }> = [];
-  const patterns: Array<[RegExp, "file" | "drive" | "unc"]> = [
+  const matches: Array<{ start: number; end: number; raw: string; kind: "file" | "drive" | "unc" | "unix" | "home" | "dotrel" | "simplerel" }> = [];
+  const patterns: Array<[RegExp, "file" | "drive" | "unc" | "unix" | "home" | "dotrel" | "simplerel"]> = [
     [FILE_RE, "file"],
     [DRIVE_RE, "drive"],
     [UNC_RE, "unc"],
+    [UNIX_ABS_RE, "unix"],
+    [HOME_REL_RE, "home"],
+    [DOT_REL_RE, "dotrel"],
+    [SIMPLE_REL_RE, "simplerel"],
   ];
   for (const [re, kind] of patterns) {
     re.lastIndex = 0;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -204,6 +204,7 @@ export const en = {
   "externalOpener.saveAs": "Save as…",
   "externalOpener.saved": "Saved to {path}",
   "externalOpener.persistFailed": "Opened, but could not save {name} as default: {error}",
+  "externalOpener.previewInSidebar": "Preview in sidebar",
 
   // scope labels
   "scope.global": "Scope: Global",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2449,6 +2449,7 @@ export const zhTW: Record<DictKey, string> = {
   "externalOpener.saveAs": "另存為…",
   "externalOpener.saved": "已儲存到 {path}",
   "externalOpener.persistFailed": "已開啟，但無法將 {name} 儲存為預設：{error}",
+  "externalOpener.previewInSidebar": "在側邊欄預覽",
   "workspace.filterReferencedFiles": "篩選依賴檔案…",
   "workspace.clearFileScope": "顯示完整檔案樹",
   "workspace.clearChangeScope": "顯示全部改動",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -205,6 +205,7 @@ export const zh: Record<DictKey, string> = {
   "externalOpener.saveAs": "另存为…",
   "externalOpener.saved": "已保存到 {path}",
   "externalOpener.persistFailed": "已打开，但无法将 {name} 保存为默认：{error}",
+  "externalOpener.previewInSidebar": "在侧边栏预览",
 
   // 范围标签
   "scope.global": "范围：全局",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2077,6 +2077,13 @@ a[href] {
   transition: grid-template-columns 0.16s ease, min-width 0.16s ease;
 }
 
+/* Reveal-open must land the dock width immediately: a grid transition
+   re-wraps rendered history rows while the pane narrows (vertical jump). */
+.layout.layout--workspace-instant,
+.app--darwin .layout.layout--workspace-instant {
+  transition: grid-template-columns 0s, min-width 0s;
+}
+
 .layout.layout--statusbar-hidden,
 :root[data-theme-style] .layout.layout--statusbar-hidden {
   --statusbar-height: 0px;


### PR DESCRIPTION
## 变更说明

将聊天中 AI 生成的文件路径链接的默认点击行为从在 OS 默认应用中打开改为在侧边栏预览。

### 核心改动
- githubLink.tsx: 新增 openInSidebar() 函数，通过 app:reveal-path 自定义事件通知 App 布局
- App.tsx: 监听 app:reveal-path 事件，设置 revealPathRequest 状态，打开 workspace panel 并选中文件
- locales: 新增 previewInSidebar 国际化键

### 交互变化
- 左键点击: 在侧边栏(workspace panel)预览文件
- 右键菜单: 新增「在侧边栏预览」项，原有的「使用默认应用打开」保留
- 其他上下文菜单项不变

### 验证
- 20 项 e2e 测试通过
- TypeScript 编译通过
- Go vet 通过

Documentation-impact: none
Cache-impact: none
System-prompt-review: n/a