### PR TITLE
feat(boot): tell the agent its model identity and input modality

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -597,6 +597,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		sysPrompt = outputstyle.Apply(sysPrompt, st)
 	}
 	sysPrompt = appendCorePolicies(sysPrompt)
+	sysPrompt = appendModelIdentity(sysPrompt, entry)
 	if workspaceLine := currentWorkspacePromptLine(root); workspaceLine != "" {
 		sysPrompt += "\n\n" + workspaceLine
 	}

--- a/internal/boot/model_identity.go
+++ b/internal/boot/model_identity.go
@@ -1,0 +1,37 @@
+package boot
+
+import (
+	"fmt"
+	"strings"
+
+	"reasonix/internal/config"
+)
+
+// appendModelIdentity folds the session's model identity and input modality
+// into the cache-stable system prefix. A model cannot introspect which
+// provider instance or SKU it is running as, and vision-capable SKUs kept
+// answering "I am a text-only model" — then routed image work through MCP
+// vision bridges or OCR instead of reading attached images directly (#9288).
+//
+// The section derives only from config-resolved entries (ref + EffectiveVision
+// + context window), so within one session it is byte-identical every boot
+// assembly and cannot churn the provider prefix cache the way a live probe
+// would. Vision wording is behavioral: it tells the agent to read attached
+// images directly and treat bridges/OCR as opt-in fallbacks, not defaults.
+func appendModelIdentity(prompt string, e *config.ProviderEntry) string {
+	if e == nil || strings.TrimSpace(e.Model) == "" {
+		return prompt
+	}
+	ref := e.Name + "/" + e.Model
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("## Model\n\nYou are running as `%s`", ref))
+	if window := e.ContextWindow; window > 0 {
+		b.WriteString(fmt.Sprintf(" with a %d-token context window", window))
+	}
+	if config.EffectiveVision(e) {
+		b.WriteString(".\nYou accept images as direct input: when the user attaches or pastes an\nimage (including screenshots arriving with a plain description of a\nproblem), read the image itself first and answer from what you see. Treat\nexternal vision bridges (MCP servers) and OCR tools as opt-in fallbacks for\nwhen direct viewing is not enough — do not route image understanding through\nthem by default, and never state that you cannot see images.\n")
+	} else {
+		b.WriteString(".\nYou are a text-only model: you cannot see image content. When the user\nattaches an image, say so plainly and ask for a description, or use a\nconfigured vision/OCR tool when one is available — do not claim to have\nread the image.\n")
+	}
+	return prompt + "\n\n" + b.String()
+}

--- a/internal/boot/model_identity_test.go
+++ b/internal/boot/model_identity_test.go
@@ -1,0 +1,84 @@
+package boot
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/config"
+)
+
+func identityEntry(vision bool) *config.ProviderEntry {
+	e := &config.ProviderEntry{
+		Name:          "deepseek",
+		Kind:          "openai",
+		BaseURL:       "https://api.deepseek.com",
+		Model:         "deepseek-v4-flash",
+		ContextWindow: 131072,
+		Vision:        vision,
+	}
+	if vision {
+		// The official vision SKU is detected by name on the DeepSeek base URL
+		// regardless of the provider-wide flag.
+		e.Model = "deepseek-v4-flash-vision-exp"
+	}
+	return e
+}
+
+// A vision-capable SKU must learn its own identity and its direct-input
+// behavior from the prompt: models cannot introspect this, which is why the
+// vision SKU answered "I am a text-only model" and routed screenshots through
+// MCP bridges / OCR instead of reading them (#9288).
+func TestModelIdentityTellsVisionModelsToReadImagesDirectly(t *testing.T) {
+	got := appendModelIdentity("BASE", identityEntry(true))
+
+	if !strings.Contains(got, "`deepseek/deepseek-v4-flash-vision-exp`") {
+		t.Fatalf("identity section must name the provider-qualified ref:\n%s", got)
+	}
+	if !strings.Contains(got, "131072-token context window") {
+		t.Fatalf("identity section must state the context window:\n%s", got)
+	}
+	for _, phrase := range []string{
+		"You accept images as direct input",
+		"read the image itself first",
+		"opt-in fallbacks",
+		"never state that you cannot see images",
+	} {
+		if !strings.Contains(got, phrase) {
+			t.Fatalf("vision identity missing %q:\n%s", phrase, got)
+		}
+	}
+	if !strings.HasPrefix(got, "BASE\n\n## Model") {
+		t.Fatalf("identity must append after the base prompt, got prefix %q", got[:min(len(got), 40)])
+	}
+}
+
+// A text-only model gets the honest inverse: no claimed vision, an explicit
+// ask-for-description path, and no silent pretending.
+func TestModelIdentityTellsTextModelsTheyCannotSeeImages(t *testing.T) {
+	got := appendModelIdentity("BASE", identityEntry(false))
+
+	if !strings.Contains(got, "You are a text-only model") || !strings.Contains(got, "cannot see image content") {
+		t.Fatalf("text identity must state the modality limit:\n%s", got)
+	}
+	if strings.Contains(got, "You accept images as direct input") {
+		t.Fatalf("text identity must not claim vision:\n%s", got)
+	}
+}
+
+// The section sits inside the provider-cached prefix: it must be a pure
+// function of the resolved entry, byte-identical across assemblies.
+func TestModelIdentityIsByteStableForSameEntry(t *testing.T) {
+	e := identityEntry(true)
+	if appendModelIdentity("BASE", e) != appendModelIdentity("BASE", e) {
+		t.Fatal("identity section must be deterministic for the same entry")
+	}
+}
+
+func TestModelIdentityOmitsEmptyModels(t *testing.T) {
+	if got := appendModelIdentity("BASE", &config.ProviderEntry{Name: "x"}); got != "BASE" {
+		t.Fatalf("entry without a model must not inject identity, got %q", got)
+	}
+	if got := appendModelIdentity("BASE", nil); got != "BASE" {
+		t.Fatalf("nil entry must not inject identity, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implements fix directions **1 + 4** from #9288: a model cannot introspect which provider instance or SKU it runs as, so on the vision SKU (`deepseek/deepseek-v4-flash-vision-exp`) the agent answered "我是纯文本模型，不能识图" and routed pasted screenshots through the MCP vision bridge / built-in OCR instead of reading them directly — the image channel itself worked fine.

## Change

The boot-composed **cache-stable system prefix** gains a `## Model` section:

- the **provider-qualified ref** (`deepseek/deepseek-v4-flash-vision-exp`) and the **context window**;
- the **effective input modality** from `config.EffectiveVision` — the same resolver that already gates whether images ride the request at all:
  - **vision-capable**: "You accept images as direct input… read the image itself first… Treat external vision bridges (MCP servers) and OCR tools as opt-in fallbacks… never state that you cannot see images." The wording targets the reported scenario B: a screenshot attached alongside a plain description of the problem, where the model previously didn't consider itself able to look.
  - **text-only**: the honest inverse — state the limit, ask for a description, use a vision/OCR tool when available.

**Cache stability**: the section is a pure function of the resolved config entry (ref + `EffectiveVision` + context window) — no live probing — so within one session it is byte-identical on every assembly, exactly like the snapshotted environment section beside it. It is appended after the core policies and before the workspace line.

## Testing

Four unit tests on the new `appendModelIdentity` (`internal/boot/model_identity_test.go`):

- vision entry names the qualified ref + window and carries the direct-input behavioral instructions;
- text entry states the modality limit and never claims vision (the fixture respects `officialDeepSeekEffectiveVision`'s name-based detection — the first draft wrongly expected `Vision:false` to disable a vision-*named* SKU, which the production resolver intentionally does not);
- byte-stability for the same entry (the prefix-cache contract);
- nil / model-less entries inject nothing.

`go vet ./internal/boot` clean; neighboring boot suites green.

Fixes #9288
