### PR TITLE
perf(crash-worker): retire the metric_users rollup that was the entire D1 read bill

### DIFF
--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -240,7 +240,7 @@ func (c *Client) flushPending(ctx context.Context) error {
 			continue
 		}
 		if err := c.post(ctx, "/metrics", metricsPayload{
-			InstallID: c.installID, Version: g.payload.Version, OS: g.payload.OS, Surface: "cli", Counters: counters,
+			Version: g.payload.Version, OS: g.payload.OS, Surface: "cli", Counters: counters,
 		}); err != nil {
 			return err
 		}

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -134,14 +134,13 @@ func TestFlushPendingAggregatesAndDeletesOnlyAfterSuccess(t *testing.T) {
 		}
 	}
 	requests := 0
-	var client *Client
-	client = testClient(home, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := testClient(home, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requests++
 		var payload metricsPayload
 		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
 			t.Fatal(err)
 		}
-		if payload.Surface != "cli" || payload.OS != "android" || payload.InstallID != client.installID {
+		if payload.Surface != "cli" || payload.OS != "android" {
 			t.Fatalf("metrics payload = %+v", payload)
 		}
 		got := map[string]int{}

--- a/internal/telemetry/payload.go
+++ b/internal/telemetry/payload.go
@@ -21,9 +21,8 @@ type pingPayload struct {
 }
 
 type metricsPayload struct {
-	InstallID string    `json:"installId,omitempty"`
-	Version   string    `json:"version"`
-	OS        string    `json:"os"`
-	Surface   string    `json:"surface"`
-	Counters  []Counter `json:"counters"`
+	Version  string    `json:"version"`
+	OS       string    `json:"os"`
+	Surface  string    `json:"surface"`
+	Counters []Counter `json:"counters"`
 }

--- a/workers/crash-report/migrate-drop-metric-users.sql
+++ b/workers/crash-report/migrate-drop-metric-users.sql
@@ -1,0 +1,15 @@
+-- Apply: wrangler d1 execute reasonix-crash --remote --file=migrate-drop-metric-users.sql
+--
+-- Retires per-install metric detail. The 30-day COUNT(DISTINCT install_id) it
+-- fed was the database's entire read bill: the primary key leads with `date`,
+-- so the rollup's `date >= ... AND signal = ?` could only prune the window and
+-- scanned all ~28M rows once per signal, eight signals an hour — ~5.4B rows
+-- read a day for one dashboard module. The aggregate `metrics` tables keep the
+-- same signals as event counts at ~180k rows total.
+--
+-- Deploy the worker first: it stops writing these tables and stops creating
+-- them at runtime, so a DROP before that just gets rebuilt on the next request.
+DROP TABLE IF EXISTS metric_user_rollup;
+DROP TABLE IF EXISTS metric_user_rollup_state;
+DROP TABLE IF EXISTS metric_users;
+DROP TABLE IF EXISTS cli_metric_users;

--- a/workers/crash-report/schema.sql
+++ b/workers/crash-report/schema.sql
@@ -131,30 +131,6 @@ CREATE TABLE IF NOT EXISTS cli_metrics (
   PRIMARY KEY (date, version, os, signal, bucket)
 );
 
--- Deduplicated Desktop DAU for opt-in metric buckets. install_id is the same
--- random anonymous install id used by launch pings; it is not an account id.
-CREATE TABLE IF NOT EXISTS metric_users (
-  date TEXT NOT NULL,
-  signal TEXT NOT NULL,
-  bucket TEXT NOT NULL,
-  install_id TEXT NOT NULL,
-  version TEXT NOT NULL,
-  os TEXT NOT NULL,
-  arch TEXT NOT NULL DEFAULT '',
-  os_build INTEGER NOT NULL DEFAULT 0,
-  os_revision INTEGER NOT NULL DEFAULT 0,
-  channel TEXT NOT NULL DEFAULT '',
-  distro_id TEXT NOT NULL DEFAULT '',
-  distro_version TEXT NOT NULL DEFAULT '',
-  kernel_version TEXT NOT NULL DEFAULT '',
-  session_type TEXT NOT NULL DEFAULT '',
-  runtime_engine TEXT NOT NULL DEFAULT '',
-  runtime_version TEXT NOT NULL DEFAULT '',
-  gpu_mode TEXT NOT NULL DEFAULT '',
-  event_count INTEGER NOT NULL DEFAULT 0,
-  PRIMARY KEY (date, signal, bucket, install_id)
-);
-
 CREATE TABLE IF NOT EXISTS report_daily (
   date TEXT NOT NULL,
   fingerprint TEXT NOT NULL,
@@ -236,48 +212,6 @@ CREATE TABLE IF NOT EXISTS diagnostics_meta (
 
 INSERT OR IGNORE INTO diagnostics_meta (key, value)
 VALUES ('installation_linked_since', date('now'));
-
-CREATE TABLE IF NOT EXISTS cli_metric_users (
-  date TEXT NOT NULL,
-  signal TEXT NOT NULL,
-  bucket TEXT NOT NULL,
-  install_id TEXT NOT NULL,
-  version TEXT NOT NULL,
-  os TEXT NOT NULL,
-  arch TEXT NOT NULL DEFAULT '',
-  os_build INTEGER NOT NULL DEFAULT 0,
-  os_revision INTEGER NOT NULL DEFAULT 0,
-  channel TEXT NOT NULL DEFAULT '',
-  distro_id TEXT NOT NULL DEFAULT '',
-  distro_version TEXT NOT NULL DEFAULT '',
-  kernel_version TEXT NOT NULL DEFAULT '',
-  session_type TEXT NOT NULL DEFAULT '',
-  runtime_engine TEXT NOT NULL DEFAULT '',
-  runtime_version TEXT NOT NULL DEFAULT '',
-  gpu_mode TEXT NOT NULL DEFAULT '',
-  event_count INTEGER NOT NULL DEFAULT 0,
-  PRIMARY KEY (date, signal, bucket, install_id)
-);
-
--- Cron-built answer to the preferences module's 30-day deduplication, which
--- spans ~28M rows of metric_users: too many to count per request, and not
--- summable from daily totals. refreshMetricUserRollup fills it one signal at a
--- time. The worker creates both tables at runtime, so existing databases need
--- no manual migration.
-CREATE TABLE IF NOT EXISTS metric_user_rollup (
-  window_days INTEGER NOT NULL,
-  signal TEXT NOT NULL,
-  bucket TEXT NOT NULL,
-  total INTEGER NOT NULL,
-  computed_at TEXT NOT NULL,
-  PRIMARY KEY (window_days, signal, bucket)
-);
-
-CREATE TABLE IF NOT EXISTS metric_user_rollup_state (
-  id INTEGER PRIMARY KEY CHECK (id = 1),
-  next_signal INTEGER NOT NULL,
-  updated_at TEXT NOT NULL
-);
 
 -- Legacy local auth — superseded by id.reasonix.io identity + the `access`
 -- table below. Kept during the transition; migrate-access.sql copies roles over.

--- a/workers/crash-report/src/diagnostics_v2.test.ts
+++ b/workers/crash-report/src/diagnostics_v2.test.ts
@@ -136,8 +136,6 @@ describe("diagnostics v2 compatibility and privacy", () => {
         reports: ["webview2", "web_runtime"],
         pings: ["os_build", "os_revision", "distro_id", "session_type", "runtime_engine", "gpu_mode"],
         cli_pings: ["os_build", "os_revision", "distro_id", "session_type", "runtime_engine", "gpu_mode"],
-        metric_users: ["arch", "os_build", "os_revision", "distro_id", "session_type", "runtime_engine", "gpu_mode", "event_count"],
-        cli_metric_users: ["arch", "os_build", "os_revision", "distro_id", "session_type", "runtime_engine", "gpu_mode", "event_count"],
       };
       for (const [table, expected] of Object.entries(additiveColumns)) {
         expect(columns(migrated, table)).toEqual(expect.arrayContaining(expected));
@@ -147,7 +145,7 @@ describe("diagnostics v2 compatibility and privacy", () => {
       for (const table of ["report_daily", "report_installations", "report_event_dimensions", "diagnostics_meta"]) {
         expect(columns(migrated, table)).toEqual(columns(fresh, table));
       }
-      for (const table of ["cli_pings", "cli_metric_users"]) {
+      for (const table of ["cli_pings"]) {
         expect(columns(runtimeBootstrap, table)).toEqual(columns(fresh, table));
       }
       expect(classifyDiagnosticsV2Schema(

--- a/workers/crash-report/src/index.test.ts
+++ b/workers/crash-report/src/index.test.ts
@@ -11,7 +11,6 @@ import {
   Metrics,
   CLI_TELEMETRY_SCHEMA_SQL,
   ensureCLITelemetrySchema,
-  refreshMetricUserRollup,
   severityForReport,
   maxSeverity,
   nativeWebRuntimeFingerprintBasis,
@@ -135,12 +134,10 @@ describe("telemetry deployment order compatibility", () => {
     expect(telemetryTableNames("desktop")).toEqual({
       pings: "pings",
       metrics: "metrics",
-      metricUsers: "metric_users",
     });
     expect(telemetryTableNames("cli")).toEqual({
       pings: "cli_pings",
       metrics: "cli_metrics",
-      metricUsers: "cli_metric_users",
     });
   });
 
@@ -160,8 +157,7 @@ describe("telemetry deployment order compatibility", () => {
     const runtimeSchema = CLI_TELEMETRY_SCHEMA_SQL.join("\n");
     expect(runtimeSchema).toContain("os_build INTEGER NOT NULL DEFAULT 0");
     expect(runtimeSchema).toContain("os_revision INTEGER NOT NULL DEFAULT 0");
-    expect(runtimeSchema).toContain("arch TEXT NOT NULL DEFAULT ''");
-    expect(runtimeSchema).toContain("event_count INTEGER NOT NULL DEFAULT 0");
+    expect(runtimeSchema).toContain("arch TEXT NOT NULL");
   });
 
   it("uses additive idempotent DDL when the Worker deploys before the migration", async () => {
@@ -205,85 +201,6 @@ describe("telemetry deployment order compatibility", () => {
     await expect(ensureCLITelemetrySchema({ DB: db })).rejects.toThrow("temporary D1 failure");
     await expect(ensureCLITelemetrySchema({ DB: db })).resolves.toBeUndefined();
     expect(batches).toBe(2);
-  });
-});
-
-function fakeRollupDB(options: { failAtQuery?: number } = {}) {
-  const cursor = { next_signal: 0 };
-  const queried: string[] = [];
-  const batches: string[][] = [];
-  const db = {
-    prepare(sql: string) {
-      const stmt = {
-        sql,
-        binds: [] as unknown[],
-        bind(...args: unknown[]) {
-          stmt.binds = args;
-          return stmt;
-        },
-        async first() {
-          return sql.includes("FROM metric_user_rollup_state") ? { next_signal: cursor.next_signal } : null;
-        },
-        async all() {
-          if (!sql.includes("COUNT(DISTINCT install_id)")) return { results: [] };
-          const nth = queried.length;
-          queried.push(String(stmt.binds[0]));
-          if (options.failAtQuery === nth) throw new Error("D1 DB exceeded its CPU time limit and was reset");
-          return { results: [{ bucket: "dark", total: 7 }] };
-        },
-        async run() {
-          if (sql.includes("INSERT INTO metric_user_rollup_state")) cursor.next_signal = Number(stmt.binds[0]);
-          return {};
-        },
-      };
-      return stmt;
-    },
-    async batch(stmts: { sql: string }[]) {
-      batches.push(stmts.map((s) => s.sql));
-      return [];
-    },
-  } as unknown as D1Database;
-  return { env: { DB: db } as unknown as Parameters<typeof refreshMetricUserRollup>[0], cursor, queried, batches };
-}
-
-describe("metric_user rollup", () => {
-  it("walks the whole signal list across runs without repeating one", async () => {
-    const { env, cursor, queried } = fakeRollupDB();
-
-    await refreshMetricUserRollup(env, 3);
-    expect(cursor.next_signal).toBe(3);
-    await refreshMetricUserRollup(env, 3);
-    expect(cursor.next_signal).toBe(6);
-
-    expect(queried).toHaveLength(6);
-    expect(new Set(queried).size).toBe(6);
-  });
-
-  it("wraps the cursor back to the start after a full pass", async () => {
-    const { env, cursor, queried } = fakeRollupDB();
-    await refreshMetricUserRollup(env, 10_000);
-    expect(queried.length).toBeGreaterThan(50);
-    expect(new Set(queried).size).toBe(queried.length);
-    expect(cursor.next_signal).toBe(0);
-  });
-
-  it("moves past a signal whose query is abandoned instead of retrying it forever", async () => {
-    const { env, cursor, queried } = fakeRollupDB({ failAtQuery: 1 });
-    await refreshMetricUserRollup(env, 3);
-    expect(queried).toHaveLength(3);
-    expect(cursor.next_signal).toBe(3);
-  });
-
-  it("replaces a signal's rows in one batch so no reader sees it half-written", async () => {
-    const { env, batches } = fakeRollupDB();
-    await refreshMetricUserRollup(env, 2);
-
-    const writes = batches.filter((b) => b.some((sql) => /DELETE FROM metric_user_rollup\b/.test(sql)));
-    expect(writes).toHaveLength(2);
-    for (const batch of writes) {
-      expect(batch[0]).toMatch(/DELETE FROM metric_user_rollup\b/);
-      expect(batch.slice(1).every((sql) => /INSERT INTO metric_user_rollup\b/.test(sql))).toBe(true);
-    }
   });
 });
 
@@ -475,9 +392,6 @@ describe("diagnostics dashboard lanes", () => {
       ],
       metrics: [],
       previousMetrics: [],
-      metricUsers: [],
-      metricUsersUnavailable: false,
-      metricUsersComputedAt: "",
       sources: [],
       overview: { latestAdoptionPct: null, openReports: 4, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 1 },
       latestVersion: "v1.40.0",
@@ -491,7 +405,6 @@ describe("diagnostics dashboard lanes", () => {
         newLatest: false,
         regressed: false,
         windowDays: 30,
-        preferenceMode: "users",
       },
     };
 
@@ -522,9 +435,6 @@ describe("diagnostics dashboard lanes", () => {
       crashes: [],
       metrics: [],
       previousMetrics: [],
-      metricUsers: [],
-      metricUsersUnavailable: false,
-      metricUsersComputedAt: "",
       sources: [],
       overview: { latestAdoptionPct: null, openReports: 0, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 0 },
       latestVersion: "",
@@ -538,7 +448,6 @@ describe("diagnostics dashboard lanes", () => {
         newLatest: false,
         regressed: false,
         windowDays: 30,
-        preferenceMode: "users",
       },
     };
     const html = renderStats(
@@ -551,113 +460,4 @@ describe("diagnostics dashboard lanes", () => {
     expect(html).toContain('href="/stats"');
   });
 
-  it("says the deduplication did not finish instead of showing an empty dashboard", () => {
-    type StatsData = Parameters<typeof renderStats>[0];
-    const data: StatsData = {
-      daily: [],
-      versions: [],
-      platforms: [],
-      crashes: [],
-      metrics: [],
-      previousMetrics: [],
-      metricUsers: [],
-        metricUsersUnavailable: true,
-      metricUsersComputedAt: "",
-      sources: [],
-      overview: { latestAdoptionPct: null, openReports: 0, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 0 },
-      latestVersion: "",
-      filters: {
-        surface: "desktop",
-        status: "",
-        source: "",
-        version: "",
-        os: "",
-        platform: "",
-        newLatest: false,
-        regressed: false,
-        windowDays: 30,
-        preferenceMode: "users",
-      },
-    };
-    const html = renderStats(
-      data,
-      { id: 1, email: "viewer@example.com", role: "viewer", created_at: "", approved_at: "" },
-      "preferences",
-    );
-    const installs = html.slice(html.indexOf("Deduplicated installs"), html.indexOf("Launch/open snapshots"));
-    expect(installs).toContain("deduplication");
-    expect(installs).toContain("window=7d");
-    expect(installs).not.toContain("No settings preference metrics yet");
-  });
-
-  it("shows how old the precomputed window is", () => {
-    type StatsData = Parameters<typeof renderStats>[0];
-    const data: StatsData = {
-      daily: [],
-      versions: [],
-      platforms: [],
-      crashes: [],
-      metrics: [],
-      previousMetrics: [],
-      metricUsers: [{ signal: "settings_theme", bucket: "dark", total: 12 }],
-      metricUsersUnavailable: false,
-      metricUsersComputedAt: "2026-08-03T07:28:41.019Z",
-      sources: [],
-      overview: { latestAdoptionPct: null, openReports: 0, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 0 },
-      latestVersion: "",
-      filters: {
-        surface: "desktop",
-        status: "",
-        source: "",
-        version: "",
-        os: "",
-        platform: "",
-        newLatest: false,
-        regressed: false,
-        windowDays: 30,
-        preferenceMode: "users",
-      },
-    };
-    const user = { id: 1, email: "viewer@example.com", role: "viewer", created_at: "", approved_at: "" } as const;
-    expect(renderStats(data, user, "preferences")).toContain("2026-08-03 07:28Z");
-  });
-
-  it("shows deduplicated affected installs on agent health", () => {
-    type StatsData = Parameters<typeof renderStats>[0];
-    const data: StatsData = {
-      daily: [],
-      versions: [],
-      platforms: [],
-      crashes: [],
-      metrics: [{ signal: "desktop_hang", bucket: "windows_ui_thread", total: 12 }],
-      previousMetrics: [],
-      metricUsers: [{ signal: "desktop_hang", bucket: "windows_ui_thread", total: 3 }],
-      metricUsersUnavailable: false,
-      metricUsersComputedAt: "",
-      sources: [],
-      overview: { latestAdoptionPct: null, openReports: 0, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 0 },
-      latestVersion: "v1.19.4",
-      filters: {
-        surface: "desktop",
-        status: "",
-        source: "",
-        version: "",
-        os: "",
-        platform: "",
-        newLatest: false,
-        regressed: false,
-        windowDays: 7,
-        preferenceMode: "users",
-      },
-    };
-    const html = renderStats(
-      data,
-      { id: 1, email: "viewer@example.com", role: "viewer", created_at: "", approved_at: "" },
-      "health",
-    );
-    const installs = html.slice(html.indexOf("Affected installs"), html.indexOf("Signal distributions"));
-    expect(installs).toContain("Desktop hangs");
-    expect(installs).toContain(">3<");
-    expect(installs).not.toContain(">12<");
-  });
 });

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -58,12 +58,11 @@ type ClientSurfaceName = z.infer<typeof ClientSurface>;
 type TelemetryTableNames = {
   pings: "pings" | "cli_pings";
   metrics: "metrics" | "cli_metrics";
-  metricUsers: "metric_users" | "cli_metric_users";
 };
 
 const TELEMETRY_TABLES: Record<ClientSurfaceName, TelemetryTableNames> = {
-  desktop: { pings: "pings", metrics: "metrics", metricUsers: "metric_users" },
-  cli: { pings: "cli_pings", metrics: "cli_metrics", metricUsers: "cli_metric_users" },
+  desktop: { pings: "pings", metrics: "metrics" },
+  cli: { pings: "cli_pings", metrics: "cli_metrics" },
 };
 
 export function telemetryTableNames(surface: ClientSurfaceName): TelemetryTableNames {
@@ -99,27 +98,6 @@ export const CLI_TELEMETRY_SCHEMA_SQL = [
      bucket TEXT NOT NULL,
      count INTEGER NOT NULL DEFAULT 0,
      PRIMARY KEY (date, version, os, signal, bucket)
-   )`,
-  `CREATE TABLE IF NOT EXISTS cli_metric_users (
-     date TEXT NOT NULL,
-     signal TEXT NOT NULL,
-     bucket TEXT NOT NULL,
-     install_id TEXT NOT NULL,
-     version TEXT NOT NULL,
-     os TEXT NOT NULL,
-     arch TEXT NOT NULL DEFAULT '',
-     os_build INTEGER NOT NULL DEFAULT 0,
-     os_revision INTEGER NOT NULL DEFAULT 0,
-     channel TEXT NOT NULL DEFAULT '',
-     distro_id TEXT NOT NULL DEFAULT '',
-     distro_version TEXT NOT NULL DEFAULT '',
-     kernel_version TEXT NOT NULL DEFAULT '',
-     session_type TEXT NOT NULL DEFAULT '',
-     runtime_engine TEXT NOT NULL DEFAULT '',
-     runtime_version TEXT NOT NULL DEFAULT '',
-     gpu_mode TEXT NOT NULL DEFAULT '',
-     event_count INTEGER NOT NULL DEFAULT 0,
-     PRIMARY KEY (date, signal, bucket, install_id)
    )`,
   // No secondary indexes: each primary key already leads with `date`, which is
   // what every dashboard query filters on. See migrate-window-index-fix.sql.
@@ -266,10 +244,6 @@ const UnknownMetricCounter = z
   .transform(() => null);
 
 export const Metrics = z.object({
-  installId: z
-    .string()
-    .regex(/^[0-9a-f]{32}$/)
-    .optional(),
   version: z.string().min(1).max(64),
   os: z.string().min(1).max(32),
   arch: z.string().max(32).optional(),
@@ -776,32 +750,6 @@ async function handleMetrics(request: Request, env: Env): Promise<Response> {
   } catch (err) {
     return storageUnavailable("metrics", err);
   }
-  if (m.installId) {
-    const userUpsert = env.DB.prepare(
-      `INSERT INTO ${tables.metricUsers} (
-         date, version, os, arch, os_build, os_revision, channel, distro_id, distro_version,
-         kernel_version, session_type, runtime_engine, runtime_version, gpu_mode,
-         signal, bucket, install_id, event_count
-       )
-       VALUES (date('now'), ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
-       ON CONFLICT (date, signal, bucket, install_id) DO UPDATE SET
-         version = ?1, os = ?2, arch = ?3, os_build = ?4, os_revision = ?5,
-         channel = ?6, distro_id = ?7, distro_version = ?8, kernel_version = ?9,
-         session_type = ?10, runtime_engine = ?11, runtime_version = ?12, gpu_mode = ?13,
-         event_count = event_count + ?17`,
-    );
-    try {
-      await env.DB.batch(m.counters.map((c) => userUpsert.bind(
-        m.version, m.os, m.arch ?? "", m.osBuild ?? 0, m.osRevision ?? 0,
-        m.channel ?? "", m.distroId ?? "", m.distroVersion ?? "", m.kernelVersion ?? "",
-        m.sessionType ?? "", m.runtimeEngine ?? "", m.runtimeVersion ?? "", m.gpuMode ?? "",
-        c.signal, c.bucket, m.installId, c.count,
-      )));
-    } catch (err) {
-      console.warn("metric_users write failed", err);
-    }
-  }
-
   return new Response("ok", { status: 202 });
 }
 
@@ -971,59 +919,11 @@ async function metricRows(env: Env, days: 7 | 30, surface: ClientSurfaceName, pr
   return rows.results;
 }
 
-// The 30-day desktop window is served from the cron-built rollup: computing it
-// live exceeds what D1 spends on one query (see refreshMetricUserRollup). Null
-// here means "not computed yet", which the dashboard says out loud rather than
-// rendering as an empty result.
-async function rollupMetricUserRows(
-  env: Env,
-): Promise<{ rows: { signal: string; bucket: string; total: number }[]; computedAt: string } | null> {
-  try {
-    await ensureRollupSchema(env);
-    const rows = await env.DB.prepare(
-      `SELECT signal, bucket, total, computed_at FROM metric_user_rollup WHERE window_days = ?1 ORDER BY signal, total DESC`,
-    )
-      .bind(ROLLUP_WINDOW_DAYS)
-      .all<{ signal: string; bucket: string; total: number; computed_at: string }>();
-    if (!rows.results.length) return null;
-    // Oldest wins: the cursor refreshes a slice at a time, so this is how far
-    // behind the least recently recomputed signal is.
-    const computedAt = rows.results.reduce((min, r) => (r.computed_at < min ? r.computed_at : min), rows.results[0].computed_at);
-    return { rows: rows.results, computedAt };
-  } catch (err) {
-    console.warn("metric_user_rollup read failed", err);
-    return null;
-  }
-}
-
-// Null means the query did not complete, which is distinct from "no rows": at
-// ~1M rows a day, the 30-day COUNT(DISTINCT install_id) exceeds what D1 will
-// spend on one query and comes back as a CPU-limit reset. Rendering that as an
-// empty dashboard would read as "nobody uses these settings".
-async function metricUserRows(
-  env: Env,
-  days: 7 | 30,
-  surface: ClientSurfaceName,
-): Promise<{ rows: { signal: string; bucket: string; total: number }[]; computedAt: string } | null> {
-  if (surface === "desktop" && days === ROLLUP_WINDOW_DAYS) return rollupMetricUserRows(env);
-  try {
-    const table = telemetryTableNames(surface).metricUsers;
-    const rows = await env.DB.prepare(
-      `SELECT signal, bucket, COUNT(DISTINCT install_id) AS total FROM ${table} WHERE date >= date('now', '${currentWindowSince(days)}') GROUP BY signal, bucket ORDER BY signal, total DESC`,
-    ).all<{ signal: string; bucket: string; total: number }>();
-    return { rows: rows.results, computedAt: "" };
-  } catch (err) {
-    console.warn("metric_users query failed", err);
-    return null;
-  }
-}
-
 type Bar = { label: string; users: number };
 type MetricTotals = { signal: string; bucket: string; total: number }[];
 
-// Each stats module renders only its own section, so a page load should query
-// only what that section shows — the 30-day COUNT(DISTINCT) over metric_users,
-// the heaviest query, is read solely by the preferences module.
+// Each stats module renders only its own section, so a page load queries only
+// what that section shows.
 async function handleStats(request: Request, env: Env, user: User, activeModule: StatsModule): Promise<Response> {
   const url = new URL(request.url);
   const filters = statsFilters(url);
@@ -1045,9 +945,6 @@ async function handleStats(request: Request, env: Env, user: User, activeModule:
   let crashes: Awaited<ReturnType<typeof crashGroups>>["results"] = [];
   let metrics: MetricTotals = [];
   let previousMetrics: MetricTotals = [];
-  let metricUsers: MetricTotals = [];
-  let metricUsersUnavailable = false;
-  let metricUsersComputedAt = "";
   let sources: Bar[] = [];
   let diagnosticFacets: DiagnosticFacets = {
     versions: [], platforms: [],
@@ -1096,27 +993,19 @@ async function handleStats(request: Request, env: Env, user: User, activeModule:
     diagnosticFacets = facets;
     installationLinkedSince = linkedSince?.value ?? "";
   } else if (activeModule === "preferences") {
-    const [metricsR, usersR] = await Promise.all([metricRows(env, days, surface), metricUserRows(env, days, surface)]);
-    metrics = metricsR;
-    metricUsersUnavailable = usersR === null;
-    metricUsers = usersR?.rows ?? [];
-    metricUsersComputedAt = usersR?.computedAt ?? "";
+    metrics = await metricRows(env, days, surface);
   } else {
-    const [metricsR, previousMetricsR, usersR] = await Promise.all([
+    const [metricsR, previousMetricsR] = await Promise.all([
       metricRows(env, days, surface),
       metricRows(env, days, surface, true),
-      metricUserRows(env, days, surface),
     ]);
     metrics = metricsR;
     previousMetrics = previousMetricsR;
-    metricUsersUnavailable = usersR === null;
-    metricUsers = usersR?.rows ?? [];
-    metricUsersComputedAt = usersR?.computedAt ?? "";
   }
 
   return html(
     renderStats(
-      { daily, versions, platforms, crashes, metrics, previousMetrics, metricUsers, metricUsersUnavailable, metricUsersComputedAt, sources, diagnosticFacets, installationLinkedSince, overview, latestVersion, filters },
+      { daily, versions, platforms, crashes, metrics, previousMetrics, sources, diagnosticFacets, installationLinkedSince, overview, latestVersion, filters },
       user,
       activeModule,
     ),
@@ -1349,10 +1238,8 @@ const RETENTION = [
   { table: "report_event_dimensions", keepDays: 30 },
   { table: "pings", keepDays: 30 },
   { table: "metrics", keepDays: 60 },
-  { table: "metric_users", keepDays: 30 },
   { table: "cli_pings", keepDays: 30 },
   { table: "cli_metrics", keepDays: 60 },
-  { table: "cli_metric_users", keepDays: 30 },
 ] as const;
 // Deletes run in rowid chunks so a run never holds one giant transaction.
 // Steady state is one expired day per table; the chunk cap is a backstop that
@@ -1364,102 +1251,6 @@ const RETENTION_MAX_CHUNKS = 200;
 // scheduled handler dispatches on controller.cron; every other trigger
 // (the retention cron, manual runs) falls through to the purge.
 const SENTINEL_CRON = "17 1,7,13,19 * * *";
-const ROLLUP_CRON = "23 * * * *";
-
-// The preferences module's 30-day COUNT(DISTINCT install_id) spans ~28M rows
-// and D1 abandons it mid-query. It cannot be summed from per-day totals either:
-// an install active on twelve days would count twelve times. So the window is
-// computed here instead, one signal at a time — a single signal takes ~1s, and
-// the cursor spreads the ~57 of them across hourly runs rather than blowing one
-// invocation's CPU budget.
-const ROLLUP_WINDOW_DAYS = 30;
-const ROLLUP_SIGNALS_PER_RUN = 8;
-
-const ROLLUP_SCHEMA_SQL = [
-  `CREATE TABLE IF NOT EXISTS metric_user_rollup (
-     window_days INTEGER NOT NULL,
-     signal TEXT NOT NULL,
-     bucket TEXT NOT NULL,
-     total INTEGER NOT NULL,
-     computed_at TEXT NOT NULL,
-     PRIMARY KEY (window_days, signal, bucket)
-   )`,
-  `CREATE TABLE IF NOT EXISTS metric_user_rollup_state (
-     id INTEGER PRIMARY KEY CHECK (id = 1),
-     next_signal INTEGER NOT NULL,
-     updated_at TEXT NOT NULL
-   )`,
-] as const;
-
-const rollupSchemaPromises = new WeakMap<object, Promise<void>>();
-
-function ensureRollupSchema(env: Pick<Env, "DB">): Promise<void> {
-  const key = env.DB as unknown as object;
-  const existing = rollupSchemaPromises.get(key);
-  if (existing) return existing;
-  const creation = env.DB
-    .batch(ROLLUP_SCHEMA_SQL.map((sql) => env.DB.prepare(sql)))
-    .then(() => undefined)
-    .catch((err) => {
-      rollupSchemaPromises.delete(key);
-      throw err;
-    });
-  rollupSchemaPromises.set(key, creation);
-  return creation;
-}
-
-export async function refreshMetricUserRollup(env: Env, signalsPerRun = ROLLUP_SIGNALS_PER_RUN): Promise<void> {
-  await ensureRollupSchema(env);
-  const state = await env.DB.prepare("SELECT next_signal FROM metric_user_rollup_state WHERE id = 1").first<{
-    next_signal: number;
-  }>();
-  const start = Number(state?.next_signal ?? 0) % METRIC_SIGNALS.length;
-  const now = new Date().toISOString();
-  let advanced = 0;
-
-  for (let i = 0; i < signalsPerRun && i < METRIC_SIGNALS.length; i++) {
-    const signal = METRIC_SIGNALS[(start + i) % METRIC_SIGNALS.length];
-    try {
-      const rows = await env.DB.prepare(
-        `SELECT bucket, COUNT(DISTINCT install_id) AS total FROM metric_users
-         WHERE date >= date('now', '-${ROLLUP_WINDOW_DAYS - 1} day') AND signal = ?1
-         GROUP BY bucket`,
-      )
-        .bind(signal)
-        .all<{ bucket: string; total: number }>();
-      // Delete and insert in one batch so a reader never sees a signal
-      // half-replaced; an empty result still clears the previous window's rows.
-      await env.DB.batch([
-        env.DB
-          .prepare("DELETE FROM metric_user_rollup WHERE window_days = ?1 AND signal = ?2")
-          .bind(ROLLUP_WINDOW_DAYS, signal),
-        ...rows.results.map((r) =>
-          env.DB
-            .prepare(
-              `INSERT INTO metric_user_rollup (window_days, signal, bucket, total, computed_at)
-               VALUES (?1, ?2, ?3, ?4, ?5)`,
-            )
-            .bind(ROLLUP_WINDOW_DAYS, signal, r.bucket, r.total, now),
-        ),
-      ]);
-      advanced++;
-    } catch (err) {
-      // One signal timing out must not strand the cursor on it forever.
-      console.error(`rollup: ${signal} failed`, err);
-      advanced++;
-    }
-  }
-
-  await env.DB
-    .prepare(
-      `INSERT INTO metric_user_rollup_state (id, next_signal, updated_at) VALUES (1, ?1, ?2)
-       ON CONFLICT(id) DO UPDATE SET next_signal = ?1, updated_at = ?2`,
-    )
-    .bind((start + advanced) % METRIC_SIGNALS.length, now)
-    .run();
-  console.log(`rollup: refreshed ${advanced} signals from index ${start}`);
-}
-
 // Ingest sentinel. The 2026-07-03 blackout went unnoticed for ten days because
 // clients swallow ping failures by design and nothing watched the write path.
 // Four times a day (hours chosen so the UTC day always has >1h of traffic;
@@ -1688,10 +1479,6 @@ export default {
   async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
     if (controller.cron === SENTINEL_CRON) {
       ctx.waitUntil(runIngestSentinel(env));
-      return;
-    }
-    if (controller.cron === ROLLUP_CRON) {
-      ctx.waitUntil(refreshMetricUserRollup(env));
       return;
     }
     ctx.waitUntil(purgeExpiredStatsRows(env));

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -567,11 +567,6 @@ function navLink(href: string, label: { en: string; zh: string }, active = false
   return `<a${active ? ` class="active" aria-current="page"` : ""} href="${esc(href)}">${i18n(label.en, label.zh)}</a>`;
 }
 
-function preferencePanel(title: string, body: string, active: boolean): string {
-  return `<section class="module-panel preference-panel${active ? " active" : ""}"${active ? ` aria-current="true"` : ""}>
-<h3>${title}</h3>${body}</section>`;
-}
-
 function reportGroups(rows: CrashRow[], compact = false): string {
   if (!rows.length) return `<div class="empty">${i18n("No diagnostic reports yet — that's the good kind of empty", "还没有诊断报告，这是好消息")}</div>`;
   return `<div class="crash-list${compact ? " compact" : ""}"><div class="crash-head"><span>${i18n("summary", "摘要")}</span><span>${i18n("scope", "范围")}</span><span>${i18n("health", "状态")}</span><span title="${i18n("Window events and affected installs; lifetime count remains visible for historical context", "窗口事件数和受影响安装数；同时保留全生命周期累计次数")}">${i18n("window / lifetime", "窗口 / 累计")}</span></div>${rows
@@ -599,10 +594,7 @@ export function renderStats(
     crashes: CrashRow[];
     metrics: MetricRow[];
     previousMetrics: MetricRow[];
-    metricUsers: MetricRow[];
-    metricUsersUnavailable: boolean;
     /** Oldest computed_at in the rollup; empty when the window was queried live. */
-    metricUsersComputedAt: string;
     sources: { label: string; users: number }[];
     diagnosticFacets?: {
       osBuilds: BarRow[];
@@ -649,7 +641,6 @@ export function renderStats(
       newLatest: boolean;
       regressed: boolean;
       windowDays: 7 | 30;
-      preferenceMode: "users" | "opens";
     };
   },
   user: User,
@@ -667,12 +658,10 @@ export function renderStats(
   const anyPing = days.some((d) => d.opens > 0);
   const agentMetrics = data.metrics.filter((r) => AGENT_METRIC_SIGNALS.includes(r.signal));
   const previousAgentMetrics = data.previousMetrics.filter((r) => AGENT_METRIC_SIGNALS.includes(r.signal));
-  const agentMetricUsers = data.metricUsers.filter((r) => AGENT_METRIC_SIGNALS.includes(r.signal));
   const isSettingsSignal = (signal: string) =>
     signal === "client_surface" || signal === "client_version" || signal.startsWith("settings_") ||
     ["cli_mode", "cli_profile", "cli_permission_mode", "cli_session_mode"].includes(signal);
   const settingsMetrics = data.metrics.filter((r) => isSettingsSignal(r.signal));
-  const settingsMetricUsers = data.metricUsers.filter((r) => isSettingsSignal(r.signal));
   const cache = cacheHitRate(agentMetrics);
   const providerRate = ratioPer100(agentMetrics, "provider_error");
   const toolRate = ratioPer100(agentMetrics, "tool_error");
@@ -716,7 +705,6 @@ export function renderStats(
     if (data.filters.newLatest) params.set("new", "latest");
     if (data.filters.regressed) params.set("regressed", "1");
     if (data.filters.windowDays === 7) params.set("window", "7d");
-    if (module === "preferences" && data.filters.preferenceMode === "opens") params.set("prefs", "opens");
     for (const [k, v] of Object.entries(patch)) {
       if (v) params.set(k, v);
       else params.delete(k);
@@ -736,14 +724,6 @@ export function renderStats(
   const surfaceControls = `<div class="segmented" aria-label="Client surface">
 <a class="${data.filters.surface === "desktop" ? "active" : ""}"${data.filters.surface === "desktop" ? ` aria-current="true"` : ""} href="${esc(filterQS({ surface: "" }))}">${i18n("Desktop", "桌面端")}</a>
 <a class="${data.filters.surface === "cli" ? "active" : ""}"${data.filters.surface === "cli" ? ` aria-current="true"` : ""} href="${esc(filterQS({ surface: "cli" }))}">CLI</a>
-</div>`;
-  const preferenceControls = `<div class="segmented" aria-label="Preference metric mode">
-<a class="${data.filters.preferenceMode === "users" ? "active" : ""}"${data.filters.preferenceMode === "users" ? ` aria-current="true"` : ""} href="${esc(
-    filterQS({ prefs: "" }, "preferences"),
-  )}">${i18n("Installs", "按安装")}</a>
-<a class="${data.filters.preferenceMode === "opens" ? "active" : ""}"${data.filters.preferenceMode === "opens" ? ` aria-current="true"` : ""} href="${esc(
-    filterQS({ prefs: "opens" }, "preferences"),
-  )}">${i18n("Opens", "按启动")}</a>
 </div>`;
   const overviewTone = topSeverityTone(data.overview.openReports, data.overview.regressedReports, data.overview.criticalOpenReports);
   const isDevelopmentDiagnostic = (row: CrashRow) => row.development ?? row.fingerprint.startsWith("dev:");
@@ -807,49 +787,10 @@ ${developmentDiagnostics.length ? `<section class="module-panel"><h3>${i18nHTML(
 ${filters}
 <section class="module-panel"><h3>${i18nHTML("All report groups <b>— open, regression, severity, count, recency</b>", "全部诊断分组 <b>— 未处理、回归、严重性、次数和最近出现</b>")}</h3>${reportGroups(data.crashes)}</section>
 </section>`;
-  const sevenDayHref = esc(filterQS({ window: "7d" }, "preferences"));
-  const unavailableNotice =
-    range === 30
-      ? i18nHTML(
-          `The 30-day deduplication is precomputed hourly and has not reached every signal yet. <a href="${sevenDayHref}">Use 7d</a> meanwhile.`,
-          `30 天去重统计由后台每小时预聚合，目前还没覆盖到全部信号。<a href="${sevenDayHref}">先看 7 天</a>。`,
-        )
-      : i18nHTML(`The ${rangeText} deduplication did not finish.`, `${rangeText} 的去重统计没能跑完。`);
-  // A precomputed window can silently go stale if the rollup cron stops, so the
-  // heading carries how old the least recently recomputed signal is.
-  const computedAt = data.metricUsersComputedAt
-    ? ` <b>${esc(data.metricUsersComputedAt.slice(0, 16).replace("T", " "))}Z</b>`
-    : "";
-  const healthComputedAt = data.metricUsersComputedAt
-    ? ` ${esc(data.metricUsersComputedAt.slice(0, 16).replace("T", " "))}Z`
-    : "";
-  const installsPanel = preferencePanel(
-    i18nHTML(
-      `Deduplicated installs <b>— ${rangeText}</b>${computedAt ? ` computed${computedAt}` : ""}`,
-      `按安装去重 <b>— ${rangeText}</b>${computedAt ? ` 统计于${computedAt}` : ""}`,
-    ),
-    data.metricUsersUnavailable
-      ? `<div class="empty">${unavailableNotice}</div>`
-      : settingsDashboard(settingsMetricUsers, { collapseSections: true }),
-    data.filters.preferenceMode === "users",
-  );
-  const opensPanel = preferencePanel(
-    i18nHTML(`Launch/open snapshots <b>— ${rangeText}</b>`, `启动/开启快照 <b>— ${rangeText}</b>`),
-    settingsDashboard(settingsMetrics, { collapseSections: true }),
-    data.filters.preferenceMode === "opens",
-  );
-  const preferencePanels = data.filters.preferenceMode === "opens" ? `${opensPanel}${installsPanel}` : `${installsPanel}${opensPanel}`;
-  const preferencesModule = `<section id="preferences" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Settings preferences", "设置偏好")}</h2></div><div class="module-actions">${preferenceControls}</div></div>
-<div class="preference-compare">${preferencePanels}</div></section>`;
+  const preferencesModule = `<section id="preferences" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Settings preferences", "设置偏好")}</h2></div></div>
+<section class="module-panel"><h3>${i18nHTML(`Launch/open snapshots <b>— ${rangeText}</b>`, `启动/开启快照 <b>— ${rangeText}</b>`)}</h3>${settingsDashboard(settingsMetrics, { collapseSections: true })}</section></section>`;
   const healthModule = `<section id="health" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Agent health", "运行健康")}</h2></div><div class="module-actions"><a class="module-action" href="${esc(filterQS({}, "preferences"))}">${i18n("Preferences", "设置偏好")}</a></div></div>
 <section class="module-panel"><h3>${i18nHTML(`Health summary <b>— ${rangeText}, compared with previous window</b>`, `健康摘要 <b>— ${rangeText}，对比上一窗口</b>`)}</h3>${agentHealth(agentMetrics, previousAgentMetrics)}</section>
-<section class="module-panel"><h3>${i18nHTML(`Affected installs <b>— ${rangeText}, deduplicated${healthComputedAt ? `, computed ${healthComputedAt}` : ""}</b>`, `受影响安装 <b>— ${rangeText}，按安装去重${healthComputedAt ? `，统计于 ${healthComputedAt}` : ""}</b>`)}</h3>${
-    data.metricUsersUnavailable
-      ? `<div class="empty">${range === 30
-          ? i18nHTML(`The 30-day deduplication is not ready. <a href="${esc(filterQS({ window: "7d" }, "health"))}">Use 7d</a> meanwhile.`, `30 天去重统计尚未就绪。<a href="${esc(filterQS({ window: "7d" }, "health"))}">先看 7 天</a>。`)
-          : i18n(`The ${rangeText} deduplication did not finish.`, `${rangeText} 的去重统计没能跑完。`)}</div>`
-          : metricsCards(agentMetricUsers, ["desktop_hang", "desktop_hang_age", "desktop_web_runtime_failure", "desktop_webview2_failure", "desktop_restore", "desktop_exit"])
-  }</section>
 <section class="module-panel"><h3>${i18nHTML(`Signal distributions <b>— ${rangeText}, opt-in aggregate</b>`, `信号分布 <b>— ${rangeText}，opt-in 汇总</b>`)}</h3>${metricsCards(agentMetrics)}</section>
 </section>`;
   const activeModuleHTML: Record<StatsModule, string> = {

--- a/workers/crash-report/src/stats_filters.ts
+++ b/workers/crash-report/src/stats_filters.ts
@@ -23,7 +23,6 @@ export type StatsFilters = {
   newLatest: boolean;
   regressed: boolean;
   windowDays: 7 | 30;
-  preferenceMode: "users" | "opens";
 };
 
 const limited = (url: URL, name: string, max: number) => (url.searchParams.get(name) ?? "").slice(0, max);
@@ -57,6 +56,5 @@ export function statsFilters(url: URL): StatsFilters {
     newLatest: limited(url, "new", 6) === "latest",
     regressed: limited(url, "regressed", 1) === "1",
     windowDays: windowParam === "7d" ? 7 : 30,
-    preferenceMode: limited(url, "prefs", 5) === "opens" ? "opens" : "users",
   };
 }

--- a/workers/crash-report/wrangler.toml
+++ b/workers/crash-report/wrangler.toml
@@ -14,12 +14,8 @@ routes = [{ pattern = "crash.reasonix.io", custom_domain = true }]
 # secret of the same name by deploy-crash-worker.yml on every deploy — set it
 # under repo Settings → Secrets → Actions, no Cloudflare login needed. The
 # sentinel expression must stay in sync with SENTINEL_CRON in src/index.ts.
-# Third entry: hourly metric_user rollup (refreshMetricUserRollup) — the
-# preferences module reads it instead of a 30-day query D1 will not finish. Each
-# run advances a cursor through the signal list, so a full pass takes several
-# hours. Must stay in sync with ROLLUP_CRON in src/index.ts.
 [triggers]
-crons = ["47 19 * * *", "17 1,7,13,19 * * *", "23 * * * *"]
+crons = ["47 19 * * *", "17 1,7,13,19 * * *"]
 
 [vars]
 # Emails force-promoted to dashboard admin — the owner is never locked out even


### PR DESCRIPTION
## What

The dashboard's 30-day deduplicated install count was computed by an hourly cron over `metric_users`. That table's primary key leads with `date`, so the rollup's `WHERE date >= ... AND signal = ?` could only prune the window — every signal scanned the full table.

| | |
|---|---|
| `metric_users` size | ~28M rows (per `schema.sql` comment) |
| Rows read per signal | full table, no pruning on `signal` |
| Signals per run | 8 (`ROLLUP_SIGNALS_PER_RUN`) |
| Frequency | hourly (`23 * * * *`) |
| **Rows read per day** | **~5.4 billion** |

That is the database's entire read bill, spent on one dashboard panel — and `metric_users` had no other reader (the panel itself reads the small `metric_user_rollup` result table).

## Change

Retires the detail table and everything feeding it:

- the hourly rollup cron, `refreshMetricUserRollup`, and its two tables
- the per-install `metric_users` write on the metrics ingest path
- the dashboard's own full-table window query (7-day and CLI surface)
- the runtime bootstrap that recreated `cli_metric_users` on the next request
- `install_id` on the metrics payload, client and server — nothing receives it now

Kept: the aggregate `metrics` tables (same signals as event counts, ~180k rows) and `pings` (per-day deduplicated installs).

The two panels that rendered the retired number are **removed** rather than left showing a permanent error — the 30-day notice linked to a 7-day view that no longer had data either.

## Deploy order

`migrate-drop-metric-users.sql` reclaims the ~5.6GB the table held. **Merge and let this deploy first**, then run:

```
wrangler d1 execute reasonix-crash --remote --file=workers/crash-report/migrate-drop-metric-users.sql
```

Running the DROP first just gets the table rebuilt by the runtime bootstrap on the next CLI request.

## Verification

- `npx tsc --noEmit` clean; worker tests 89/89
- `make lint` (golangci-lint + repolint) clean
- `go test ./internal/telemetry/ ./internal/cli/` pass