### PR TITLE
fix(desktop): allow deleting configured default providers / 修复已配置默认模型服务无法删除

### DIFF
--- a/desktop/frontend/src/__tests__/provider-access-card.test.tsx
+++ b/desktop/frontend/src/__tests__/provider-access-card.test.tsx
@@ -115,6 +115,15 @@ function group(providers: ProviderView[]): ProviderAccessGroup {
   };
 }
 
+function customGroup(provider: ProviderView): ProviderAccessGroup {
+  return {
+    ...group([provider]),
+    id: `custom:${provider.name}`,
+    label: provider.name,
+    builtIn: false,
+  };
+}
+
 function renderCard(
   providerGroup: ProviderAccessGroup,
   actions: {
@@ -128,7 +137,6 @@ function renderCard(
         group={providerGroup}
         busy={false}
         fetching={false}
-        defaultProvider=""
         editing={null}
         kinds={["anthropic", "openai"]}
         onEdit={() => undefined}
@@ -218,6 +226,39 @@ await act(async () => {
 ok(
   removedProviders.join(",") === "deepseek-flash,deepseek-pro",
   "card-level removal submits every grouped provider in one action",
+);
+
+let removedCustomProviders: string[] = [];
+await act(async () => {
+  root.render(renderCard(customGroup({ ...deepSeekAnthropic, name: "my-proxy", builtIn: false }), {
+    onDelete: async (providers) => {
+      removedCustomProviders = providers.map((provider) => provider.name);
+    },
+  }));
+  await flushPromises();
+});
+const defaultCustomMoreButton = rootEl.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]');
+ok(defaultCustomMoreButton?.disabled === false, "configured custom providers keep the removal menu available");
+await act(async () => {
+  defaultCustomMoreButton?.click();
+  await flushPromises();
+});
+let deleteDefaultCustomButton = Array.from(document.querySelectorAll("button"))
+  .find((button) => button.textContent?.trim() === "Remove access") as HTMLButtonElement | undefined;
+await act(async () => {
+  deleteDefaultCustomButton?.click();
+  await flushPromises();
+});
+deleteDefaultCustomButton = Array.from(document.querySelectorAll("button"))
+  .find((button) => button.textContent?.trim() === "Confirm delete provider") as HTMLButtonElement | undefined;
+ok(deleteDefaultCustomButton !== undefined, "configured custom provider can be confirmed for deletion");
+await act(async () => {
+  deleteDefaultCustomButton?.click();
+  await flushPromises();
+});
+ok(
+  removedCustomProviders.join(",") === "my-proxy",
+  "configured custom provider removal submits the selected provider",
 );
 
 await act(async () => {

--- a/desktop/frontend/src/__tests__/provider-access-card.test.tsx
+++ b/desktop/frontend/src/__tests__/provider-access-card.test.tsx
@@ -8,10 +8,13 @@ import {
   AddProviderPanel,
   ProviderAccessCard,
   providerAccessGroups,
+  SettingsPanel,
   type ProviderAccessGroup,
 } from "../components/SettingsPanel";
 import { LocaleProvider } from "../lib/i18n";
-import type { ProviderPresetView, ProviderView } from "../lib/types";
+import type { AppBindings } from "../lib/bridge";
+import type { ProviderPresetView, ProviderView, SettingsView } from "../lib/types";
+import { baseSettings } from "../test-support/settingsTestFixtures";
 
 let passed = 0;
 let failed = 0;
@@ -260,6 +263,88 @@ ok(
   removedCustomProviders.join(",") === "my-proxy",
   "configured custom provider removal submits the selected provider",
 );
+
+const defaultCustomSettings: SettingsView = baseSettings("standard");
+const defaultCustomProvider: ProviderView = {
+  ...deepSeekAnthropic,
+  name: "my-proxy",
+  builtIn: false,
+  added: true,
+  kind: "openai",
+  baseUrl: "https://proxy.example/v1",
+  models: ["my-model"],
+  default: "my-model",
+  apiKeyEnv: "",
+  keySet: true,
+  configured: true,
+  webSearch: false,
+  serverWebSearchCapability: false,
+};
+defaultCustomSettings.defaultModel = "my-proxy/my-model";
+defaultCustomSettings.providers = [defaultCustomProvider];
+defaultCustomSettings.providerKinds = ["openai"];
+let removedDefaultCustomProviders: string[] = [];
+window.go = {
+  main: {
+    App: {
+      Settings: async () => defaultCustomSettings,
+      RemoveProviderAccesses: async (names: string[]) => {
+        removedDefaultCustomProviders = [...names];
+        defaultCustomSettings.providers = defaultCustomSettings.providers.filter((provider) => !names.includes(provider.name));
+      },
+    } as Partial<AppBindings> as AppBindings,
+  },
+};
+const settingsRootEl = document.createElement("div");
+document.body.appendChild(settingsRootEl);
+const settingsRoot = createRoot(settingsRootEl);
+await act(async () => {
+  settingsRoot.render(
+    <LocaleProvider>
+      <SettingsPanel
+        initialTab="models"
+        initialFocus={{ target: "model-access", requestId: 1 }}
+        desktopPlatform="linux"
+        onClose={() => undefined}
+        onChanged={() => undefined}
+        onUseSubagent={() => undefined}
+      />
+    </LocaleProvider>,
+  );
+  await flushPromises();
+  await flushPromises();
+});
+const defaultCustomSettingsMoreButton = settingsRootEl.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]');
+ok(
+  defaultCustomSettingsMoreButton?.disabled === false,
+  "current default custom provider keeps the removal menu available",
+);
+await act(async () => {
+  defaultCustomSettingsMoreButton?.click();
+  await flushPromises();
+});
+let deleteCurrentDefaultButton = Array.from(document.querySelectorAll("button"))
+  .find((button) => button.textContent?.trim() === "Remove access") as HTMLButtonElement | undefined;
+await act(async () => {
+  deleteCurrentDefaultButton?.click();
+  await flushPromises();
+});
+deleteCurrentDefaultButton = Array.from(document.querySelectorAll("button"))
+  .find((button) => button.textContent?.trim() === "Confirm delete provider") as HTMLButtonElement | undefined;
+ok(deleteCurrentDefaultButton !== undefined, "current default custom provider can be confirmed for deletion");
+await act(async () => {
+  deleteCurrentDefaultButton?.click();
+  await flushPromises();
+  await flushPromises();
+});
+ok(
+  removedDefaultCustomProviders.join(",") === "my-proxy",
+  "current default custom provider removal reaches the settings backend",
+);
+await act(async () => {
+  settingsRoot.unmount();
+});
+settingsRootEl.remove();
 
 await act(async () => {
   root.render(renderCard(group([

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -4943,7 +4943,6 @@ function proxyModeLabel(mode: ProxyMode, t: ReturnType<typeof useT>): string {
 
 function ProvidersSection({ s, busy, apply }: SectionProps) {
   const t = useT();
-  const defaultProvider = toRef(s.defaultModel, s).split("/")[0];
   const [editing, setEditing] = useState<string | null>(null);
   const [adding, setAdding] = useState<AddProviderMode>(null);
   const [revealedProvider, setRevealedProvider] = useState<string | null>(null);
@@ -5245,7 +5244,6 @@ function ProvidersSection({ s, busy, apply }: SectionProps) {
             fetching={fetchingProviders.has(group.id)}
             fetchResult={fetchResults[group.id]}
             modelDraft={modelDrafts[group.id]}
-            defaultProvider={defaultProvider}
             editing={editing}
             kinds={s.providerKinds}
             onEdit={setEditing}
@@ -5855,7 +5853,6 @@ export function ProviderAccessCard({
   fetching,
   fetchResult,
   modelDraft,
-  defaultProvider,
   editing,
   kinds,
   onEdit,
@@ -5879,7 +5876,6 @@ export function ProviderAccessCard({
   fetching: boolean;
   fetchResult?: ProviderFetchResult;
   modelDraft?: ProviderModelDraft;
-  defaultProvider: string;
   editing: string | null;
   kinds: string[];
   onEdit: (name: string) => void;
@@ -5901,7 +5897,6 @@ export function ProviderAccessCard({
   const t = useT();
   const editableProvider = group.providers[0];
   const isOpenCodeGoConnection = group.id === "custom:opencode-go";
-  const isDefault = group.providers.some((p) => p.name === defaultProvider);
   const editingProvider = group.providers.find((p) => editing === p.name);
   const upgradeProvider = group.providers.find((p) => p.recommendedUpgradeAvailable);
   const primaryProviderExpanded = Boolean(editableProvider && editing === editableProvider.name);
@@ -5977,7 +5972,6 @@ export function ProviderAccessCard({
           {editableProvider && onDelete && (
             <ProviderAccessMoreMenu
               busy={busy}
-              removeDisabled={isDefault && !group.builtIn}
               builtIn={group.builtIn}
               onRemove={() => onDelete(group.providers)}
             />
@@ -6161,20 +6155,18 @@ function providerProtocolDisplayName(kind: string): string {
 
 function ProviderAccessMoreMenu({
   busy,
-  removeDisabled,
   builtIn,
   onRemove,
 }: {
   busy: boolean;
-  removeDisabled: boolean;
   builtIn: boolean;
   onRemove: () => void | Promise<void>;
 }) {
   const t = useT();
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const disabled = busy || removeDisabled;
-  const tooltip = removeDisabled ? t("settings.cantDeleteDefault") : t("settings.themeGallery.moreActions");
+  const disabled = busy;
+  const tooltip = t("settings.themeGallery.moreActions");
 
   return (
     <div className="provider-access-more">


### PR DESCRIPTION
## Summary

Allow configured provider cards to open the removal flow even when the provider is the current default. The backend remains the source of truth for fallback retargeting and safety checks.

## Problem

Users could not delete a configured custom provider when it was selected as the current default because the frontend disabled the provider access menu.

## Root cause

`ProviderAccessCard` applied `removeDisabled={isDefault && !group.builtIn}`, while the backend `DeleteProvider` flow already retargets references to a configured fallback and rejects the operation when no safe fallback exists.

## Fix

- Remove the frontend-only default-provider deletion gate.
- Keep the removal menu disabled only while settings are busy.
- Add regression coverage for opening, confirming, and submitting configured custom provider removal.

## Verification

- `pnpm exec tsx src/__tests__/provider-access-card.test.tsx` (27 passed)
- `pnpm exec tsc --noEmit`
- `pnpm test:typecheck`
- `pnpm exec eslint src/components/SettingsPanel.tsx src/__tests__/provider-access-card.test.tsx`
- `pnpm check:css`
- `cd desktop && go test ./...`

## Compatibility and cache impact

No persisted-format, Wails contract, public API, prompt construction, or provider serialization changes. No prompt-cache impact expected.

Documentation-impact: none - Existing provider settings and removal behavior documentation remain correct; this change restores the UI action to the backend behavior already described by the product.
