### PR TITLE
feat(cli): optional download mirror for release upgrades

### DIFF
--- a/internal/cli/asset_mirror.go
+++ b/internal/cli/asset_mirror.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"net/url"
+	"strings"
+)
+
+// mirrorAssetURL rewrites one release-asset URL onto the configured download
+// mirror. Only host-hopped paths are rewritten: the mirror base keeps an
+// optional path prefix, and the asset keeps its exact owner/repo/tag/file
+// tail so a mirror that serves the same release layout works unmodified.
+// API URLs (api.github.com) are never mirrored — the releases metadata still
+// comes from GitHub so asset identity and sizes stay authoritative.
+func mirrorAssetURL(raw, mirror string) string {
+	raw = strings.TrimSpace(raw)
+	mirror = strings.TrimSpace(mirror)
+	if raw == "" || mirror == "" || !strings.HasPrefix(raw, "https://github.com/") {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	if !strings.Contains(mirror, "://") {
+		mirror = "https://" + mirror
+	}
+	m, err := url.Parse(mirror)
+	if err != nil || m.Scheme == "" || m.Host == "" {
+		return raw
+	}
+	tail := strings.TrimPrefix(u.Path, "/")
+	if tail == "" {
+		return raw
+	}
+	m.Path = strings.TrimRight(m.Path, "/") + "/" + tail
+	return m.String()
+}

--- a/internal/cli/asset_mirror_test.go
+++ b/internal/cli/asset_mirror_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import "testing"
+
+func TestMirrorAssetURL(t *testing.T) {
+	const asset = "https://github.com/esengine/DeepSeek-Reasonix/releases/download/v1.31.3/reasonix_windows_amd64.zip"
+
+	cases := []struct {
+		name   string
+		raw    string
+		mirror string
+		want   string
+	}{
+		{
+			name:   "host mirror keeps the asset tail",
+			raw:    asset,
+			mirror: "https://mirror.example.com",
+			want:   "https://mirror.example.com/esengine/DeepSeek-Reasonix/releases/download/v1.31.3/reasonix_windows_amd64.zip",
+		},
+		{
+			name:   "path-prefixed mirror appends the tail",
+			raw:    asset,
+			mirror: "https://mirror.example.com/gh",
+			want:   "https://mirror.example.com/gh/esengine/DeepSeek-Reasonix/releases/download/v1.31.3/reasonix_windows_amd64.zip",
+		},
+		{
+			name:   "scheme-less mirror defaults to https",
+			raw:    asset,
+			mirror: "mirror.example.com",
+			want:   "https://mirror.example.com/esengine/DeepSeek-Reasonix/releases/download/v1.31.3/reasonix_windows_amd64.zip",
+		},
+		{
+			name:   "trailing slash on the mirror does not double",
+			raw:    asset,
+			mirror: "https://mirror.example.com/",
+			want:   "https://mirror.example.com/esengine/DeepSeek-Reasonix/releases/download/v1.31.3/reasonix_windows_amd64.zip",
+		},
+		{
+			name:   "empty mirror downloads from github unchanged",
+			raw:    asset,
+			mirror: "",
+			want:   asset,
+		},
+		{
+			name:   "non-github URL is never rewritten",
+			raw:    "https://api.github.com/repos/esengine/DeepSeek-Reasonix/releases",
+			mirror: "https://mirror.example.com",
+			want:   "https://api.github.com/repos/esengine/DeepSeek-Reasonix/releases",
+		},
+		{
+			name:   "garbage mirror leaves the URL alone",
+			raw:    asset,
+			mirror: "::::not-a-url",
+			want:   asset,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mirrorAssetURL(tc.raw, tc.mirror); got != tc.want {
+				t.Fatalf("mirrorAssetURL(%q, %q) =\n  %q\nwant\n  %q", tc.raw, tc.mirror, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -287,7 +287,8 @@ func upgradeCommand(args []string, version string) int {
 
 	// 7. Download archive.
 	fmt.Printf(i18n.M.UpgradeDownloadingFmt+"\n", asset.Name, humanSize(asset.Size))
-	archiveData, err := fetchBytesSized(c, asset.BrowserDownloadURL, asset.Size)
+	mirrorBase := cfg.CLIDownloadMirror()
+	archiveData, err := fetchBytesSized(c, mirrorAssetURL(asset.BrowserDownloadURL, mirrorBase), asset.Size)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s "+i18n.M.UpgradeDownloadFailed+"\n", i18n.M.ErrorPrefix, err)
 		return 1
@@ -295,7 +296,7 @@ func upgradeCommand(args []string, version string) int {
 
 	// 8. Verify SHA256 checksum — fail closed: abort on any verification error.
 	fmt.Println(i18n.M.UpgradeVerifying)
-	checksumData, err := fetchBytesSized(c, checksumAsset.BrowserDownloadURL, checksumAsset.Size)
+	checksumData, err := fetchBytesSized(c, mirrorAssetURL(checksumAsset.BrowserDownloadURL, mirrorBase), checksumAsset.Size)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s "+i18n.M.UpgradeChecksumFailed+"\n", i18n.M.ErrorPrefix, err)
 		return 1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -273,6 +273,14 @@ type CLIConfig struct {
 	// configurations. Runtime behavior is always the official release channel,
 	// and the canonical renderer intentionally drops this field.
 	UpdateChannel string `toml:"update_channel"`
+	// DownloadMirror rewrites release-asset downloads (the upgrade archive and
+	// its SHA256SUMS) to this base URL — for networks where github.com release
+	// downloads are throttled. The releases API is never mirrored, and the
+	// archive checksum is still verified against the mirrored checksums file,
+	// so the mirror cannot serve tampered bytes without failing the upgrade.
+	// Empty downloads straight from github.com. REASONIX_DOWNLOAD_MIRROR
+	// overrides the file value for one run.
+	DownloadMirror string `toml:"download_mirror"`
 }
 
 // DesktopConfig controls desktop-only UI preferences. It is intentionally
@@ -629,6 +637,24 @@ func (c *Config) CLIUpdateChannel() string {
 		return "stable"
 	}
 	return NormalizeCLIUpdateChannel(c.CLI.UpdateChannel)
+}
+
+// CLIDownloadMirror returns the release-asset download mirror base, with
+// REASONIX_DOWNLOAD_MIRROR overriding the file value for one run. Empty means
+// downloading straight from github.com. The value is normalized to a bare
+// scheme+host (+ optional path prefix) with no trailing slash.
+func (c *Config) CLIDownloadMirror() string {
+	raw := strings.TrimSpace(os.Getenv("REASONIX_DOWNLOAD_MIRROR"))
+	if raw == "" && c != nil {
+		raw = strings.TrimSpace(c.CLI.DownloadMirror)
+	}
+	if raw == "" {
+		return ""
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	return strings.TrimRight(raw, "/")
 }
 
 // NormalizeDesktopUpdateChannel returns the only public Desktop update channel.

--- a/internal/config/download_mirror_test.go
+++ b/internal/config/download_mirror_test.go
@@ -1,0 +1,34 @@
+package config
+
+import "testing"
+
+func TestCLIDownloadMirrorEnvOverridesFile(t *testing.T) {
+	t.Setenv("REASONIX_DOWNLOAD_MIRROR", "https://mirror.example.com/gh")
+	cfg := Default()
+	cfg.CLI.DownloadMirror = "https://file-mirror.example.com"
+	if got := cfg.CLIDownloadMirror(); got != "https://mirror.example.com/gh" {
+		t.Fatalf("CLIDownloadMirror() = %q, want the env override", got)
+	}
+}
+
+func TestCLIDownloadMirrorNormalizes(t *testing.T) {
+	t.Setenv("REASONIX_DOWNLOAD_MIRROR", "")
+	for raw, want := range map[string]string{
+		"mirror.example.com":         "https://mirror.example.com",
+		"https://mirror.example.com": "https://mirror.example.com",
+		"https://m.example.com/gh/":  "https://m.example.com/gh",
+	} {
+		cfg := Default()
+		cfg.CLI.DownloadMirror = raw
+		if got := cfg.CLIDownloadMirror(); got != want {
+			t.Fatalf("CLIDownloadMirror() for %q = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+func TestCLIDownloadMirrorEmptyWhenUnset(t *testing.T) {
+	t.Setenv("REASONIX_DOWNLOAD_MIRROR", "")
+	if got := Default().CLIDownloadMirror(); got != "" {
+		t.Fatalf("CLIDownloadMirror() = %q, want empty (github.com direct)", got)
+	}
+}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -34,6 +34,9 @@ turn_done = true   # notify when a turn finishes
 approval_request = true   # notify when a tool approval is waiting
 ask_request = true   # notify when a question is waiting
 
+# [cli]
+# download_mirror = ""    # release-asset download mirror for slow github.com routes; empty = direct (env: REASONIX_DOWNLOAD_MIRROR)
+
 [agent]
 # system_prompt = "You are ..."   # custom persona/prompt; unset or empty = built-in default
 # system_prompt_file = "prompts/system.md"   # project paths stay in <workspace>; user paths may fall back to <reasonix home>


### PR DESCRIPTION
## Summary

On networks where github.com release downloads are throttled (#9270), the updater already honors the configured proxy — but a proxy is not always available, and the common split is *API reachable while asset downloads crawl*. This adds the missing lever: an opt-in **release-asset download mirror**.

## Change

- **`[cli].download_mirror`** (TOML) / **`REASONIX_DOWNLOAD_MIRROR`** (env, overrides the file per run): rewrites **only the release-asset URLs** — the upgrade archive and its `SHA256SUMS` — onto the mirror base, preserving the exact `owner/repo/tag/file` tail so any layout-compatible mirror works (scheme-less values default to https; trailing slashes normalize).
- **Not mirrored**: the GitHub Releases API. Release metadata — asset identity and sizes — stays authoritative from GitHub, so a mirror cannot change *what* upgrades, only *where bytes come from*.
- **Integrity unchanged**: the archive checksum is still verified against the (mirrored) `SHA256SUMS`; a mirror serving tampered bytes fails the upgrade exactly as before. Size pre-validation (`fetchBytesSized`) also still applies.

## Testing

- 7-case table test on `mirrorAssetURL`: host mirror, path-prefixed mirror, scheme-less default, trailing slash, empty mirror (URL unchanged), **non-github URL never rewritten** (the API case), garbage mirror → URL untouched.
- 3 tests on `CLIDownloadMirror()`: env overrides file, normalization map, empty when unset.
- `go vet` clean on cli + config; documented in `reasonix.example.toml`.

Fixes #9270
