### PR TITLE
fix(billing): bill whole Beijing weekends off-peak for DeepSeek V4

### DIFF
--- a/docs/BILLING.md
+++ b/docs/BILLING.md
@@ -57,7 +57,11 @@ For official DeepSeek OpenAI, Responses, and Anthropic endpoints, V4 Flash,
 `deepseek-v4-flash-vision-exp` (same list price as Flash), and V4 Pro use
 occurrence-time pricing from 2026-08-17 00:00 Beijing time. Peak windows are
 09:00–12:00 and 14:00–18:00 Beijing time; boundaries are left-closed/right-open
-and all other times are off-peak. The request-completion timestamp is used
+and all other times are off-peak. From 2026-08-23 00:00 Beijing time, Saturdays
+and Sundays bill off-peak for the whole day, peak hours included. That weekend
+is bounded in Beijing time, so it runs 16:00Z Friday to 16:00Z Sunday — the same
+window written against a UTC weekday would be a different 48 hours. The
+request-completion timestamp is used
 because the provider does not report per-token billing time. Images sent to the
 vision SKU are billed as input tokens from provider usage.
 

--- a/docs/BILLING.zh-CN.md
+++ b/docs/BILLING.zh-CN.md
@@ -51,7 +51,9 @@ billing_mode = "payg"       # payg | subscription_equivalent
 从北京时间 2026-08-17 00:00 起，DeepSeek 官方 OpenAI、Responses 与
 Anthropic 端点上的 V4 Flash、`deepseek-v4-flash-vision-exp`（价卡与 Flash 相同）
 和 V4 Pro 按请求发生时刻计价。北京时间 09:00–12:00、14:00–18:00 为高峰，区间左闭右开，
-其余为低峰。由于供应商不提供逐 token 计费时刻，Reasonix 使用取得 usage 的请求完成时刻，
+其余为低峰。从北京时间 2026-08-23 00:00 起，周六和周日全天按低峰计价，高峰时段也在内；
+这个周末以北京时间划界，落在 UTC 上是周五 16:00Z 到周日 16:00Z——按 UTC 星期几判定，
+圈到的是另外 48 小时。由于供应商不提供逐 token 计费时刻，Reasonix 使用取得 usage 的请求完成时刻，
 并继续把报价标记为估算。发给视觉 SKU 的图片按供应商 usage 计入输入 token。
 
 配置中保存的价格仍是高峰基准价。只有 PAYG 且完整价格精确匹配官方高峰基准价时才启用

--- a/internal/billing/catalog.go
+++ b/internal/billing/catalog.go
@@ -14,6 +14,15 @@ const (
 
 var deepSeekV4August2026EffectiveAt = time.Date(2026, time.August, 16, 16, 0, 0, 0, time.UTC)
 
+// deepSeekBillingZone is the zone DeepSeek states its weekend rule in. China has
+// observed a fixed UTC+08:00 with no daylight saving since 1991, so a fixed zone
+// is exact here and does not depend on host tzdata being installed.
+var deepSeekBillingZone = time.FixedZone("CST", 8*60*60)
+
+// deepSeekWeekendOffPeakFrom is when the weekend-wide off-peak rule takes effect:
+// 00:00 Beijing time on Sunday 2026-08-23, i.e. 2026-08-22T16:00Z.
+var deepSeekWeekendOffPeakFrom = time.Date(2026, time.August, 23, 0, 0, 0, 0, deepSeekBillingZone)
+
 // CatalogEntry is one official list price for a model in a billing currency.
 type CatalogEntry struct {
 	Provider      string // deepseek | longcat | mimo
@@ -112,10 +121,33 @@ func catalogEntryEffective(e CatalogEntry, at time.Time) bool {
 	return e.EffectiveTo.IsZero() || at.Before(e.EffectiveTo)
 }
 
+// deepSeekWeekendOffPeak reports whether at falls on a Beijing-time Saturday or
+// Sunday with the weekend-wide off-peak rule already in force.
+//
+// The weekend is bounded in Beijing time, so it runs from 16:00Z Friday to
+// 16:00Z Sunday; the same test written as at.UTC().Weekday() covers a different
+// 48 hours. Both spellings happen to agree on the band today, because the two
+// peak windows (01:00-04:00 and 06:00-10:00 UTC) sit entirely outside the 16
+// hours they disagree over. This one keeps agreeing if the windows move.
+func deepSeekWeekendOffPeak(at time.Time) bool {
+	if at.Before(deepSeekWeekendOffPeakFrom) {
+		return false
+	}
+	switch at.In(deepSeekBillingZone).Weekday() {
+	case time.Saturday, time.Sunday:
+		return true
+	}
+	return false
+}
+
 // DeepSeekRateBand selects the documented Beijing peak windows by their stable
-// UTC equivalents.
+// UTC equivalents, and from 2026-08-22T16:00Z bills whole Beijing weekends
+// off-peak.
 func DeepSeekRateBand(at time.Time) string {
 	at = at.UTC()
+	if deepSeekWeekendOffPeak(at) {
+		return RateBandOffPeak
+	}
 	minutes := at.Hour()*60 + at.Minute()
 	if (minutes >= 60 && minutes < 240) || (minutes >= 360 && minutes < 600) {
 		return RateBandPeak

--- a/internal/billing/catalog_test.go
+++ b/internal/billing/catalog_test.go
@@ -38,6 +38,63 @@ func TestResolveDeepSeekScheduledRateBoundaries(t *testing.T) {
 	}
 }
 
+func TestDeepSeekRateBandWeekendOffPeak(t *testing.T) {
+	tests := []struct {
+		name string
+		at   string
+		want string
+	}{
+		// Rule not yet in force: a Beijing Saturday still bills peak by the hour.
+		{name: "saturday before rule takes effect", at: "2026-08-22T06:00:00Z", want: RateBandPeak},
+		// First window the old hour-only logic gets wrong: Beijing Sunday 09:00.
+		{name: "first sunday morning peak hour after rule", at: "2026-08-23T01:00:00Z", want: RateBandOffPeak},
+		{name: "first sunday afternoon peak hour after rule", at: "2026-08-23T09:59:59Z", want: RateBandOffPeak},
+		// Beijing Monday 09:00 is a weekday again.
+		{name: "monday after that weekend", at: "2026-08-24T01:00:00Z", want: RateBandPeak},
+		{name: "later friday peak hour", at: "2026-08-28T06:00:00Z", want: RateBandPeak},
+		{name: "later saturday peak hour", at: "2026-08-29T06:00:00Z", want: RateBandOffPeak},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			at, err := time.Parse(time.RFC3339, tc.at)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := DeepSeekRateBand(at); got != tc.want {
+				t.Fatalf("DeepSeekRateBand(%s) = %q, want %q", tc.at, got, tc.want)
+			}
+		})
+	}
+}
+
+// The weekend is bounded in Beijing time, so it starts and ends at 16:00Z. These
+// four instants are all off-peak by the hour, so DeepSeekRateBand cannot tell
+// them apart today; pinning the predicate keeps the boundary right if the peak
+// windows ever move into the hours where UTC and Beijing weekdays disagree.
+func TestDeepSeekWeekendOffPeakEdgesAreBeijingBounded(t *testing.T) {
+	tests := []struct {
+		name string
+		at   string
+		want bool
+	}{
+		{name: "one second before beijing saturday", at: "2026-08-28T15:59:59Z", want: false},
+		{name: "beijing saturday begins", at: "2026-08-28T16:00:00Z", want: true},
+		{name: "beijing sunday ends", at: "2026-08-30T15:59:59Z", want: true},
+		{name: "beijing monday begins", at: "2026-08-30T16:00:00Z", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			at, err := time.Parse(time.RFC3339, tc.at)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := deepSeekWeekendOffPeak(at); got != tc.want {
+				t.Fatalf("deepSeekWeekendOffPeak(%s) = %v, want %v", tc.at, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildQuoteScheduledRateUsesMatchingPeerBand(t *testing.T) {
 	at := time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC)
 	q := BuildQuote(QuoteInput{


### PR DESCRIPTION
## What's wrong

`DeepSeekRateBand` decides the band from the UTC hour alone. DeepSeek's pricing
page now says:

> Effective 00:00 (Beijing Time) on Sunday, August 23, 2026, we will adjust our
> peak/off-peak billing rules … with off-peak rates applying throughout the day
> on weekends (Saturdays and Sundays, Beijing Time)

That instant is **2026-08-22T16:00Z — already past.** So on a Beijing Saturday or
Sunday, `01:00–04:00` and `06:00–10:00` UTC still resolve to `peak`, while
DeepSeek bills off-peak. Off-peak is exactly half of peak, so every quote landing
in those windows comes out **2×**.

The first window this gets wrong is **2026-08-23 01:00–04:00 UTC** (Beijing
Sunday 09:00–12:00).

## The part that is easy to get subtly wrong

The weekend is bounded in **Beijing** time, not UTC: it runs from `16:00Z Friday`
to `16:00Z Sunday`. Writing the check as `at.UTC().Weekday()` selects a different
48 hours.

I want to be straight about the size of that second point: with today's peak
windows it changes nothing, because `01:00–04:00` and `06:00–10:00` UTC both sit
outside the 16 hours where the two spellings disagree. It is not a live bug — it
is a trap that arms itself the day the windows move. I took the weekday in a
fixed `UTC+08:00` zone anyway and left a comment saying exactly that, so the next
reader knows it was a decision rather than an accident.

`time.FixedZone` rather than `time.LoadLocation("Asia/Shanghai")`: China has run
a fixed UTC+08:00 with no daylight saving since 1991, so the fixed zone is exact
here, and it keeps the billing path from depending on host tzdata being installed.

## Changes

- `internal/billing/catalog.go` — `deepSeekWeekendOffPeak` predicate, gated on
  `deepSeekWeekendOffPeakFrom` (00:00 Beijing on 2026-08-23), consulted first by
  `DeepSeekRateBand`.
- `internal/billing/catalog_test.go` — six cases through `DeepSeekRateBand`
  (including a Beijing Saturday *before* the rule takes effect, which must still
  be `peak`), plus four that pin the 16:00Z weekend edges directly on the
  predicate. Those four are all off-peak by the hour, so they cannot be asserted
  through `DeepSeekRateBand` today — that is precisely why they are worth pinning.
- `docs/BILLING.md`, `docs/BILLING.zh-CN.md` — the rule and its UTC edges.

`TestResolveDeepSeekScheduledRateBoundaries` and
`TestDeepSeekScheduledRatesAllModelsCurrenciesAndTokenClasses` are unchanged and
still pass: their timestamps are Beijing weekdays, and the `2026-08-16T16:00Z`
cutover case predates the weekend rule.

## Verification

```
gofmt -l internal/billing/   # clean
go vet ./internal/billing/   # clean
go test ./internal/billing/ ./internal/event/ ./internal/eventwire/   # all ok
```

`go test ./internal/cli/` fails on this host both with and without the patch
(`TestMiddleClickUsesPrimarySelectionOutsideTmux`, no X11 primary selection in a
headless container) — pre-existing and unrelated.

Cache-impact: none — billing resolution only, no provider-visible prompt, tool
schema, or request serialization touched.
Cache-guard: not applicable; no cache-sensitive path in the diff.
