### PR TITLE
fix(desktop): keep frozen transcript height shim only for pending rows / 修复会话滚动错排：冻结高度仅作用于未就绪行

### DIFF
--- a/desktop/frontend/src/lib/transcriptNativeScrollbar.ts
+++ b/desktop/frontend/src/lib/transcriptNativeScrollbar.ts
@@ -31,7 +31,11 @@ export function measureTranscriptVirtuosoItem(
   field: Parameters<SizeFunction>[1],
   freeze: boolean,
 ): number {
-  if (freeze) {
+  // Freeze only rows whose async content is still pending geometry. Keeping
+  // the freeze narrowly scoped avoids returning stale estimates for already
+  // rendered rows, which would leave them visually misaligned after a manual
+  // scroll/selection gesture ends (#transcript-misalignment).
+  if (freeze && field === "offsetHeight" && hasPendingTranscriptGeometry(element)) {
     const transcriptEstimate = Number.parseFloat(element.dataset.transcriptEstimate ?? "");
     if (Number.isFinite(transcriptEstimate) && transcriptEstimate > 0) return transcriptEstimate;
     const knownSize = Number.parseFloat(element.dataset.knownSize ?? "");

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -486,7 +486,7 @@ export function useTranscriptScrollArbiter({
     }
     const measured = measureTranscriptVirtuosoItem(element, field, frozen);
     const pendingGeometry = field === "offsetHeight" && hasPendingTranscriptGeometry(element);
-    if (field === "offsetHeight" && frozen) {
+    if (field === "offsetHeight" && frozen && pendingGeometry) {
       const estimate = Number.parseFloat(element.dataset.transcriptEstimate ?? element.dataset.knownSize ?? element.dataset.staticEstimate ?? "");
       if (Number.isFinite(estimate) && estimate > 0) {
         // Native thumb dragging owns the physical track. Keep the currently


### PR DESCRIPTION
## Summary

During transcript scrolling (especially when using the native scrollbar), already-rendered rows could become visibly misaligned. Holding the pointer made the layout correct; releasing it returned the stale estimate-based height, so rows overlapped or shifted.

## Problem

`measureTranscriptVirtuosoItem` and the `itemSize` frozen-height shim applied the freeze to **every** row while the native scrollbar was dragging:

- `measureTranscriptVirtuosoItem(..., freeze=true)` returned the old `transcriptEstimate`/`knownSize` for all rows.
- `itemSize` also forced `element.style.height = estimate` for every frozen row.

The freeze is intended to keep a row box stable only while its async content (Markdown, KaTeX, code highlighting) is still pending. For already-rendered rows, returning/forcing the old estimate leaves the DOM box different from the real content height, which is what produced the misalignment after the gesture ended.

## Fix

- `transcriptNativeScrollbar.ts`: only return the seed/estimate when `freeze && offsetHeight && hasPendingTranscriptGeometry(element)`.
- `useTranscriptScrollArbiter.ts`: only apply the frozen-height shim when `frozen && pendingGeometry`.

Already-rendered rows now keep their real measured height even during native scrollbar drag, while pending async rows still keep a stable seed to avoid reverse frames.

## Verification

- Desktop: scroll long transcripts with pasted text blocks / multi-line math / code blocks upward and down; rows no longer overlap after releasing the scrollbar.
- Existing scroll/readiness tests still pass.

## Cache impact / guards

Cache-impact: none- desktop host-only UI measurement change; no provider-visible prompt/tool changes.
Cache-guard: none- existing transcript scroll diagnostics / desktop tests; no new guard needed for host-only CSS/measurement path.
Documentation-impact: none- no user-facing docs or config changed.
System-prompt-review: none- desktop host-only change; no system-prompt/boot/config changes.

## Chinese summary

修复会话滚动时已渲染行错排：原生滚动条拖动期间，冻结高度只应作用于尚未渲染完的异步内容行；已就绪行应保持真实测量高度。本次在测量函数与 `itemSize` 两处收窄冻结范围。

