### PR TITLE
fix(agent): stop empty summarizer finishes from wedging compaction

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -30,6 +30,7 @@ const (
 var (
 	errSummaryOutputTruncated = errors.New("summarizer output truncated")
 	errCheckpointRejected     = errors.New("checkpoint candidate rejected")
+	errSummaryEmptyOutput     = errors.New("summarizer returned empty output")
 )
 
 // summaryTag wraps the compaction summary so the model can distinguish it from
@@ -419,6 +420,7 @@ func (a *Agent) summarize(ctx context.Context, region []provider.Message, instru
 
 	// Unblock on timeout if the stream stalls while open.
 	var b strings.Builder
+	var reasoning strings.Builder
 	for {
 		select {
 		case <-ctx.Done():
@@ -430,13 +432,24 @@ func (a *Agent) summarize(ctx context.Context, region []provider.Message, instru
 				}
 				s := strings.TrimSpace(b.String())
 				if s == "" {
-					return "", usage, fmt.Errorf("summarizer returned empty output")
+					// Reasoning-first models can spend the whole output budget
+					// thinking and finish with zero visible text. That
+					// thinking is still a summary of the region — failing the
+					// fold here wedges the session (the context stays over the
+					// limit and every later turn trips the same error), so the
+					// reasoning text is the last-resort summary source.
+					if r := strings.TrimSpace(reasoning.String()); r != "" {
+						return r, usage, nil
+					}
+					return "", usage, fmt.Errorf("%w (model produced no visible or reasoning text)", errSummaryEmptyOutput)
 				}
 				return s, usage, nil
 			}
 			switch chunk.Type {
 			case provider.ChunkText:
 				b.WriteString(chunk.Text)
+			case provider.ChunkReasoning:
+				reasoning.WriteString(chunk.Text)
 			case provider.ChunkUsage:
 				usage = chunk.Usage
 			case provider.ChunkError:
@@ -446,11 +459,24 @@ func (a *Agent) summarize(ctx context.Context, region []provider.Message, instru
 	}
 }
 
-// summarizeOnce performs exactly one application-layer summary request.
-// Timeouts, empty results, stream errors, and output truncation all fail once
-// with no second attempt.
+// summarizeOnce performs the application-layer summary request with exactly
+// one bounded retry on an empty finish. A genuinely transient empty stream
+// (load-shed gateway, keep-alive hiccup) must not fail the fold — the fold
+// failing while the context is over the limit wedges every later turn — but
+// the retry is capped at one so a persistently broken endpoint still
+// surfaces an error instead of doubling compaction latency forever.
 func (a *Agent) summarizeOnce(ctx context.Context, fold []provider.Message, instructions string) (string, *provider.Usage, error) {
-	return a.summarize(ctx, fold, instructions)
+	summary, usage, err := a.summarize(ctx, fold, instructions)
+	if err == nil || !errors.Is(err, errSummaryEmptyOutput) {
+		return summary, usage, err
+	}
+	retried, retriedUsage, retryErr := a.summarize(ctx, fold, instructions)
+	if retryErr != nil {
+		// Report the original empty-output cause: the retry shape is
+		// identical, so a second empty finish is the same failure.
+		return "", usage, err
+	}
+	return retried, retriedUsage, nil
 }
 
 // renderTranscript flattens messages into a readable transcript for summarization.

--- a/internal/agent/compact_empty_summary_test.go
+++ b/internal/agent/compact_empty_summary_test.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// scriptStream is one Stream call's chunk script.
+type scriptStream struct {
+	chunks []provider.Chunk
+}
+
+// sequenceProvider serves one scriptStream per Stream call and counts calls.
+type sequenceProvider struct {
+	scripts []scriptStream
+	calls   int
+}
+
+func (p *sequenceProvider) Name() string { return "sequence" }
+func (p *sequenceProvider) Stream(_ context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	i := p.calls
+	p.calls++
+	if i >= len(p.scripts) {
+		return nil, errors.New("sequenceProvider: no script")
+	}
+	ch := make(chan provider.Chunk, len(p.scripts[i].chunks))
+	for _, c := range p.scripts[i].chunks {
+		ch <- c
+	}
+	close(ch)
+	return ch, nil
+}
+
+func newSummaryTestAgent(p provider.Provider) *Agent {
+	return New(p, tool.NewRegistry(), &Session{Messages: []provider.Message{{Role: provider.RoleSystem, Content: "sys"}}}, Options{}, event.Discard)
+}
+
+// A reasoning-first model can spend the whole output budget thinking and
+// finish with zero visible text. Failing the fold there wedges the session —
+// the context stays over the limit and every later turn trips the same
+// error — so the reasoning text is the last-resort summary source.
+func TestSummarizeFallsBackToReasoningWhenVisibleTextIsEmpty(t *testing.T) {
+	prov := &sequenceProvider{scripts: []scriptStream{{
+		chunks: []provider.Chunk{
+			{Type: provider.ChunkReasoning, Text: "The user fixed the login bug in auth.go; tests pass; remaining work is the rate limiter."},
+			{Type: provider.ChunkDone},
+		},
+	}}}
+	a := newSummaryTestAgent(prov)
+
+	summary, _, err := a.summarizeOnce(context.Background(), []provider.Message{{Role: provider.RoleUser, Content: "old"}}, "")
+	if err != nil {
+		t.Fatalf("reasoning-only finish must not fail the summary: %v", err)
+	}
+	if summary != "The user fixed the login bug in auth.go; tests pass; remaining work is the rate limiter." {
+		t.Fatalf("unexpected summary: %q", summary)
+	}
+	if prov.calls != 1 {
+		t.Fatalf("reasoning fallback must not need a retry, calls = %d", prov.calls)
+	}
+}
+
+// A transient empty finish (load-shed gateway, keep-alive hiccup) gets
+// exactly one retry before the fold gives up.
+func TestSummarizeOnceRetriesOneEmptyFinish(t *testing.T) {
+	prov := &sequenceProvider{scripts: []scriptStream{
+		{chunks: []provider.Chunk{{Type: provider.ChunkDone}}},
+		{chunks: []provider.Chunk{
+			{Type: provider.ChunkText, Text: "digest"},
+			{Type: provider.ChunkDone},
+		}},
+	}}
+	a := newSummaryTestAgent(prov)
+
+	summary, _, err := a.summarizeOnce(context.Background(), []provider.Message{{Role: provider.RoleUser, Content: "old"}}, "")
+	if err != nil {
+		t.Fatalf("transient empty finish must recover on retry: %v", err)
+	}
+	if summary != "digest" {
+		t.Fatalf("unexpected summary: %q", summary)
+	}
+	if prov.calls != 2 {
+		t.Fatalf("expected exactly one retry (2 calls), got %d", prov.calls)
+	}
+}
+
+// A persistently empty endpoint still surfaces the empty-output error — the
+// retry is capped at one, so compaction latency does not double forever.
+func TestSummarizeOnceCapsRetryAtOne(t *testing.T) {
+	prov := &sequenceProvider{scripts: []scriptStream{
+		{chunks: []provider.Chunk{{Type: provider.ChunkDone}}},
+		{chunks: []provider.Chunk{{Type: provider.ChunkDone}}},
+		{chunks: []provider.Chunk{{Type: provider.ChunkDone}}},
+	}}
+	a := newSummaryTestAgent(prov)
+
+	_, _, err := a.summarizeOnce(context.Background(), []provider.Message{{Role: provider.RoleUser, Content: "old"}}, "")
+	if !errors.Is(err, errSummaryEmptyOutput) {
+		t.Fatalf("persistent empty finish must report the sentinel, got %v", err)
+	}
+	if prov.calls != 2 {
+		t.Fatalf("retry must be capped at one extra call, got %d", prov.calls)
+	}
+}

--- a/internal/agent/compact_fold_input_test.go
+++ b/internal/agent/compact_fold_input_test.go
@@ -76,17 +76,28 @@ func TestSummaryCollectorStoresOnlyVisibleText(t *testing.T) {
 
 func TestSummaryCollectorRejectsEmptyAndLengthLimitedOutput(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		chunks []provider.Chunk
-		want   string
+		name    string
+		chunks  []provider.Chunk
+		wantErr string
+		wantOut string
 	}{
 		{
-			name: "reasoning and tool call are empty",
+			// Contract change: a reasoning-only finish is the last-resort
+			// summary source. Failing the fold on it wedged sessions whose
+			// context was already over the limit (#8378, #9258) — the
+			// reasoning is model-authored content about the transcript, and
+			// it only rides when no visible text exists at all.
+			name: "reasoning-only finish becomes the summary",
 			chunks: []provider.Chunk{
-				{Type: provider.ChunkReasoning, Text: "PRIVATE REASONING"},
+				{Type: provider.ChunkReasoning, Text: "REASONING DIGEST"},
 				{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "call-1", Name: "read_file"}},
 			},
-			want: "empty output",
+			wantOut: "REASONING DIGEST",
+		},
+		{
+			name:   "genuinely empty finish still errors",
+			chunks: []provider.Chunk{{Type: provider.ChunkDone}},
+			wantErr: "empty output",
 		},
 		{
 			name: "length finish",
@@ -94,14 +105,24 @@ func TestSummaryCollectorRejectsEmptyAndLengthLimitedOutput(t *testing.T) {
 				{Type: provider.ChunkText, Text: "partial"},
 				{Type: provider.ChunkUsage, Usage: &provider.Usage{FinishReason: "length"}},
 			},
-			want: "output token limit",
+			wantErr: "output token limit",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			prov := &summaryChunksProvider{chunks: tc.chunks}
 			a := New(prov, tool.NewRegistry(), NewSession("system"), Options{}, event.Discard)
-			if _, _, err := a.summarize(context.Background(), []provider.Message{{Role: provider.RoleUser, Content: "old"}}, ""); err == nil || !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("summarize error = %v, want %q", err, tc.want)
+			summary, _, err := a.summarize(context.Background(), []provider.Message{{Role: provider.RoleUser, Content: "old"}}, "")
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("summarize error = %v, want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("summarize error = %v, want success", err)
+			}
+			if !strings.Contains(summary, tc.wantOut) {
+				t.Fatalf("summary = %q, want %q", summary, tc.wantOut)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`summarizer returned empty output` failed the compaction fold outright — and a fold failing **while the context is already over the provider limit** wedges every later turn: the session can neither compact nor continue, exactly the #8378 / #9258 reports ("没办法压缩会话，导致没办法再继续回复", intermittent "context exceeds provider limit and compaction failed"). Two shapes reach that path:

1. **reasoning-first models** spend the whole summary budget in `reasoning_content` and finish with zero visible text — the collector ignored `ChunkReasoning` entirely, so a full digest that existed was discarded and reported as empty;
2. **transient empty finishes** (load-shed gateways, connection recycling) fail a single attempt with no retry.

## Change

- `summarize` collects reasoning deltas alongside visible text; on an empty visible finish, the **reasoning text becomes the last-resort summary** — it is model-authored content about the transcript, and it only rides when no visible text exists at all. (Deliberate contract change; the old collector test's `PRIVATE REASONING` fixture asserted rejection — updated, see below.)
- `summarizeOnce` retries a **genuinely empty** finish exactly once: same request shape (prefix-cache preserved), retry cap at one so a persistently broken endpoint still surfaces the error and compaction latency at most doubles on the failure path. The retry reports the original empty-output cause, and the sentinel (`errSummaryEmptyOutput`) becomes an `errors.Is`-able symbol.
- Truncation (`finish_reason=length`) still fails without retry — that's a budget problem, not a transient one.

## Testing

Three new tests (`compact_empty_summary_test.go`, scripted-chunk providers):

- reasoning-only finish → summary returns the reasoning text, **no retry needed** (1 call);
- transient empty → one retry recovers (exactly 2 calls);
- persistent empty → `errSummaryEmptyOutput` after exactly 2 calls (cap proven).

The legacy `TestSummaryCollectorRejectsEmptyAndLengthLimitedOutput` is updated: the reasoning-only case now asserts the fallback succeeds, and a new *genuinely empty* case preserves the error path. Differential: with `compact.go` stashed the new suite does not compile (sentinel absent) and the reasoning case regains its old failing contract.

Note: `TestSummaryKeepsToolHeavySessionBounded` fails identically on **unmodified main** in this sandbox (a local system proxy 502s the test's httptest upstream) — verified by stashing; unrelated to this change and green in CI.

Fixes #8378
Fixes #9258
