### PR TITLE
fix(desktop): remove grouped OpenCode Go providers

### DIFF
--- a/desktop/provider_access_removal.go
+++ b/desktop/provider_access_removal.go
@@ -34,9 +34,27 @@ func (a *App) DeleteProvider(name string) error {
 }
 
 // RemoveProviderAccess hides one provider access card. The plural form keeps
-// official provider profiles represented by a single card failure-atomic.
+// provider profiles represented by a single card failure-atomic.
 func (a *App) RemoveProviderAccess(name string) error {
 	return a.RemoveProviderAccesses([]string{name})
+}
+
+func isOpenCodeGoProviderAccessGroup(names []string) bool {
+	if len(names) < 2 {
+		return false
+	}
+	for _, name := range names {
+		switch strings.TrimSpace(name) {
+		case "opencode-go",
+			"opencode-go-anthropic",
+			"opencode-go-responses",
+			"opencode-go-deepseek-anthropic",
+			"opencode-go-deepseek-responses":
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func (a *App) RemoveProviderAccesses(rawNames []string) error {
@@ -49,6 +67,7 @@ func (a *App) RemoveProviderAccesses(rawNames []string) error {
 		return err
 	}
 	officialKind := ""
+	openCodeGoGroup := isOpenCodeGoProviderAccessGroup(names)
 	for _, name := range names {
 		p, ok := cfg.Provider(name)
 		if !ok {
@@ -59,12 +78,18 @@ func (a *App) RemoveProviderAccesses(rawNames []string) error {
 			if len(names) == 1 {
 				return a.deleteProviderAndRetargetTabs(name)
 			}
-			return fmt.Errorf("remove provider access: custom provider %q cannot be removed as part of a group", name)
+			if !openCodeGoGroup {
+				return fmt.Errorf("remove provider access: custom provider %q cannot be removed as part of a group", name)
+			}
+			continue
 		}
 		if officialKind != "" && kind != officialKind {
 			return fmt.Errorf("remove provider access: providers do not belong to one official group")
 		}
 		officialKind = kind
+	}
+	if openCodeGoGroup {
+		return a.deleteProvidersAndRetargetTabs(names)
 	}
 	return a.removeBuiltInProviderAccessAndRetargetTabs(names)
 }
@@ -262,12 +287,14 @@ func (a *App) planProviderRemoval(names []string, official bool) (providerRemova
 			return providerRemovalPlan{}, err
 		}
 	} else {
-		p, ok := cfg.Provider(names[0])
-		if !ok {
-			return providerRemovalPlan{}, fmt.Errorf("remove provider: %q not found", names[0])
-		}
-		if isOfficialBuiltInProvider(*p) {
-			return providerRemovalPlan{}, fmt.Errorf("remove provider: %q is now an official provider; retry", names[0])
+		for _, name := range names {
+			p, ok := cfg.Provider(name)
+			if !ok {
+				return providerRemovalPlan{}, fmt.Errorf("remove provider: %q not found", name)
+			}
+			if isOfficialBuiltInProvider(*p) {
+				return providerRemovalPlan{}, fmt.Errorf("remove provider: %q is now an official provider; retry", name)
+			}
 		}
 	}
 	targets := names
@@ -375,7 +402,7 @@ func (a *App) commitOfficialProviderRemoval(plan providerRemovalPlan, names []st
 	return fallbackRef, fresh.SaveTo(path)
 }
 
-func (a *App) commitCustomProviderRemoval(plan providerRemovalPlan, name string) (string, error) {
+func (a *App) commitCustomProviderRemoval(plan providerRemovalPlan, names []string) (string, error) {
 	unlock, err := lockProviderRemovalState()
 	if err != nil {
 		return "", err
@@ -385,12 +412,14 @@ func (a *App) commitCustomProviderRemoval(plan providerRemovalPlan, name string)
 	if err != nil {
 		return "", err
 	}
-	p, ok := fresh.Provider(name)
-	if !ok {
-		return "", fmt.Errorf("provider configuration changed while removing %q; retry", name)
-	}
-	if isOfficialBuiltInProvider(*p) {
-		return "", fmt.Errorf("provider configuration changed while removing %q; it is now an official provider; retry", name)
+	for _, name := range names {
+		p, ok := fresh.Provider(name)
+		if !ok {
+			return "", fmt.Errorf("provider configuration changed while removing %q; retry", name)
+		}
+		if isOfficialBuiltInProvider(*p) {
+			return "", fmt.Errorf("provider configuration changed while removing %q; it is now an official provider; retry", name)
+		}
 	}
 	if err := validateProviderRemovalFingerprint(fresh, plan.fingerprint); err != nil {
 		return "", err
@@ -407,10 +436,12 @@ func (a *App) commitCustomProviderRemoval(plan providerRemovalPlan, name string)
 		persistedFallback = providerName
 	}
 	retargetProviderReferences(fresh, plan.targets, persistedFallback)
-	if err := fresh.RemoveProvider(name); err != nil {
-		return "", err
+	for _, name := range names {
+		if err := fresh.RemoveProvider(name); err != nil {
+			return "", err
+		}
 	}
-	removeProviderAccess(fresh, name)
+	removeProviderAccess(fresh, names...)
 	return fallbackRef, fresh.SaveTo(path)
 }
 
@@ -541,6 +572,10 @@ func (a *App) deleteProviderAndRetargetTabs(name string) error {
 	if name == "" {
 		return fmt.Errorf("remove provider: empty provider name")
 	}
+	return a.deleteProvidersAndRetargetTabs([]string{name})
+}
+
+func (a *App) deleteProvidersAndRetargetTabs(names []string) error {
 	defer a.lockRuntimeMutation("delete-provider")()
 	releaseGates, err := a.lockRuntimeTurnGates("provider", nil)
 	if err != nil {
@@ -548,26 +583,27 @@ func (a *App) deleteProviderAndRetargetTabs(name string) error {
 	}
 	defer releaseGates()
 
-	plan, err := a.planProviderRemoval([]string{name}, false)
+	plan, err := a.planProviderRemoval(names, false)
 	if err != nil {
 		return err
 	}
-	affected, referencesRemoved, err := a.affectedProviderRemovalTabs(plan, name, "deleting the provider")
+	label := strings.Join(names, ", ")
+	affected, referencesRemoved, err := a.affectedProviderRemovalTabs(plan, label, "deleting the provider")
 	if err != nil {
 		return err
 	}
 	if plan.fallbackRef == "" && referencesRemoved {
-		return fmt.Errorf("remove provider: %q is in use and no other configured provider exists", name)
+		return fmt.Errorf("remove provider: %q is in use and no other configured provider exists", label)
 	}
 	if len(affected) == 0 {
 		if err := a.ensureActiveTabRebuildAllowed("provider"); err != nil {
 			return err
 		}
 	}
-	if err := snapshotProviderRemovalTabs(affected, name, "deleting provider"); err != nil {
+	if err := snapshotProviderRemovalTabs(affected, label, "deleting provider"); err != nil {
 		return err
 	}
-	fallbackRef, err := a.commitCustomProviderRemoval(plan, name)
+	fallbackRef, err := a.commitCustomProviderRemoval(plan, names)
 	if err != nil {
 		return err
 	}

--- a/desktop/provider_access_removal_test.go
+++ b/desktop/provider_access_removal_test.go
@@ -72,6 +72,95 @@ func TestRemoveProviderAccessesRemovesGroupedOfficialAliasesAtomically(t *testin
 	}
 }
 
+func TestRemoveProviderAccessesRemovesOpenCodeGoGroupAtomically(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OPENCODE_GO_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "FALLBACK_KEY", "sk-test")
+
+	preset, ok := config.CuratedProviderPreset("opencode-go-recommended")
+	if !ok || len(preset.Entries) != 3 {
+		t.Fatalf("recommended OpenCode Go preset = %+v, found=%v", preset, ok)
+	}
+	names := make([]string, 0, len(preset.Entries))
+	for _, entry := range preset.Entries {
+		names = append(names, entry.Name)
+	}
+	fallback := config.ProviderEntry{
+		Name: "fallback", Kind: "openai", BaseURL: "https://fallback.example.invalid/v1",
+		Model: "fallback-model", APIKeyEnv: "FALLBACK_KEY",
+	}
+	cfg := config.Default()
+	cfg.DefaultModel = "opencode-go/glm-5.3"
+	cfg.Agent.PlannerModel = "opencode-go-responses/grok-4.5"
+	cfg.Agent.VisionModel = "opencode-go/kimi-k3"
+	cfg.Agent.SubagentModel = "opencode-go-anthropic/qwen3.7-plus"
+	cfg.Agent.SubagentModels = map[string]string{"review": "opencode-go-responses/grok-4.5"}
+	cfg.Desktop.ProviderAccess = append(append([]string(nil), names...), fallback.Name)
+	cfg.Providers = append(append([]config.ProviderEntry(nil), preset.Entries...), fallback)
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	app := NewApp()
+	tab := &WorkspaceTab{ID: "opencode", Scope: "global", model: cfg.DefaultModel, Label: cfg.DefaultModel}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	if err := app.RemoveProviderAccesses(names); err != nil {
+		t.Fatalf("RemoveProviderAccesses: %v", err)
+	}
+
+	got := config.LoadForEdit(config.UserConfigPath())
+	for _, name := range names {
+		if _, ok := got.Provider(name); ok {
+			t.Fatalf("OpenCode Go provider %q still exists", name)
+		}
+	}
+	if _, ok := got.Provider(fallback.Name); !ok {
+		t.Fatal("fallback provider was removed with the OpenCode Go group")
+	}
+	if access := providerAccessSet(got.Desktop.ProviderAccess); len(access) != 1 || !access[fallback.Name] {
+		t.Fatalf("provider_access = %+v, want only %q", got.Desktop.ProviderAccess, fallback.Name)
+	}
+	if got.DefaultModel != fallback.Name || got.Agent.PlannerModel != fallback.Name || got.Agent.SubagentModel != fallback.Name || got.Agent.SubagentModels["review"] != fallback.Name {
+		t.Fatalf("grouped provider refs were not retargeted: default=%q planner=%q subagent=%q skills=%+v", got.DefaultModel, got.Agent.PlannerModel, got.Agent.SubagentModel, got.Agent.SubagentModels)
+	}
+	if got.Agent.VisionModel != "" {
+		t.Fatalf("vision_model = %q, want cleared removed provider reference", got.Agent.VisionModel)
+	}
+	fallbackRef := fallback.Name + "/" + fallback.Model
+	if tab.model != fallbackRef || tab.Label != fallbackRef {
+		t.Fatalf("tab model/label = %q/%q, want %q", tab.model, tab.Label, fallbackRef)
+	}
+}
+
+func TestRemoveProviderAccessesRejectsOpenCodeGoMixedWithCustomProvider(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	cfg := config.Default()
+	cfg.DefaultModel = "opencode-go/glm-5.3"
+	cfg.Desktop.ProviderAccess = []string{"opencode-go", "custom"}
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "opencode-go", Kind: "openai", BaseURL: "https://opencode.ai/zen/go/v1", Model: "glm-5.3"},
+		{Name: "custom", Kind: "openai", BaseURL: "https://custom.example.invalid/v1", Model: "custom-model"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	err := NewApp().RemoveProviderAccesses([]string{"opencode-go", "custom"})
+	if err == nil || !strings.Contains(err.Error(), `custom provider "opencode-go" cannot be removed as part of a group`) {
+		t.Fatalf("RemoveProviderAccesses error = %v, want mixed custom-group rejection", err)
+	}
+	got := config.LoadForEdit(config.UserConfigPath())
+	if _, ok := got.Provider("opencode-go"); !ok {
+		t.Fatal("OpenCode Go provider was partially removed after rejection")
+	}
+	if _, ok := got.Provider("custom"); !ok {
+		t.Fatal("custom provider was partially removed after rejection")
+	}
+}
+
 func TestDeleteProviderKeepsOldControllerWhenFallbackBuildFails(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	setDesktopTestCredential(t, "REASONIX_TEST_KEY", "sk-test")


### PR DESCRIPTION
## Summary

- allow the curated OpenCode Go routes represented by one provider card to be removed as a group
- remove all grouped route entries atomically while retargeting persisted model references and active tabs
- preserve the existing rejection behavior for groups containing unrelated custom providers
- add regression coverage for successful grouped removal and failure without partial mutation

## Root cause

The settings UI groups the recommended OpenCode Go routes into one provider card and submits all route names when that card is removed.

The desktop backend previously allowed grouped removal only for official built-in providers. Since the OpenCode Go routes are stored as custom provider entries, the request was rejected with:

`custom provider "opencode-go" cannot be removed as part of a group`

## Testing

- `go test -tags webkit2_41 . -count=1`
- `go vet -tags webkit2_41 ./...`

Fixes #9338