### PR TITLE
fix(sessioncatalog): stop repeated repair reindex loop / 修复会话目录反复重新索引

### DIFF
--- a/internal/sessioncatalog/catalog.go
+++ b/internal/sessioncatalog/catalog.go
@@ -355,6 +355,21 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 	if len(records) == 0 {
 		return nil
 	}
+	// Exact-path indexing is deliberately cheap and may be requested after every
+	// defensive snapshot. Do not publish a new catalog revision when the
+	// authoritative sidecar still describes the same projection; otherwise an
+	// idle tab can make the tree churn forever and repeatedly wake repair/UI work.
+	if len(records) == 1 && generations == nil {
+		record := classifyRecoveryLineage(normalizeSessionRecord(records[0]))
+		if record.LogicalTopicID == "" {
+			record.LogicalTopicID = record.TopicID
+		}
+		if existing, ok, err := c.GetSession(ctx, record.Path); err == nil && ok && existing.Path != "" &&
+			existing.MissingSince == 0 && (sameSessionIndexInput(existing, record) ||
+			(existing.TurnsState != TurnsUnknown && record.TurnsState == TurnsUnknown && sameSessionIndexSource(existing, record))) {
+			return nil
+		}
+	}
 	tx, err := c.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err

--- a/internal/sessioncatalog/catalog.go
+++ b/internal/sessioncatalog/catalog.go
@@ -355,20 +355,12 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 	if len(records) == 0 {
 		return nil
 	}
-	// Exact-path indexing is deliberately cheap and may be requested after every
-	// defensive snapshot. Do not publish a new catalog revision when the
-	// authoritative sidecar still describes the same projection; otherwise an
-	// idle tab can make the tree churn forever and repeatedly wake repair/UI work.
 	if len(records) == 1 && generations == nil {
-		record := classifyRecoveryLineage(normalizeSessionRecord(records[0]))
-		if record.LogicalTopicID == "" {
-			record.LogicalTopicID = record.TopicID
-		}
-		if existing, ok, err := c.GetSession(ctx, record.Path); err == nil && ok && existing.Path != "" &&
-			existing.MissingSince == 0 && (sameSessionIndexInput(existing, record) ||
-			(existing.TurnsState != TurnsUnknown && record.TurnsState == TurnsUnknown && sameSessionIndexSource(existing, record))) {
+		record, skip := c.prepareExactPathProjection(ctx, records[0])
+		if skip {
 			return nil
 		}
+		records[0] = record
 	}
 	tx, err := c.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/sessioncatalog/exact_index.go
+++ b/internal/sessioncatalog/exact_index.go
@@ -1,0 +1,26 @@
+package sessioncatalog
+
+import "context"
+
+// prepareExactPathProjection avoids publishing unchanged snapshots while
+// retaining known counts when only legacy sidecar metadata is stale.
+func (c *Catalog) prepareExactPathProjection(ctx context.Context, raw SessionRecord) (SessionRecord, bool) {
+	record := classifyRecoveryLineage(normalizeSessionRecord(raw))
+	if record.LogicalTopicID == "" {
+		record.LogicalTopicID = record.TopicID
+	}
+	existing, ok, err := c.GetSession(ctx, record.Path)
+	if err != nil || !ok || existing.Path == "" || existing.MissingSince != 0 {
+		return record, false
+	}
+	if sameSessionIndexInput(existing, record) {
+		return record, true
+	}
+	if existing.TurnsState != TurnsUnknown && record.TurnsState == TurnsUnknown &&
+		existing.ContentFingerprint == record.ContentFingerprint {
+		record.Preview = existing.Preview
+		record.Turns = existing.Turns
+		record.TurnsState = existing.TurnsState
+	}
+	return record, false
+}

--- a/internal/sessioncatalog/exact_index_test.go
+++ b/internal/sessioncatalog/exact_index_test.go
@@ -1,0 +1,117 @@
+package sessioncatalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+)
+
+func TestIndexSessionPathSkipsUnchangedProjection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chat.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{
+		Scope: "global", TopicID: "topic", TopicTitle: "Chat",
+		SchemaVersion: agent.BranchMetaCountsVersion, Turns: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	events := 0
+	catalog, err := Open(ctx, Options{InMemory: true, DisableRepair: true, OnRevision: func(uint64, []string, string) { events++ }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(ctx) })
+	target := DirectoryTarget{Path: dir, Scope: "global"}
+	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
+		t.Fatal(err)
+	}
+	revision := catalog.Status().Revision
+	before, _, _ := catalog.GetSession(ctx, path)
+	for range 5 {
+		if err := catalog.IndexSessionPath(ctx, target, path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := catalog.Status().Revision; got != revision {
+		after, _, _ := catalog.GetSession(ctx, path)
+		t.Logf("before=%+v after=%+v", before, after)
+		t.Fatalf("revision after unchanged exact indexes = %d, want %d", got, revision)
+	}
+	if events != 1 {
+		t.Fatalf("revision events after unchanged exact indexes = %d, want 1", events)
+	}
+}
+
+func TestIndexSessionPathDoesNotRequeueRepairAfterRepair(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "legacy.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{TopicID: "topic", SchemaVersion: 1}); err != nil {
+		t.Fatal(err)
+	}
+	catalog, err := Open(ctx, Options{InMemory: true, QueueCapacity: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(ctx) })
+	target := DirectoryTarget{Path: dir, Scope: "global"}
+	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if catalog.Status().RepairPending == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if catalog.Status().RepairPending != 0 {
+		t.Fatal("repair did not complete")
+	}
+	for range 20 {
+		if err := catalog.IndexSessionPath(ctx, target, path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := catalog.Status().RepairPending; got != 0 {
+		t.Fatalf("repair pending after unchanged exact indexes = %d", got)
+	}
+}
+
+func TestExactIndexDoesNotDowngradeKnownCounts(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	catalog, err := Open(ctx, Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(ctx) })
+	record := SessionRecord{Path: "/sessions/chat.jsonl", Directory: "/sessions", Scope: "global", TopicID: "topic", CreatedAt: 1, LastActivityAt: 2, Preview: "hi", Turns: 1, TurnsState: TurnsValid, ContentFingerprint: "10:1", MetaFingerprint: "20:1", Health: HealthOK}
+	if err := catalog.UpsertSession(ctx, record); err != nil {
+		t.Fatal(err)
+	}
+	record.Preview, record.Turns, record.TurnsState, record.MetaFingerprint = "", 0, TurnsUnknown, "20:2"
+	if err := catalog.UpsertSession(ctx, record); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := catalog.GetSession(ctx, record.Path)
+	if err != nil || !ok {
+		t.Fatalf("GetSession: ok=%v err=%v", ok, err)
+	}
+	if got.TurnsState != TurnsValid || got.Turns != 1 || got.Preview != "hi" {
+		t.Fatalf("exact index downgraded known counts: %+v", got)
+	}
+}

--- a/internal/sessioncatalog/exact_index_test.go
+++ b/internal/sessioncatalog/exact_index_test.go
@@ -104,6 +104,7 @@ func TestExactIndexDoesNotDowngradeKnownCounts(t *testing.T) {
 		t.Fatal(err)
 	}
 	record.Preview, record.Turns, record.TurnsState, record.MetaFingerprint = "", 0, TurnsUnknown, "20:2"
+	record.Recovered, record.RecoveryReason, record.RecoveryDigest, record.ParentID = true, "recovery", "digest", "parent"
 	if err := catalog.UpsertSession(ctx, record); err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +112,8 @@ func TestExactIndexDoesNotDowngradeKnownCounts(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("GetSession: ok=%v err=%v", ok, err)
 	}
-	if got.TurnsState != TurnsValid || got.Turns != 1 || got.Preview != "hi" {
-		t.Fatalf("exact index downgraded known counts: %+v", got)
+	if got.TurnsState != TurnsValid || got.Turns != 1 || got.Preview != "hi" ||
+		!got.Recovered || got.RecoveryReason != "recovery" || got.RecoveryDigest != "digest" || got.ParentID != "parent" {
+		t.Fatalf("exact index lost known counts or recovery metadata: %+v", got)
 	}
 }

--- a/internal/sessioncatalog/reconcile_integrity.go
+++ b/internal/sessioncatalog/reconcile_integrity.go
@@ -167,11 +167,3 @@ func sameSessionIndexInput(got, want SessionRecord) bool {
 		got.ContentFingerprint == want.ContentFingerprint && got.MetaFingerprint == want.MetaFingerprint &&
 		got.Health == want.Health
 }
-
-func sameSessionIndexSource(got, want SessionRecord) bool {
-	return got.Path == want.Path && got.Directory == want.Directory &&
-		got.Scope == want.Scope && got.WorkspaceRoot == want.WorkspaceRoot &&
-		got.TopicID == want.TopicID && got.TopicTitle == want.TopicTitle &&
-		got.CustomTitle == want.CustomTitle && got.CreatedAt == want.CreatedAt &&
-		got.LastActivityAt == want.LastActivityAt && got.ContentFingerprint == want.ContentFingerprint
-}

--- a/internal/sessioncatalog/reconcile_integrity.go
+++ b/internal/sessioncatalog/reconcile_integrity.go
@@ -150,3 +150,28 @@ func sameSessionProjection(got, want SessionRecord) bool {
 		got.MetaFingerprint == want.MetaFingerprint &&
 		got.Health == want.Health
 }
+
+// sameSessionIndexInput covers fields sourced directly from the authoritative
+// transcript/branch sidecar. Derived lineage visibility is intentionally left
+// out: reconcile owns that projection and may update it without rewriting the
+// session row for every exact-path save.
+func sameSessionIndexInput(got, want SessionRecord) bool {
+	return got.Path == want.Path && got.Directory == want.Directory &&
+		got.Scope == want.Scope && got.WorkspaceRoot == want.WorkspaceRoot &&
+		got.TopicID == want.TopicID && got.TopicTitle == want.TopicTitle &&
+		got.CustomTitle == want.CustomTitle && got.CreatedAt == want.CreatedAt &&
+		got.LastActivityAt == want.LastActivityAt && got.Preview == want.Preview &&
+		got.Turns == want.Turns && got.TurnsState == want.TurnsState &&
+		got.Recovered == want.Recovered && got.RecoveryReason == want.RecoveryReason &&
+		got.RecoveryDigest == want.RecoveryDigest && got.ParentID == want.ParentID &&
+		got.ContentFingerprint == want.ContentFingerprint && got.MetaFingerprint == want.MetaFingerprint &&
+		got.Health == want.Health
+}
+
+func sameSessionIndexSource(got, want SessionRecord) bool {
+	return got.Path == want.Path && got.Directory == want.Directory &&
+		got.Scope == want.Scope && got.WorkspaceRoot == want.WorkspaceRoot &&
+		got.TopicID == want.TopicID && got.TopicTitle == want.TopicTitle &&
+		got.CustomTitle == want.CustomTitle && got.CreatedAt == want.CreatedAt &&
+		got.LastActivityAt == want.LastActivityAt && got.ContentFingerprint == want.ContentFingerprint
+}


### PR DESCRIPTION
## Summary

Fixes the desktop sidebar loop where an idle session repeatedly entered indexing/repair state, making session deletion appear unavailable.

## Root cause

Defensive exact-path indexing rewrote an unchanged session projection and published a new catalog revision on every snapshot. That revision churn could re-trigger repair and directory reconciliation continuously. A stale `unknown` exact-index input could also downgrade a completed count projection.

## Fix

- Skip unchanged exact-path projections without writing or publishing a revision.
- Preserve known counts when an older `unknown` input arrives for the same authoritative session, while still applying recovery metadata changes.
- Extract exact-path preparation from the large catalog upsert function to satisfy repository complexity and size limits.
- Add regression tests covering repeated indexing, repair completion, count preservation, and recovery metadata updates.

## Verification

- `go run ./tools/repolint`
- `go test ./internal/sessioncatalog -count=1`
- `go test -race ./internal/sessioncatalog -count=1`
- `go vet ./internal/sessioncatalog`
- `cd desktop && go test ./... -run 'Test(DeleteSession|SessionCatalog|ProjectTree|Reconcile|ListProjectTopics)' -count=1`
- `git diff --check`

Closes the reported frontend diagnostic pattern of repeated `repairPending` transitions.
