### PR TITLE
fix(provider): append /v1 to bare localhost OpenAI-compatible base URLs

### DIFF
--- a/internal/provider/openai/chaturl.go
+++ b/internal/provider/openai/chaturl.go
@@ -1,6 +1,9 @@
 package openai
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 // canonicalKnownVendorChatURL rewrites official-vendor bases whose documented
 // form differs from the OpenAI-compatible shape (Token Rhythm, StepFun step_plan).
@@ -11,12 +14,36 @@ func canonicalKnownVendorChatURL(raw string) (string, bool) {
 	return canonicalStepFunPlanChatURL(raw)
 }
 
+// canonicalLocalHostChatURL appends the conventional /v1 prefix to a bare
+// local base URL. Local OpenAI-compatible servers serve their chat surface
+// under /v1 — Ollama on :11434, LM Studio on :1234, llama.cpp and vLLM by
+// convention — so a base_url entered as "http://localhost:11434" must POST
+// /v1/chat/completions, not /chat/completions (which Ollama answers with
+// 405). Only localhost-family hosts with an empty path are rewritten; any
+// base URL that already carries a path (including an explicit /v1) is left
+// exactly as the user wrote it.
+func canonicalLocalHostChatURL(raw string) (string, bool) {
+	trimmed := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if trimmed == "" {
+		return "", false
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return "", false
+	}
+	host := u.Hostname()
+	if host != "localhost" && host != "127.0.0.1" && host != "::1" && host != "[::1]" {
+		return "", false
+	}
+	if u.Path != "" && u.Path != "/" {
+		return "", false
+	}
+	return trimmed + "/v1", true
+}
+
 func resolveOpenAIChatURL(baseURL string, extra map[string]any) string {
 	requestURL, _ := extra["request_url"].(string)
 	requestURL = strings.TrimSpace(requestURL)
-	if canonical, ok := canonicalKnownVendorChatURL(requestURL); ok {
-		return canonical
-	}
 	if requestURL != "" {
 		return requestURL
 	}
@@ -33,6 +60,9 @@ func normalizeChatURL(baseURL, chatURL string) string {
 	}
 	if canonical, ok := canonicalKnownVendorChatURL(baseURL); ok {
 		return canonical
+	}
+	if canonical, ok := canonicalLocalHostChatURL(baseURL); ok {
+		return canonical + "/chat/completions"
 	}
 	return strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/chat/completions"
 }

--- a/internal/provider/openai/chaturl_local_test.go
+++ b/internal/provider/openai/chaturl_local_test.go
@@ -1,0 +1,54 @@
+package openai
+
+import "testing"
+
+// Local OpenAI-compatible servers (Ollama on :11434, LM Studio on :1234,
+// llama.cpp, vLLM) serve their chat surface under /v1. A base_url entered as
+// a bare host used to POST /chat/completions, which Ollama answers with 405.
+func TestLocalHostBaseURLGainsV1Prefix(t *testing.T) {
+	for _, base := range []string{
+		"http://localhost:11434",
+		"http://localhost:11434/",
+		"http://127.0.0.1:11434",
+		"http://localhost:1234/",
+		"https://localhost:8080",
+	} {
+		if got := normalizeChatURL(base, ""); got != trimTrailingSlash(base)+"/v1/chat/completions" {
+			t.Fatalf("normalizeChatURL(%q) = %q, want the /v1-prefixed chat URL", base, got)
+		}
+	}
+}
+
+// Any base URL that already carries a path — including an explicit /v1 — is
+// the user's own routing decision and must not be rewritten.
+func TestLocalHostBaseURLWithPathIsUntouched(t *testing.T) {
+	for _, base := range []string{
+		"http://localhost:11434/v1",
+		"http://localhost:11434/ollama/v1",
+		"http://127.0.0.1:8080/api",
+	} {
+		if got := normalizeChatURL(base, ""); got != trimTrailingSlash(base)+"/chat/completions" {
+			t.Fatalf("normalizeChatURL(%q) = %q, want the explicit path preserved", base, got)
+		}
+	}
+}
+
+// Remote hosts are never rewritten, with or without a path.
+func TestRemoteBaseURLsAreNeverRewritten(t *testing.T) {
+	for _, base := range []string{
+		"https://api.deepseek.com",
+		"https://ollama.com/v1",
+		"http://192.168.1.5:11434",
+	} {
+		if got := normalizeChatURL(base, ""); got != trimTrailingSlash(base)+"/chat/completions" {
+			t.Fatalf("normalizeChatURL(%q) = %q, want plain suffix", base, got)
+		}
+	}
+}
+
+func trimTrailingSlash(s string) string {
+	for len(s) > 0 && s[len(s)-1] == '/' {
+		s = s[:len(s)-1]
+	}
+	return s
+}


### PR DESCRIPTION
## Summary

Local Ollama was unusable with `ollama: status 405: 405 method not allowed` while the same server worked through other clients (#9268): local OpenAI-compatible servers (Ollama `:11434`, LM Studio `:1234`, llama.cpp, vLLM) serve their chat surface under **`/v1`**, but a `base_url` entered as `http://localhost:11434` made Reasonix POST `http://localhost:11434/chat/completions` — a path Ollama rejects with 405.

## Change

`normalizeChatURL` gains a local-host canonicalization (`canonicalLocalHostChatURL`): when the base URL's host is localhost-family (`localhost` / `127.0.0.1` / `::1`) **and it carries no path**, `/v1` is appended before `/chat/completions`.

Deliberately narrow:

- any base URL that **already has a path** — an explicit `/v1`, or a gateway prefix like `/ollama/v1` or `/api` — is the user's own routing decision and is untouched;
- **remote hosts are never rewritten** (including `https://ollama.com`, the hosted Ollama Cloud preset, which already ships `/v1`);
- the pre-existing vendor canonicalizations (Token Rhythm, StepFun) keep their original precedence.

## Testing

Three table tests (`chaturl_local_test.go`): bare localhost bases across the common ports gain `/v1`; explicit paths are preserved byte-for-byte; remote hosts (including a LAN `192.168.x.x:11434`) keep the plain suffix. Differential: the gain-`/v1` test fails with the resolver stashed. `go vet` clean; neighboring URL/host tests green.

Fixes #9268
