### PR TITLE
feat(desktop): instant switch-back when target transcript is resident / 目标会话已缓存时秒切显示，跳过切换遮罩

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1116,6 +1116,7 @@ export default function App() {
     ensureBlankTab,
     ensureBlankSurface,
     commitSingleSurfaceNavigation,
+    hasLocalTranscriptForTab,
   } = useController();
   const { locale, setPref: setLocalePref } = useI18n();
   const t = useT();
@@ -3199,7 +3200,14 @@ export default function App() {
       // can wait behind an older tab switch. That immediately invalidates any
       // in-flight blank/topic completion from a previous user intent.
       const navigationIntentSeq = noteNavigationIntent();
-      beginNavigationSurface(navigationIntentSeq);
+      // When the target already holds a locally-rendered transcript, switching
+      // back renders instantly and needs no navigation-surface mask. Skip the
+      // mask so the cached conversation is visible immediately; backend
+      // activation + tab-metadata refresh still run in the background. This is
+      // the "instant switch-back" path taken when the session is resident.
+      const targetCached = hasLocalTranscriptForTab(tabId);
+      const masked = !targetCached;
+      if (masked) beginNavigationSurface(navigationIntentSeq);
       return enqueueNavigationRequest(
         { seqRef: tabSwitchSeqRef, runningRef: tabSwitchRunningRef, pendingRef: tabSwitchPendingRef },
         { tabId, optimisticTab, navigationIntentSeq },
@@ -3214,12 +3222,12 @@ export default function App() {
               { afterMutation: true },
             );
           } finally {
-            settleNavigationSurface(request.navigationIntentSeq);
+            if (masked) settleNavigationSurface(request.navigationIntentSeq);
           }
         },
       );
     },
-    [beginNavigationSurface, enterChatViewForTabNavigation, isNavigationIntentCurrent, noteNavigationIntent, refreshTabMetas, settleNavigationSurface, switchRemoteTab, switchTab],
+    [beginNavigationSurface, enterChatViewForTabNavigation, hasLocalTranscriptForTab, isNavigationIntentCurrent, noteNavigationIntent, refreshTabMetas, settleNavigationSurface, switchRemoteTab, switchTab],
   );
 
   const revealBackgroundRuntime = useCallback(async (tabId: string): Promise<void> => {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -4490,6 +4490,13 @@ export function useController() {
   }, [dispatchTo, loadSessionDataForTab]);
 
   // Tab management: switch preserves per-tab state; open creates it.
+  // Whether a target tab already holds a locally-rendered transcript. When a
+  // tab has items in memory, switching back to it is instant and does not need
+  // the navigation surface mask, so the caller can skip the mask entirely and
+  // render the cached content immediately while backend activation completes.
+  const hasLocalTranscriptForTab = useCallback((tabId: string): boolean => {
+    return Boolean(statesRef.current.get(tabId)?.items?.length);
+  }, []);
   const switchTab = useCallback(async (tabId: string, optimisticTab?: TabMeta, navigationIntentSeq?: number): Promise<TabMeta[] | undefined> => {
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
     if (!navigationCompletionCurrent(navigationSeq, "tab.switch", tabId)) return undefined;
@@ -4878,6 +4885,7 @@ export function useController() {
     refreshMeta, pickWorkspace, switchWorkspace, compact, rewind, rewindForTab, rewindForTabDetailed, undoRewindForTab, setModel, setEffort, cancelJob,
     fetchMemory, remember, forget, saveDoc,
     switchTab, switchRemoteTab, openProjectTab, openGlobalTab, openTopicSession, ensureBlankTab, activateTopic, ensureBlankSurface, createIsolatedWorktree, commitSingleSurfaceNavigation, closeTab, reorderTabs,
+    hasLocalTranscriptForTab,
     // Invalidate in-flight navigation completions (activateTopic's stale
     // guard) from outside the hook. The App-level navigation queue must call
     // this at ENQUEUE time: a queued click does not run — and so does not


### PR DESCRIPTION
## Summary

When switching tabs, if the target session's transcript is already loaded in memory (resident), skip the navigation overlay transition and display it instantly.

Previously, every tab switch went through the full navigation overlay (spinner + transition), even when the destination transcript was already cached. This PR adds a fast path: when the target surface's transcript state is already hydrated, the switch completes without the overlay animation.

## Verification

- Open multiple sessions in tabs
- Switch between already-loaded tabs → no spinner overlay, instant display
- Switch to a not-yet-loaded tab → normal overlay transition
- `pnpm typecheck` — pass

Documentation-impact: none - internal UX behaviour; no user-facing docs or config change.
Cache-impact: none - frontend navigation/painting only; no provider-visible prompt or tool schema changes.
Cache-guard: none - not required; changed paths are outside provider-visible cache construction.

System-prompt-review: none- frontend navigation/painting only; no system-prompt bytes change.
