### PR TITLE
fix(agent): document memory: capabilities in use_capability description / 在 use_capability 描述中说明记忆工具用法

### DIFF
--- a/internal/agent/usecapability.go
+++ b/internal/agent/usecapability.go
@@ -537,7 +537,7 @@ func (t *UseCapabilityTool) CloneForAgent(ledger *capability.Ledger, audit *capa
 func (*UseCapabilityTool) Name() string { return "use_capability" }
 
 func (*UseCapabilityTool) Description() string {
-	return "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. memory:remember persists facts (description+body required; activation \"relevant\" normally, \"pinned\" only by explicit request); memory:forget; tool:memory (recall). Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor."
+	return "Fixed-schema capability proxy: list, inspect, call by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a reason. memory:remember saves facts (description+body required; activation=\"relevant\" on create; omit activation on update; \"pinned\" only if user asks); memory:forget(name); tool:memory(operation=search|read|list). Calls keep the provider-visible schema fixed. Writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor."
 }
 
 func (*UseCapabilityTool) ReadOnly() bool { return true }

--- a/internal/agent/usecapability.go
+++ b/internal/agent/usecapability.go
@@ -537,7 +537,7 @@ func (t *UseCapabilityTool) CloneForAgent(ledger *capability.Ledger, audit *capa
 func (*UseCapabilityTool) Name() string { return "use_capability" }
 
 func (*UseCapabilityTool) Description() string {
-	return "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. memory: namespaces persist durable facts: memory:remember (requires description and body; use activation \"relevant\" for normal recallable rules, \"pinned\" only for always-required facts), memory:forget, memory:recall. Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor."
+	return "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. memory:remember persists facts (description+body required; activation \"relevant\" normally, \"pinned\" only by explicit request); memory:forget; tool:memory (recall). Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor."
 }
 
 func (*UseCapabilityTool) ReadOnly() bool { return true }

--- a/internal/agent/usecapability.go
+++ b/internal/agent/usecapability.go
@@ -537,7 +537,7 @@ func (t *UseCapabilityTool) CloneForAgent(ledger *capability.Ledger, audit *capa
 func (*UseCapabilityTool) Name() string { return "use_capability" }
 
 func (*UseCapabilityTool) Description() string {
-	return "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor."
+	return "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. memory: namespaces persist durable facts: memory:remember (requires description and body; use activation \"relevant\" for normal recallable rules, \"pinned\" only for always-required facts), memory:forget, memory:recall. Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor."
 }
 
 func (*UseCapabilityTool) ReadOnly() bool { return true }

--- a/internal/agent/usecapability_memory_description_test.go
+++ b/internal/agent/usecapability_memory_description_test.go
@@ -1,0 +1,49 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"reasonix/internal/memory"
+	"reasonix/internal/tool"
+)
+
+func TestUseCapabilityMemoryDescriptionNamesRoutableTools(t *testing.T) {
+	reg := tool.NewRegistry()
+	store := memory.Store{Dir: t.TempDir()}
+	for _, tl := range []tool.Tool{
+		memory.NewRecallTool(store),
+		memory.NewRememberTool(store),
+		memory.NewForgetTool(store),
+	} {
+		reg.Add(tl)
+	}
+	proxy := NewUseCapabilityTool(context.Background(), nil, nil, reg, nil, nil, nil)
+	description := proxy.Description()
+	if strings.Contains(description, "memory:recall") {
+		t.Fatal("description must not advertise the unregistered memory:recall route")
+	}
+
+	for id, wantTarget := range map[string]string{
+		"memory:remember": "remember",
+		"memory:forget":   "forget",
+		"tool:memory":     "memory",
+	} {
+		t.Run(id, func(t *testing.T) {
+			if !strings.Contains(description, id) {
+				t.Fatalf("description does not advertise %q", id)
+			}
+			call := json.RawMessage(fmt.Sprintf(`{"action":"call","capability_id":%q,"arguments":{}}`, id))
+			resolved, err := proxy.ResolveCall(context.Background(), call)
+			if err != nil {
+				t.Fatalf("ResolveCall(%q): %v", id, err)
+			}
+			if resolved.Target == nil || resolved.TargetName != wantTarget {
+				t.Fatalf("ResolveCall(%q) target = %q, want %q", id, resolved.TargetName, wantTarget)
+			}
+		})
+	}
+}

--- a/internal/agent/usecapability_memory_description_test.go
+++ b/internal/agent/usecapability_memory_description_test.go
@@ -26,6 +26,18 @@ func TestUseCapabilityMemoryDescriptionNamesRoutableTools(t *testing.T) {
 	if strings.Contains(description, "memory:recall") {
 		t.Fatal("description must not advertise the unregistered memory:recall route")
 	}
+	for _, contract := range []string{
+		"description+body required",
+		`activation="relevant" on create`,
+		"omit activation on update",
+		`"pinned" only if user asks`,
+		"memory:forget(name)",
+		"tool:memory(operation=search|read|list)",
+	} {
+		if !strings.Contains(description, contract) {
+			t.Errorf("description does not document %q", contract)
+		}
+	}
 
 	for id, wantTarget := range map[string]string{
 		"memory:remember": "remember",

--- a/internal/boot/testdata/golden/prefix_shape.json
+++ b/internal/boot/testdata/golden/prefix_shape.json
@@ -1,7 +1,7 @@
 {
   "SystemHash": "c4a54b2f61c5e15f",
-  "ToolsHash": "f784943840e7cb26",
-  "PrefixHash": "7dc3111021bc8e25",
+  "ToolsHash": "85306789aa2aa4bb",
+  "PrefixHash": "58760d5c8f3697d3",
   "LogRewriteVersion": 0,
-  "ToolSchemaTokens": 4149
+  "ToolSchemaTokens": 4138
 }

--- a/internal/boot/testdata/golden/prefix_shape.json
+++ b/internal/boot/testdata/golden/prefix_shape.json
@@ -1,7 +1,7 @@
 {
   "SystemHash": "c4a54b2f61c5e15f",
-  "ToolsHash": "991b3d43c0455e52",
-  "PrefixHash": "76e109290d2de5a8",
+  "ToolsHash": "f784943840e7cb26",
+  "PrefixHash": "7dc3111021bc8e25",
   "LogRewriteVersion": 0,
-  "ToolSchemaTokens": 4107
+  "ToolSchemaTokens": 4149
 }

--- a/internal/boot/testdata/golden/provider_request.json
+++ b/internal/boot/testdata/golden/provider_request.json
@@ -437,7 +437,7 @@
     },
     {
       "name": "use_capability",
-      "description": "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. memory: namespaces persist durable facts: memory:remember (requires description and body; use activation \"relevant\" for normal recallable rules, \"pinned\" only for always-required facts), memory:forget, memory:recall. Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor.",
+      "description": "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. memory:remember persists facts (description+body required; activation \"relevant\" normally, \"pinned\" only by explicit request); memory:forget; tool:memory (recall). Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor.",
       "parameters": {
         "properties": {
           "action": {

--- a/internal/boot/testdata/golden/provider_request.json
+++ b/internal/boot/testdata/golden/provider_request.json
@@ -437,7 +437,7 @@
     },
     {
       "name": "use_capability",
-      "description": "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. memory:remember persists facts (description+body required; activation \"relevant\" normally, \"pinned\" only by explicit request); memory:forget; tool:memory (recall). Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor.",
+      "description": "Fixed-schema capability proxy: list, inspect, call by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a reason. memory:remember saves facts (description+body required; activation=\"relevant\" on create; omit activation on update; \"pinned\" only if user asks); memory:forget(name); tool:memory(operation=search|read|list). Calls keep the provider-visible schema fixed. Writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor.",
       "parameters": {
         "properties": {
           "action": {

--- a/internal/boot/testdata/golden/provider_request.json
+++ b/internal/boot/testdata/golden/provider_request.json
@@ -437,7 +437,7 @@
     },
     {
       "name": "use_capability",
-      "description": "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor.",
+      "description": "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. memory: namespaces persist durable facts: memory:remember (requires description and body; use activation \"relevant\" for normal recallable rules, \"pinned\" only for always-required facts), memory:forget, memory:recall. Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor.",
       "parameters": {
         "properties": {
           "action": {

--- a/internal/boot/testdata/golden/tool_schemas.json
+++ b/internal/boot/testdata/golden/tool_schemas.json
@@ -417,7 +417,7 @@
   },
   {
     "Name": "use_capability",
-    "Description": "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. memory:remember persists facts (description+body required; activation \"relevant\" normally, \"pinned\" only by explicit request); memory:forget; tool:memory (recall). Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor.",
+    "Description": "Fixed-schema capability proxy: list, inspect, call by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a reason. memory:remember saves facts (description+body required; activation=\"relevant\" on create; omit activation on update; \"pinned\" only if user asks); memory:forget(name); tool:memory(operation=search|read|list). Calls keep the provider-visible schema fixed. Writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor.",
     "ReadOnly": true,
     "Schema": {
       "properties": {

--- a/internal/boot/testdata/golden/tool_schemas.json
+++ b/internal/boot/testdata/golden/tool_schemas.json
@@ -417,7 +417,7 @@
   },
   {
     "Name": "use_capability",
-    "Description": "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor.",
+    "Description": "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. memory: namespaces persist durable facts: memory:remember (requires description and body; use activation \"relevant\" for normal recallable rules, \"pinned\" only for always-required facts), memory:forget, memory:recall. Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor.",
     "ReadOnly": true,
     "Schema": {
       "properties": {

--- a/internal/boot/testdata/golden/tool_schemas.json
+++ b/internal/boot/testdata/golden/tool_schemas.json
@@ -417,7 +417,7 @@
   },
   {
     "Name": "use_capability",
-    "Description": "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. memory: namespaces persist durable facts: memory:remember (requires description and body; use activation \"relevant\" for normal recallable rules, \"pinned\" only for always-required facts), memory:forget, memory:recall. Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor.",
+    "Description": "Unified capability proxy with a fixed schema: list catalog capabilities, inspect metadata, call a capability by stable id (tool:grep, skill:review, mcp-tool:server/tool, task:subagent, workflow:name, web:/lsp:/session:/memory: namespaces), or decline a prefer capability with a non-empty reason. memory:remember persists facts (description+body required; activation \"relevant\" normally, \"pinned\" only by explicit request); memory:forget; tool:memory (recall). Calling does not change the provider-visible tool schema. Resolved writers still pass permission, plan mode, sandbox, write-path, and workspace-lease checks. The Planner leaves destructive MCP for the Executor.",
     "ReadOnly": true,
     "Schema": {
       "properties": {


### PR DESCRIPTION
## Summary

The memory capabilities are dispatched through `use_capability`, but the provider-visible description previously listed only the `memory:` namespace. A fresh model therefore had to guess which stable IDs and minimum arguments to use.

This PR gives the model a compact, accurate contract:

- `memory:remember(description, body)`: use `activation="relevant"` for a new recallable fact, omit `activation` when updating so the existing choice is preserved, and use `"pinned"` only when the user explicitly asks.
- `memory:forget(name)`: archive a saved memory by stable name.
- `tool:memory(operation=search|read|list)`: recall saved memories through the registered read-only tool.

The runtime routes, schemas, authorization checks, sandbox checks, plan-mode policy, write-path checks, workspace leases, and Planner/Executor policy are unchanged.

## Problem

- `internal/agent/usecapability.go` enumerated `memory:` without explaining its purpose or callable IDs.
- Earlier wording described `activation="relevant"` as the normal choice without distinguishing creates from updates. Passing it explicitly during an update can silently unpin an existing pinned memory; the underlying `remember` schema preserves activation only when the field is omitted.
- `forget` and recall did not expose their minimum arguments in the compact proxy description.

## Fix

- Document the registered memory routes and their minimum call contracts in `UseCapabilityTool.Description()`.
- State the create/update activation behavior and pinned opt-in explicitly.
- Add focused assertions that the model-visible contract stays present and every advertised route resolves through the capability registry.
- Regenerate all three stable-prefix goldens.

## Issues

Refs #9375. This is the provider-description phase; it does not change `use_capability(action=list)` catalog output.

## Verification

- `go test ./...` — passes on the PR head.
- `go test -race ./internal/agent -run '^TestUseCapabilityMemoryDescriptionNamesRoutableTools$' -count=1` — passes.
- `go vet ./internal/agent ./internal/boot` — passes.
- `go run ./tools/repolint` — passes.
- `go build ./cmd/reasonix` — passes.
- `go build ./internal/agent/... ./internal/capability/...` — passes.
- A synthetic merge with the latest `main-v2` at `ecc69d90a` is conflict-free and passes the same golden, race, vet, build, lint, and full-test checks.
- Golden artifacts `provider_request.json`, `tool_schemas.json`, and `prefix_shape.json` are updated. The description is 624 bytes; `ToolSchemaTokens` changes from 4107 to 4138.

Documentation-impact: none - The change is limited to the provider-visible use_capability tool description; existing user documentation remains correct.

Cache-impact: low - The fixed use_capability description changes the stable tool-prefix hash once. ToolSchemaTokens increase from 4107 to 4138 (+31, 0.75%), then remain identical across turns.

Cache-guard: `REASONIX_UPDATE_GOLDEN=1 go test ./internal/boot -run '^TestGoldenBaselineNoExtensions$' -count=1`; committed provider_request.json, tool_schemas.json, and prefix_shape.json.

System-prompt-review: @SivanCola reviewed the model-visible memory routes, activation semantics, cache delta, and stable-prefix guard.

## 中文摘要

这个 PR 为模型补充准确且精简的记忆工具契约：新建记忆使用 `activation="relevant"`，更新已有记忆时省略 `activation` 以保留原状态，只有用户明确要求时才使用 `"pinned"`；删除使用 `memory:forget(name)`；检索使用 `tool:memory(operation=search|read|list)`。

修复后，模型无需猜测即可调用已注册的记忆能力，也不会因为更新时显式传入 `relevant` 而意外取消置顶。运行时路由、权限与沙箱边界均未改变。工具 schema 相对基线增加 31 tokens（0.75%），三份 golden 已同步，PR head 与最新 `main-v2` 合并树的完整测试均通过。