### PR TITLE
fix(agent): tell the model when a step sign-off matches no canonical todo

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1458,7 +1458,22 @@ func (a *Agent) advanceCanonicalTodo(step string) {
 		return
 	}
 	m, ok := evidence.MatchStep(step, a.sess.todoState)
-	if !ok || !evidence.AdvanceSerialTodo(a.sess.todoState, m.Index-1) {
+	if !ok {
+		// The sign-off cites a step the canonical list does not know — most
+		// often a list left over from an earlier session generation whose step
+		// ids no longer match. Staying silent here taught models the todo
+		// system was "locked" and they stopped signing off at all (#9249);
+		// say what happened and what repairs it instead.
+		a.sess.todoMu.Unlock()
+		a.svc.sink.Emit(event.Event{
+			Kind:  event.Notice,
+			Level: event.LevelWarn,
+			Text:   unmatchedStepSignOffNotice,
+			Detail: "unmatched step sign-off: " + step,
+		})
+		return
+	}
+	if !evidence.AdvanceSerialTodo(a.sess.todoState, m.Index-1) {
 		a.sess.todoMu.Unlock()
 		return
 	}
@@ -1467,6 +1482,10 @@ func (a *Agent) advanceCanonicalTodo(step string) {
 	a.recordTodoState(snapshot)
 	a.emitTodoState(snapshot, m.Index)
 }
+
+// unmatchedStepSignOffNotice is the host guidance for a signed-off step the
+// canonical todo list does not know (#9249).
+const unmatchedStepSignOffNotice = "A signed-off step did not match the canonical todo list (it may be stale from an earlier session). Re-issue todo_write with the steps you are actually working now, then sign off against those ids; already-verified work is not affected."
 
 // emitTodoState emits a synthetic todo_write event so the frontend task panel
 // reflects a host-advanced completion without the model re-sending the list.

--- a/internal/agent/canonical_todo_stale_notice_test.go
+++ b/internal/agent/canonical_todo_stale_notice_test.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/event"
+)
+
+type noticeSink struct{ notices []event.Event }
+
+func newNoticeSink() *noticeSink { return &noticeSink{} }
+
+func (s *noticeSink) Emit(e event.Event) {
+	if e.Kind == event.Notice {
+		s.notices = append(s.notices, e)
+	}
+}
+
+// A signed-off step the canonical list does not know used to no-op silently
+// (#9249): with a list stale from an earlier session generation, every sign-off
+// mismatched, the model read the todo system as locked, and it narrated the
+// workaround instead of repairing the list. The mismatch now says what
+// happened and what repairs it.
+func TestAdvanceCanonicalTodoUnmatchedStepEmitsStaleListNotice(t *testing.T) {
+	sink := newNoticeSink()
+	a := &Agent{
+		svc:  agentServices{sink: sink},
+		sess: sessionRuntime{todoState: []evidence.TodoItem{{StepID: "old-1", Content: "stale item", Status: "in_progress"}}},
+	}
+
+	a.advanceCanonicalTodo("new-step-9")
+
+	if a.sess.todoState[0].Status != "in_progress" {
+		t.Fatalf("unmatched sign-off must not mutate the list: %+v", a.sess.todoState[0])
+	}
+	if len(sink.notices) != 1 {
+		t.Fatalf("notices = %d, want exactly one stale-list notice", len(sink.notices))
+	}
+	n := sink.notices[0]
+	if !strings.Contains(n.Text, "todo_write") || !strings.Contains(n.Text, "stale") {
+		t.Fatalf("notice does not guide the repair: %q", n.Text)
+	}
+	if !strings.Contains(n.Detail, "new-step-9") {
+		t.Fatalf("notice does not name the unmatched step: %q", n.Detail)
+	}
+}
+
+// A matching sign-off stays exactly as quiet as before — the notice is only
+// for the dead end.
+func TestAdvanceCanonicalTodoMatchedStepStaysSilent(t *testing.T) {
+	sink := newNoticeSink()
+	a := &Agent{
+		svc:  agentServices{sink: sink},
+		sess: sessionRuntime{todoState: []evidence.TodoItem{{Content: "sync branch", Status: "in_progress"}}},
+	}
+
+	a.advanceCanonicalTodo("sync branch")
+
+	if a.sess.todoState[0].Status != "completed" {
+		t.Fatalf("matched sign-off did not complete: %+v", a.sess.todoState[0])
+	}
+	if len(sink.notices) != 0 {
+		t.Fatalf("matched sign-off emitted %d notices, want none", len(sink.notices))
+	}
+}
+
+// An empty canonical list has nothing to be stale — still silent.
+func TestAdvanceCanonicalTodoEmptyListStaysSilent(t *testing.T) {
+	sink := newNoticeSink()
+	a := &Agent{svc: agentServices{sink: sink}}
+
+	a.advanceCanonicalTodo("anything")
+
+	if len(sink.notices) != 0 {
+		t.Fatalf("empty list emitted %d notices, want none", len(sink.notices))
+	}
+}


### PR DESCRIPTION
## Summary

A signed-off step the canonical todo list did not know **no-opped silently**. When the list was stale from an earlier session generation — its step ids no longer matching anything the model signed — every sign-off mismatched, the model read the todo system as *locked*, and it narrated workarounds ("todo 系统被此前会话的历史残留列表锁定，无法用新 step_id 签核") instead of repairing the list, while the actual file work was complete and verified (#9249). The report's quoted agent reply is exactly this dead end: correct reasoning about the evidence, total silence about the repair.

## Change

The unmatched sign-off now emits a host notice naming the dead end and the repair:

> A signed-off step did not match the canonical todo list (it may be stale from an earlier session). Re-issue todo_write with the steps you are actually working now, then sign off against those ids; already-verified work is not affected.

Deliberately narrow:

- the canonical list is **not** mutated by an unmatched citation (the existing no-mutation contract stands — position/wording ambiguity still never guesses);
- a **matching** sign-off stays exactly as quiet as before;
- an **empty** list stays silent;
- the notice carries the unmatched step id in `Detail` for diagnostics.

## Testing

Three tests (`canonical_todo_stale_notice_test.go`): the unmatched sign-off emits exactly one notice that guides the repair and names the step, without mutating the list; a matched sign-off completes and emits **zero** notices; the empty list emits none. Differential: the unmatched test fails on unpatched `agent.go` (no notice emitted). `go vet` clean; existing `TestAdvanceCanonicalTodo*` family green.

Fixes #9249
