### PR TITLE
fix(agent): retry a transient ceiling-compaction failure once

### DIFF
--- a/internal/agent/compact_ceiling_retry_test.go
+++ b/internal/agent/compact_ceiling_retry_test.go
@@ -1,0 +1,96 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// failThenSucceedProvider fails the first N summary streams with a transient
+// error, then serves a real summary.
+type failThenSucceedProvider struct {
+	failures atomic.Int32
+}
+
+func (p *failThenSucceedProvider) Name() string { return "fail-then-succeed" }
+func (p *failThenSucceedProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	if p.failures.Add(1) == 1 {
+		return nil, errors.New("transient network failure")
+	}
+	ch := make(chan provider.Chunk, 2)
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "Digest: the work completed; the rate limiter remains."}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+// A transient summarizer failure at the hard ceiling must not kill an entire
+// unattended turn with zero output (#8240): the prompt physically cannot ship
+// unfolded, so the fold gets exactly one immediate retry before the turn is
+// allowed to fail. The first Prepare attempt (under the fold trigger) consumes
+// one scripted failure; the over-ceiling attempt consumes the second and the
+// retry succeeds.
+func TestCeilingSummaryFailureRetriesOnceBeforeFailingTurn(t *testing.T) {
+	sess := foldableSessionOverForce(6)
+	prov := &failThenSucceedProvider{}
+	a := agentOverForce(t, prov, sess)
+
+	// Grow past the hard ceiling with two scripted transient failures pending.
+	big := bigFoldWord()
+	for range 6 {
+		sess.Add(provider.Message{Role: provider.RoleAssistant, Content: big})
+		sess.Add(provider.Message{Role: provider.RoleUser, Content: "continue"})
+	}
+	if est, hard := a.estimatedPromptTokens(sess.Messages), a.hardInputCeiling(); est < hard {
+		t.Fatalf("fixture estimates %d against ceiling %d; not over it", est, hard)
+	}
+
+	if err := prepareContext(context.Background(), a, CompactionTriggerPressure); err != nil {
+		t.Fatalf("transient ceiling summary must recover on retry: %v", err)
+	}
+	if degradedFold(a) {
+		t.Fatal("recovery installed a mechanical digest instead of the real summary")
+	}
+}
+
+// A persistently broken endpoint still fails the turn — the retry is capped at
+// one extra summarizer call, so latency does not grow without bound.
+func TestCeilingSummaryFailureCapsRetryAtOne(t *testing.T) {
+	sess := foldableSessionOverForce(6)
+	always := &alwaysFailProvider{}
+	a := agentOverForce(t, always, sess)
+
+	big := bigFoldWord()
+	for range 6 {
+		sess.Add(provider.Message{Role: provider.RoleAssistant, Content: big})
+		sess.Add(provider.Message{Role: provider.RoleUser, Content: "continue"})
+	}
+
+	before := always.calls.Load()
+	err := prepareContext(context.Background(), a, CompactionTriggerPressure)
+	if !errors.Is(err, ErrCompactionRequired) {
+		t.Fatalf("persistent failure = %v, want ErrCompactionRequired", err)
+	}
+	if used := always.calls.Load() - before; used > 2 {
+		t.Fatalf("retry used %d summarizer calls, want at most one extra", used)
+	}
+}
+
+type alwaysFailProvider struct{ calls atomic.Int32 }
+
+func (p *alwaysFailProvider) Name() string { return "always-fail" }
+func (p *alwaysFailProvider) Stream(_ context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	p.calls.Add(1)
+	return nil, errors.New("provider down")
+}
+
+func bigFoldWord() string {
+	out := make([]byte, 0, 2000)
+	for range 400 {
+		out = append(out, "word "...)
+	}
+	return string(out)
+}

--- a/internal/agent/context_manager.go
+++ b/internal/agent/context_manager.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"sync/atomic"
 
+	"reasonix/internal/event"
 	"reasonix/internal/provider"
 )
 
@@ -186,7 +187,29 @@ func (m ContextManager) foldContext(ctx context.Context, prepared PreparedContex
 			}
 			latest := m.currentPrepared()
 			if policy.Trigger == CompactionTriggerOverflow || latest.InputTokens >= hard {
-				return PreparedContext{}, fmt.Errorf("%w: %w", ErrCompactionRequired, err)
+				// The prompt physically cannot ship unsummarized, so a failed
+				// summary ends the turn — but a transient provider failure
+				// (network blip, load-shed 5xx) deserves exactly one immediate
+				// retry before an entire unattended run dies with zero output.
+				// Deterministic summary rejections (truncation, checkpoint)
+				// and cancel/deadline shapes already returned above; a retry
+				// here cannot loop.
+				a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+					Text:    "Compaction summary failed at the context ceiling; retrying once before failing the turn",
+					Detail:  err.Error(),
+					Source:  event.UsageSourceCompaction,
+					ModelRef: a.modelRef})
+				retryOutcome, retryErr := a.compactToProjectionLocked(ctx, policy.Trigger, policy.Instructions, forceFold, mustFree)
+				if retryErr == nil && retryOutcome != CompactionNoop {
+					a.recordContextMaintenanceOutcome(inputHash, policy.Trigger, "summary", "recovered", "retry after transient summary failure succeeded")
+					result = m.currentPrepared()
+					continue
+				}
+				if retryErr != nil {
+					a.recordContextMaintenanceOutcome(inputHash, policy.Trigger, "summary", "failed", fmt.Sprintf("context summary retry failed: %v", retryErr))
+					return PreparedContext{}, fmt.Errorf("%w: %w (retry also failed: %v)", ErrCompactionRequired, err, retryErr)
+				}
+				return PreparedContext{}, fmt.Errorf("%w: context is above the maintenance threshold but no foldable region remains after retry", ErrCompactionRequired)
 			}
 			return latest, nil
 		}


### PR DESCRIPTION
## Summary

The **resilience half** of #8240: when the prompt sits at the hard ceiling, a failed summary ends the turn — the request physically cannot ship unfolded. But a *transient* provider failure (network blip, load-shed 5xx) then killed an entire unattended ACP run with **zero output**: one `[warning] compaction failed` notice, then `stopReason=error` / `agent_error.unknown`, after the session had already done real work. The production trace in the issue shows exactly this — five tasks reused one long session, the sixth died at 10:59 on a transient summary failure, the seventh on the *same session* completed fine.

## Change

The force path (`latest.InputTokens >= hard` or Overflow) retries the summarizer **exactly once** before failing the turn:

- cancellation / deadline / stale-context (`errCompressStaleContext`) / deterministic summary rejections (truncation, checkpoint) all return **before** the retry — the extra call happens only for ordinary provider errors and **cannot loop**;
- a successful retry is recorded as a `"recovered"` maintenance outcome and the fold proceeds;
- a failed retry surfaces *both* errors in the `ErrCompactionRequired` chain; a post-retry no-fold outcome keeps the existing contract message;
- a warn notice names the retry so the host sees why a second summary call appeared.

The soft path (est below the hard ceiling) already degrades to continue-with-full-history and is untouched. The ACP `stopReason` observability half of the issue is separable and deliberately left out of this PR.

## Testing

- `TestCeilingSummaryFailureRetriesOnceBeforeFailingTurn` — over-ceiling fixture, summarizer fails once transiently, the turn **recovers** and folds with the real summary (fails on unpatched with `ErrCompactionRequired` — stash differential verified);
- `TestCeilingSummaryFailureCapsRetryAtOne` — a persistently broken endpoint still fails with `ErrCompactionRequired`, and the call-count assertion proves at most one extra summarizer call;
- existing failure-path suite (`TestSummarizer*`, `TestOverflow*`, `TestPressure*`, `TestCeiling*`, `TestFailedSummary*`, `TestCallerCancellation`) green; `go vet` clean.

Fixes #8240
