### PR TITLE
feat(acp): degrade rejected asks to the unattended fallback

### DIFF
--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -56,6 +56,10 @@ type updateSink struct {
 	cwd     string
 	approve func(id string, allow, session, persist bool)
 	answer  func(id string, answers []event.AskAnswer)
+	// rejectUnattended resolves an ask as "host has no interactive user"
+	// (ask-fallback mode): nil means unavailable and the plain dismiss path
+	// stays in effect for interactive clients (#8238).
+	rejectUnattended func(id string)
 	status  func(event.Event)
 	// extensionSurface records the client's negotiated
 	// reasonix.extensionSurface support: structured surfaces go out as vendor
@@ -91,6 +95,10 @@ func (s *updateSink) bindApprove(fn func(id string, allow, session, persist bool
 // events.
 func (s *updateSink) bindAnswer(fn func(id string, answers []event.AskAnswer)) {
 	s.answer = fn
+}
+
+func (s *updateSink) bindAskRejectUnattended(fn func(id string)) {
+	s.rejectUnattended = fn
 }
 
 // bindStatus installs the vendor-status observer. It receives typed events,
@@ -517,6 +525,15 @@ func (s *updateSink) requestAsk(ctx context.Context, a event.Ask) {
 	for _, q := range a.Questions {
 		selected, ok := s.requestAskQuestion(ctx, a.ID, q)
 		if !ok {
+			// Ask-fallback mode: a rejection means the host has no
+			// interactive user, so degrade to the agent's model-assumption
+			// fallback instead of the dismiss path that cancels the turn
+			// (#8238). Without the mode, rejection keeps the interactive
+			// dismiss contract (#6869).
+			if s.rejectUnattended != nil {
+				s.rejectUnattended(a.ID)
+				return
+			}
 			s.answer(a.ID, nil)
 			return
 		}

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -126,12 +126,15 @@ type AgentInfo struct {
 // stdout is the JSON-RPC channel: callers must keep all other output (logs,
 // diagnostics) off w and on stderr, or the wire corrupts.
 func Serve(ctx context.Context, r io.Reader, w io.Writer, factory Factory, info AgentInfo) error {
+	askFallback := strings.EqualFold(strings.TrimSpace(os.Getenv("REASONIX_ACP_ASK_FALLBACK")), "1") ||
+		strings.EqualFold(strings.TrimSpace(os.Getenv("REASONIX_ACP_ASK_FALLBACK")), "true")
 	conn := NewConn(r, w)
 	svc := &service{
-		conn:     conn,
-		factory:  factory,
-		info:     info,
-		sessions: make(map[string]*acpSession),
+		conn:                  conn,
+		factory:               factory,
+		info:                  info,
+		sessions:              make(map[string]*acpSession),
+		askFallbackUnattended: askFallback,
 	}
 	conn.Handle("initialize", svc.initialize)
 	conn.Handle("authenticate", svc.authenticate)
@@ -168,6 +171,12 @@ type service struct {
 	conn    *Conn
 	factory Factory
 	info    AgentInfo
+	// askFallbackUnattended arms #8238's degradation: a rejected ask is
+	// resolved as "no interactive user" so the agent falls back to its
+	// model-assumption path instead of cancelling the turn. Set from
+	// REASONIX_ACP_ASK_FALLBACK at Serve time; interactive clients keep the
+	// dismiss contract.
+	askFallbackUnattended bool
 
 	mu       sync.Mutex
 	sessions map[string]*acpSession
@@ -692,6 +701,9 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	ctrl.EnableInteractiveApproval()
 	sink.bindApprove(ctrl.Approve)
 	sink.bindAnswer(ctrl.AnswerQuestion)
+	if s.askFallbackUnattended {
+		sink.bindAskRejectUnattended(ctrl.RejectAskUnattended)
+	}
 
 	now := time.Now().UTC()
 	sess := &acpSession{
@@ -995,6 +1007,9 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 	ctrl.EnableInteractiveApproval()
 	sink.bindApprove(ctrl.Approve)
 	sink.bindAnswer(ctrl.AnswerQuestion)
+	if s.askFallbackUnattended {
+		sink.bindAskRejectUnattended(ctrl.RejectAskUnattended)
+	}
 
 	dir := ctrl.SessionDir()
 	if dir == "" {

--- a/internal/agent/ask.go
+++ b/internal/agent/ask.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"errors"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -124,10 +125,24 @@ func (*AskTool) Execute(ctx context.Context, args json.RawMessage) (string, erro
 
 	answers, err := asker.Ask(ctx, qs)
 	if err != nil {
+		// A host with no interactive user (unattended daemon answering every
+		// prompt with a rejection) must not kill the turn: degrade to the same
+		// explicit model-assumption fallback the headless run produces, so
+		// autonomous ACP runs keep going (#8238). Every other ask error stays
+		// an error.
+		if errors.Is(err, ErrAskUnattended) {
+			return "No interactive user answered. This is a model-assumption fallback, not a user answer. Proceed with your best judgment, state the assumption you made, and prefer the safest reversible option when choices differ in risk.", nil
+		}
 		return "", fmt.Errorf("ask: %w", err)
 	}
 	return formatAnswers(qs, answers), nil
 }
+
+// ErrAskUnattended is returned by an Asker when the host resolved the
+// question with no interactive user available at all (an unattended daemon
+// answering every prompt with a rejection). The ask tool maps it to its
+// model-assumption fallback instead of failing the turn (#8238).
+var ErrAskUnattended = errors.New("ask: no interactive user is available on this host")
 
 // formatAnswers renders the user's selections as a compact, model-facing summary,
 // keyed by question header so the model can tell which answer is which. When the

--- a/internal/agent/ask_unattended_fallback_test.go
+++ b/internal/agent/ask_unattended_fallback_test.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+type unattendedAskerProvider struct {
+	streams int
+}
+
+// Stream never runs: the fixture drives the ask tool directly. Kept to satisfy
+// provider.Provider.
+func (p *unattendedAskerProvider) Name() string { return "unattended-asker-host" }
+func (p *unattendedAskerProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	ch := make(chan provider.Chunk, 2)
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "ok"}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+type failingAsker struct{ err error }
+
+func (a failingAsker) Ask(_ context.Context, _ []event.AskQuestion) ([]event.AskAnswer, error) {
+	return nil, a.err
+}
+
+func withAsker(ctx context.Context, asker Asker) context.Context {
+	return WithToolCallContext(ctx, "test-parent", nil, asker, false)
+}
+
+// An ErrAskUnattended resolution must degrade to the model-assumption fallback
+// — the same text the headless run produces — so unattended ACP runs keep
+// going instead of the turn dying (#8238).
+func TestAskToolFallsBackWhenHostIsUnattended(t *testing.T) {
+	askTool := NewAskTool()
+
+	out, err := askTool.Execute(withAsker(context.Background(), failingAsker{err: ErrAskUnattended}),
+		[]byte(`{"questions":[{"question":"How should the autopilot proceed?","options":[{"label":"A"},{"label":"B"}]}]}`))
+	if err != nil {
+		t.Fatalf("unattended ask must not fail the tool: %v", err)
+	}
+	if !strings.Contains(out, "No interactive user answered") || !strings.Contains(out, "model-assumption fallback") {
+		t.Fatalf("unexpected fallback text: %q", out)
+	}
+}
+
+// Every other ask error stays an error — only the unattended sentinel degrades.
+func TestAskToolKeepsOrdinaryAskErrors(t *testing.T) {
+	askTool := NewAskTool()
+
+	if _, err := askTool.Execute(withAsker(context.Background(), failingAsker{err: errors.New("host exploded")}),
+		[]byte(`{"questions":[{"question":"q","options":[{"label":"A"}]}]}`)); err == nil {
+		t.Fatal("ordinary ask error must surface")
+	}
+}

--- a/internal/control/approval.go
+++ b/internal/control/approval.go
@@ -435,12 +435,12 @@ func (a *approvalManager) resolveTool(id, tool string) (pendingApproval, bool) {
 // returns the reply channel. The ask starts queued: registering before the
 // prompt lock is what makes a question waiting behind another prompt visible
 // at all, instead of existing only inside a blocked goroutine.
-func (a *approvalManager) registerAsk(questions []event.AskQuestion) (string, chan []event.AskAnswer) {
+func (a *approvalManager) registerAsk(questions []event.AskQuestion) (string, chan askResolution) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.nextID++
 	id := strconv.Itoa(a.nextID)
-	reply := make(chan []event.AskAnswer, 1)
+	reply := make(chan askResolution, 1)
 	a.asks[id] = pendingAsk{questions: questions, reply: reply, queued: true}
 	return id, reply
 }

--- a/internal/control/ask_unattended_test.go
+++ b/internal/control/ask_unattended_test.go
@@ -1,0 +1,109 @@
+package control
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+)
+
+// RejectAskUnattended must resolve a pending ask with ErrAskUnattended — not
+// the empty-selection path, which cancels the active turn and kills unattended
+// runs (#8238).
+func TestRejectAskUnattendedFailsAskWithoutCancellingTurn(t *testing.T) {
+	sink := &askProbeSink{}
+	c := New(Options{Sink: sink, SessionDir: t.TempDir()})
+
+	askErr := make(chan error, 1)
+	go func() {
+		_, err := c.Ask(context.Background(), askProbeQuestions())
+		askErr <- err
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if asks, _ := sink.counts(); asks == 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("AskRequest never emitted")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	id := sink.lastAskID()
+
+	c.RejectAskUnattended(id)
+
+	select {
+	case err := <-askErr:
+		if err == nil || err.Error() != agent.ErrAskUnattended.Error() {
+			t.Fatalf("Ask error = %v, want ErrAskUnattended", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ask did not resolve after RejectAskUnattended")
+	}
+
+	// No turn was ever started, so there is nothing to cancel; the point is
+	// that RejectAskUnattended itself never arms cancellation — contrast
+	// AnswerQuestion with no selections, which calls Cancel on active turns.
+	if c.cancel != nil {
+		t.Fatal("RejectAskUnattended armed turn cancellation")
+	}
+}
+
+// The interactive dismiss contract (#6869) is unchanged: an empty-selection
+// AnswerQuestion on an active turn still cancels it.
+func TestEmptyAnswerStillCancelsActiveTurn(t *testing.T) {
+	sink := &askProbeSink{}
+	c := New(Options{Sink: sink, SessionDir: t.TempDir()})
+	cancelled := make(chan struct{}, 1)
+	ctx, cancelAsk := context.WithCancel(context.Background())
+	defer cancelAsk()
+	c.mu.Lock()
+	c.cancel = func() {
+		cancelled <- struct{}{}
+		cancelAsk()
+	}
+	c.mu.Unlock()
+
+	askErr := make(chan error, 1)
+	go func() {
+		_, err := c.Ask(ctx, askProbeQuestions())
+		askErr <- err
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if asks, _ := sink.counts(); asks == 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("AskRequest never emitted")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	id := sink.lastAskID()
+
+	c.AnswerQuestion(id, nil)
+
+	select {
+	case <-cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("empty-selection answer no longer cancels the active turn")
+	}
+	<-askErr
+}
+
+func (s *askProbeSink) lastAskID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.asks) == 0 {
+		return ""
+	}
+	return s.asks[len(s.asks)-1].ID
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -351,8 +351,17 @@ type pendingApproval struct {
 // event (see ReplayPendingPrompts).
 type pendingAsk struct {
 	questions []event.AskQuestion
-	reply     chan []event.AskAnswer
+	reply     chan askResolution
 	queued    bool // registered but not yet shown; replay must skip it
+}
+
+// askResolution is one settled AskRequest. answers carries the user's (or
+// host's) selections; unattended marks a host that has no interactive user at
+// all, so the ask tool should fall back to its unattended judgment path
+// instead of reading the empty selection as a deliberate dismiss (#8238).
+type askResolution struct {
+	answers    []event.AskAnswer
+	unattended bool
 }
 
 type plannerSessionResetter interface {
@@ -2508,8 +2517,11 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 	defer cancelWait()
 
 	select {
-	case ans := <-reply:
-		return ans, nil
+	case res := <-reply:
+		if res.unattended {
+			return nil, ErrAskUnattended
+		}
+		return res.answers, nil
 	case <-waitCtx.Done():
 		c.approval.cancelAsk(id)
 		return nil, waitCtx.Err()
@@ -2533,7 +2545,27 @@ func (c *Controller) AnswerQuestion(id string, answers []event.AskAnswer) {
 			}
 		}
 		c.recordAskDecisionReceipt(id, pending, answers)
-		pending.reply <- answers // buffered, never blocks
+		pending.reply <- askResolution{answers: answers} // buffered, never blocks
+	}
+}
+
+// ErrAskUnattended is agent.ErrAskUnattended re-exported for hosts: Ask fails
+// with it when the question was resolved by RejectAskUnattended — no
+// interactive user exists on the other side, and the caller should fall back
+// to its unattended judgment path instead of treating the resolution as a
+// user decision.
+var ErrAskUnattended = agent.ErrAskUnattended
+
+// RejectAskUnattended resolves a pending AskRequest as coming from a host with
+// no interactive user (an unattended daemon answering every prompt with a
+// rejection). Ask then fails with ErrAskUnattended, which the ask tool maps to
+// the same model-assumption fallback `reasonix run -p` produces — instead of
+// the empty-selection path, which cancels the turn and kills unattended runs
+// (#8238). Unknown/expired IDs are ignored.
+func (c *Controller) RejectAskUnattended(id string) {
+	if pending, ok := c.approval.resolveAsk(id); ok {
+		c.recordAskDecisionReceipt(id, pending, nil)
+		pending.reply <- askResolution{unattended: true} // buffered, never blocks
 	}
 }
 


### PR DESCRIPTION
## Summary

An unattended ACP host (daemon, CI, bot schedule) has no interactive user, so it answers every `session/request_permission` ask with the only safe option — `reject_once`. Reasonix read that rejection through the **empty-selection path, which cancels the active turn**: an entire autonomous task died with `Reasonix requested interactive user input, which is unavailable` after the model had already done real work (#8238 — three identical production failures in five minutes, each after the agent had discovered the fork points and only needed a decision). The headless `reasonix run -p` fallback existed but was unreachable through ACP, because ACP always installs an asker.

## Change

The ask resolution now carries an explicit **unattended** distinction instead of overloading the empty selection:

- **`Controller.RejectAskUnattended(id)`** resolves a pending ask with `agent.ErrAskUnattended` (re-exported as `control.ErrAskUnattended` for hosts). The `pendingAsk` reply channel carries a small `askResolution{answers, unattended}` struct, so the dismiss path and the unattended path cannot be confused.
- **The `ask` tool** maps that sentinel to the exact headless fallback text — *"No interactive user answered. This is a model-assumption fallback… proceed with your best judgment, state the assumption, prefer the safest reversible option"* — instead of failing the turn. Every other `Asker` error still surfaces as an error.
- **ACP arms it only under `REASONIX_ACP_ASK_FALLBACK=1`** (read at `Serve`, bound per session). The ACP protocol carries no "this host is unattended" signal — a plain behavior change would silently regress interactive clients, where a rejected ask is a deliberate dismiss — so the degradation is **opt-in** for daemon hosts. Interactive clients keep the #6869 contract byte-for-byte.

## Testing

- `TestRejectAskUnattendedFailsAskWithoutCancellingTurn` — Ask fails with the sentinel and the turn is never cancelled;
- `TestEmptyAnswerStillCancelsActiveTurn` — the interactive dismiss contract is unchanged (empty selection on an active turn still cancels);
- `TestAskToolFallsBackWhenHostIsUnattended` — the tool returns the fallback text; `TestAskToolKeepsOrdinaryAskErrors` — only the sentinel degrades.
- Differential: the agent-side test cannot compile against the unpatched `ask.go` (sentinel undefined); `go vet` clean across agent/control/acp; ACP ask/permission suites green.
