### PR TITLE
fix(windows): restore taskbar icon on the running desktop window / 修复运行窗口任务栏图标显示空白

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -475,6 +475,9 @@ func (a *App) startup(ctx context.Context) {
 			slog.Debug("desktop: repair native icon integration", "err", err)
 		}
 	})
+	a.goSafe("applyWindowIconsFromExecutable", func() {
+		applyWindowIconsFromExecutable()
+	})
 
 	if cfg, err := config.Load(); err == nil && cfg.DesktopMetrics() && version != "dev" {
 		a.metrics.Store(newMetricsAggregator(config.MemoryUserDir()))

--- a/desktop/window_icon_other.go
+++ b/desktop/window_icon_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package main
+
+// applyWindowIconsFromExecutable is a Windows-only fix: Wails v2 creates its
+// window class without an hIcon, and once the process sets an explicit
+// AppUserModelID (PR #7925), Win11's taskbar prefers AUMID-registered
+// resources over the executable's embedded icon, so the running window's
+// taskbar button renders the generic blank-document glyph. The Windows
+// implementation loads the executable's own icon and assigns it to the
+// window via WM_SETICON. No-op elsewhere.
+func applyWindowIconsFromExecutable() {}

--- a/desktop/window_icon_windows.go
+++ b/desktop/window_icon_windows.go
@@ -1,0 +1,106 @@
+//go:build windows
+
+package main
+
+import (
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	windowIconUser32   = windows.NewLazySystemDLL("user32.dll")
+	windowIconShell32  = windows.NewLazySystemDLL("shell32.dll")
+	windowIconKernel32 = windows.NewLazySystemDLL("kernel32.dll")
+
+	windowIconSendMessage  = windowIconUser32.NewProc("SendMessageW")
+	windowIconSetClassLong = windowIconUser32.NewProc("SetClassLongPtrW")
+	windowIconExtractIcons = windowIconShell32.NewProc("ExtractIconExW")
+	windowIconGetModuleFn  = windowIconKernel32.NewProc("GetModuleFileNameW")
+
+	// Injectable seams for tests (mirrors icon_repair_windows.go's pattern).
+	windowIconFindWindow   = currentProcessTopLevelWindow
+	windowIconLoadIcons    = loadExecutableIcons
+	windowIconAssignWindow = assignWindowIcons
+)
+
+const (
+	wmSetIcon = 0x0080
+	iconBig   = 1
+	iconSmall = 2
+
+	// GCLP_HICON / GCLP_HICONSM as signed int32 index values; must be passed
+	// as uintptr after the two's-complement wrap for 64-bit SetClassLongPtrW.
+	gclpHicon   = uintptr(^uint32(13)) // -14
+	gclpHiconSm = uintptr(^uint32(33)) // -34
+)
+
+// applyWindowIconsFromExecutable restores the brand icon on the Wails main
+// window. Wails v2 registers its window class ("wailsWindow") without an
+// hIcon/hIconSm, so the window answers WM_GETICON with NULL. On Windows 10
+// Explorer then falls back to the executable's first embedded icon, but on
+// Windows 11, once the process carries an explicit AppUserModelID (PR #7925:
+// SetCurrentProcessExplicitAppUserModelID("Reasonix")), the taskbar prefers
+// resources registered for that AUMID and, finding none, renders the
+// blank-document glyph.
+//
+// The fix loads the first icon group from this executable and assigns it both
+// to the window (WM_SETICON big+small) and to the window class (class icons),
+// which also covers Alt+Tab and window-switcher rendering.
+func applyWindowIconsFromExecutable() {
+	// The Wails window may not exist yet at OnStartup; retry briefly until
+	// it does rather than racing window creation.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if hwnd := windowIconFindWindow(); hwnd != 0 {
+			windowIconAssignWindow(hwnd)
+			return
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+func assignWindowIcons(hwnd uintptr) {
+	large, small := windowIconLoadIcons()
+	if large == 0 && small == 0 {
+		return
+	}
+	if large != 0 {
+		windowIconSendMessage.Call(hwnd, wmSetIcon, iconBig, large)
+		windowIconSetClassLong.Call(hwnd, gclpHicon, large)
+	}
+	if small != 0 {
+		windowIconSendMessage.Call(hwnd, wmSetIcon, iconSmall, small)
+		windowIconSetClassLong.Call(hwnd, gclpHiconSm, small)
+	}
+}
+
+// loadExecutableIcons extracts the first icon group embedded in this
+// executable via ExtractIconExW. Handle ownership transfers to the window;
+// the handles are process-wide, shared by the window and its class, so no
+// DestroyIcon is needed here.
+func loadExecutableIcons() (large, small uintptr) {
+	var exePath [2048]uint16
+	if _, _, _ = windowIconGetModuleFn.Call(
+		0,
+		uintptr(unsafe.Pointer(&exePath[0])),
+		uintptr(len(exePath)),
+	); exePath[0] == 0 {
+		return 0, 0
+	}
+	n, _, _ := windowIconExtractIcons.Call(
+		uintptr(unsafe.Pointer(&exePath[0])),
+		0,
+		uintptr(unsafe.Pointer(&large)),
+		uintptr(unsafe.Pointer(&small)),
+		1,
+	)
+	if int32(n) <= 0 {
+		return 0, 0
+	}
+	return large, small
+}

--- a/desktop/window_icon_windows.go
+++ b/desktop/window_icon_windows.go
@@ -14,21 +14,23 @@ var (
 	windowIconShell32  = windows.NewLazySystemDLL("shell32.dll")
 	windowIconKernel32 = windows.NewLazySystemDLL("kernel32.dll")
 
-	windowIconSendMessage  = windowIconUser32.NewProc("SendMessageW")
-	windowIconSetClassLong = windowIconUser32.NewProc("SetClassLongPtrW")
-	windowIconExtractIcons = windowIconShell32.NewProc("ExtractIconExW")
-	windowIconGetModuleFn  = windowIconKernel32.NewProc("GetModuleFileNameW")
+	windowIconSendMessageProc  = windowIconUser32.NewProc("SendMessageW")
+	windowIconSetClassLongProc = windowIconUser32.NewProc("SetClassLongPtrW")
+	windowIconExtractIcons     = windowIconShell32.NewProc("ExtractIconExW")
+	windowIconGetModuleFn      = windowIconKernel32.NewProc("GetModuleFileNameW")
 
 	// Injectable seams for tests (mirrors icon_repair_windows.go's pattern).
 	windowIconFindWindow   = currentProcessTopLevelWindow
 	windowIconLoadIcons    = loadExecutableIcons
 	windowIconAssignWindow = assignWindowIcons
+	windowIconSendMessage  = sendWindowIconMessage
+	windowIconSetClassLong = setWindowClassIcon
 )
 
 const (
 	wmSetIcon = 0x0080
 	iconBig   = 1
-	iconSmall = 2
+	iconSmall = 0
 
 	// GCLP_HICON / GCLP_HICONSM as signed int32 index values; must be passed
 	// as uintptr after the two's-complement wrap for 64-bit SetClassLongPtrW.
@@ -70,19 +72,28 @@ func assignWindowIcons(hwnd uintptr) {
 		return
 	}
 	if large != 0 {
-		windowIconSendMessage.Call(hwnd, wmSetIcon, iconBig, large)
-		windowIconSetClassLong.Call(hwnd, gclpHicon, large)
+		windowIconSendMessage(hwnd, wmSetIcon, iconBig, large)
+		windowIconSetClassLong(hwnd, gclpHicon, large)
 	}
 	if small != 0 {
-		windowIconSendMessage.Call(hwnd, wmSetIcon, iconSmall, small)
-		windowIconSetClassLong.Call(hwnd, gclpHiconSm, small)
+		windowIconSendMessage(hwnd, wmSetIcon, iconSmall, small)
+		windowIconSetClassLong(hwnd, gclpHiconSm, small)
 	}
 }
 
+func sendWindowIconMessage(hwnd, message, iconType, icon uintptr) {
+	windowIconSendMessageProc.Call(hwnd, message, iconType, icon)
+}
+
+func setWindowClassIcon(hwnd, index, icon uintptr) {
+	windowIconSetClassLongProc.Call(hwnd, index, icon)
+}
+
 // loadExecutableIcons extracts the first icon group embedded in this
-// executable via ExtractIconExW. Handle ownership transfers to the window;
-// the handles are process-wide, shared by the window and its class, so no
-// DestroyIcon is needed here.
+// executable via ExtractIconExW. The window and its class retain references,
+// not ownership, so the handles must remain valid for the Wails process
+// lifetime. This startup path runs once and retains at most two handles; the
+// operating system reclaims them when the process exits.
 func loadExecutableIcons() (large, small uintptr) {
 	var exePath [2048]uint16
 	if _, _, _ = windowIconGetModuleFn.Call(

--- a/desktop/window_icon_windows_test.go
+++ b/desktop/window_icon_windows_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 )
 
+type windowIconCall struct {
+	hwnd, selector, icon uintptr
+}
+
 func TestApplyWindowIconsFromExecutableRetriesUntilWindowAppears(t *testing.T) {
 	var findCalls atomic.Int32
 	var assigned atomic.Int32
@@ -42,11 +46,62 @@ func TestApplyWindowIconsFromExecutableRetriesUntilWindowAppears(t *testing.T) {
 }
 
 func TestAssignWindowIconsSkipsWhenNoIconLoaded(t *testing.T) {
+	oldLoad, oldSend, oldSetClass := windowIconLoadIcons, windowIconSendMessage, windowIconSetClassLong
 	windowIconLoadIcons = func() (uintptr, uintptr) { return 0, 0 }
-	defer func() { windowIconLoadIcons = loadExecutableIcons }()
+	windowIconSendMessage = func(uintptr, uintptr, uintptr, uintptr) {
+		t.Fatal("SendMessageW called without a loaded icon")
+	}
+	windowIconSetClassLong = func(uintptr, uintptr, uintptr) {
+		t.Fatal("SetClassLongPtrW called without a loaded icon")
+	}
+	t.Cleanup(func() {
+		windowIconLoadIcons, windowIconSendMessage, windowIconSetClassLong = oldLoad, oldSend, oldSetClass
+	})
 
-	// Must not panic and must not reach SendMessage; if it did, SendMessage
-	// with hwnd 0 is harmless, so just assert no panic + no icon load path
-	// return that crashes. The real assertion is that with (0,0) we return.
 	assignWindowIcons(0xDEAD)
+}
+
+func TestAssignWindowIconsUsesWin32BigAndSmallSelectors(t *testing.T) {
+	oldLoad, oldSend, oldSetClass := windowIconLoadIcons, windowIconSendMessage, windowIconSetClassLong
+	t.Cleanup(func() {
+		windowIconLoadIcons, windowIconSendMessage, windowIconSetClassLong = oldLoad, oldSend, oldSetClass
+	})
+
+	windowIconLoadIcons = func() (uintptr, uintptr) { return 0xAAAA, 0xBBBB }
+	var messages []windowIconCall
+	windowIconSendMessage = func(hwnd, message, selector, icon uintptr) {
+		if message != wmSetIcon {
+			t.Fatalf("SendMessageW message = 0x%X, want WM_SETICON", message)
+		}
+		messages = append(messages, windowIconCall{hwnd: hwnd, selector: selector, icon: icon})
+	}
+	var classIcons []windowIconCall
+	windowIconSetClassLong = func(hwnd, selector, icon uintptr) {
+		classIcons = append(classIcons, windowIconCall{hwnd: hwnd, selector: selector, icon: icon})
+	}
+
+	assignWindowIcons(0x1234)
+
+	wantMessages := []windowIconCall{
+		{hwnd: 0x1234, selector: 1, icon: 0xAAAA}, // ICON_BIG
+		{hwnd: 0x1234, selector: 0, icon: 0xBBBB}, // ICON_SMALL
+	}
+	assertWindowIconCalls(t, "window messages", messages, wantMessages)
+	wantClassIcons := []windowIconCall{
+		{hwnd: 0x1234, selector: gclpHicon, icon: 0xAAAA},
+		{hwnd: 0x1234, selector: gclpHiconSm, icon: 0xBBBB},
+	}
+	assertWindowIconCalls(t, "class icons", classIcons, wantClassIcons)
+}
+
+func assertWindowIconCalls(t *testing.T, label string, got, want []windowIconCall) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s count = %d, want %d: %#v", label, len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s[%d] = %#v, want %#v", label, i, got[i], want[i])
+		}
+	}
 }

--- a/desktop/window_icon_windows_test.go
+++ b/desktop/window_icon_windows_test.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package main
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+func TestApplyWindowIconsFromExecutableRetriesUntilWindowAppears(t *testing.T) {
+	var findCalls atomic.Int32
+	var assigned atomic.Int32
+
+	find := func() uintptr {
+		findCalls.Add(1)
+		if findCalls.Load() < 3 {
+			return 0 // window not ready on first two attempts
+		}
+		return 0x1234
+	}
+	assign := func(hwnd uintptr) {
+		if hwnd != 0x1234 {
+			t.Errorf("assignWindowIcons got hwnd 0x%X, want 0x1234", hwnd)
+		}
+		assigned.Add(1)
+	}
+
+	oldFind, oldAssign := windowIconFindWindow, windowIconAssignWindow
+	windowIconFindWindow, windowIconAssignWindow = find, assign
+	defer func() {
+		windowIconFindWindow, windowIconAssignWindow = oldFind, oldAssign
+	}()
+
+	applyWindowIconsFromExecutable()
+
+	if assigned.Load() != 1 {
+		t.Fatalf("assignWindowIcons called %d times, want exactly 1", assigned.Load())
+	}
+	if findCalls.Load() != 3 {
+		t.Fatalf("findWindow called %d times, want 3 (two misses then hit)", findCalls.Load())
+	}
+}
+
+func TestAssignWindowIconsSkipsWhenNoIconLoaded(t *testing.T) {
+	windowIconLoadIcons = func() (uintptr, uintptr) { return 0, 0 }
+	defer func() { windowIconLoadIcons = loadExecutableIcons }()
+
+	// Must not panic and must not reach SendMessage; if it did, SendMessage
+	// with hwnd 0 is harmless, so just assert no panic + no icon load path
+	// return that crashes. The real assertion is that with (0,0) we return.
+	assignWindowIcons(0xDEAD)
+}


### PR DESCRIPTION
Closes #9363

## Summary

The running `reasonix-desktop.exe` window now carries the Reasonix brand icon on its Windows taskbar button, loaded from the executable's own icon resource at startup.

## Problem

On Windows 11, the taskbar button for the running desktop window rendered the generic blank-document glyph, while pinned shortcuts (Start menu / taskbar) showed the correct icon. Users on v1.31.x installs saw a blank icon for the live window every launch.

## Root cause

Wails v2 registers its main window class (`wailsWindow`) without an `hIcon`/`hIconSm`, so the window answers `WM_GETICON` with NULL and `GetClassLongPtr(GCLP_HICON/GCLP_HICONSM)` return 0. On Windows 10, Explorer falls back to the executable's first embedded icon, which masked the gap. After #7925 added `SetCurrentProcessExplicitAppUserModelID("Reasonix")`, Windows 11's taskbar prefers resources registered for that AUMID over the embedded executable icon; the AUMID has no registered icon resource, so the fallback chain ends in the blank-document glyph.

Probed on a live v1.31.3 process (`EnumWindows` + `GetWindowThreadProcessId`): `WM_GETICON ICON_BIG/SMALL/SMALL2` -> 0x0, `GCLP_HICON`/`GCLP_HICONSM` -> 0x0, while `PrivateExtractIcons` on the same exe returns a valid brand icon — the resource is fine, only the window/class assignment is missing.

## Fix

- New `desktop/window_icon_windows.go`: `applyWindowIconsFromExecutable()` loads the first icon group from the running executable via `ExtractIconExW` and assigns it with `WM_SETICON` (big + small) plus `SetClassLongPtr(GCLP_HICON, GCLP_HICONSM)` — the class icons also cover Alt+Tab and the window switcher.
- Retries briefly (150 ms interval, 5 s deadline) until the `wailsWindow` appears, since the window may not exist yet at `OnStartup`.
- New `desktop/window_icon_other.go`: no-op for non-Windows.
- `desktop/app.go`: invoke `applyWindowIconsFromExecutable()` in `startup` via `a.goSafe`, next to the existing `repairDesktopIconIntegration()`.
- Injectable seams (`windowIconFindWindow` / `windowIconLoadIcons` / `windowIconAssignWindow`) mirror the existing `icon_repair_windows.go` pattern so the retry and no-icon paths are unit-testable.

Boundary vs related work: #6549 restored icon resources for the launcher/support EXEs (why pinned shortcuts look right); #7925 unified the AUMID (grouping); #7929 is an alternative grouping proposal. None of them set an icon on the running window itself — this PR fills that gap and is independently mergeable.

## Verification

- `go vet ./...` (in `desktop/`)
- `go test -run 'TestApplyWindowIconsFromExecutableRetriesUntilWindowAppears|TestAssignWindowIconsSkipsWhenNoIconLoaded' -v -count=1 .` (in `desktop/`, both pass)
- Isolated Win32 A/B repro (no-hIcon window class + explicit AUMID, no Reasonix code): taskbar screenshot high-saturation pixels 30,684 -> 85,928, avg saturation 0.456 -> 0.742 after `WM_SETICON` (see #9363 for the full numbers)

## Compatibility and cache impact

No persisted-format, Wails contract, public API, prompt construction, or provider serialization changes. Windows shell packaging only; no prompt-cache impact.

Documentation-impact: none - internal Windows shell icon fix; no user-facing setup, command, or configuration documentation changes.
