### PR TITLE
fix(boot): enable the planner when two providers share a model name

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1681,7 +1681,12 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 			Text: fmt.Sprintf("planner_model %q is not a configured provider — continuing with the executor alone", pm)})
 	}
 	if pm != "" && plannerResolved {
-		if pe.Model != entry.Model {
+		// Distinctness must be judged on the full provider-qualified ref, not
+		// the bare model name: two providers (deepseek vs a vendor gateway)
+		// offering the same model name are genuinely different models, each
+		// with its own pricing, context window, and cache prefix. Comparing
+		// bare names collapsed that setup into "no planner" (#8230).
+		if modelRefFromEntry(pe) != modelRefFromEntry(entry) {
 			plannerProv, err := resolveProvider(effectiveResolver, cfg, proxySpec, provider.Selection{Ref: modelRefFromEntry(pe)})
 			if err != nil {
 				return nil, fmt.Errorf("planner %q: %w", pm, err)
@@ -1724,7 +1729,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 				StateRoot:                    config.MemoryUserDir(),
 			}
 			runner = agent.NewCoordinatorWithPlannerPolicy(plannerProv, plannerSess, pe.Price, plannerTools, plannerOpts, executor, cfg.Agent.Temperature, sink, control.NewPlannerPolicy())
-			label = entry.Model + " + planner " + pe.Model
+			label = modelRefFromEntry(entry) + " + planner " + modelRefFromEntry(pe)
 		}
 	}
 	visionProviderResolver := func(ref string) (provider.Provider, error) {

--- a/internal/boot/planner_same_model_name_test.go
+++ b/internal/boot/planner_same_model_name_test.go
@@ -1,0 +1,84 @@
+package boot
+
+import (
+	"context"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+)
+
+// Two providers can offer the same model name (deepseek vs a vendor gateway
+// both serving deepseek-v4-flash). They are distinct models — separate
+// pricing, context window, and cache prefix — so two-model collaboration must
+// engage. Boot used to compare bare model names, collapsing this setup into
+// "no planner" (#8230).
+func TestBuildEnablesPlannerWhenProvidersShareModelName(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	registerBootTokenProfileTestProvider()
+	setBootTokenProfileTestProvider(t, testutil.NewMock("deepseek-v4-flash"))
+
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "deepseek/deepseek-v4-flash"
+
+[agent]
+planner_model = "vendor-gw/deepseek-v4-flash"
+
+[[providers]]
+name = "deepseek"
+kind = "boot-token-profile-test"
+model = "deepseek-v4-flash"
+
+[[providers]]
+name = "vendor-gw"
+kind = "boot-token-profile-test"
+model = "deepseek-v4-flash"
+`)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.FuncSink(func(event.Event) {})})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if ctrl == nil {
+		t.Fatal("Build returned no controller")
+	}
+	if !ctrl.DualModel() {
+		t.Fatal("same model name under two providers must still enable the planner")
+	}
+}
+
+// The identical single-provider case (planner ref equals the executor ref)
+// stays single-model: a model planning with itself gains nothing and would
+// only duplicate the session.
+func TestBuildKeepsSingleModelWhenPlannerRefEqualsExecutor(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	registerBootTokenProfileTestProvider()
+	setBootTokenProfileTestProvider(t, testutil.NewMock("deepseek-v4-flash"))
+
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "deepseek/deepseek-v4-flash"
+
+[agent]
+planner_model = "deepseek/deepseek-v4-flash"
+
+[[providers]]
+name = "deepseek"
+kind = "boot-token-profile-test"
+model = "deepseek-v4-flash"
+`)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.FuncSink(func(event.Event) {})})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if ctrl == nil {
+		t.Fatal("Build returned no controller")
+	}
+	if ctrl.DualModel() {
+		t.Fatal("planner ref identical to the executor ref must stay single-model")
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -4921,6 +4921,19 @@ func (c *Controller) Executor() *agent.Agent {
 	return c.executor
 }
 
+// DualModel reports whether the runner wraps the executor in a two-model
+// Coordinator (planner_model configured AND distinct from the executor on the
+// full provider/model ref). Hosts surface planner state and pricing off this
+// instead of re-deriving it from config, which cannot see runtime degradation
+// (an unresolvable planner silently continues executor-only).
+func (c *Controller) DualModel() bool {
+	if c == nil {
+		return false
+	}
+	_, ok := c.runner.(*agent.Coordinator)
+	return ok
+}
+
 func (c *Controller) Skills() []skill.Skill {
 	return c.skills.list()
 }


### PR DESCRIPTION
## Summary

Two providers serving the **same model name** (e.g. `deepseek/deepseek-v4-flash` as executor and a vendor gateway's `vendor-gw/deepseek-v4-flash` as planner) silently ran single-model: the coordinator gate at boot compared **bare model names** (`pe.Model != entry.Model`), so the pairing read as "no planner" — no collaboration, one merged desktop picker entry, no second cost stream (#8230).

## Root cause

`internal/boot/boot.go` gated the Coordinator on `pe.Model != entry.Model`. Provider identity — where the model actually routes, its pricing, its context window, its independent cache prefix — lives in the full `provider/model` ref that the rest of boot already resolves through (`modelRefFromEntry`).

## Change

- The distinctness check compares the **full provider-qualified refs** (`modelRefFromEntry(pe) != modelRefFromEntry(entry)`); an identical ref still stays single-model, and different model names behave exactly as before.
- The session label names both sides with qualified refs, so `deepseek-v4-flash + planner deepseek-v4-flash` (ambiguous before) becomes legible.
- `Controller.DualModel()` exposes the *runtime* pairing: hosts no longer re-derive it from config, which cannot express the degradation path where an unresolvable `planner_model` deliberately continues executor-only (the #4615 path this file already handles).

## Testing

- `TestBuildEnablesPlannerWhenProvidersShareModelName` — the reported setup, asserting `DualModel()` engages; fails on the previous bare-name comparison (verified by stashing the boot change) and passes with it.
- `TestBuildKeepsSingleModelWhenPlannerRefEqualsExecutor` — the identical-ref guard.
- `go vet ./internal/boot ./internal/control` clean; controller suite green.

Fixes #8230
