### PR TITLE
fix(skill): accept JSON-string-wrapped arguments on the skill paths

### DIFF
--- a/internal/agent/argunwrap.go
+++ b/internal/agent/argunwrap.go
@@ -1,0 +1,26 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// jsonStringOfObject reports whether raw is a JSON-encoded string whose
+// content is itself a JSON object, returning the decoded object bytes. The
+// capability proxy declares `arguments` as an object, but models sometimes
+// emit "{\"task\": …}" — a string wrapping the object. Name injection and the
+// underlying skill tools both need the object form (#8472).
+func jsonStringOfObject(raw json.RawMessage) (json.RawMessage, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '"' {
+		return nil, false
+	}
+	var inner string
+	if err := json.Unmarshal(trimmed, &inner); err != nil {
+		return nil, false
+	}
+	if candidate := bytes.TrimSpace([]byte(inner)); len(candidate) > 0 && candidate[0] == '{' {
+		return candidate, true
+	}
+	return nil, false
+}

--- a/internal/agent/argunwrap_test.go
+++ b/internal/agent/argunwrap_test.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestJSONStringOfObject(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string // "" means not unwrapped
+	}{
+		{`"{\"name\":\"explore\"}"`, `{"name":"explore"}`},
+		{`" {\"task\":\"x\"} "`, `{"task":"x"}`},
+		{`"plain text"`, ""},
+		{`""`, ""},
+		{`{"name":"explore"}`, ""},
+		{`42`, ""},
+		{`null`, ""},
+	}
+	for _, tc := range cases {
+		got, ok := jsonStringOfObject(json.RawMessage(tc.raw))
+		if tc.want == "" {
+			if ok {
+				t.Fatalf("jsonStringOfObject(%q) unwrapped to %q, want no unwrap", tc.raw, got)
+			}
+			continue
+		}
+		if !ok || string(got) != tc.want {
+			t.Fatalf("jsonStringOfObject(%q) = (%q, %v), want %q", tc.raw, got, ok, tc.want)
+		}
+	}
+}

--- a/internal/agent/usecapability.go
+++ b/internal/agent/usecapability.go
@@ -1088,6 +1088,12 @@ func (t *UseCapabilityTool) resolveSkillCall(skillName, id string, args json.Raw
 	for _, toolName := range []string{"run_skill", "read_only_skill", "read_skill"} {
 		if tl, ok := t.registry.Get(toolName); ok {
 			payload := args
+			// The proxy schema types arguments as an object, but models
+			// sometimes emit a JSON-encoded string of that object; unwrap one
+			// level so name injection below still lands on the object form.
+			if s, ok := jsonStringOfObject(payload); ok {
+				payload = s
+			}
 			if len(payload) == 0 || string(payload) == "null" {
 				payload = json.RawMessage(fmt.Sprintf(`{"name":%q}`, skillName))
 			} else {

--- a/internal/skill/argunwrap.go
+++ b/internal/skill/argunwrap.go
@@ -1,0 +1,31 @@
+package skill
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// unwrapJSONStringArgs tolerates tool arguments that arrive as a JSON-encoded
+// string of the intended object. Providers occasionally double-encode — the
+// capability proxy declares `arguments` as an object, but models emit
+// "{\"task\": …}" (a string containing JSON), and unmarshaling that into the
+// arg struct fails with "cannot unmarshal string into Go value of type
+// struct {…}" and kills the call (#8472). One unwrap level is enough; a
+// string containing a string containing an object is not a shape any real
+// caller produces, and silently unwrapping deeper would mask genuine misuse.
+func unwrapJSONStringArgs(args []byte) []byte {
+	trimmed := bytes.TrimSpace(args)
+	if len(trimmed) == 0 || trimmed[0] != '"' {
+		return args
+	}
+	var inner string
+	if err := json.Unmarshal(trimmed, &inner); err != nil {
+		return args
+	}
+	// Only accept the unwrap when the decoded string is itself a JSON object;
+	// a plain string argument ("some text") stays a plain string.
+	if candidate := bytes.TrimSpace([]byte(inner)); len(candidate) > 0 && candidate[0] == '{' {
+		return candidate
+	}
+	return args
+}

--- a/internal/skill/argunwrap_test.go
+++ b/internal/skill/argunwrap_test.go
@@ -1,0 +1,80 @@
+package skill
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+type recordingSubagentRunner struct {
+	called bool
+	task   string
+}
+
+func (r *recordingSubagentRunner) run(context.Context, Skill, string, SubagentRunOptions) (string, error) {
+	r.called = true
+	return "ok", nil
+}
+
+func subagentSkillHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/explore.md", "---\ndescription: explore\nrunAs: subagent\n---\nbody")
+	return home
+}
+
+// The capability proxy types arguments as an object, but models sometimes
+// emit a JSON-encoded string of that object — exactly the #8472 payload:
+//
+//	arguments: "{\"name\": \"explore\", \"arguments\": \"...\"}"
+//
+// run_skill used to fail that with "json: cannot unmarshal string into Go
+// value of type struct { Name …; Arguments … }", killing every explore call.
+func TestRunSkillAcceptsStringWrappedObjectArgs(t *testing.T) {
+	runner := &recordingSubagentRunner{}
+	tl := NewRunSkillTool(New(Options{HomeDir: subagentSkillHome(t), DisableBuiltins: true}), runner.run)
+
+	inner := map[string]any{"name": "explore", "arguments": "survey the codebase"}
+	wrapped, err := json.Marshal(inner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doubleEncoded, err := json.Marshal(string(wrapped))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := tl.Execute(context.Background(), doubleEncoded); err != nil {
+		t.Fatalf("string-wrapped object args must run: %v", err)
+	}
+	if !runner.called {
+		t.Fatal("subagent did not run")
+	}
+}
+
+// Plain-object args keep working byte-for-byte.
+func TestRunSkillKeepsObjectArgs(t *testing.T) {
+	runner := &recordingSubagentRunner{}
+	tl := NewRunSkillTool(New(Options{HomeDir: subagentSkillHome(t), DisableBuiltins: true}), runner.run)
+
+	if _, err := tl.Execute(context.Background(), json.RawMessage(`{"name":"explore","arguments":"look around"}`)); err != nil {
+		t.Fatalf("object args: %v", err)
+	}
+	if !runner.called {
+		t.Fatal("subagent did not run")
+	}
+}
+
+// A plain string (not JSON-of-object) is left alone: it is not a wrapped
+// object, and silently reinterpreting it would mask genuine misuse.
+func TestUnwrapIgnoresNonObjectStrings(t *testing.T) {
+	for _, raw := range []string{`"just text"`, `""`, `123`, `null`, `{"name":"explore"}`, ``} {
+		if got := string(unwrapJSONStringArgs([]byte(raw))); got != raw {
+			t.Fatalf("unwrapJSONStringArgs(%q) = %q, want unchanged", raw, got)
+		}
+	}
+	if got := string(unwrapJSONStringArgs([]byte(`"{\"name\":\"explore\"}"`))); !strings.HasPrefix(got, "{") {
+		t.Fatalf("wrapped object not unwrapped: %q", got)
+	}
+}

--- a/internal/skill/tools.go
+++ b/internal/skill/tools.go
@@ -87,7 +87,7 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 		Continue  string `json:"continue_from"`
 		Fork      string `json:"fork_from"`
 	}
-	if err := json.Unmarshal(args, &p); err != nil {
+	if err := json.Unmarshal(unwrapJSONStringArgs(args), &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
 	}
 	name := cleanSkillName(p.Name)
@@ -196,7 +196,7 @@ func (t *readOnlySkillTool) Execute(ctx context.Context, args json.RawMessage) (
 		Name      string `json:"name"`
 		Arguments string `json:"arguments"`
 	}
-	if err := json.Unmarshal(args, &p); err != nil {
+	if err := json.Unmarshal(unwrapJSONStringArgs(args), &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
 	}
 	name := cleanSkillName(p.Name)


### PR DESCRIPTION
## Summary

Every `explore` subagent call died with `invalid args: json: cannot unmarshal string into Go value of type struct { Name "json:\"name\""; Arguments …; Continue "continue_from"; Fork "fork_from" }` (#8472): the capability proxy declares `arguments` as an **object**, but models sometimes emit a JSON-encoded **string** of that object —

```json
{"action":"call","capability_id":"skill:explore","arguments":"{\"task\": \"…探索任务…"}"}
```

— which flowed into `run_skill`'s struct unmarshal and failed there. The reporter pinned it as a 1.24.1 regression against 1.24.0; the shape still reaches the same struct on current main.

## Change

One unwrap level on both surfaces the payload crosses:

- **`run_skill` / `read_only_skill`** (`internal/skill`): before parsing, `unwrapJSONStringArgs` accepts a string **whose decoded content is itself a JSON object** and substitutes the decoded object. Plain strings (`"just text"`, `""`), numbers, `null`, and ordinary objects pass through unchanged — only the exact double-encoded shape is normalized, so genuine misuse still surfaces as a parse error.
- **`use_capability`'s skill routing** (`internal/agent`): the same unwrap (`jsonStringOfObject`) runs before the existing `name` injection, so the `skill:<name>` merge lands on the object form instead of forwarding the string onward.

## Testing

- `TestRunSkillAcceptsStringWrappedObjectArgs` — the issue's exact double-encoded payload through `run_skill` reaches the subagent runner (fails on unpatched with the reported unmarshal error — verified via stash differential).
- `TestRunSkillKeepsObjectArgs` — object args unchanged.
- `TestUnwrapIgnoresNonObjectStrings` — plain strings/numbers/null/objects are untouched; the wrapped-object case unwraps.
- `TestJSONStringOfObject` — table test for the agent-side helper (wrapped object, whitespace-padded, plain string, empty, number, null).
- Existing skill suite (`TestRunSkill*`) green; `go vet` on both packages clean.

Fixes #8472
