### PR TITLE
fix(mcp): dispatch host-session MCP servers supplied over ACP

### DIFF
--- a/internal/agent/mcp_availability.go
+++ b/internal/agent/mcp_availability.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func (r *MCPCapabilityRuntime) serverRegistered(server string) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	_, ok := r.servers[strings.TrimSpace(server)]
+	r.mu.RUnlock()
+	return ok
+}
+
+func mcpServerUnregisteredMessage(server string) string {
+	return fmt.Sprintf("MCP server %q is not registered in this session", server)
+}
+
+func mcpServerDisabledMessage(server string) string {
+	return fmt.Sprintf("MCP server %q is disabled in this session", server)
+}
+
+func mcpServerUnregisteredError(server string) error {
+	return errors.New(mcpServerUnregisteredMessage(server))
+}
+
+func mcpServerDisabledError(server string) error {
+	return errors.New(mcpServerDisabledMessage(server))
+}
+
+func (t *UseCapabilityTool) serverRegistered(server string) bool {
+	if t.runtime != nil {
+		return t.runtime.serverRegistered(server)
+	}
+	// Standalone proxies have no authoritative runtime inventory to miss from.
+	return true
+}
+
+// serverUnavailableReason distinguishes a disabled server from one this
+// session never registered so the refusal points to the correct remedy.
+func (t *UseCapabilityTool) serverUnavailableReason(server string) string {
+	if !t.serverRegistered(server) {
+		return mcpServerUnregisteredMessage(server)
+	}
+	return mcpServerDisabledMessage(server)
+}

--- a/internal/agent/mcp_server_unavailable_reason_test.go
+++ b/internal/agent/mcp_server_unavailable_reason_test.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/config"
+)
+
+// "disabled" and "never registered" have different causes and different fixes.
+// Reporting the second as the first sends the user looking for a toggle that
+// does not exist — which is exactly what a host-session MCP server used to hit,
+// since it connects and lists its tools while the capability runtime has no
+// record of it at all.
+func TestServerUnavailableReasonSeparatesUnregisteredFromDisabled(t *testing.T) {
+	r := runtimeWithServers(config.PluginEntry{Name: "enabled-server"})
+	r.servers["disabled-server"] = mcpRuntimeServer{
+		entry:   config.PluginEntry{Name: "disabled-server"},
+		enabled: false,
+	}
+	frontend := r.NewFrontend(nil, nil)
+
+	if got := frontend.serverUnavailableReason("disabled-server"); !strings.Contains(got, "is disabled in this session") {
+		t.Errorf("registered-but-disabled server: reason = %q, want it to say disabled", got)
+	}
+	if got := frontend.serverUnavailableReason("ghost-server"); !strings.Contains(got, "is not registered in this session") {
+		t.Errorf("unregistered server: reason = %q, want it to say not registered", got)
+	}
+	if !frontend.serverEnabled("enabled-server") {
+		t.Error("enabled-server should dispatch")
+	}
+	if frontend.serverEnabled("disabled-server") || frontend.serverEnabled("ghost-server") {
+		t.Error("neither a disabled nor an unregistered server may dispatch")
+	}
+}

--- a/internal/agent/usecapability.go
+++ b/internal/agent/usecapability.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"sort"
@@ -291,26 +290,6 @@ func (r *MCPCapabilityRuntime) enabledSpec(server string) (plugin.Spec, bool) {
 		return plugin.Spec{}, false
 	}
 	return cloneMCPSpec(configured.spec), true
-}
-
-// ServerEnabled is the exported form of serverEnabled. Hosts and regression
-// tests need to assert against the real dispatch gate rather than a proxy for
-// it, because a server can connect and list tools while still being refused.
-func (r *MCPCapabilityRuntime) ServerEnabled(server string) bool {
-	return r.serverEnabled(server)
-}
-
-// serverRegistered reports whether this runtime knows the server at all,
-// independent of whether it is enabled. The two states have different causes and
-// different fixes, so they must not share one message.
-func (r *MCPCapabilityRuntime) serverRegistered(server string) bool {
-	if r == nil {
-		return false
-	}
-	r.mu.RLock()
-	_, ok := r.servers[strings.TrimSpace(server)]
-	r.mu.RUnlock()
-	return ok
 }
 
 func (r *MCPCapabilityRuntime) serverEnabled(server string) bool {
@@ -1404,7 +1383,7 @@ func (t *UseCapabilityTool) lockAuthorizedRuntimeServer(ctx context.Context, ser
 	if t.runtime == nil {
 		spec, ok := t.specFor(server)
 		if !ok {
-			return plugin.Spec{}, func() {}, errors.New(mcpServerUnregisteredMessage(server))
+			return plugin.Spec{}, func() {}, mcpServerUnregisteredError(server)
 		}
 		spec = plugin.ResolveStoredAuthorization(ctx, spec)
 		if !spec.ServerAuthorized() {
@@ -1420,11 +1399,11 @@ func (t *UseCapabilityTool) lockAuthorizedRuntimeServer(ctx context.Context, ser
 	t.runtime.mu.RUnlock()
 	if !ok {
 		unlock()
-		return plugin.Spec{}, func() {}, errors.New(mcpServerUnregisteredMessage(server))
+		return plugin.Spec{}, func() {}, mcpServerUnregisteredError(server)
 	}
 	if !configured.enabled {
 		unlock()
-		return plugin.Spec{}, func() {}, errors.New(mcpServerDisabledMessage(server))
+		return plugin.Spec{}, func() {}, mcpServerDisabledError(server)
 	}
 	spec := plugin.ResolveStoredAuthorization(ctx, cloneMCPSpec(configured.spec))
 	if !spec.ServerAuthorized() {
@@ -1468,42 +1447,6 @@ func (t *UseCapabilityTool) serverEnabled(server string) bool {
 	// Standalone proxies predate the authoritative runtime and may resolve
 	// already-registered MCP tools without carrying a duplicate spec slice.
 	return true
-}
-
-// mcpServerUnregisteredMessage is the single wording for "this session has no
-// such MCP server". Both dispatch routes reach that state — the registry-resident
-// mcp__server__tool path through lockAuthorizedRuntimeServer, and use_capability
-// through serverEnabled — so they share one spelling rather than drifting into
-// "not configured" and "not registered" for one condition.
-func mcpServerUnregisteredMessage(server string) string {
-	return fmt.Sprintf("MCP server %q is not registered in this session", server)
-}
-
-// mcpServerDisabledMessage is the counterpart for a server this session knows
-// but the user turned off. Distinct from the above on purpose: the two have
-// different causes and different fixes.
-func mcpServerDisabledMessage(server string) string {
-	return fmt.Sprintf("MCP server %q is disabled in this session", server)
-}
-
-func (t *UseCapabilityTool) serverRegistered(server string) bool {
-	if t.runtime != nil {
-		return t.runtime.serverRegistered(server)
-	}
-	// Mirrors serverEnabled's standalone branch: without a runtime there is no
-	// registry to be absent from.
-	return true
-}
-
-// serverUnavailableReason explains why dispatch was refused. A server the
-// runtime never registered is not a server the user disabled, and saying
-// "disabled" for the first case sends people hunting for a toggle that does not
-// exist.
-func (t *UseCapabilityTool) serverUnavailableReason(server string) string {
-	if !t.serverRegistered(server) {
-		return mcpServerUnregisteredMessage(server)
-	}
-	return mcpServerDisabledMessage(server)
 }
 
 func (t *UseCapabilityTool) configuredServers() []mcpRuntimeServer {

--- a/internal/agent/usecapability.go
+++ b/internal/agent/usecapability.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"sort"
@@ -1082,7 +1083,7 @@ func (t *UseCapabilityTool) resolveCall(ctx context.Context, id string, args jso
 		var ok bool
 		spec, ok = t.specFor(server)
 		if !ok {
-			return t.resolveUnavailable(base, id, modelName, fmt.Sprintf("MCP server %q is not configured", server)), nil
+			return t.resolveUnavailable(base, id, modelName, mcpServerUnregisteredMessage(server)), nil
 		}
 		spec = plugin.ResolveStoredAuthorization(ctx, spec)
 	}
@@ -1403,7 +1404,7 @@ func (t *UseCapabilityTool) lockAuthorizedRuntimeServer(ctx context.Context, ser
 	if t.runtime == nil {
 		spec, ok := t.specFor(server)
 		if !ok {
-			return plugin.Spec{}, func() {}, fmt.Errorf("MCP server %q is not configured", server)
+			return plugin.Spec{}, func() {}, errors.New(mcpServerUnregisteredMessage(server))
 		}
 		spec = plugin.ResolveStoredAuthorization(ctx, spec)
 		if !spec.ServerAuthorized() {
@@ -1419,11 +1420,11 @@ func (t *UseCapabilityTool) lockAuthorizedRuntimeServer(ctx context.Context, ser
 	t.runtime.mu.RUnlock()
 	if !ok {
 		unlock()
-		return plugin.Spec{}, func() {}, fmt.Errorf("MCP server %q is not configured", server)
+		return plugin.Spec{}, func() {}, errors.New(mcpServerUnregisteredMessage(server))
 	}
 	if !configured.enabled {
 		unlock()
-		return plugin.Spec{}, func() {}, fmt.Errorf("MCP server %q is disabled in this session", server)
+		return plugin.Spec{}, func() {}, errors.New(mcpServerDisabledMessage(server))
 	}
 	spec := plugin.ResolveStoredAuthorization(ctx, cloneMCPSpec(configured.spec))
 	if !spec.ServerAuthorized() {
@@ -1469,6 +1470,22 @@ func (t *UseCapabilityTool) serverEnabled(server string) bool {
 	return true
 }
 
+// mcpServerUnregisteredMessage is the single wording for "this session has no
+// such MCP server". Both dispatch routes reach that state — the registry-resident
+// mcp__server__tool path through lockAuthorizedRuntimeServer, and use_capability
+// through serverEnabled — so they share one spelling rather than drifting into
+// "not configured" and "not registered" for one condition.
+func mcpServerUnregisteredMessage(server string) string {
+	return fmt.Sprintf("MCP server %q is not registered in this session", server)
+}
+
+// mcpServerDisabledMessage is the counterpart for a server this session knows
+// but the user turned off. Distinct from the above on purpose: the two have
+// different causes and different fixes.
+func mcpServerDisabledMessage(server string) string {
+	return fmt.Sprintf("MCP server %q is disabled in this session", server)
+}
+
 func (t *UseCapabilityTool) serverRegistered(server string) bool {
 	if t.runtime != nil {
 		return t.runtime.serverRegistered(server)
@@ -1484,9 +1501,9 @@ func (t *UseCapabilityTool) serverRegistered(server string) bool {
 // exist.
 func (t *UseCapabilityTool) serverUnavailableReason(server string) string {
 	if !t.serverRegistered(server) {
-		return fmt.Sprintf("MCP server %q is not registered in this session", server)
+		return mcpServerUnregisteredMessage(server)
 	}
-	return fmt.Sprintf("MCP server %q is disabled in this session", server)
+	return mcpServerDisabledMessage(server)
 }
 
 func (t *UseCapabilityTool) configuredServers() []mcpRuntimeServer {

--- a/internal/agent/usecapability.go
+++ b/internal/agent/usecapability.go
@@ -292,6 +292,26 @@ func (r *MCPCapabilityRuntime) enabledSpec(server string) (plugin.Spec, bool) {
 	return cloneMCPSpec(configured.spec), true
 }
 
+// ServerEnabled is the exported form of serverEnabled. Hosts and regression
+// tests need to assert against the real dispatch gate rather than a proxy for
+// it, because a server can connect and list tools while still being refused.
+func (r *MCPCapabilityRuntime) ServerEnabled(server string) bool {
+	return r.serverEnabled(server)
+}
+
+// serverRegistered reports whether this runtime knows the server at all,
+// independent of whether it is enabled. The two states have different causes and
+// different fixes, so they must not share one message.
+func (r *MCPCapabilityRuntime) serverRegistered(server string) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	_, ok := r.servers[strings.TrimSpace(server)]
+	r.mu.RUnlock()
+	return ok
+}
+
 func (r *MCPCapabilityRuntime) serverEnabled(server string) bool {
 	if r == nil {
 		return false
@@ -875,7 +895,7 @@ func (t *UseCapabilityTool) inspect(ctx context.Context, id string) (string, err
 			}
 			if server != "" {
 				if !t.serverEnabled(server) {
-					return string(b) + "\n\nServer is disabled in this session.", nil
+					return string(b) + "\n\n" + t.serverUnavailableReason(server), nil
 				}
 				if t.host != nil && t.host.HasClient(server) {
 					// serverTools refreshes the snapshot too: inspecting a
@@ -991,7 +1011,7 @@ func (t *UseCapabilityTool) resolveCall(ctx context.Context, id string, args jso
 		return tool.ResolvedCall{}, err
 	}
 	if !t.serverEnabled(server) {
-		return t.resolveUnavailable(base, id, plugin.ModelToolName(server, raw), fmt.Sprintf("MCP server %q is disabled in this session", server)), nil
+		return t.resolveUnavailable(base, id, plugin.ModelToolName(server, raw), t.serverUnavailableReason(server)), nil
 	}
 	var runtimeSpec plugin.Spec
 	releaseRuntime := func() {}
@@ -1449,6 +1469,26 @@ func (t *UseCapabilityTool) serverEnabled(server string) bool {
 	return true
 }
 
+func (t *UseCapabilityTool) serverRegistered(server string) bool {
+	if t.runtime != nil {
+		return t.runtime.serverRegistered(server)
+	}
+	// Mirrors serverEnabled's standalone branch: without a runtime there is no
+	// registry to be absent from.
+	return true
+}
+
+// serverUnavailableReason explains why dispatch was refused. A server the
+// runtime never registered is not a server the user disabled, and saying
+// "disabled" for the first case sends people hunting for a toggle that does not
+// exist.
+func (t *UseCapabilityTool) serverUnavailableReason(server string) string {
+	if !t.serverRegistered(server) {
+		return fmt.Sprintf("MCP server %q is not registered in this session", server)
+	}
+	return fmt.Sprintf("MCP server %q is disabled in this session", server)
+}
+
 func (t *UseCapabilityTool) configuredServers() []mcpRuntimeServer {
 	if t.runtime != nil {
 		return t.runtime.configuredServers()
@@ -1496,7 +1536,7 @@ func parseMCPServerCapabilityID(id string) (string, bool) {
 func (t *UseCapabilityTool) resolveServerConnect(ctx context.Context, server string, base tool.ResolvedCall) (tool.ResolvedCall, error) {
 	id := "mcp-server:" + server
 	if !t.serverEnabled(server) {
-		return t.resolveUnavailable(base, id, plugin.ToolPrefix(server), fmt.Sprintf("MCP server %q is disabled in this session", server)), nil
+		return t.resolveUnavailable(base, id, plugin.ToolPrefix(server), t.serverUnavailableReason(server)), nil
 	}
 	if t.host != nil && t.host.HasClient(server) {
 		out, err := t.listServerTools(ctx, server)

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -785,17 +785,6 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		}
 		applyMCPIsolation(&extraSpecs[i], root, pluginSpecOptions)
 	}
-	// Host-session servers arrive through an explicit host action (ACP
-	// session/new mcpServers), so they are authoritative for use_capability
-	// dispatch exactly like an auto-started config plugin. Without this they
-	// connect and list their tools, but every mcp-tool:<server>/<tool> call is
-	// refused: enabledMCPNames is otherwise built only from config
-	// autoStartEntries, so a host-session name is never marked enabled.
-	for i := range extraSpecs {
-		if name := strings.TrimSpace(extraSpecs[i].Name); name != "" {
-			enabledMCPNames[name] = true
-		}
-	}
 	// Auto-demote: any eager plugin that has been chronically slow (recent
 	// samples repeatedly hit the blocking startup budget) drops to background
 	// for this session. The user keeps eager intent, just doesn't pay for it
@@ -1561,11 +1550,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 	// without inheriting dynamic mcp__* schemas.
 	var capLedger *capability.Ledger
 	var capAudit *capability.Audit
-	capEntries, capSpecs := mergeHostSessionCapabilitySpecs(
-		cfg.Plugins,
-		PluginSpecsForRootWithOptions(cfg.Plugins, root, pluginSpecOptions),
-		extraSpecs,
-	)
+	capEntries, capSpecs := capabilityServerInventory(cfg.Plugins, root, pluginSpecOptions, extraSpecs, enabledMCPNames)
 	cachedTools, cacheKeyOK := capability.LoadCachedToolsForSpecs(capSpecs)
 	skillStore.ConfigureToolBindings(func(sk skill.Skill) []tool.MCPBinding {
 		return skillMCPBindings(sk, reg, capSpecs, cachedTools, cacheKeyOK)
@@ -2097,53 +2082,6 @@ func applyUnifiedProviderToolSurface(reg *tool.Registry) {
 		}
 	}
 	reg.SetProviderVisibleTools(allow)
-}
-
-// mergeHostSessionCapabilitySpecs builds the inventory the capability runtime
-// dispatches against: the config servers, plus the host-session servers an ACP
-// client supplied through session/new.mcpServers.
-//
-// Host-session specs must be here at all — they already reach pluginHost through
-// eagerSpecs, so they connect and their tools appear in the catalog, but the
-// capability runtime is a separate registry seeded only from cfg.Plugins, and
-// use_capability resolves mcp-server:/mcp-tool: ids against that registry.
-//
-// On a name collision the host-session server wins, matching the choice the
-// registration tier already makes (see the extraNames filter before
-// registerEnabledMCP): the client asked for that endpoint in this session, and it
-// is the spec pluginHost connected and registered tools for. The shadowed config
-// spec and its entry are dropped explicitly rather than left to slice order plus
-// ConfigureServers' map-overwrite, so the rule is stated where it is decided.
-// Dropping the entry matters too: ConfigureServers pairs an entry with a spec by
-// name, so a surviving config entry would pair auto_start = false with the live
-// host-session spec and report one server as simultaneously not-auto-start and
-// not-disabled.
-func mergeHostSessionCapabilitySpecs(configEntries []config.PluginEntry, configSpecs, hostSession []plugin.Spec) ([]config.PluginEntry, []plugin.Spec) {
-	if len(hostSession) == 0 {
-		return configEntries, configSpecs
-	}
-	shadowed := make(map[string]bool, len(hostSession))
-	for _, spec := range hostSession {
-		if name := strings.TrimSpace(spec.Name); name != "" {
-			shadowed[name] = true
-		}
-	}
-	specs := make([]plugin.Spec, 0, len(configSpecs)+len(hostSession))
-	for _, spec := range configSpecs {
-		if shadowed[strings.TrimSpace(spec.Name)] {
-			continue
-		}
-		specs = append(specs, spec)
-	}
-	specs = append(specs, hostSession...)
-	entries := make([]config.PluginEntry, 0, len(configEntries))
-	for _, entry := range configEntries {
-		if shadowed[strings.TrimSpace(entry.Name)] {
-			continue
-		}
-		entries = append(entries, entry)
-	}
-	return entries, specs
 }
 
 // effectivePlannerModel centralizes planner precedence. Every role setting

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1561,13 +1561,11 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 	// without inheriting dynamic mcp__* schemas.
 	var capLedger *capability.Ledger
 	var capAudit *capability.Audit
-	capSpecs := PluginSpecsForRootWithOptions(cfg.Plugins, root, pluginSpecOptions)
-	// extraSpecs already reach pluginHost through eagerSpecs, which is why a
-	// host-session server connects and its tools appear in the catalog. The
-	// capability runtime is a second, separate registry seeded only from
-	// cfg.Plugins, so it must be told about them too or use_capability cannot
-	// resolve mcp-server:/mcp-tool: ids that the catalog just advertised.
-	capSpecs = append(capSpecs, extraSpecs...)
+	capEntries, capSpecs := mergeHostSessionCapabilitySpecs(
+		cfg.Plugins,
+		PluginSpecsForRootWithOptions(cfg.Plugins, root, pluginSpecOptions),
+		extraSpecs,
+	)
 	cachedTools, cacheKeyOK := capability.LoadCachedToolsForSpecs(capSpecs)
 	skillStore.ConfigureToolBindings(func(sk skill.Skill) []tool.MCPBinding {
 		return skillMCPBindings(sk, reg, capSpecs, cachedTools, cacheKeyOK)
@@ -1604,7 +1602,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 	// Always build the capability runtime and provider-visible use_capability
 	// proxy so all three role settings share one tool schema.
 	capRuntime = agent.NewMCPCapabilityRuntime(ctx, pluginHost, capSpecs, reg, catalogFn)
-	capRuntime.ConfigureServers(cfg.Plugins, capSpecs, enabledMCPNames)
+	capRuntime.ConfigureServers(capEntries, capSpecs, enabledMCPNames)
 	capLedger = capability.NewLedger()
 	capAudit = &capability.Audit{}
 	capProxy = capRuntime.NewFrontend(capLedger, capAudit)
@@ -2082,6 +2080,53 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 // applyUnifiedProviderToolSurface restricts Schemas/ContractEntries to the
 // shared core + host-control tools. use_capability can still Get every
 // registered tool, including those hidden from the provider schema.
+// mergeHostSessionCapabilitySpecs builds the inventory the capability runtime
+// dispatches against: the config servers, plus the host-session servers an ACP
+// client supplied through session/new.mcpServers.
+//
+// Host-session specs must be here at all — they already reach pluginHost through
+// eagerSpecs, so they connect and their tools appear in the catalog, but the
+// capability runtime is a separate registry seeded only from cfg.Plugins, and
+// use_capability resolves mcp-server:/mcp-tool: ids against that registry.
+//
+// On a name collision the host-session server wins, matching the choice the
+// registration tier already makes (see the extraNames filter before
+// registerEnabledMCP): the client asked for that endpoint in this session, and it
+// is the spec pluginHost connected and registered tools for. The shadowed config
+// spec and its entry are dropped explicitly rather than left to slice order plus
+// ConfigureServers' map-overwrite, so the rule is stated where it is decided.
+// Dropping the entry matters too: ConfigureServers pairs an entry with a spec by
+// name, so a surviving config entry would pair auto_start = false with the live
+// host-session spec and report one server as simultaneously not-auto-start and
+// not-disabled.
+func mergeHostSessionCapabilitySpecs(configEntries []config.PluginEntry, configSpecs, hostSession []plugin.Spec) ([]config.PluginEntry, []plugin.Spec) {
+	if len(hostSession) == 0 {
+		return configEntries, configSpecs
+	}
+	shadowed := make(map[string]bool, len(hostSession))
+	for _, spec := range hostSession {
+		if name := strings.TrimSpace(spec.Name); name != "" {
+			shadowed[name] = true
+		}
+	}
+	specs := make([]plugin.Spec, 0, len(configSpecs)+len(hostSession))
+	for _, spec := range configSpecs {
+		if shadowed[strings.TrimSpace(spec.Name)] {
+			continue
+		}
+		specs = append(specs, spec)
+	}
+	specs = append(specs, hostSession...)
+	entries := make([]config.PluginEntry, 0, len(configEntries))
+	for _, entry := range configEntries {
+		if shadowed[strings.TrimSpace(entry.Name)] {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries, specs
+}
+
 func applyUnifiedProviderToolSurface(reg *tool.Registry) {
 	if reg == nil {
 		return

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -2080,6 +2080,25 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 // applyUnifiedProviderToolSurface restricts Schemas/ContractEntries to the
 // shared core + host-control tools. use_capability can still Get every
 // registered tool, including those hidden from the provider schema.
+func applyUnifiedProviderToolSurface(reg *tool.Registry) {
+	if reg == nil {
+		return
+	}
+	allow := make([]string, 0, 16)
+	for _, name := range UnifiedProviderToolNames() {
+		if _, ok := reg.Get(name); ok {
+			allow = append(allow, name)
+		}
+	}
+	// Always keep use_capability if somehow only that remains.
+	if len(allow) == 0 {
+		if _, ok := reg.Get("use_capability"); ok {
+			allow = []string{"use_capability"}
+		}
+	}
+	reg.SetProviderVisibleTools(allow)
+}
+
 // mergeHostSessionCapabilitySpecs builds the inventory the capability runtime
 // dispatches against: the config servers, plus the host-session servers an ACP
 // client supplied through session/new.mcpServers.
@@ -2125,25 +2144,6 @@ func mergeHostSessionCapabilitySpecs(configEntries []config.PluginEntry, configS
 		entries = append(entries, entry)
 	}
 	return entries, specs
-}
-
-func applyUnifiedProviderToolSurface(reg *tool.Registry) {
-	if reg == nil {
-		return
-	}
-	allow := make([]string, 0, 16)
-	for _, name := range UnifiedProviderToolNames() {
-		if _, ok := reg.Get(name); ok {
-			allow = append(allow, name)
-		}
-	}
-	// Always keep use_capability if somehow only that remains.
-	if len(allow) == 0 {
-		if _, ok := reg.Get("use_capability"); ok {
-			allow = []string{"use_capability"}
-		}
-	}
-	reg.SetProviderVisibleTools(allow)
 }
 
 // effectivePlannerModel centralizes planner precedence. Every role setting

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -785,6 +785,17 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		}
 		applyMCPIsolation(&extraSpecs[i], root, pluginSpecOptions)
 	}
+	// Host-session servers arrive through an explicit host action (ACP
+	// session/new mcpServers), so they are authoritative for use_capability
+	// dispatch exactly like an auto-started config plugin. Without this they
+	// connect and list their tools, but every mcp-tool:<server>/<tool> call is
+	// refused: enabledMCPNames is otherwise built only from config
+	// autoStartEntries, so a host-session name is never marked enabled.
+	for i := range extraSpecs {
+		if name := strings.TrimSpace(extraSpecs[i].Name); name != "" {
+			enabledMCPNames[name] = true
+		}
+	}
 	// Auto-demote: any eager plugin that has been chronically slow (recent
 	// samples repeatedly hit the blocking startup budget) drops to background
 	// for this session. The user keeps eager intent, just doesn't pay for it
@@ -1551,6 +1562,12 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 	var capLedger *capability.Ledger
 	var capAudit *capability.Audit
 	capSpecs := PluginSpecsForRootWithOptions(cfg.Plugins, root, pluginSpecOptions)
+	// extraSpecs already reach pluginHost through eagerSpecs, which is why a
+	// host-session server connects and its tools appear in the catalog. The
+	// capability runtime is a second, separate registry seeded only from
+	// cfg.Plugins, so it must be told about them too or use_capability cannot
+	// resolve mcp-server:/mcp-tool: ids that the catalog just advertised.
+	capSpecs = append(capSpecs, extraSpecs...)
 	cachedTools, cacheKeyOK := capability.LoadCachedToolsForSpecs(capSpecs)
 	skillStore.ConfigureToolBindings(func(sk skill.Skill) []tool.MCPBinding {
 		return skillMCPBindings(sk, reg, capSpecs, cachedTools, cacheKeyOK)

--- a/internal/boot/mcp_host_session.go
+++ b/internal/boot/mcp_host_session.go
@@ -1,0 +1,50 @@
+package boot
+
+import (
+	"strings"
+
+	"reasonix/internal/config"
+	"reasonix/internal/plugin"
+)
+
+// capabilityServerInventory adds explicitly supplied host-session servers to
+// the capability runtime and marks only those additions enabled.
+func capabilityServerInventory(configEntries []config.PluginEntry, root string, opts PluginSpecOptions, hostSession []plugin.Spec, enabled map[string]bool) ([]config.PluginEntry, []plugin.Spec) {
+	for _, spec := range hostSession {
+		if name := strings.TrimSpace(spec.Name); name != "" {
+			enabled[name] = true
+		}
+	}
+	configSpecs := PluginSpecsForRootWithOptions(configEntries, root, opts)
+	return mergeHostSessionCapabilitySpecs(configEntries, configSpecs, hostSession)
+}
+
+// mergeHostSessionCapabilitySpecs makes the host-session endpoint authoritative
+// on a name collision and drops the shadowed config entry with its stale state.
+func mergeHostSessionCapabilitySpecs(configEntries []config.PluginEntry, configSpecs, hostSession []plugin.Spec) ([]config.PluginEntry, []plugin.Spec) {
+	if len(hostSession) == 0 {
+		return configEntries, configSpecs
+	}
+	shadowed := make(map[string]bool, len(hostSession))
+	for _, spec := range hostSession {
+		if name := strings.TrimSpace(spec.Name); name != "" {
+			shadowed[name] = true
+		}
+	}
+
+	specs := make([]plugin.Spec, 0, len(configSpecs)+len(hostSession))
+	for _, spec := range configSpecs {
+		if !shadowed[strings.TrimSpace(spec.Name)] {
+			specs = append(specs, spec)
+		}
+	}
+	specs = append(specs, hostSession...)
+
+	entries := make([]config.PluginEntry, 0, len(configEntries))
+	for _, entry := range configEntries {
+		if !shadowed[strings.TrimSpace(entry.Name)] {
+			entries = append(entries, entry)
+		}
+	}
+	return entries, specs
+}

--- a/internal/boot/mcp_host_session_enabled_test.go
+++ b/internal/boot/mcp_host_session_enabled_test.go
@@ -1,0 +1,101 @@
+package boot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/plugin"
+)
+
+// mcpHostSessionStub is a minimal Streamable-HTTP MCP server: enough to complete
+// initialize + tools/list so the spec reaches pluginHost exactly as a real
+// host-session server would.
+func mcpHostSessionStub(t *testing.T, name string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     *json.RawMessage `json:"id"`
+			Method string           `json:"method"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.ID == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		var result any
+		switch req.Method {
+		case "initialize":
+			result = map[string]any{
+				"protocolVersion": "2024-11-05",
+				"serverInfo":      map[string]any{"name": name, "version": "1"},
+				"capabilities":    map[string]any{"tools": map[string]any{}},
+			}
+		case "tools/list":
+			result = map[string]any{"tools": []map[string]any{{
+				"name":        "ping",
+				"description": "probe tool",
+				"inputSchema": map[string]any{"type": "object"},
+			}}}
+		default:
+			http.Error(w, "unsupported method", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": result})
+	}))
+}
+
+// A host-session MCP server (ACP session/new mcpServers) arrives as
+// Options.ExtraPlugins and reaches pluginHost through eagerSpecs, so it connects
+// and its tools show up in the capability catalog as ready. The capability
+// runtime is a separate registry seeded only from cfg.Plugins, so before this
+// fix every mcp-tool:<server>/<tool> dispatch was refused — a failure invisible
+// to a happy-path turn and only reachable once the model actually called the
+// tool mid-turn.
+func TestBuildEnablesHostSessionMCPForCapabilityDispatch(t *testing.T) {
+	isolateConfigHome(t)
+	t.Chdir(robustTempDir(t))
+
+	srv := mcpHostSessionStub(t, "acp-extra")
+	defer srv.Close()
+
+	ctrl, err := Build(context.Background(), Options{
+		Sink: event.Discard,
+		ExtraPlugins: []plugin.Spec{{
+			Name:       "acp-extra",
+			Type:       "http",
+			URL:        srv.URL,
+			Authorized: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	if !ctrl.CapabilityServerEnabled("acp-extra") {
+		t.Fatal("host-supplied MCP server is not dispatchable through use_capability; " +
+			"session/new mcpServers would connect and list tools but refuse every call")
+	}
+}
+
+// A name nobody supplied must stay undispatchable, so the fix above cannot be
+// satisfied by defaulting unknown servers to enabled.
+func TestBuildLeavesUnknownMCPServerUndispatchable(t *testing.T) {
+	isolateConfigHome(t)
+	t.Chdir(robustTempDir(t))
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	if ctrl.CapabilityServerEnabled("never-configured") {
+		t.Fatal("an unconfigured MCP server must not be dispatchable")
+	}
+}

--- a/internal/boot/mcp_host_session_enabled_test.go
+++ b/internal/boot/mcp_host_session_enabled_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"reasonix/internal/config"
 	"reasonix/internal/event"
 	"reasonix/internal/plugin"
 )
@@ -80,6 +81,121 @@ func TestBuildEnablesHostSessionMCPForCapabilityDispatch(t *testing.T) {
 	if !ctrl.CapabilityServerEnabled("acp-extra") {
 		t.Fatal("host-supplied MCP server is not dispatchable through use_capability; " +
 			"session/new mcpServers would connect and list tools but refuse every call")
+	}
+}
+
+// A config server the user explicitly turned off must stay off, even while an
+// unrelated host-session server is being enabled in the same boot. This is the
+// invariant the enablement loop could plausibly break in a future refactor —
+// widen it from "every extraSpec name" to "every name" and only this test
+// notices.
+func TestBuildLeavesDisabledConfigMCPUndispatchableAlongsideHostSession(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	cfgSrv := mcpHostSessionStub(t, "config-off")
+	defer cfgSrv.Close()
+	extraSrv := mcpHostSessionStub(t, "acp-extra")
+	defer extraSrv.Close()
+
+	writeFile(t, dir, "reasonix.toml", `
+[[plugins]]
+name = "config-off"
+type = "http"
+url = "`+cfgSrv.URL+`"
+auto_start = false
+`)
+
+	ctrl, err := Build(context.Background(), Options{
+		Sink: event.Discard,
+		ExtraPlugins: []plugin.Spec{{
+			Name:       "acp-extra",
+			Type:       "http",
+			URL:        extraSrv.URL,
+			Authorized: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	if !ctrl.CapabilityServerEnabled("acp-extra") {
+		t.Error("the host-session server should be dispatchable")
+	}
+	if ctrl.CapabilityServerEnabled("config-off") {
+		t.Error("a config server with auto_start = false must stay undispatchable; " +
+			"enabling host-session servers must not enable anything else")
+	}
+}
+
+// A host-session server takes precedence over a same-named config entry,
+// including a disabled one: the client asked for that endpoint in this session,
+// and it is the spec pluginHost connected and registered tools for.
+//
+// Asserted on the merge directly rather than through a booted Controller,
+// because what must hold is which spec lands in the runtime registry — and the
+// only way to observe that from outside would be to add a production accessor
+// that exists solely for this test.
+func TestMergeHostSessionCapabilitySpecsPrefersHostSessionOnNameCollision(t *testing.T) {
+	autoStartOff := false
+	configEntries := []config.PluginEntry{
+		{Name: "shared-name", Type: "http", URL: "http://config.invalid", AutoStart: &autoStartOff},
+		{Name: "config-only", Type: "http", URL: "http://config-only.invalid"},
+	}
+	configSpecs := []plugin.Spec{
+		{Name: "shared-name", Type: "http", URL: "http://config.invalid"},
+		{Name: "config-only", Type: "http", URL: "http://config-only.invalid"},
+	}
+	hostSession := []plugin.Spec{
+		{Name: "shared-name", Type: "http", URL: "http://host-session.invalid"},
+	}
+
+	entries, specs := mergeHostSessionCapabilitySpecs(configEntries, configSpecs, hostSession)
+
+	byName := map[string]plugin.Spec{}
+	for _, spec := range specs {
+		if _, dup := byName[spec.Name]; dup {
+			t.Fatalf("%q appears twice; ConfigureServers would resolve it by slice order", spec.Name)
+		}
+		byName[spec.Name] = spec
+	}
+	if got := byName["shared-name"].URL; got != "http://host-session.invalid" {
+		t.Errorf("collision resolved to %q, want the host-session endpoint", got)
+	}
+	if got := byName["config-only"].URL; got != "http://config-only.invalid" {
+		t.Errorf("non-colliding config server = %q, want it untouched", got)
+	}
+	// The shadowed entry must go too, or ConfigureServers pairs auto_start=false
+	// with the live host-session spec and shows it as neither auto-start nor
+	// disabled.
+	for _, entry := range entries {
+		if entry.Name == "shared-name" {
+			t.Error("shadowed config entry survived; it would be paired with the host-session spec")
+		}
+	}
+	if len(entries) != 1 || entries[0].Name != "config-only" {
+		t.Errorf("entries = %+v, want only config-only", entries)
+	}
+}
+
+// With no host-session servers the inventory must be handed through untouched —
+// the merge is not allowed to reorder or reallocate the ordinary config path.
+func TestMergeHostSessionCapabilitySpecsIsIdentityWithoutHostSession(t *testing.T) {
+	entriesIn := []config.PluginEntry{{Name: "a"}, {Name: "b"}}
+	specsIn := []plugin.Spec{{Name: "a"}, {Name: "b"}}
+
+	entries, specs := mergeHostSessionCapabilitySpecs(entriesIn, specsIn, nil)
+
+	if len(entries) != len(entriesIn) || len(specs) != len(specsIn) {
+		t.Fatalf("lengths changed: entries %d->%d, specs %d->%d",
+			len(entriesIn), len(entries), len(specsIn), len(specs))
+	}
+	for i := range specs {
+		if specs[i].Name != specsIn[i].Name || entries[i].Name != entriesIn[i].Name {
+			t.Fatalf("order changed at %d", i)
+		}
 	}
 }
 

--- a/internal/boot/mcp_host_session_enabled_test.go
+++ b/internal/boot/mcp_host_session_enabled_test.go
@@ -3,19 +3,24 @@ package boot
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
+	"reasonix/internal/agent/testutil"
 	"reasonix/internal/config"
 	"reasonix/internal/event"
 	"reasonix/internal/plugin"
+	"reasonix/internal/provider"
 )
 
 // mcpHostSessionStub is a minimal Streamable-HTTP MCP server: enough to complete
 // initialize + tools/list so the spec reaches pluginHost exactly as a real
 // host-session server would.
-func mcpHostSessionStub(t *testing.T, name string) *httptest.Server {
+func mcpHostSessionStub(t *testing.T, name string, calls *atomic.Int32) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
@@ -41,6 +46,14 @@ func mcpHostSessionStub(t *testing.T, name string) *httptest.Server {
 				"description": "probe tool",
 				"inputSchema": map[string]any{"type": "object"},
 			}}}
+		case "tools/call":
+			if calls != nil {
+				calls.Add(1)
+			}
+			result = map[string]any{"content": []map[string]any{{
+				"type": "text",
+				"text": "pong:" + name,
+			}}}
 		default:
 			http.Error(w, "unsupported method", http.StatusBadRequest)
 			return
@@ -48,6 +61,66 @@ func mcpHostSessionStub(t *testing.T, name string) *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": result})
 	}))
+}
+
+const mcpCapabilityTestProviderConfig = `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "boot-token-profile-test"
+model = "x"
+`
+
+func runUseCapabilityCalls(t *testing.T, opts Options, capabilityIDs ...string) string {
+	t.Helper()
+	registerBootTokenProfileTestProvider()
+	turns := make([]testutil.Turn, 0, len(capabilityIDs)+1)
+	for i, id := range capabilityIDs {
+		args, err := json.Marshal(map[string]any{
+			"action":        "call",
+			"capability_id": id,
+			"arguments":     map[string]any{},
+		})
+		if err != nil {
+			t.Fatalf("marshal use_capability call: %v", err)
+		}
+		turns = append(turns, testutil.Turn{ToolCalls: []provider.ToolCall{{
+			ID:        fmt.Sprintf("mcp-%d", i),
+			Name:      "use_capability",
+			Arguments: string(args),
+		}}})
+	}
+	turns = append(turns, testutil.Turn{Text: "done"})
+	prov := testutil.NewMock("mcp-host-session", turns...)
+	setBootTokenProfileTestProvider(t, prov)
+
+	ctrl, err := Build(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	if err := ctrl.Run(context.Background(), "call the requested MCP capability"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, req := range prov.Requests() {
+		for _, name := range toolSchemaNames(req.Tools) {
+			if strings.HasPrefix(name, "mcp__") {
+				t.Fatalf("dynamic MCP tool leaked into provider-visible schemas: %v", toolSchemaNames(req.Tools))
+			}
+		}
+	}
+
+	var out strings.Builder
+	for _, msg := range ctrl.History() {
+		if msg.Role == provider.RoleTool {
+			out.WriteString(msg.Content)
+		}
+	}
+	return out.String()
 }
 
 // A host-session MCP server (ACP session/new mcpServers) arrives as
@@ -59,12 +132,15 @@ func mcpHostSessionStub(t *testing.T, name string) *httptest.Server {
 // tool mid-turn.
 func TestBuildEnablesHostSessionMCPForCapabilityDispatch(t *testing.T) {
 	isolateConfigHome(t)
-	t.Chdir(robustTempDir(t))
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", mcpCapabilityTestProviderConfig)
 
-	srv := mcpHostSessionStub(t, "acp-extra")
+	var calls atomic.Int32
+	srv := mcpHostSessionStub(t, "acp-extra", &calls)
 	defer srv.Close()
 
-	ctrl, err := Build(context.Background(), Options{
+	out := runUseCapabilityCalls(t, Options{
 		Sink: event.Discard,
 		ExtraPlugins: []plugin.Spec{{
 			Name:       "acp-extra",
@@ -72,15 +148,9 @@ func TestBuildEnablesHostSessionMCPForCapabilityDispatch(t *testing.T) {
 			URL:        srv.URL,
 			Authorized: true,
 		}},
-	})
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-	defer ctrl.Close()
-
-	if !ctrl.CapabilityServerEnabled("acp-extra") {
-		t.Fatal("host-supplied MCP server is not dispatchable through use_capability; " +
-			"session/new mcpServers would connect and list tools but refuse every call")
+	}, "mcp-tool:acp-extra/ping")
+	if calls.Load() != 1 || !strings.Contains(out, "pong:acp-extra") {
+		t.Fatalf("host-session dispatch calls=%d output=%q, want one successful tools/call", calls.Load(), out)
 	}
 }
 
@@ -94,12 +164,14 @@ func TestBuildLeavesDisabledConfigMCPUndispatchableAlongsideHostSession(t *testi
 	dir := robustTempDir(t)
 	t.Chdir(dir)
 
-	cfgSrv := mcpHostSessionStub(t, "config-off")
+	var cfgCalls atomic.Int32
+	cfgSrv := mcpHostSessionStub(t, "config-off", &cfgCalls)
 	defer cfgSrv.Close()
-	extraSrv := mcpHostSessionStub(t, "acp-extra")
+	var extraCalls atomic.Int32
+	extraSrv := mcpHostSessionStub(t, "acp-extra", &extraCalls)
 	defer extraSrv.Close()
 
-	writeFile(t, dir, "reasonix.toml", `
+	writeFile(t, dir, "reasonix.toml", mcpCapabilityTestProviderConfig+`
 [[plugins]]
 name = "config-off"
 type = "http"
@@ -107,7 +179,7 @@ url = "`+cfgSrv.URL+`"
 auto_start = false
 `)
 
-	ctrl, err := Build(context.Background(), Options{
+	out := runUseCapabilityCalls(t, Options{
 		Sink: event.Discard,
 		ExtraPlugins: []plugin.Spec{{
 			Name:       "acp-extra",
@@ -115,18 +187,12 @@ auto_start = false
 			URL:        extraSrv.URL,
 			Authorized: true,
 		}},
-	})
-	if err != nil {
-		t.Fatalf("Build: %v", err)
+	}, "mcp-tool:acp-extra/ping", "mcp-tool:config-off/ping")
+	if extraCalls.Load() != 1 || !strings.Contains(out, "pong:acp-extra") {
+		t.Errorf("host-session dispatch calls=%d output=%q, want success", extraCalls.Load(), out)
 	}
-	defer ctrl.Close()
-
-	if !ctrl.CapabilityServerEnabled("acp-extra") {
-		t.Error("the host-session server should be dispatchable")
-	}
-	if ctrl.CapabilityServerEnabled("config-off") {
-		t.Error("a config server with auto_start = false must stay undispatchable; " +
-			"enabling host-session servers must not enable anything else")
+	if cfgCalls.Load() != 0 || !strings.Contains(out, `MCP server "config-off" is disabled in this session`) {
+		t.Errorf("disabled config dispatch calls=%d output=%q, want refusal without tools/call", cfgCalls.Load(), out)
 	}
 }
 
@@ -203,15 +269,12 @@ func TestMergeHostSessionCapabilitySpecsIsIdentityWithoutHostSession(t *testing.
 // satisfied by defaulting unknown servers to enabled.
 func TestBuildLeavesUnknownMCPServerUndispatchable(t *testing.T) {
 	isolateConfigHome(t)
-	t.Chdir(robustTempDir(t))
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", mcpCapabilityTestProviderConfig)
 
-	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-	defer ctrl.Close()
-
-	if ctrl.CapabilityServerEnabled("never-configured") {
-		t.Fatal("an unconfigured MCP server must not be dispatchable")
+	out := runUseCapabilityCalls(t, Options{Sink: event.Discard}, "mcp-tool:never-configured/ping")
+	if !strings.Contains(out, `MCP server "never-configured" is not registered in this session`) {
+		t.Fatalf("unknown server output=%q, want an unregistered refusal", out)
 	}
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -6238,3 +6238,15 @@ func (c *Controller) emitPlanModeReadOnlyCommandTrustResult(r PlanModeReadOnlyCo
 		c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(i18n.M.PlanModeReadOnlyCommandTrustAlreadyFmt, r.Path, r.CoveredBy)})
 	}
 }
+
+// CapabilityServerEnabled reports whether the use_capability proxy may dispatch
+// to an MCP server. It mirrors the exact gate guarding mcp-tool: calls, so it is
+// false both when the capability runtime never registered the server and when it
+// registered it as disabled — the two states a host-session server can land in
+// while still connecting and listing its tools normally.
+func (c *Controller) CapabilityServerEnabled(name string) bool {
+	if c == nil || c.capabilityRuntime == nil {
+		return false
+	}
+	return c.capabilityRuntime.ServerEnabled(name)
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -6238,15 +6238,3 @@ func (c *Controller) emitPlanModeReadOnlyCommandTrustResult(r PlanModeReadOnlyCo
 		c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(i18n.M.PlanModeReadOnlyCommandTrustAlreadyFmt, r.Path, r.CoveredBy)})
 	}
 }
-
-// CapabilityServerEnabled reports whether the use_capability proxy may dispatch
-// to an MCP server. It mirrors the exact gate guarding mcp-tool: calls, so it is
-// false both when the capability runtime never registered the server and when it
-// registered it as disabled — the two states a host-session server can land in
-// while still connecting and listing its tools normally.
-func (c *Controller) CapabilityServerEnabled(name string) bool {
-	if c == nil || c.capabilityRuntime == nil {
-		return false
-	}
-	return c.capabilityRuntime.ServerEnabled(name)
-}


### PR DESCRIPTION
## Problem

An MCP server supplied through ACP `session/new.mcpServers` connects, completes `initialize` + `tools/list`, and its tools are advertised in the capability catalog as `status: "ready"` — but **every call to them is refused**:

```
MCP server "acppassed" is disabled in this session
```

and the server itself is not addressable at all:

```
use_capability action=inspect capability_id=mcp-server:acppassed
  -> unknown capability_id "mcp-server:acppassed"
```

The server was never disabled by anyone. It is simply absent from the registry that guards dispatch, and the catalog and the gate disagree.

This is invisible to a happy-path turn: discovery looks correct, and the failure only appears once the model actually calls the tool mid-turn.

## Root cause

There are two registries, and host-session specs only reach one of them.

`internal/cli/acp.go` passes the ACP servers in as `ExtraPlugins`, and inside `build()`:

- `eagerSpecs = append(eagerSpecs, extraSpecs...)` → **`pluginHost`**. This is why the server connects and its tools list.
- `capSpecs := PluginSpecsForRootWithOptions(cfg.Plugins, ...)` → **config only**.
- `enabledMCPNames` is built from `autoStartEntries` → **config only**.

Both of the latter feed the one call that seeds the dispatch registry:

```go
capRuntime.ConfigureServers(cfg.Plugins, capSpecs, enabledMCPNames)
```

The gate is `present && enabled`:

```go
func (r *MCPCapabilityRuntime) serverEnabled(server string) bool {
	...
	configured, ok := r.servers[strings.TrimSpace(server)]
	...
	return ok && configured.enabled
}
```

A host-session server is absent from `r.servers`, so `ok` is false and `resolveMCPTool` reports it as "disabled". `mcp-server:<name>` is unknown for the same reason — `catalogStateLocked()` iterates `r.servers`.

## Fix

Register host-session specs with the capability runtime and mark them enabled. This follows the intent already stated where they are built — they arrive through an explicit host action, so they are authoritative exactly like an auto-started config plugin (the code already sets `Authorized = true` for them on that basis).

Both changes are required and neither is sufficient alone:

- The `capSpecs` change alone registers the server with `enabled == false`, because `ConfigureServers` reads an absent `enabled[name]` as false.
- The `enabledMCPNames` change alone marks a name that is not in `r.servers`, so `serverEnabled` still fails its `ok` check.

Also separates **"not registered"** from **"disabled"** in the refusal message. They have different causes and different fixes, and reporting the former as the latter sends users looking for a toggle that does not exist. `lockAuthorizedRuntimeServer` already made this distinction; the three `use_capability` resolve paths did not.

### Precedence on a name collision

Host-session servers take precedence over a same-named config entry, **including a disabled one**.
If a user has `[[plugins]] name = "github"` with `auto_start = false` and a client sends
`session/new.mcpServers = [{"name":"github", …}]`, the client's endpoint is what the session
dispatches to.

This is not new intent — the registration tier already makes exactly that choice, filtering colliding
config specs out of `configSpecs` before `registerEnabledMCP` (*"eagerSpecs already includes
extraSpecs; avoid double registration of host-session servers that connected above"*). What is new is
that `mergeHostSessionCapabilitySpecs` now **states** it where the inventory is built, instead of
letting it fall out of slice order plus `ConfigureServers`' `next[name] = …` map overwrite. Reorder
that append, or make `ConfigureServers` first-wins, and the old arrangement silently inverts into the
worst case: a user-disabled config spec marked enabled, with an identity that no longer matches the
tools `pluginHost` registered.

The merge drops the shadowed config **entry** as well. `ConfigureServers` pairs an entry with a spec
by name, so a surviving entry paired `auto_start = false` with the live host-session spec, and `/mcp`
showed one server as simultaneously not-auto-start and not-disabled.

## Reproduction (byte-level, against v1.31.3)

Probed with a local Streamable-HTTP MCP server and a config containing a provider and **zero** `[[plugins]]` stanzas, so this is not the config path in disguise.

| Probe | v1.31.3 | with this change |
| --- | --- | --- |
| `use_capability list` → `mcp-server:acppassed` | *absent* | `ready` |
| `use_capability list` → `mcp-tool:acppassed/traycer_probe_ping` | `ready` | `ready` |
| `inspect mcp-server:acppassed` | `unknown capability_id "mcp-server:acppassed"` | completed, `auto_start: true` |
| `call mcp-tool:acppassed/traycer_probe_ping` | `MCP server "acppassed" is disabled in this session` | returns the tool result |
| MCP server received `tools/call` | never | yes |

The frame that motivated this, from the unpatched build — note the tool is advertised ready and refused in the same session:

```json
{"sessionUpdate":"tool_call_update","toolCallId":"c2","status":"failed",
 "content":[{"type":"content","content":{"type":"text",
   "text":"MCP server \"traycerprobe\" is disabled in this session"}}]}
```

Verified transport-independent: a `stdio` host-session server fails identically after the same successful `initialize` + `tools/list`.

## Tests

Six tests now. The three behavioural ones were each mutation-checked — the guard is not that they pass, but that they fail when the thing they pin is removed:

| Test | Mutation that must break it |
| --- | --- |
| `TestBuildEnablesHostSessionMCPForCapabilityDispatch` | revert the host-session inventory enablement/registration |
| `TestMergeHostSessionCapabilitySpecsPrefersHostSessionOnNameCollision` | replace the merge with a naive append |
| `TestBuildLeavesDisabledConfigMCPUndispatchableAlongsideHostSession` | widen the enablement loop from "every host-session name" to "every name" |

All three confirmed failing under their mutation and passing without it.
`TestBuildLeavesUnknownMCPServerUndispatchable` passes before and after by design — it exists so the fix cannot be satisfied by defaulting unknown servers to enabled.

### Why this went unnoticed

Not for lack of a test exercising host-session MCP — there is a green one.
`TestBuildDeepSeekTextParentCanUseImageReturningMCPAndVisionSubagent`
(`boot_test.go:607`) builds with `ExtraPlugins: [{Name: "vision-reader", …}]`, runs a real turn, and
asserts `mcpCalls == 1`. A host-session MCP server is successfully called on `main-v2` today.

It passes because there are **two dispatch routes and only one carries the enablement gate**:

| Route | Gate | Host-session server |
| --- | --- | --- |
| Registry-resident `mcp__server__tool` | `mcpServerAuthorized` only (`execute_one.go:501-507`) | works today |
| `use_capability` → `mcp-tool:<server>/<tool>` | `serverEnabled` | refused |

That test emits the raw registry name `mcp__vision-reader__inspect` (`boot_test.go:1032`) and takes
the ungated route. **In an ACP session that route does not exist**:
`applyUnifiedProviderToolSurface` narrows the provider-visible set to the fixed
`UnifiedProviderToolNames()` allowlist, so the model never sees an `mcp__*` name and `use_capability`
is the only way to reach an MCP tool.

So the accurate gap is narrower than "no test covers enablement": **no test covers a host-session
server reached through `use_capability`** — which happens to be the only route an ACP client has.
Post-patch the two routes agree for host-session servers; before it they disagreed, and the green
end-to-end test sat on the agreeing side.

## Checks run locally (go1.26.6, darwin/arm64)

```
gofmt -l          clean
go vet ./internal/boot/ ./internal/agent/ ./internal/control/   clean
go build ./...    ok
go test -p 4 ./internal/boot/... ./internal/agent/... ./internal/acp/...   ok
go test -p 1 ./internal/control/...                                        ok
go test -race ./internal/boot/ ./internal/agent/ ./internal/control/       ok
```

## Notes

- No protocol, schema, or capability surface change. `initialize` output is byte-identical. The only observable difference is that a previously-refused call now succeeds.
- The host-session regression now drives the real `use_capability` proxy through `tools/call`, so the test-only `ServerEnabled` / `CapabilityServerEnabled` accessors were removed after the ownership refactor. `go run ./tools/repolint` is clean without any baseline change.


## Impact declarations

Documentation-impact: none - no `docs/*.md` changed. This restores the already-documented behaviour of `session/new.mcpServers` (an MCP server the client asks the agent to connect) rather than introducing or altering a documented surface; no protocol, schema, config key, or CLI flag is added.

Cache-impact: none - structurally, not just observationally. (1) The system prompt cannot be affected: the last write to `sysPrompt` is `boot.go:673` (`config.ApplyOfficialDeepSeekV4ProPersona`, just past the `skill.ApplyIndex` call at `:670`), while the capability inventory does not exist until `boot.go:1564` — there is no write-back. (2) Provider-visible tools cannot be affected: `applyUnifiedProviderToolSurface` sets the visible set from the fixed `UnifiedProviderToolNames()` allowlist, so registering an MCP server cannot add a tool to it — `SetProviderVisibleTools` is an allowlist, not a diff. (3) The skill index cannot be affected, the one non-obvious path since the widened inventory does flow into `skillMCPBindings`: ACP specs are built with no `Package` (`service.go:3035-3046`), `skillMCPBindings` matches on `binding.Package == sk.Plugin`, and `skill.Store.Prepare` short-circuits on empty `sk.Plugin` — so a host-session server can never contribute a skill binding. Removing one cannot either, and that motion is new in this round: `mergeHostSessionCapabilitySpecs` drops the shadowed config spec from the slice passed to `skillMCPBindings` (`boot.go:1571`). That is normally a no-op — `skillMCPBindings` already skips any spec whose name is in `liveServers`, and the host-session server registered its tools under that same `mcp__<name>__` prefix, so the shadowed spec was being skipped anyway. In the one residual case (the host-session server fails to connect and registers nothing) it still cannot move the prompt: bindings are consumed lazily by `skill.Store.Prepare` at invocation time, and `skill.ApplyIndex` has already run regardless. Confirmed empirically as well: the same ACP session driven against the released `v1.31.3` binary and against this branch produced byte-identical provider requests — `tools=13 sha256=6ea9ba724c1851f6e50c2bba699406cc`, `system_msgs=1 sha256=02c53689292e07c4a443bf1d85627eef`.

Cache-guard: three focused guard tests near the changed surface, each mutation-checked — `TestBuildEnablesHostSessionMCPForCapabilityDispatch` (fails if the host-session inventory enablement/registration is reverted), `TestMergeHostSessionCapabilitySpecsPrefersHostSessionOnNameCollision` (fails if the merge becomes a naive append), and `TestBuildLeavesDisabledConfigMCPUndispatchableAlongsideHostSession` (fails if the enablement loop widens from host-session names to every name). `TestBuildLeavesUnknownMCPServerUndispatchable` and `TestMergeHostSessionCapabilitySpecsIsIdentityWithoutHostSession` pass either way by design: they pin that the fix is not default-allow and that the ordinary config path is handed through untouched. For the prompt/tool-prefix surface specifically, the guard is the released-vs-branch request comparison described above, reproducible without credentials: drive one `session/new` + `session/prompt` against a local OpenAI-compatible endpoint that logs the request body, once per binary, and diff the `tools` array and system message.

System-prompt-review: no maintainer sign-off has been obtained — I am an outside contributor and cannot self-approve one, so please treat this as a request for review rather than a record of it. What I can attest concretely: `internal/boot/boot.go` is flagged system-prompt-sensitive because it assembles the agent, but this change adds only MCP registration/enablement inside `build()` and touches no prompt, tool description, or instruction text. The hash comparison under Cache-impact is the evidence, and it covers the assembled system message end to end.




