### PR TITLE
feat(desktop): per-task model selection for heartbeat tasks / 心跳任务支持按任务选择模型

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -154,6 +154,7 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // production and 2358.3 KiB in test: about 9.0 KiB (0.38%) over main-v2's
 // channel gates. Retain that attributable UI capacity with 0.1 KiB of build-SHA
 // headroom without widening the gzip or largest-chunk exceptions.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_358.4 : 2_353.2;
+// Heartbeat per-task model picker (dropdown + i18n, ~0.3 KiB) raises it again.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_358.7 : 2_353.5;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/__tests__/heartbeat-editor.test.tsx
+++ b/desktop/frontend/src/__tests__/heartbeat-editor.test.tsx
@@ -72,6 +72,12 @@ Object.assign(window, {
         async HeartbeatTriggerNow() {},
         async HeartbeatGenerateID() { nextID += 1; return `draft-${nextID}`; },
         async ListWorkspaces() { return [{ name: "Project One", path: "/project-one", current: true }]; },
+        async Models() {
+          return [
+            { ref: "deepseek/deepseek-v4", provider: "deepseek", model: "deepseek-v4", current: true },
+            { ref: "17an/deepseek-v4-flash", provider: "17an", model: "deepseek-v4-flash", current: false },
+          ];
+        },
       },
     },
   },
@@ -210,6 +216,47 @@ await act(async () => {
 });
 ok(document.querySelector<HTMLInputElement>('[aria-label="Title"]')?.value === "Product update digest", "parent save conflict keeps the unsaved recommendation draft open");
 ok(document.querySelector('.heartbeat-editor__save-error')?.textContent?.includes("Your draft is still here") === true, "parent save conflict is reported instead of marking the draft clean");
+
+console.log("\nheartbeat editor model picker");
+
+let modelSubmitted: HeartbeatTask | null = null;
+await act(async () => {
+  renderEditor({ ...originalTask, id: "model-task" }, async (task) => { modelSubmitted = task; return true; }, "model");
+  await flush();
+  await flush();
+});
+const modelTrigger = document.querySelector<HTMLButtonElement>(".heartbeat-model-select");
+ok(modelTrigger != null, "model picker renders for an existing task");
+ok(modelTrigger?.textContent?.includes("Default model") === true, "empty model shows the default-model label");
+await act(async () => {
+  document.querySelector<HTMLButtonElement>(".heartbeat-model-select")?.click();
+  await flush();
+});
+const modelItems = Array.from(document.querySelectorAll(".heartbeat-model-menu .heartbeat-project-menu__item"));
+ok(modelItems.length === 3, "model menu lists the default entry plus configured models");
+await act(async () => {
+  Array.from(document.querySelectorAll(".heartbeat-model-menu .heartbeat-project-menu__item"))
+    .find((item) => item.textContent?.includes("17an/deepseek-v4-flash"))?.click();
+  await flush();
+});
+ok(button("Save") != null, "selecting a model marks the editor dirty");
+await act(async () => {
+  button("Save")?.click();
+  await flush();
+});
+ok(modelSubmitted?.model === "17an/deepseek-v4-flash", "save persists the selected model ref");
+await act(async () => {
+  renderEditor({ ...originalTask, id: "model-preset", model: "deepseek/deepseek-v4" }, async () => true, "model-preset");
+  await flush();
+  await flush();
+});
+ok(document.querySelector<HTMLButtonElement>(".heartbeat-model-select")?.textContent?.includes("deepseek/deepseek-v4") === true, "an existing model selection shows its ref in the trigger");
+await act(async () => {
+  document.querySelector<HTMLButtonElement>(".heartbeat-model-select")?.click();
+  await flush();
+});
+ok(Array.from(document.querySelectorAll(".heartbeat-model-menu .heartbeat-project-menu__item"))
+  .find((item) => item.textContent?.includes("deepseek/deepseek-v4")) != null, "the selected model stays listed in the menu");
 
 await act(async () => root.unmount());
 dom.window.close();

--- a/desktop/frontend/src/custom/features/heartbeat/HeartbeatTaskEditor.tsx
+++ b/desktop/frontend/src/custom/features/heartbeat/HeartbeatTaskEditor.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { Check, ChevronsUpDown, CirclePause, Play, Trash2, X } from "lucide-react";
 import { Tooltip } from "../../../components/Tooltip";
 import { app } from "../../../lib/bridge";
-import type { WorkspaceView } from "../../../lib/types";
+import type { ModelInfo, WorkspaceView } from "../../../lib/types";
 import { CycleEditor } from "./HeartbeatCycleEditor";
 import { CirclePlaySolid, mergeEngineRunState } from "./HeartbeatShared";
 import { useHeartbeatT } from "./heartbeat.i18n";
@@ -34,15 +34,22 @@ export function TaskEditor({
   const t = useHeartbeatT();
   const titleRef = useRef<HTMLInputElement>(null);
   const [workspaces, setWorkspaces] = useState<WorkspaceView[]>([]);
+  const [models, setModels] = useState<ModelInfo[]>([]);
   const [projectOpen, setProjectOpen] = useState(false);
+  const [modelOpen, setModelOpen] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState(false);
   const [frequencyError, setFrequencyError] = useState(false);
   const projectRef = useRef<HTMLDivElement>(null);
+  const modelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     app.ListWorkspaces().then((list) => setWorkspaces(list ?? [])).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    app.Models().then((list) => setModels(list ?? [])).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -55,6 +62,17 @@ export function TaskEditor({
     document.addEventListener("click", close);
     return () => document.removeEventListener("click", close);
   }, [projectOpen]);
+
+  useEffect(() => {
+    if (!modelOpen) return;
+    const close = (e: MouseEvent) => {
+      if (modelRef.current && !modelRef.current.contains(e.target as Node)) {
+        setModelOpen(false);
+      }
+    };
+    document.addEventListener("click", close);
+    return () => document.removeEventListener("click", close);
+  }, [modelOpen]);
 
   const [draft, setDraft] = useState(task);
   const initialTaskRef = useRef(task);
@@ -80,7 +98,8 @@ export function TaskEditor({
     || draft.scope !== initialTaskRef.current.scope
     || draft.workspaceRoot !== initialTaskRef.current.workspaceRoot
     || draft.timeWindowStart !== initialTaskRef.current.timeWindowStart
-    || draft.timeWindowEnd !== initialTaskRef.current.timeWindowEnd;
+    || draft.timeWindowEnd !== initialTaskRef.current.timeWindowEnd
+    || draft.model !== initialTaskRef.current.model;
 
   useEffect(() => {
     onDirtyChange?.(isDirty);
@@ -317,6 +336,52 @@ export function TaskEditor({
           placeholder={t("heartbeat.promptPlaceholder")}
           rows={5}
         />
+      </div>
+
+      {/* Model（可选）：任务执行时切换到指定模型；留空使用当前模型 */}
+      <div className="heartbeat-editor__field">
+        <label>{t("heartbeat.fieldModel")} <span className="heartbeat-editor__optional">{t("heartbeat.optional")}</span></label>
+        <div className="heartbeat-scope-wrap" ref={modelRef}>
+          <button
+            className="heartbeat-scope-select heartbeat-model-select"
+            onClick={() => setModelOpen((v) => !v)}
+          >
+            <span>{draft.model || t("heartbeat.modelDefault")}</span>
+            <ChevronsUpDown size={12} />
+          </button>
+          {modelOpen && (
+            <div className="heartbeat-project-menu heartbeat-model-menu">
+              <button
+                className={`heartbeat-project-menu__item${!draft.model ? " heartbeat-project-menu__item--active" : ""}`}
+                onClick={() => {
+                  setDraft((prev) => ({ ...prev, model: undefined }));
+                  setModelOpen(false);
+                }}
+              >
+                {t("heartbeat.modelDefault")}
+                {!draft.model && <Check size={12} className="heartbeat-filter-menu__check" />}
+              </button>
+              {models.length === 0 ? (
+                <div className="heartbeat-project-menu__empty">{t("heartbeat.modelNoModels")}</div>
+              ) : (
+                models.map((m) => (
+                  <button
+                    key={m.ref}
+                    className={`heartbeat-project-menu__item${draft.model === m.ref ? " heartbeat-project-menu__item--active" : ""}`}
+                    onClick={() => {
+                      setDraft((prev) => ({ ...prev, model: m.ref }));
+                      setModelOpen(false);
+                    }}
+                  >
+                    <span className="heartbeat-model-menu__ref">{m.ref}</span>
+                    {draft.model === m.ref && <Check size={12} className="heartbeat-filter-menu__check" />}
+                  </button>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+        <span className="heartbeat-editor__mode-hint">{t("heartbeat.modelHint")}</span>
       </div>
 
       {/* Approval Mode（竖排） */}

--- a/desktop/frontend/src/custom/features/heartbeat/heartbeat.css
+++ b/desktop/frontend/src/custom/features/heartbeat/heartbeat.css
@@ -1649,6 +1649,28 @@
   color: var(--fg-faint);
 }
 
+/* Model picker: long "provider/model" refs ellipsize in both the trigger and
+   the menu; the menu keeps the current-model tag and check on one line. */
+.heartbeat-model-select {
+  max-width: 240px;
+}
+.heartbeat-model-select > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.heartbeat-model-menu__ref {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-right: auto;
+  min-width: 0;
+}
+.heartbeat-model-menu .heartbeat-project-menu__item {
+  gap: 8px;
+}
+
 /* ── footer hint ──────────────────────────────────────────────── */
 
 

--- a/desktop/frontend/src/custom/features/heartbeat/heartbeat.i18n.ts
+++ b/desktop/frontend/src/custom/features/heartbeat/heartbeat.i18n.ts
@@ -65,6 +65,10 @@ export const heartbeatFeatureEn = {
   "heartbeat.unitDay": "d",
   "heartbeat.viewFlat": "Flat list",
   "heartbeat.viewGrouped": "Group by project",
+  "heartbeat.fieldModel": "Model",
+  "heartbeat.modelDefault": "Default model",
+  "heartbeat.modelNoModels": "No models available",
+  "heartbeat.modelHint": "Optional model used to run this task. Empty keeps the topic's current model.",
 } as const;
 
 export type HeartbeatFeatureKey = keyof typeof heartbeatFeatureEn;
@@ -138,6 +142,10 @@ const heartbeatFeatureZh = {
   "heartbeat.unitDay": "天",
   "heartbeat.viewFlat": "纯列表",
   "heartbeat.viewGrouped": "按项目分组",
+  "heartbeat.fieldModel": "模型",
+  "heartbeat.modelDefault": "默认模型",
+  "heartbeat.modelNoModels": "暂无可用模型",
+  "heartbeat.modelHint": "可选：运行该任务时使用的模型。留空则使用话题当前模型。",
 } satisfies Record<HeartbeatFeatureKey, string>;
 
 const heartbeatFeatureZhTW = {
@@ -204,6 +212,10 @@ const heartbeatFeatureZhTW = {
   "heartbeat.unitDay": "天",
   "heartbeat.viewFlat": "純列表",
   "heartbeat.viewGrouped": "按專案分組",
+  "heartbeat.fieldModel": "模型",
+  "heartbeat.modelDefault": "預設模型",
+  "heartbeat.modelNoModels": "暫無可用模型",
+  "heartbeat.modelHint": "可選：執行此任務時使用的模型。留空則沿用話題目前的模型。",
 } satisfies Record<HeartbeatFeatureKey, string>;
 
 export const heartbeatFeatureKeys = Object.keys(heartbeatFeatureEn) as HeartbeatFeatureKey[];

--- a/desktop/frontend/src/custom/features/heartbeat/heartbeat.types.ts
+++ b/desktop/frontend/src/custom/features/heartbeat/heartbeat.types.ts
@@ -22,4 +22,5 @@ export interface HeartbeatTask {
   timeWindowStart?: string; // "HH:MM" — interval tasks only run after this time
   timeWindowEnd?: string;   // "HH:MM" — interval tasks only run before this time
   notifyChannels?: boolean; // true = push to bot channels; false/nil = skip
+  model?: string;           // optional "provider/model" ref; empty = keep the topic's current model
 }

--- a/desktop/heartbeat.go
+++ b/desktop/heartbeat.go
@@ -49,6 +49,7 @@ type HeartbeatTask struct {
 	TimeWindowStart        string         `json:"timeWindowStart,omitempty"` // "HH:MM" — interval tasks only run after this time (inclusive)
 	TimeWindowEnd          string         `json:"timeWindowEnd,omitempty"`   // "HH:MM" — interval tasks only run before this time (exclusive)
 	NotifyChannels         *bool          `json:"notifyChannels,omitempty"`  // true = push to bot channels; nil/false = skip
+	Model                  string         `json:"model,omitempty"`           // optional "provider/model" ref; empty = keep the topic's current model
 }
 
 // HeartbeatRun records a single successful execution of a heartbeat task.
@@ -65,6 +66,7 @@ const maxRunHistory = 20
 // heartbeatSchemaVersion is the current on-disk config schema version.
 // v1 (schemaVersion absent/0): interval-only tasks, no runHistory.
 // v2: adds runHistory per task (execution history, capped at maxRunHistory).
+// v3: adds Model per task (optional per-task "provider/model" ref).
 //
 // Migration boundary: configs written by v2+ binaries are read fine by older
 // binaries (unknown fields are ignored by json.Unmarshal), but an older
@@ -73,7 +75,7 @@ const maxRunHistory = 20
 // upgrade — once a v2+ binary has saved, do not run an older binary that
 // writes the config. writeTasks refuses to overwrite a config with a
 // schemaVersion newer than this binary understands (forward protection).
-const heartbeatSchemaVersion = 2
+const heartbeatSchemaVersion = 3
 
 // heartbeatConfig is the on-disk format.
 type heartbeatConfig struct {
@@ -135,6 +137,10 @@ type HeartbeatEngine struct {
 	done           chan struct{}
 	running        bool
 	app            *App // back-reference for topic creation, tab routing, and prompt submission
+	// applyTaskModel switches a task's tab to its configured model before the
+	// prompt is submitted. Defaults to the app model switch; injectable in
+	// tests, where a full controller rebuild is not available.
+	applyTaskModel func(tabID, model string) error
 }
 
 type heartbeatPendingTopic struct {
@@ -444,6 +450,11 @@ func (e *HeartbeatEngine) executeTaskOwned(t HeartbeatTask) HeartbeatTask {
 		}
 		e.mu.Unlock()
 		return e.executeTaskOwned(t)
+	}
+
+	t, ok = e.applyConfiguredModel(t, tabMeta.ID)
+	if !ok {
+		return t
 	}
 
 	// Set the task's approval mode only after confirming the controller is idle.

--- a/desktop/heartbeat_model.go
+++ b/desktop/heartbeat_model.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"reasonix/internal/secrets"
+)
+
+// applyConfiguredModel switches the task tab to the task's configured model
+// (if any) with the controller idle, so the rebuild is synchronous instead of
+// deferred behind a running turn. A failed or unready switch skips the run.
+func (e *HeartbeatEngine) applyConfiguredModel(t HeartbeatTask, tabID string) (HeartbeatTask, bool) {
+	if t.Model == "" {
+		return t, true
+	}
+	apply := e.applyTaskModel
+	if apply == nil {
+		apply = e.app.SetModelForTab
+	}
+	if err := apply(tabID, t.Model); err != nil {
+		log.Printf("[heartbeat] model switch for %q: %v", t.Title, secrets.RedactError(err))
+		// Advance LastRunAt so a misconfigured model is retried on the next
+		// scheduled tick instead of hammering the switch every 30s.
+		t.LastRunAt = time.Now().UnixMilli()
+		return t, false
+	}
+	// The rebuild replaced the controller; re-resolve and re-check it before
+	// the caller submits. Transient failures skip only this tick, so LastRunAt
+	// stays untouched (unlike the config error above).
+	ctrl := e.app.ctrlByTabID(tabID)
+	if ctrl == nil {
+		log.Printf("[heartbeat] controller not ready after model switch for %q, skipping", t.Title)
+		return t, false
+	}
+	if heartbeatControllerBusy(ctrl) {
+		log.Printf("[heartbeat] controller busy after model switch for %q, skipping", t.Title)
+		return t, false
+	}
+	return t, true
+}

--- a/desktop/heartbeat_model_test.go
+++ b/desktop/heartbeat_model_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// injectHeartbeatStubCtrl waits for the heartbeat execution path to open a tab
+// and replaces its in-flight controller build with the stub, mirroring the
+// per-test injection loops in the tests above.
+func injectHeartbeatStubCtrl(app *App, ctrl *heartbeatExecuteTaskCtrlStub) chan struct{} {
+	injected := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-injected:
+				return
+			case <-ticker.C:
+				var cancel context.CancelFunc
+				var tabToInject *WorkspaceTab
+				app.mu.Lock()
+				for _, tab := range app.tabs {
+					if tab == nil {
+						continue
+					}
+					tab.removed = true
+					cancel = tab.buildCancel
+					tabToInject = tab
+					break
+				}
+				app.mu.Unlock()
+				if tabToInject == nil {
+					continue
+				}
+				if cancel != nil {
+					cancel()
+				}
+				app.mu.Lock()
+				if tabToInject.Ctrl == nil {
+					tabToInject.Ctrl = ctrl
+					tabToInject.Ready = true
+					tabToInject.StartupErr = ""
+					app.advanceSessionRuntimeEpochLocked(tabToInject)
+					app.mu.Unlock()
+					close(injected)
+					return
+				}
+				app.mu.Unlock()
+			}
+		}
+	}()
+	return injected
+}
+
+func TestHeartbeatExecuteTaskSwitchesToConfiguredModel(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	app.runtimeEvents.emit = func(context.Context, string, ...any) {}
+	engine := &HeartbeatEngine{
+		app:           app,
+		pendingTopics: map[string]heartbeatPendingTopic{},
+	}
+	seed := HeartbeatTask{
+		ID:           "model-task",
+		Title:        "Model task",
+		Prompt:       "ping",
+		ApprovalMode: "auto",
+		Model:        "deepseek/deepseek-v4",
+	}
+	if err := engine.saveTasks([]HeartbeatTask{seed}); err != nil {
+		t.Fatal(err)
+	}
+	engine.ReloadConfig()
+	var switchedTab, switchedModel string
+	engine.applyTaskModel = func(tabID, model string) error {
+		switchedTab, switchedModel = tabID, model
+		return nil
+	}
+	ctrl := &heartbeatExecuteTaskCtrlStub{}
+	injectHeartbeatStubCtrl(app, ctrl)
+
+	got := engine.executeTask(seed)
+
+	if switchedTab == "" {
+		t.Fatal("configured model should switch the task tab before submit")
+	}
+	if switchedModel != "deepseek/deepseek-v4" {
+		t.Fatalf("switched model = %q, want deepseek/deepseek-v4", switchedModel)
+	}
+	if len(ctrl.submitted) != 1 || ctrl.submitted[0] != "ping" {
+		t.Fatalf("submitted prompts = %v, want [ping] after model switch", ctrl.submitted)
+	}
+	if got.LastRunAt == 0 {
+		t.Fatal("model switch success should complete the run")
+	}
+}
+
+func TestHeartbeatExecuteTaskSkipsOnFailedModelSwitch(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	app.runtimeEvents.emit = func(context.Context, string, ...any) {}
+	engine := &HeartbeatEngine{
+		app:           app,
+		pendingTopics: map[string]heartbeatPendingTopic{},
+	}
+	seed := HeartbeatTask{
+		ID:           "model-task",
+		Title:        "Model task",
+		Prompt:       "ping",
+		ApprovalMode: "auto",
+		Model:        "nope/missing",
+	}
+	if err := engine.saveTasks([]HeartbeatTask{seed}); err != nil {
+		t.Fatal(err)
+	}
+	engine.ReloadConfig()
+	engine.applyTaskModel = func(tabID, model string) error {
+		return errors.New("unknown model \"nope/missing\"")
+	}
+	ctrl := &heartbeatExecuteTaskCtrlStub{}
+	injectHeartbeatStubCtrl(app, ctrl)
+
+	got := engine.executeTask(seed)
+
+	if len(ctrl.submitted) != 0 {
+		t.Fatalf("submitted prompts = %v, want none when model switch fails", ctrl.submitted)
+	}
+	if got.LastRunAt == 0 {
+		t.Fatal("failed model switch should advance LastRunAt so the next tick retries")
+	}
+}


### PR DESCRIPTION
## 变更摘要

心跳任务（Automation 面板）支持**按任务选择模型**：每个任务可指定一个 `"provider/model"`，执行时引擎先把该任务的 tab 切到指定模型再提交 prompt。

### 后端
- `HeartbeatTask` 新增 `Model` 字段（`json:"model,omitempty"`，格式 `provider/model`）；留空 = 使用话题当前模型，完全向后兼容
- `heartbeatSchemaVersion` 2 → 3：旧版二进制对 v3 配置做全量保存会被 forward protection 拒绝，防止新字段被旧版覆盖丢失
- 新文件 `desktop/heartbeat_model.go`：`applyConfiguredModel` 在确认 controller 空闲后同步切换模型（`SetModelForTab`，重建同步完成而非 defer），切完重新解析 controller 并做 busy 防御检查；切换失败（如模型名无效）跳过本次执行并推进 `LastRunAt` 下周期重试
- `HeartbeatEngine.applyTaskModel` 可注入（测试用），默认走 `app.SetModelForTab`

### 前端
- 任务详情新增「模型」下拉：默认模型 + 全部可用模型（`app.Models()`），长 ref 省略号，菜单滚动；选择后编辑器变脏可保存
- 3 个 locale（en / 简体 / 繁体）各 5 个 key
- 复用现有 scope 选择器样式（`heartbeat-project-menu`），新增 22 行 CSS

### 测试
- 后端 `heartbeat_model_test.go`：2 个测试（切换成功正常提交 / 切换失败跳过并推进 LastRunAt），`TestHeartbeat` 全过，desktop 全量测试通过
- 前端 `heartbeat-editor.test.tsx`：7 条新断言（下拉渲染 / 默认标签 / 菜单项 / 脏状态 / 保存持久化 / 已有选择回显 / 选中项在菜单中），25/25 通过

## 验证

- `go build` / `go vet` / `go test`（desktop 全量，`env -u REASONIX_DEV`）通过
- 前端 `tsc --noEmit`、`eslint`、`heartbeat-editor.test.tsx`（25/25）通过
- `go run ./tools/repolint` clean（0 新增违规）
- bundle budget 主动调整 +0.3 KiB（production 2353.2→2353.5，test 2358.4→2358.7）

## 说明

- 模型切换失败只记录日志并跳过本轮（模型名配置错误是低频、明显的配置错误）；任务 tab 的模型会被持久应用（与 approval mode 的既有语义一致）
- 本 PR 基于 `upstream/main-v2` 最新（`b9cf32f81`），单 commit，未混入其他功能

Documentation-impact: none - 纯功能改动（desktop 心跳任务），未修改 docs/，现有文档仍准确