### PR TITLE
feat(config): make the reasoning byte-limit guard configurable

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1647,6 +1647,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		CapabilityAudit:              capAudit,
 		ContextWindow:                entry.ContextWindow,
 		MaxOutputTokens:              entry.MaxOutputTokens,
+		ReasoningByteLimit:           cfg.Agent.ReasoningByteLimit,
 		SoftCompactRatio:             cfg.Agent.SoftCompactRatio,
 		ToolResultSnipRatio:          cfg.Agent.ToolResultSnipRatio,
 		CompactRatio:                 cfg.Agent.CompactRatio,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1307,6 +1307,11 @@ type AgentConfig struct {
 	SubagentEffort      string            `toml:"subagent_effort"`
 	SubagentEfforts     map[string]string `toml:"subagent_efforts"`
 	MaxSubagentDepth    int               `toml:"max_subagent_depth"`
+	// ReasoningByteLimit bounds one stream's hidden reasoning bytes. Zero
+	// keeps the default client guard; a negative value disables it. The
+	// REASONIX_REASONING_BYTE_LIMIT environment variable overrides the file
+	// value per run (same semantics).
+	ReasoningByteLimit int `toml:"reasoning_byte_limit"`
 	// TaskCostBudget lands a task on one summary once it spends this much.
 	TaskCostBudget float64 `toml:"task_cost_budget"`
 	// TaskTimeBudgetMinutes is the same gate on wall clock. Both ship off.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strconv"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -218,6 +219,7 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	normalizePluginCommandLines(cfg)
 	normalizeLegacyEffort(cfg)
 	cfg.ignoredLegacyStepLimits = normalizeLegacyAgentStepLimits(cfg)
+	applyReasoningByteLimitEnv(cfg)
 	normalizeRetiredAutoPlan(cfg)
 	normalizeLegacyMCPTiers(cfg)
 	normalizeLegacyStepFunBaseURLs(cfg)
@@ -947,6 +949,22 @@ func normalizeLegacyMCPTiers(c *Config) {
 // normalizeLegacyAgentStepLimits keeps old TOML readable without allowing a
 // stale hidden value to override the adaptive progress policy. The fields stay
 // in AgentConfig for decoder and cross-version desktop compatibility only.
+// applyReasoningByteLimitEnv lets REASONIX_REASONING_BYTE_LIMIT override the
+// [agent].reasoning_byte_limit file value for one run. Same semantics as the
+// TOML key: zero/unset keeps the default guard, negative disables it, positive
+// bounds one stream's hidden reasoning bytes.
+func applyReasoningByteLimitEnv(c *Config) {
+	raw := strings.TrimSpace(os.Getenv("REASONIX_REASONING_BYTE_LIMIT"))
+	if raw == "" {
+		return
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return
+	}
+	c.Agent.ReasoningByteLimit = v
+}
+
 func normalizeLegacyAgentStepLimits(c *Config) bool {
 	if c == nil {
 		return false

--- a/internal/config/reasoning_byte_limit_test.go
+++ b/internal/config/reasoning_byte_limit_test.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReasoningByteLimitEnvOverridesFile(t *testing.T) {
+	t.Setenv("REASONIX_REASONING_BYTE_LIMIT", "131072")
+	cfg := Default()
+	applyReasoningByteLimitEnv(cfg)
+	if cfg.Agent.ReasoningByteLimit != 131072 {
+		t.Fatalf("env override not applied: %d", cfg.Agent.ReasoningByteLimit)
+	}
+}
+
+// Negative means disabled — the same convention agent.Options.ReasoningByteLimit
+// already honors, so the value flows through boot untouched.
+func TestReasoningByteLimitEnvNegativeDisables(t *testing.T) {
+	t.Setenv("REASONIX_REASONING_BYTE_LIMIT", "-1")
+	cfg := Default()
+	applyReasoningByteLimitEnv(cfg)
+	if cfg.Agent.ReasoningByteLimit != -1 {
+		t.Fatalf("negative override not applied: %d", cfg.Agent.ReasoningByteLimit)
+	}
+}
+
+func TestReasoningByteLimitEnvUnsetKeepsFileValue(t *testing.T) {
+	os.Unsetenv("REASONIX_REASONING_BYTE_LIMIT")
+	cfg := Default()
+	cfg.Agent.ReasoningByteLimit = 4 << 20
+	applyReasoningByteLimitEnv(cfg)
+	if cfg.Agent.ReasoningByteLimit != 4<<20 {
+		t.Fatalf("unset env must keep the file value: %d", cfg.Agent.ReasoningByteLimit)
+	}
+}
+
+func TestReasoningByteLimitEnvGarbageIgnored(t *testing.T) {
+	t.Setenv("REASONIX_REASONING_BYTE_LIMIT", "not-a-number")
+	cfg := Default()
+	cfg.Agent.ReasoningByteLimit = 999
+	applyReasoningByteLimitEnv(cfg)
+	if cfg.Agent.ReasoningByteLimit != 999 {
+		t.Fatalf("garbage env must not clobber the file value: %d", cfg.Agent.ReasoningByteLimit)
+	}
+}
+
+// The TOML key must round-trip through the decoder as a recognized agent key.
+func TestReasoningByteLimitTOMLKeyDecodes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reasonix.toml")
+	if err := os.WriteFile(path, []byte("[agent]\nreasoning_byte_limit = 2097152\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := Default()
+	meta, err := mergeFileSnapshot(cfg, path)
+	if err != nil {
+		t.Fatalf("mergeFileSnapshot: %v", err)
+	}
+	if !meta.IsDefined("agent", "reasoning_byte_limit") {
+		t.Fatal("reasoning_byte_limit not recognized as a defined agent key")
+	}
+	if cfg.Agent.ReasoningByteLimit != 2097152 {
+		t.Fatalf("decoded = %d, want 2097152", cfg.Agent.ReasoningByteLimit)
+	}
+}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -40,6 +40,7 @@ ask_request = true   # notify when a question is waiting
 temperature       = 0.0
 # recovery_model = ""               # optional reviewer for low-risk automatic recovery; falls back to guardian_model then main model
 # reasoning_language = "auto"   # visible reasoning text: auto|zh|en
+# reasoning_byte_limit = 0    # one stream's hidden reasoning byte cap; 0 = default guard, negative = disable (env: REASONIX_REASONING_BYTE_LIMIT)
 # plan_mode_read_only_commands = ["gh issue view"]   # legacy compatibility only; Plan bash uses Permissions
 compact_ratio       = 0.80  # sole auto trigger; presets 0.70 (active) / 0.80 (recommended default) / 0.85 (late)
 # planner_model = "deepseek-pro"   # optional: enable two-model collaboration


### PR DESCRIPTION
## Summary

Implements **proposed solution 1** from #8798: the per-stream hidden-reasoning guard was hard-compiled — when one turn's reasoning exceeded it, the reply force-stopped with `response stopped: hit the client reasoning safety limit`, a secondary mid-stream decode error followed (`unexpected end of JSON input`), and users who legitimately needed long reasoning had no path except `thinking = "disabled"`.

## Change

- **`[agent].reasoning_byte_limit`** (TOML): `0` keeps the default guard (behavior unchanged), positive bounds one stream's hidden reasoning bytes, **negative disables only this client guard** — the exact `zero=default / negative=disable` convention `agent.Options.ReasoningByteLimit` already implements, so the value flows through `boot` into the existing option untouched (one wiring line).
- **`REASONIX_REASONING_BYTE_LIMIT`** (env): overrides the file value for one run. Applied late in `loadForRoot` next to the legacy step-limit normalization; a non-numeric value is **ignored** rather than guessed at, leaving the file value intact.
- Documented in `reasonix.example.toml` beside `reasoning_language`.

The default stays exactly as today — this only adds the opt-in/opt-out knob.

## Testing

Five tests (`internal/config/reasoning_byte_limit_test.go`): env sets a positive limit; env `-1` disables; unset env keeps the file value; garbage env does not clobber it; the TOML key round-trips through the decoder as a recognized `agent` key (`meta.IsDefined`). Differential: the TOML-key test cannot compile against stashed sources (field absent). Full `go build ./...` and `go vet` on config+boot clean.

Fixes #8798
