### PR TITLE
feat: cache the automation panel's open detail across view switches / 自动化面板详情打开状态缓存

### DIFF
--- a/desktop/frontend/scripts/run-tests.mjs
+++ b/desktop/frontend/scripts/run-tests.mjs
@@ -74,7 +74,7 @@ for (const [name, owner] of OWNED_ELSEWHERE) {
 
 // Suites that statically import CSS (e.g. HeartbeatPanel's heartbeat.css) need
 // the css-stub loader hook so tsx resolves the import under node.
-const CSS_STUB_SUITES = new Set(["heartbeat-editor.test.tsx", "heartbeat-next-run.test.ts"]);
+const CSS_STUB_SUITES = new Set(["heartbeat-editor.test.tsx", "heartbeat-next-run.test.ts", "heartbeat-detail-cache.test.tsx"]);
 
 const suites = files.filter((name) => !OWNED_ELSEWHERE.has(name));
 console.log(`run-tests: ${suites.length} discovered suites (${OWNED_ELSEWHERE.size} owned by dedicated scripts)`);

--- a/desktop/frontend/scripts/run-tests.mjs
+++ b/desktop/frontend/scripts/run-tests.mjs
@@ -74,7 +74,7 @@ for (const [name, owner] of OWNED_ELSEWHERE) {
 
 // Suites that statically import CSS (e.g. HeartbeatPanel's heartbeat.css) need
 // the css-stub loader hook so tsx resolves the import under node.
-const CSS_STUB_SUITES = new Set(["heartbeat-editor.test.tsx", "heartbeat-next-run.test.ts", "heartbeat-detail-cache.test.tsx"]);
+const CSS_STUB_SUITES = new Set(["heartbeat-editor.test.tsx", "heartbeat-next-run.test.ts", "heartbeat-detail-cache.test.tsx", "heartbeat-filter-cache.test.tsx"]);
 
 const suites = files.filter((name) => !OWNED_ELSEWHERE.has(name));
 console.log(`run-tests: ${suites.length} discovered suites (${OWNED_ELSEWHERE.size} owned by dedicated scripts)`);

--- a/desktop/frontend/src/__tests__/heartbeat-detail-cache.test.tsx
+++ b/desktop/frontend/src/__tests__/heartbeat-detail-cache.test.tsx
@@ -1,0 +1,274 @@
+// Run: node --import ./scripts/css-stub-register.mjs --import tsx src/__tests__/heartbeat-detail-cache.test.tsx
+
+import { JSDOM } from "jsdom";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { HeartbeatView } from "../custom/features/heartbeat/HeartbeatPanel";
+import type { HeartbeatTask } from "../custom/features/heartbeat/heartbeat.types";
+import { LocaleProvider } from "../lib/i18n";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: unknown, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find((item) => item.textContent?.trim() === label);
+}
+
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+// 模拟真实 webview：localStorage 可用（HeartbeatPanel 内部读写详情缓存）
+globalThis.localStorage = dom.window.localStorage;
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+globalThis.Node = dom.window.Node;
+globalThis.Element = dom.window.Element;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;
+globalThis.HTMLInputElement = dom.window.HTMLInputElement;
+globalThis.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
+globalThis.Event = dom.window.Event;
+globalThis.MouseEvent = dom.window.MouseEvent;
+globalThis.ResizeObserver = NoopResizeObserver as unknown as typeof ResizeObserver;
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+
+let backendTasks: HeartbeatTask[] = [
+  {
+    id: "task-1",
+    title: "Cached detail task",
+    prompt: "prompt",
+    interval: "30m",
+    enabled: true,
+    createdAt: 1,
+  },
+  {
+    id: "task-2",
+    title: "Another task",
+    prompt: "prompt",
+    interval: "1h",
+    enabled: false,
+    createdAt: 2,
+  },
+];
+// 可控延迟的 ReloadConfig：模拟初始加载慢（Codex P1 竞态）
+let reloadGate: Promise<void> | null = null;
+let releaseReload: (() => void) | null = null;
+function gateReload() {
+  reloadGate = new Promise((resolve) => { releaseReload = resolve; });
+}
+function releaseReloadGate() {
+  releaseReload?.();
+  reloadGate = null;
+}
+Object.assign(window, {
+  go: {
+    main: {
+      App: {
+        async HeartbeatReloadConfig() {
+          if (reloadGate) await reloadGate;
+          return { revision: 1, etag: "test", tasks: backendTasks };
+        },
+        async HeartbeatSaveConfig(update: { tasks?: HeartbeatTask[] }) {
+          backendTasks = update.tasks ?? [];
+          return { revision: 2, etag: "saved", tasks: backendTasks };
+        },
+        async HeartbeatTriggerNow() {},
+        async HeartbeatGenerateID() { return "draft-1"; },
+        async ListWorkspaces() { return []; },
+      },
+    },
+  },
+});
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("missing root");
+const root = createRoot(rootElement);
+
+function renderView() {
+  root.render(
+    <LocaleProvider>
+      <HeartbeatView />
+    </LocaleProvider>,
+  );
+}
+
+// 模拟 App 条件渲染：mainView 从 automation 切走时 HeartbeatView 卸载（root 保留），
+// 切回时重新挂载。用 root.render(null) 卸载组件树而不是销毁 root。
+function unmountView() {
+  root.render(null);
+}
+
+console.log("\nheartbeat detail cache");
+
+// 1. 打开任务详情 → 写入缓存
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+await act(async () => {
+  document.querySelector<HTMLDivElement>(".worktree-node--task")?.click();
+  await flush();
+  await flush();
+});
+ok(document.querySelector<HTMLInputElement>('[aria-label="Title"]')?.value === "Cached detail task", "clicking a task opens its detail editor");
+ok(localStorage.getItem("reasonix-heartbeat-detail")?.includes("task-1") === true, "opening a detail writes the open-state cache");
+
+// 2. 卸载后重新挂载（模拟切换对话再回到自动化面板）→ 详情自动恢复
+await act(async () => { unmountView(); await flush(); });
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+ok(document.querySelector<HTMLInputElement>('[aria-label="Title"]')?.value === "Cached detail task", "detail reopens from cache after remount without a click");
+ok(document.querySelector(".heartbeat-split__right") != null, "detail panel is visible after remount");
+
+// 3. 关闭详情 → 清除缓存 → 再挂载不恢复
+await act(async () => {
+  document.querySelector<HTMLButtonElement>(".heartbeat-editor__close")?.click();
+  await flush();
+});
+ok(localStorage.getItem("reasonix-heartbeat-detail") == null, "closing the detail clears the cache");
+await act(async () => { unmountView(); await flush(); });
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+ok(document.querySelector(".heartbeat-split__right") == null, "no detail restore when the cache was cleared");
+
+// 4. 缓存指向已删除任务 → 不恢复
+await act(async () => {
+  localStorage.setItem("reasonix-heartbeat-detail", JSON.stringify({ open: true, taskId: "ghost-task" }));
+  unmountView();
+  await flush();
+});
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+ok(document.querySelector(".heartbeat-split__right") == null, "stale cache for a deleted task does not restore a detail");
+ok(document.body.textContent?.includes("Select a task to view details") !== true, "stale cache leaves the panel in the list-only state");
+
+// 5. Codex P1：加载慢时用户先打开草稿，恢复回调不得覆盖草稿
+localStorage.setItem("reasonix-heartbeat-detail", JSON.stringify({ open: true, taskId: "task-1" }));
+gateReload();
+await act(async () => {
+  unmountView();
+  renderView();
+  await flush();
+});
+await act(async () => {
+  // 加载未完成时点开建议草稿（工具条/建议区在 loading 期间仍可交互）
+  document.querySelector<HTMLButtonElement>(".heartbeat-suggestion")?.click();
+  await flush();
+});
+await act(async () => {
+  releaseReloadGate();
+  await flush();
+  await flush();
+});
+ok(document.querySelector<HTMLInputElement>('[aria-label="Title"]')?.value === "Daily review", "a draft opened during slow load is not overwritten by cache restoration");
+ok(localStorage.getItem("reasonix-heartbeat-detail")?.includes("task-1") === true, "blocked restore leaves the existing cache untouched");
+
+// 6. Codex P2：新建任务保存后缓存指向新任务，切走再回来恢复它
+await act(async () => {
+  unmountView();
+  renderView();
+  await flush();
+  await flush();
+});
+await act(async () => {
+  document.querySelector<HTMLDivElement>(".worktree-node--task")?.click();
+  await flush();
+  await flush();
+});
+ok(localStorage.getItem("reasonix-heartbeat-detail")?.includes("task-1") === true, "opening a task again re-caches it");
+// 建议区草稿预填 title+prompt，无需模拟受控输入即可保存
+await act(async () => {
+  document.querySelector<HTMLButtonElement>(".heartbeat-suggestion")?.click();
+  await flush();
+  await flush();
+});
+ok(document.querySelector<HTMLInputElement>('[aria-label="Title"]')?.value === "Daily review", "suggestion draft opens with a prefilled title");
+await act(async () => {
+  button("Save")?.click();
+  await flush();
+  await flush();
+});
+ok(localStorage.getItem("reasonix-heartbeat-detail")?.includes("draft-1") === true, "saving a new draft updates the cache to the new task id");
+await act(async () => { unmountView(); await flush(); });
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+ok(document.querySelector<HTMLInputElement>('[aria-label="Title"]')?.value === "Daily review", "remount restores the newly saved task instead of the previously opened one");
+
+// 7. Codex P2：搜索过滤隐式关闭编辑器时清除缓存
+// jsdom 下 dispatchEvent 不驱动 React 19 受控组件的 onChange，直接调用
+// React 绑定的 onChange prop（测试环境锁定 React 19，内部属性稳定）。
+function typeInto(el: Element | null, value: string) {
+  if (!el) return;
+  const key = Object.keys(el).find((k) => k.startsWith("__reactProps"));
+  const props = (el as unknown as Record<string, { onChange?: (e: { target: { value: string } }) => void }>)[key ?? ""];
+  props?.onChange?.({ target: { value } });
+}
+await act(async () => {
+  unmountView();
+  renderView();
+  await flush();
+  await flush();
+});
+await act(async () => {
+  document.querySelector<HTMLDivElement>(".worktree-node--task")?.click();
+  await flush();
+  await flush();
+});
+ok(localStorage.getItem("reasonix-heartbeat-detail")?.includes("task-1") === true, "task detail is cached again for the filter scenario");
+await act(async () => {
+  typeInto(document.querySelector<HTMLInputElement>(".heartbeat-list-search__input"), "zzz-no-match");
+  await flush();
+  await flush();
+});
+ok(document.querySelector('[aria-label="Title"]') == null, "filtering out the edited task closes its editor");
+ok(localStorage.getItem("reasonix-heartbeat-detail") == null, "implicit editor close clears the cache");
+await act(async () => { unmountView(); await flush(); });
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+ok(document.querySelector(".heartbeat-split__right") == null, "no restore after the filtered-out task was deselected");
+
+await act(async () => root.unmount());
+dom.window.close();
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/heartbeat-detail-cache.test.tsx
+++ b/desktop/frontend/src/__tests__/heartbeat-detail-cache.test.tsx
@@ -267,6 +267,41 @@ await act(async () => {
 });
 ok(document.querySelector(".heartbeat-split__right") == null, "no restore after the filtered-out task was deselected");
 
+// 8. 删除当前编辑的任务 → 清除缓存 + 关闭详情
+await act(async () => { unmountView(); await flush(); });
+// #7 遗留的搜索词（zzz-no-match）会过滤掉全部任务，先清掉以便点击任务
+localStorage.removeItem("reasonix-heartbeat-filter");
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+await act(async () => {
+  document.querySelector<HTMLDivElement>(".worktree-node--task")?.click();
+  await flush();
+  await flush();
+});
+ok(localStorage.getItem("reasonix-heartbeat-detail")?.includes("task-1") === true, "task detail is cached before deleting");
+await act(async () => {
+  // 删除需二次确认：首次点击进入确认态，再次点击真正删除
+  document.querySelector<HTMLButtonElement>(".heartbeat-editor__header-action--danger")?.click();
+  await flush();
+});
+await act(async () => {
+  document.querySelector<HTMLButtonElement>(".heartbeat-editor__header-action--danger")?.click();
+  await flush();
+  await flush();
+});
+ok(localStorage.getItem("reasonix-heartbeat-detail") == null, "deleting the edited task clears the cache");
+ok(document.querySelector(".heartbeat-split__right") == null, "detail closes after deleting the edited task");
+await act(async () => { unmountView(); await flush(); });
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+ok(document.querySelector(".heartbeat-split__right") == null, "no detail restore after the cached task was deleted");
+
 await act(async () => root.unmount());
 dom.window.close();
 

--- a/desktop/frontend/src/__tests__/heartbeat-filter-cache.test.tsx
+++ b/desktop/frontend/src/__tests__/heartbeat-filter-cache.test.tsx
@@ -1,0 +1,224 @@
+// Run: node --import ./scripts/css-stub-register.mjs --import tsx src/__tests__/heartbeat-filter-cache.test.tsx
+
+import { JSDOM } from "jsdom";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { HeartbeatView } from "../custom/features/heartbeat/HeartbeatPanel";
+import type { HeartbeatTask } from "../custom/features/heartbeat/heartbeat.types";
+import { LocaleProvider } from "../lib/i18n";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: unknown, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find((item) => item.textContent?.trim() === label);
+}
+
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+// 模拟真实 webview：localStorage 可用（HeartbeatPanel 内部读写过滤/详情缓存）
+globalThis.localStorage = dom.window.localStorage;
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+globalThis.Node = dom.window.Node;
+globalThis.Element = dom.window.Element;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;
+globalThis.HTMLInputElement = dom.window.HTMLInputElement;
+globalThis.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
+globalThis.Event = dom.window.Event;
+globalThis.MouseEvent = dom.window.MouseEvent;
+globalThis.ResizeObserver = NoopResizeObserver as unknown as typeof ResizeObserver;
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+
+let backendTasks: HeartbeatTask[] = [
+  {
+    id: "task-1",
+    title: "Daily review",
+    prompt: "prompt",
+    interval: "30m",
+    enabled: true,
+    createdAt: 1,
+  },
+  {
+    id: "task-2",
+    title: "Weekly report",
+    prompt: "prompt",
+    interval: "1h",
+    enabled: false,
+    createdAt: 2,
+  },
+];
+Object.assign(window, {
+  go: {
+    main: {
+      App: {
+        async HeartbeatReloadConfig() {
+          return { revision: 1, etag: "test", tasks: backendTasks };
+        },
+        async HeartbeatSaveConfig(update: { tasks?: HeartbeatTask[] }) {
+          backendTasks = update.tasks ?? [];
+          return { revision: 2, etag: "saved", tasks: backendTasks };
+        },
+        async HeartbeatTriggerNow() {},
+        async HeartbeatGenerateID() { return "draft-1"; },
+        async ListWorkspaces() { return []; },
+      },
+    },
+  },
+});
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("missing root");
+const root = createRoot(rootElement);
+
+function renderView() {
+  root.render(
+    <LocaleProvider>
+      <HeartbeatView />
+    </LocaleProvider>,
+  );
+}
+
+// 模拟 App 条件渲染：mainView 从 automation 切走时 HeartbeatView 卸载（root 保留），
+// 切回时重新挂载。用 root.render(null) 卸载组件树而不是销毁 root。
+function unmountView() {
+  root.render(null);
+}
+
+// jsdom 下 dispatchEvent 不驱动 React 19 受控组件的 onChange，直接调用
+// React 绑定的 onChange prop（测试环境锁定 React 19，内部属性稳定）。
+function typeInto(el: Element | null, value: string) {
+  if (!el) return;
+  const key = Object.keys(el).find((k) => k.startsWith("__reactProps"));
+  const props = (el as unknown as Record<string, { onChange?: (e: { target: { value: string } }) => void }>)[key ?? ""];
+  props?.onChange?.({ target: { value } });
+}
+
+console.log("\nheartbeat filter cache");
+
+localStorage.removeItem("reasonix-heartbeat-filter");
+localStorage.removeItem("reasonix-heartbeat-detail");
+
+// 1. 输入搜索词 → 写入过滤缓存，列表被过滤
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+await act(async () => {
+  typeInto(document.querySelector<HTMLInputElement>(".heartbeat-list-search__input"), "daily");
+  await flush();
+});
+let filterCache = JSON.parse(localStorage.getItem("reasonix-heartbeat-filter") ?? "{}");
+ok(filterCache.searchQuery === "daily", "typing a search query writes the filter cache");
+ok(document.querySelectorAll(".worktree-node--task").length === 1, "search filters the list to the matching task");
+
+// 2. 卸载后重新挂载（模拟切换对话再回到自动化面板）→ 搜索词恢复，列表仍被过滤
+await act(async () => { unmountView(); await flush(); });
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+ok(document.querySelector<HTMLInputElement>(".heartbeat-list-search__input")?.value === "daily", "search query restores from cache after remount");
+ok(document.body.textContent?.includes("Weekly report") === false, "remounted list is still filtered by the restored query");
+
+// 3. 清空搜索 → 缓存更新为空 → 再挂载不恢复旧词
+await act(async () => {
+  typeInto(document.querySelector<HTMLInputElement>(".heartbeat-list-search__input"), "");
+  await flush();
+});
+filterCache = JSON.parse(localStorage.getItem("reasonix-heartbeat-filter") ?? "{}");
+ok(filterCache.searchQuery === "", "clearing the search writes the empty query to cache");
+await act(async () => { unmountView(); await flush(); });
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+ok(document.querySelector<HTMLInputElement>(".heartbeat-list-search__input")?.value === "", "no stale search query after clearing");
+
+// 4. 切换状态筛选（Paused）→ 写缓存 → 重挂载恢复
+await act(async () => {
+  button("Paused")?.click();
+  await flush();
+});
+filterCache = JSON.parse(localStorage.getItem("reasonix-heartbeat-filter") ?? "{}");
+ok(filterCache.statusFilter === "disabled", "switching the status filter writes the filter cache");
+ok(document.querySelectorAll(".worktree-node--task").length === 1, "status filter hides enabled tasks");
+await act(async () => { unmountView(); await flush(); });
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+ok(document.querySelector<HTMLButtonElement>('[role="tab"][aria-selected="true"]')?.textContent?.trim() === "Paused", "status filter restores from cache after remount");
+ok(document.body.textContent?.includes("Daily review") === false, "remounted list respects the restored status filter");
+
+// 5. scopeFilter 恢复：缓存含项目范围筛选时重挂载恢复（flat 视图下下拉按钮文本）
+await act(async () => { unmountView(); await flush(); });
+localStorage.setItem("reasonix-heartbeat-filter", JSON.stringify({ searchQuery: "", statusFilter: "all", scopeFilter: "global" }));
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+await act(async () => {
+  // 默认 grouped 视图无范围下拉，切到 flat 视图后可见
+  document.querySelector<HTMLButtonElement>(".heartbeat-toolbar__btn--icon")?.click();
+  await flush();
+});
+ok(document.querySelector<HTMLButtonElement>(".heartbeat-toolbar__btn--select")?.textContent?.trim() === "Global", "scope filter restores from cache after remount");
+
+// 6. 组合：恢复的搜索词过滤掉缓存详情任务 → 详情被关闭（而非展示被过滤的任务）
+await act(async () => { unmountView(); await flush(); });
+localStorage.setItem("reasonix-heartbeat-detail", JSON.stringify({ open: true, taskId: "task-1" }));
+localStorage.setItem("reasonix-heartbeat-filter", JSON.stringify({ searchQuery: "zzz-no-match", statusFilter: "all", scopeFilter: "all" }));
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+ok(document.querySelector<HTMLInputElement>(".heartbeat-list-search__input")?.value === "zzz-no-match", "search query restores alongside the detail cache");
+ok(document.querySelector('[aria-label="Title"]') == null, "editor is closed when the restored query filters out the cached task");
+ok(localStorage.getItem("reasonix-heartbeat-detail") == null, "implicit editor close clears the detail cache");
+ok(document.body.textContent?.includes("No matching tasks") === true, "restored query leaves the list in the no-match state");
+await act(async () => { unmountView(); await flush(); });
+await act(async () => {
+  renderView();
+  await flush();
+  await flush();
+});
+ok(document.querySelector(".heartbeat-split__right") == null, "no detail restore after the filtered-out task was deselected");
+
+await act(async () => root.unmount());
+dom.window.close();
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
+++ b/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
@@ -80,15 +80,47 @@ function writeDetailCache(cache: DetailCache | null) {
   }
 }
 
+// 过滤状态缓存：搜索词/状态筛选/范围筛选在切换对话或视图导致面板 unmount
+// 后重新进入时恢复（与详情缓存 reasonix-heartbeat-detail 同一模式）。
+const FILTER_CACHE_KEY = "reasonix-heartbeat-filter";
+
+interface FilterCache {
+  searchQuery: string;
+  statusFilter: "all" | "enabled" | "disabled";
+  scopeFilter: string;
+}
+
+function readFilterCache(): FilterCache | null {
+  try {
+    const raw = localStorage.getItem(FILTER_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as FilterCache;
+    if (typeof parsed.searchQuery !== "string") return null;
+    if (parsed.statusFilter !== "all" && parsed.statusFilter !== "enabled" && parsed.statusFilter !== "disabled") return null;
+    if (typeof parsed.scopeFilter !== "string") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeFilterCache(cache: FilterCache) {
+  try {
+    localStorage.setItem(FILTER_CACHE_KEY, JSON.stringify(cache));
+  } catch {
+    // Storage may be unavailable in hardened webviews; in-memory state still works.
+  }
+}
+
 export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
   const t = useHeartbeatT();
   const [tasks, setTasks] = useState<HeartbeatTask[]>([]);
   const [loading, setLoading] = useState(false);
   const [mutationError, setMutationError] = useState(false);
   const [editing, setEditing] = useState<HeartbeatTask | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState<"all" | "enabled" | "disabled">("all");
-  const [scopeFilter, setScopeFilter] = useState<string>("all");
+  const [searchQuery, setSearchQuery] = useState(() => readFilterCache()?.searchQuery ?? "");
+  const [statusFilter, setStatusFilter] = useState<"all" | "enabled" | "disabled">(() => readFilterCache()?.statusFilter ?? "all");
+  const [scopeFilter, setScopeFilter] = useState<string>(() => readFilterCache()?.scopeFilter ?? "all");
   const [scopeFilterOpen, setScopeFilterOpen] = useState(false);
   const scopeFilterRef = useRef<HTMLButtonElement>(null);
   const [expandedProjects, setExpandedProjects] = useState<Set<string> | null>(null);
@@ -238,8 +270,6 @@ export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
   useEffect(() => {
     restoreBlockedRef.current = false;
     setEditing(null);
-    setSearchQuery("");
-    setStatusFilter("all");
     void loadTasks().then((taskList) => {
       if (!taskList || restoreBlockedRef.current) return;
       // 恢复上次查看的详情：切换对话/视图导致面板 unmount 后重新进入时，
@@ -253,6 +283,12 @@ export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
       }
     });
   }, [loadTasks]);
+
+  // 过滤状态变化时写缓存（首次渲染写入恢复值，幂等）。切换对话/视图导致
+  // 面板 unmount 后重新挂载时，搜索词与筛选条件从缓存恢复。
+  useEffect(() => {
+    writeFilterCache({ searchQuery, statusFilter, scopeFilter });
+  }, [searchQuery, statusFilter, scopeFilter]);
 
   // Clear editing when the edited task is no longer in the filtered list.
   // Unsaved drafts (created via Add/scoped-Add/startNew) are not yet in

--- a/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
+++ b/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
@@ -65,7 +65,7 @@ function readDetailCache(): DetailCache | null {
     const raw = localStorage.getItem(DETAIL_CACHE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as DetailCache;
-    return parsed && typeof parsed.taskId === "string" ? parsed : null;
+    return parsed && typeof parsed.taskId === "string" && typeof parsed.open === "boolean" ? parsed : null;
   } catch {
     return null;
   }

--- a/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
+++ b/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
@@ -51,6 +51,35 @@ interface HeartbeatPanelProps {
   onOpenTopic?: (scope: string, workspaceRoot: string, topicId: string) => void;
 }
 
+// 详情打开状态缓存：切换对话/视图导致面板 unmount 后，重新进入时恢复上次
+// 查看的任务详情（与列表宽度缓存 reasonix-heartbeat-list-width 同一模式）。
+const DETAIL_CACHE_KEY = "reasonix-heartbeat-detail";
+
+interface DetailCache {
+  open: boolean;
+  taskId: string;
+}
+
+function readDetailCache(): DetailCache | null {
+  try {
+    const raw = localStorage.getItem(DETAIL_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as DetailCache;
+    return parsed && typeof parsed.taskId === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeDetailCache(cache: DetailCache | null) {
+  try {
+    if (cache) localStorage.setItem(DETAIL_CACHE_KEY, JSON.stringify(cache));
+    else localStorage.removeItem(DETAIL_CACHE_KEY);
+  } catch {
+    // Storage may be unavailable in hardened webviews; in-memory state still works.
+  }
+}
+
 export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
   const t = useHeartbeatT();
   const [tasks, setTasks] = useState<HeartbeatTask[]>([]);
@@ -80,6 +109,9 @@ export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
     }
   });
   const dirtyRef = useRef(false);
+  // 加载慢时用户可能先打开草稿/其他任务：置位后跳过挂载时的缓存恢复，
+  // 避免延迟完成的恢复回调覆盖用户已打开的编辑器（Codex P1）。
+  const restoreBlockedRef = useRef(false);
   // IDs of drafts created via Add/scoped-Add/startNew that have not been saved yet.
   // They are intentionally absent from `tasks`, so the "clear editing" effect
   // below must not close the editor for them.
@@ -204,10 +236,22 @@ export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
   }, []);
 
   useEffect(() => {
+    restoreBlockedRef.current = false;
     setEditing(null);
     setSearchQuery("");
     setStatusFilter("all");
-    void loadTasks();
+    void loadTasks().then((taskList) => {
+      if (!taskList || restoreBlockedRef.current) return;
+      // 恢复上次查看的详情：切换对话/视图导致面板 unmount 后重新进入时，
+      // 重新打开之前缓存的任务。任务已不存在（被删除）时不恢复。
+      const cached = readDetailCache();
+      if (!cached?.open || !cached.taskId) return;
+      const task = taskList.find((t) => t.id === cached.taskId);
+      if (task) {
+        setEditing({ ...task });
+        setDetailOpen(true);
+      }
+    });
   }, [loadTasks]);
 
   // Clear editing when the edited task is no longer in the filtered list.
@@ -218,18 +262,20 @@ export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
     if (!editing) return;
     if (unsavedDraftIdsRef.current.has(editing.id)) return;
     // 过滤变化导致编辑任务不可见时，直接关闭（丢弃未保存修改）。
-    const closeIfNotDirty = () => {
+    // 隐式关闭同样要清除缓存，否则切走再回来会恢复已被取消选中的任务（Codex P2）。
+    const closeEditor = () => {
       dirtyRef.current = false;
-      return true;
+      setEditing(null);
+      writeDetailCache(null);
     };
     const match = tasks.find(t => t.id === editing.id);
-    if (!match) { if (closeIfNotDirty()) setEditing(null); return; }
+    if (!match) { closeEditor(); return; }
     // 状态筛选切换（全部↔已开启↔已暂停）不关闭已打开的详情——右侧详情跟随任务，
     // 与左侧列表筛选解耦（用户明确要求：已激活任务的详情不受筛选影响）。
-    if (searchQuery && !match.title.toLowerCase().includes(searchQuery.toLowerCase())) { if (closeIfNotDirty()) setEditing(null); return; }
+    if (searchQuery && !match.title.toLowerCase().includes(searchQuery.toLowerCase())) { closeEditor(); return; }
     // 与列表过滤一致：scopeFilter 过滤掉正在编辑的任务时关闭编辑器。
-    if (scopeFilter === "global" && (match.scope === "project" && match.workspaceRoot)) { if (closeIfNotDirty()) setEditing(null); return; }
-    if (scopeFilter !== "all" && scopeFilter !== "global" && (match.scope !== "project" || match.workspaceRoot !== scopeFilter)) { if (closeIfNotDirty()) setEditing(null); }
+    if (scopeFilter === "global" && (match.scope === "project" && match.workspaceRoot)) { closeEditor(); return; }
+    if (scopeFilter !== "all" && scopeFilter !== "global" && (match.scope !== "project" || match.workspaceRoot !== scopeFilter)) { closeEditor(); }
   }, [tasks, editing?.id, statusFilter, searchQuery, scopeFilter, t]);
 
   const save = useCallback(
@@ -252,6 +298,7 @@ export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
   );
 
   const openUnsavedDraft = useCallback((task: HeartbeatTask) => {
+    restoreBlockedRef.current = true;
     unsavedDraftIdsRef.current.add(task.id);
     setEditing(task);
     setDetailOpen(true);
@@ -328,9 +375,11 @@ export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
   const handleEdit = useCallback((task: HeartbeatTask) => {
     // 分栏模式下切换任务直接丢弃当前编辑器未保存改动（ChatGPT 式，不确认）。
     dirtyRef.current = false;
+    restoreBlockedRef.current = true;
     unsavedDraftIdsRef.current.delete(task.id);
     setEditing({ ...task });
     setDetailOpen(true);
+    writeDetailCache({ open: true, taskId: task.id });
   }, []);
 
   // 列表行点击状态图标切换任务启用/暂停（即时保存）
@@ -392,6 +441,9 @@ export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
       // The draft is now persisted; stop treating it as an unsaved draft.
       unsavedDraftIdsRef.current.delete(task.id);
       setEditing({ ...(saved.find((item) => item.id === task.id) ?? persisted) });
+      // 保存后编辑器仍打开该任务：缓存指向它，新建任务保存后切走再回来
+      // 恢复的是当前打开的 B 而不是之前的 A（Codex P2）。
+      writeDetailCache({ open: true, taskId: task.id });
       return true;
     },
     [save],
@@ -911,9 +963,10 @@ export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
                   if (deleted) {
                     setEditing(null);
                     setDetailOpen(false);
+                    writeDetailCache(null);
                   }
                   return deleted;
-                }} onCloseDetail={() => { setDetailOpen(false); }} onDirtyChange={(d) => { dirtyRef.current = d; }} onOpenTopic={onOpenTopic} onTrigger={handleTrigger} />
+                }} onCloseDetail={() => { setDetailOpen(false); writeDetailCache(null); }} onDirtyChange={(d) => { dirtyRef.current = d; }} onOpenTopic={onOpenTopic} onTrigger={handleTrigger} />
               ) : (
                 <div className="heartbeat-split__empty">
                   <div className="heartbeat-split__empty-inner">


### PR DESCRIPTION
## Summary

自动化任务面板（Heartbeat）的查看状态目前不持久化：切换对话/视图导致面板 unmount 后，重新进入时回到初始态。本 PR 将两类状态缓存到 localStorage，切换对话再回到自动化面板时自动恢复：

1. **详情打开状态**（`reasonix-heartbeat-detail`，存 `{open, taskId}`）：恢复上次查看的任务详情（与面板已有列表宽度缓存 `reasonix-heartbeat-list-width` 同一模式）
2. **搜索/筛选状态**（`reasonix-heartbeat-filter`，存 `{searchQuery, statusFilter, scopeFilter}`）：恢复搜索词、状态筛选（全部/已开启/已暂停）、范围筛选，列表仍按恢复条件过滤

关键行为：
- 打开任务详情 / 输入搜索词 / 切换筛选 → 写入缓存（详情从磁盘最新数据恢复，而非过期快照）
- 面板因条件渲染（`mainView === "automation"`）卸载后再挂载 → 自动恢复上次的详情与过滤状态
- 关闭详情 / 删除当前任务 / 隐式关闭（过滤掉编辑中任务）→ 清除对应缓存；缓存指向的任务已不存在（被删除）时不恢复
- 恢复的搜索词过滤掉缓存详情任务时，编辑器关闭并清除详情缓存（复用既有 clear-editing 逻辑），不会展示被过滤任务
- 新建草稿（Add / 建议区）不写缓存，恢复无意义

## Issues

任务看板 issue R87850A56D62-8（自动化面板需要缓存更多内容，比如说搜索的状态），非 GitHub issue

## Verification

- `heartbeat-detail-cache.test.tsx`（22 项断言）：打开写入缓存 / 重挂载自动恢复 / 关闭清除缓存 / 失效缓存不恢复 / 慢加载竞态（restoreBlocked）/ 保存后缓存新任务 / 搜索过滤隐式关闭清缓存 / 删除任务清缓存
- `heartbeat-filter-cache.test.tsx`（16 项断言）：搜索词写入/恢复/清空 / 状态筛选写入/恢复 / 范围筛选恢复 / 与详情缓存组合
- `tsc --noEmit` 与 `tsc --noEmit -p tsconfig.test.json` 通过
- 完整前端套件中 `composer-goal-toggle.test.tsx` 失败为基线预存（不 import heartbeat 代码，与本次改动无关）

## Documentation impact

Documentation-impact: none - 纯前端 UI 状态缓存功能，不涉及 CLI/配置/提供方行为，现有自动化面板相关文档仍准确，无需更新。

## Cache impact

Cache-impact: none - 仅 desktop/frontend 前端改动，不触及 provider-visible 前缀或任何缓存敏感路径（internal/tool、internal/provider、internal/boot 等）。

Cache-guard: N/A - 前端行为由 heartbeat 测试套件覆盖（detail-cache 22 项 + filter-cache 16 项验证缓存读写/恢复/清除）。

System-prompt-review: N/A - 不触及 internal/config、internal/memory、internal/outputstyle、internal/skill、internal/boot。
