### PR TITLE
Split release notes by Desktop and CLI / 按桌面端与 CLI 拆分更新日志

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
     paths:
       - "release-notes/**"
+      - "scripts/generate-release-notes.mjs"
       - "scripts/release-notes*.mjs"
       - "site/src/pages/changelog/**"
       - "site/src/components/ChangelogPage.astro"
+      - "site/src/data/releases.ts"
+      - "site/src/styles/changelog.css"
       - "desktop/frontend/src/App.tsx"
       - "desktop/frontend/src/components/SettingsPanel.tsx"
       - "desktop/frontend/src/components/UpdateBanner.tsx"

--- a/internal/productdocs/release_notes.go
+++ b/internal/productdocs/release_notes.go
@@ -3,6 +3,7 @@ package productdocs
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -166,12 +167,7 @@ func releaseItems(release releaseRecord) []releaseItem {
 }
 
 func releaseItemHasTarget(item releaseItem, target string) bool {
-	for _, candidate := range item.Targets {
-		if candidate == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(item.Targets, target)
 }
 
 func releaseTargetCount(release releaseRecord, target string) int {

--- a/internal/productdocs/release_notes.go
+++ b/internal/productdocs/release_notes.go
@@ -12,28 +12,30 @@ type localizedText struct {
 }
 
 type releaseItem struct {
-	Kind  string        `json:"kind"`
-	Level string        `json:"level"`
-	Title localizedText `json:"title"`
-	Body  localizedText `json:"body"`
-	Href  string        `json:"href"`
-	Refs  []int         `json:"refs"`
+	Kind    string        `json:"kind"`
+	Level   string        `json:"level"`
+	Title   localizedText `json:"title"`
+	Body    localizedText `json:"body"`
+	Href    string        `json:"href"`
+	Refs    []int         `json:"refs"`
+	Targets []string      `json:"targets"`
 }
 
 type releaseRecord struct {
-	Version      string        `json:"version"`
-	Date         string        `json:"date"`
-	Channel      string        `json:"channel"`
-	Status       string        `json:"status"`
-	Title        localizedText `json:"title"`
-	Summary      localizedText `json:"summary"`
-	Surfaces     []string      `json:"surfaces"`
-	Guides       []releaseItem `json:"guides"`
-	Highlights   []releaseItem `json:"highlights"`
-	Upgrade      []releaseItem `json:"upgrade"`
-	Risks        []releaseItem `json:"risks"`
-	Contributors []string      `json:"contributors"`
-	Changes      struct {
+	Version          string        `json:"version"`
+	TargetingVersion int           `json:"targetingVersion"`
+	Date             string        `json:"date"`
+	Channel          string        `json:"channel"`
+	Status           string        `json:"status"`
+	Title            localizedText `json:"title"`
+	Summary          localizedText `json:"summary"`
+	Surfaces         []string      `json:"surfaces"`
+	Guides           []releaseItem `json:"guides"`
+	Highlights       []releaseItem `json:"highlights"`
+	Upgrade          []releaseItem `json:"upgrade"`
+	Risks            []releaseItem `json:"risks"`
+	Contributors     []string      `json:"contributors"`
+	Changes          struct {
 		New      []releaseItem `json:"new"`
 		Improved []releaseItem `json:"improved"`
 		Fixed    []releaseItem `json:"fixed"`
@@ -124,12 +126,24 @@ func renderReleaseMarkdown(release releaseRecord, locale string) string {
 	}
 
 	fmt.Fprintf(&b, "\n## %s\n\n%s\n", heading("Summary", "摘要"), localize(release.Summary))
-	renderReleaseItems(&b, heading("Highlights", "亮点"), release.Highlights, localize, heading)
-	if len(release.Changes.New)+len(release.Changes.Improved)+len(release.Changes.Fixed) > 0 {
-		fmt.Fprintf(&b, "\n## %s\n", heading("Changes", "变更"))
-		renderReleaseItemGroup(&b, heading("New", "新增"), release.Changes.New, localize, heading)
-		renderReleaseItemGroup(&b, heading("Improved", "改进"), release.Changes.Improved, localize, heading)
-		renderReleaseItemGroup(&b, heading("Fixed", "修复"), release.Changes.Fixed, localize, heading)
+	if release.TargetingVersion == 1 {
+		fmt.Fprintf(
+			&b,
+			"\n**Desktop %d · CLI %d**\n",
+			releaseTargetCount(release, "desktop"),
+			releaseTargetCount(release, "cli"),
+		)
+		renderReleaseTargetSection(&b, release, "desktop", heading("Desktop updates", "桌面端更新"), localize, heading)
+		renderReleaseTargetSection(&b, release, "cli", heading("CLI updates", "CLI 端更新"), localize, heading)
+		renderOtherReleaseUpdates(&b, release, localize, heading)
+	} else {
+		renderReleaseItems(&b, heading("Highlights", "亮点"), release.Highlights, localize, heading)
+		if len(release.Changes.New)+len(release.Changes.Improved)+len(release.Changes.Fixed) > 0 {
+			fmt.Fprintf(&b, "\n## %s\n", heading("Changes", "变更"))
+			renderReleaseItemGroup(&b, heading("New", "新增"), release.Changes.New, localize, heading)
+			renderReleaseItemGroup(&b, heading("Improved", "改进"), release.Changes.Improved, localize, heading)
+			renderReleaseItemGroup(&b, heading("Fixed", "修复"), release.Changes.Fixed, localize, heading)
+		}
 	}
 	renderReleaseItems(&b, heading("Upgrade notes", "升级说明"), release.Upgrade, localize, heading)
 	renderReleaseItems(&b, heading("Known risks", "已知风险"), release.Risks, localize, heading)
@@ -138,6 +152,105 @@ func renderReleaseMarkdown(release releaseRecord, locale string) string {
 		fmt.Fprintf(&b, "\n## %s\n\n%s\n", heading("Contributors", "贡献者"), strings.Join(release.Contributors, ", "))
 	}
 	return strings.TrimSpace(b.String()) + "\n"
+}
+
+func releaseItems(release releaseRecord) []releaseItem {
+	items := make([]releaseItem, 0, len(release.Highlights)+len(release.Changes.New)+len(release.Changes.Improved)+len(release.Changes.Fixed)+len(release.Upgrade)+len(release.Risks))
+	items = append(items, release.Highlights...)
+	items = append(items, release.Changes.New...)
+	items = append(items, release.Changes.Improved...)
+	items = append(items, release.Changes.Fixed...)
+	items = append(items, release.Upgrade...)
+	items = append(items, release.Risks...)
+	return items
+}
+
+func releaseItemHasTarget(item releaseItem, target string) bool {
+	for _, candidate := range item.Targets {
+		if candidate == target {
+			return true
+		}
+	}
+	return false
+}
+
+func releaseTargetCount(release releaseRecord, target string) int {
+	count := 0
+	for _, item := range releaseItems(release) {
+		if releaseItemHasTarget(item, target) {
+			count++
+		}
+	}
+	return count
+}
+
+func releaseItemsForTarget(items []releaseItem, target string) []releaseItem {
+	filtered := make([]releaseItem, 0, len(items))
+	for _, item := range items {
+		if releaseItemHasTarget(item, target) {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func renderReleaseTargetSection(
+	b *strings.Builder,
+	release releaseRecord,
+	target string,
+	title string,
+	localize func(localizedText) string,
+	heading func(string, string) string,
+) {
+	fmt.Fprintf(b, "\n## %s\n", title)
+	highlights := releaseItemsForTarget(release.Highlights, target)
+	newItems := releaseItemsForTarget(release.Changes.New, target)
+	improved := releaseItemsForTarget(release.Changes.Improved, target)
+	fixed := releaseItemsForTarget(release.Changes.Fixed, target)
+	renderReleaseItemGroup(b, heading("Highlights", "重点内容"), highlights, localize, heading)
+	renderReleaseItemGroup(b, heading("New", "新增"), newItems, localize, heading)
+	renderReleaseItemGroup(b, heading("Improved", "改进"), improved, localize, heading)
+	renderReleaseItemGroup(b, heading("Fixed", "修复"), fixed, localize, heading)
+	if len(highlights)+len(newItems)+len(improved)+len(fixed) > 0 {
+		return
+	}
+	if target == "cli" && releaseTargetCount(release, target) == 0 {
+		fmt.Fprintf(b, "\n%s\n", heading(
+			"This release has no CLI features, improvements, or fixes; CLI users may skip it if preferred.",
+			"本版本没有 CLI 相关功能、改进或修复，CLI 用户可按需跳过。",
+		))
+		return
+	}
+	fmt.Fprintf(b, "\n%s\n", heading(
+		"No feature or fix entries are listed here; see the upgrade and risk notes below.",
+		"此板块没有功能或修复条目；相关说明请查看下方升级提醒和风险提示。",
+	))
+}
+
+func otherOnlyReleaseItems(items []releaseItem) []releaseItem {
+	filtered := make([]releaseItem, 0, len(items))
+	for _, item := range items {
+		if len(item.Targets) > 0 && !releaseItemHasTarget(item, "desktop") && !releaseItemHasTarget(item, "cli") {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func renderOtherReleaseUpdates(
+	b *strings.Builder,
+	release releaseRecord,
+	localize func(localizedText) string,
+	heading func(string, string) string,
+) {
+	items := otherOnlyReleaseItems(release.Highlights)
+	items = append(items, otherOnlyReleaseItems(release.Changes.New)...)
+	items = append(items, otherOnlyReleaseItems(release.Changes.Improved)...)
+	items = append(items, otherOnlyReleaseItems(release.Changes.Fixed)...)
+	if len(items) == 0 {
+		return
+	}
+	renderReleaseItems(b, heading("Other project updates", "其他项目更新"), items, localize, heading)
 }
 
 func renderReleaseItems(
@@ -181,6 +294,13 @@ func renderReleaseItemBullets(
 			continue
 		}
 		fmt.Fprintf(b, "\n- **%s**", title)
+		if len(item.Targets) > 0 {
+			labels := make([]string, 0, len(item.Targets))
+			for _, target := range item.Targets {
+				labels = append(labels, releaseTargetLabel(target, heading))
+			}
+			fmt.Fprintf(b, " [%s]", strings.Join(labels, " · "))
+		}
 		if item.Kind != "" {
 			fmt.Fprintf(b, " [%s]", item.Kind)
 		} else if item.Level != "" {
@@ -200,5 +320,20 @@ func renderReleaseItemBullets(
 			fmt.Fprintf(b, " (%s: %s)", heading("Refs", "关联"), strings.Join(refs, ", "))
 		}
 		b.WriteByte('\n')
+	}
+}
+
+func releaseTargetLabel(target string, heading func(string, string) string) string {
+	switch target {
+	case "desktop":
+		return heading("Desktop", "桌面端")
+	case "cli":
+		return "CLI"
+	case "site":
+		return heading("Site", "网站")
+	case "service":
+		return heading("Service", "服务端")
+	default:
+		return target
 	}
 }

--- a/internal/productdocs/release_notes_test.go
+++ b/internal/productdocs/release_notes_test.go
@@ -1,0 +1,92 @@
+package productdocs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTargetedReleaseDocumentsSplitDesktopAndCLIUpdates(t *testing.T) {
+	documents, _, err := renderReleaseDocuments([]byte(`{
+		"releases": [{
+			"version": "2.0.0",
+			"targetingVersion": 1,
+			"date": "2026-01-01",
+			"channel": "stable",
+			"status": "reviewed",
+			"title": {"en": "Targeted", "zh": "分类版本"},
+			"summary": {"en": "Summary", "zh": "摘要"},
+			"surfaces": ["desktop", "cli", "service"],
+			"highlights": [
+				{"kind": "fixed", "targets": ["desktop", "cli"], "title": {"en": "Shared fix", "zh": "共享修复"}, "body": {"en": "Shared body.", "zh": "共享正文。"}},
+				{"kind": "improved", "targets": ["service"], "title": {"en": "Service work", "zh": "服务端改进"}, "body": {"en": "Service body.", "zh": "服务正文。"}}
+			],
+			"changes": {
+				"new": [],
+				"improved": [],
+				"fixed": [{"targets": ["desktop"], "title": {"en": "Desktop fix", "zh": "桌面端修复"}, "body": {"en": "Desktop body.", "zh": "桌面端正文。"}}]
+			},
+			"upgrade": [],
+			"risks": []
+		}]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var chinese string
+	for _, document := range documents {
+		if document.locale == "zh-CN" {
+			chinese = document.content
+			break
+		}
+	}
+	for _, want := range []string{"## 桌面端更新", "## CLI 端更新", "## 其他项目更新", "[桌面端 · CLI]", "[服务端]"} {
+		if !strings.Contains(chinese, want) {
+			t.Fatalf("targeted release document missing %q:\n%s", want, chinese)
+		}
+	}
+	if got := strings.Count(chinese, "共享修复"); got != 2 {
+		t.Fatalf("shared item rendered %d times, want once per client section:\n%s", got, chinese)
+	}
+}
+
+func TestLegacyReleaseDocumentsKeepOriginalSections(t *testing.T) {
+	documents, _, err := renderReleaseDocuments([]byte(`{
+		"releases": [{
+			"version": "1.0.0",
+			"title": {"en": "Legacy", "zh": "旧版"},
+			"summary": {"en": "Summary", "zh": "摘要"},
+			"highlights": [{"kind": "fixed", "title": {"en": "Fix", "zh": "修复"}, "body": {"en": "Body.", "zh": "正文。"}}],
+			"changes": {"new": [], "improved": [], "fixed": []}
+		}]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	english := documents[0].content
+	if !strings.Contains(english, "## Highlights") {
+		t.Fatalf("legacy release lost original sections:\n%s", english)
+	}
+	if strings.Contains(english, "## Desktop updates") || strings.Contains(english, "## CLI updates") {
+		t.Fatalf("legacy release unexpectedly used targeted sections:\n%s", english)
+	}
+}
+
+func TestTargetedReleaseDocumentsExplainEmptyCLISection(t *testing.T) {
+	release := releaseRecord{
+		Version:          "2.0.1",
+		TargetingVersion: 1,
+		Title:            localizedText{English: "Desktop only", Chinese: "仅桌面端"},
+		Summary:          localizedText{English: "Summary", Chinese: "摘要"},
+		Surfaces:         []string{"desktop"},
+		Highlights: []releaseItem{{
+			Kind:    "fixed",
+			Targets: []string{"desktop"},
+			Title:   localizedText{English: "Desktop fix", Chinese: "桌面端修复"},
+			Body:    localizedText{English: "Body.", Chinese: "正文。"},
+		}},
+	}
+	markdown := renderReleaseMarkdown(release, "zh-CN")
+	if !strings.Contains(markdown, "CLI 用户可按需跳过") {
+		t.Fatalf("empty CLI section missing actionable guidance:\n%s", markdown)
+	}
+}

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -3,6 +3,7 @@
   "releases": [
     {
       "version": "1.31.4",
+      "targetingVersion": 1,
       "date": "2026-08-25",
       "channel": "stable",
       "title": {
@@ -14,7 +15,9 @@
         "zh": "此版本修复了多个桌面端问题，包括损坏的会话元数据恢复、后台任务通知、模型服务删除和会话滚动。同时通过移除高成本的指标汇总提升了性能。"
       },
       "surfaces": [
-        "desktop"
+        "desktop",
+        "cli",
+        "service"
       ],
       "guides": [
         {
@@ -54,6 +57,10 @@
       "highlights": [
         {
           "kind": "fixed",
+          "targets": [
+            "desktop",
+            "cli"
+          ],
           "title": {
             "en": "Recover from corrupted session metadata",
             "zh": "从损坏的会话元数据中恢复"
@@ -68,6 +75,10 @@
         },
         {
           "kind": "improved",
+          "targets": [
+            "desktop",
+            "cli"
+          ],
           "title": {
             "en": "Clearer background job notifications",
             "zh": "更清晰的后台任务通知"
@@ -82,6 +93,9 @@
         },
         {
           "kind": "fixed",
+          "targets": [
+            "desktop"
+          ],
           "title": {
             "en": "Delete configured default providers",
             "zh": "删除已配置的默认模型服务"
@@ -96,6 +110,9 @@
         },
         {
           "kind": "fixed",
+          "targets": [
+            "desktop"
+          ],
           "title": {
             "en": "Stable transcript scrolling",
             "zh": "稳定的会话滚动"
@@ -111,6 +128,9 @@
         },
         {
           "kind": "improved",
+          "targets": [
+            "service"
+          ],
           "title": {
             "en": "Reduced database read costs",
             "zh": "降低数据库读取成本"
@@ -128,6 +148,10 @@
         "new": [],
         "improved": [
           {
+            "targets": [
+              "desktop",
+              "cli"
+            ],
             "title": {
               "en": "Better math rendering in desktop and CLI",
               "zh": "桌面端和 CLI 中更好的数学渲染"
@@ -141,6 +165,9 @@
             ]
           },
           {
+            "targets": [
+              "desktop"
+            ],
             "title": {
               "en": "Preserve sidebar activity order",
               "zh": "保持侧栏活动顺序"
@@ -154,6 +181,9 @@
             ]
           },
           {
+            "targets": [
+              "desktop"
+            ],
             "title": {
               "en": "Stop repeated session catalog reindexing",
               "zh": "停止会话目录反复重新索引"
@@ -169,6 +199,9 @@
         ],
         "fixed": [
           {
+            "targets": [
+              "desktop"
+            ],
             "title": {
               "en": "Atomic OpenCode Go group removal",
               "zh": "OpenCode Go 分组原子删除"
@@ -182,6 +215,10 @@
             ]
           },
           {
+            "targets": [
+              "desktop",
+              "cli"
+            ],
             "title": {
               "en": "Restore explicit readiness recovery",
               "zh": "恢复显式收尾恢复"

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -9,6 +9,7 @@ import { loadCatalog, upsertRelease, validateCatalog } from "./release-notes.mjs
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const apiBase = process.env.DEEPSEEK_API_BASE || "https://api.deepseek.com";
 const model = process.env.DEEPSEEK_MODEL || "deepseek-v4-pro";
+const releaseTargetOrder = ["desktop", "cli", "site", "service"];
 
 function parseArgs(argv) {
   const values = {};
@@ -66,6 +67,47 @@ async function githubJson(path, { allowMissing = false } = {}) {
   return response.json();
 }
 
+async function githubList(path) {
+  const items = [];
+  for (let page = 1; ; page += 1) {
+    const separator = path.includes("?") ? "&" : "?";
+    const batch = await githubJson(`${path}${separator}per_page=100&page=${page}`);
+    items.push(...batch);
+    if (batch.length < 100) return items;
+  }
+}
+
+export function inferPullTargetHints(labels, files) {
+  const labelSet = new Set(labels);
+  const targets = new Set();
+  const add = (target) => targets.add(target);
+  const hasPath = (pattern) => files.some((path) => pattern.test(path));
+
+  const explicitlyDesktop = labelSet.has("desktop");
+  const explicitlyCLI = labelSet.has("tui") || labelSet.has("cli");
+  if (explicitlyDesktop) add("desktop");
+  if (explicitlyCLI) add("cli");
+  if (hasPath(/^desktop\//)) add("desktop");
+  if (hasPath(/^(?:internal\/cli\/|cmd\/)/)) add("cli");
+  if (hasPath(/^site\//)) add("site");
+  if (hasPath(/^(?:workers\/|\.github\/|scripts\/|release-notes\/)/)) add("service");
+
+  const hasSharedProductCode = files.some((path) =>
+    /^(?:internal\/|sdk\/|npm\/)/.test(path) &&
+    !/^internal\/cli\//.test(path) &&
+    !/^internal\/telemetry\//.test(path),
+  );
+  if (!explicitlyDesktop && !explicitlyCLI && hasSharedProductCode) {
+    add("desktop");
+    add("cli");
+  }
+  if (!targets.size) {
+    add("desktop");
+    add("cli");
+  }
+  return releaseTargetOrder.filter((target) => targets.has(target));
+}
+
 async function collectPullRequests(repository, commits) {
   const numbers = new Set(prNumbersFromCommits(commits));
   const associated = await Promise.all(
@@ -73,13 +115,41 @@ async function collectPullRequests(repository, commits) {
   );
   for (const pulls of associated) for (const pull of pulls || []) numbers.add(pull.number);
   const pulls = await Promise.all([...numbers].map((number) => githubJson(`/repos/${repository}/pulls/${number}`, { allowMissing: true })));
-  return pulls.filter(Boolean).map((pull) => ({
-    number: pull.number,
-    title: pull.title,
-    body: String(pull.body || "").slice(0, 2000),
-    author: pull.user?.login || "",
-    labels: (pull.labels || []).map((label) => label.name),
+  return Promise.all(pulls.filter(Boolean).map(async (pull) => {
+    const labels = (pull.labels || []).map((label) => label.name);
+    const files = (await githubList(`/repos/${repository}/pulls/${pull.number}/files`)).map((file) => file.filename);
+    return {
+      number: pull.number,
+      title: pull.title,
+      body: String(pull.body || "").slice(0, 2000),
+      author: pull.user?.login || "",
+      labels,
+      changedFileCount: files.length,
+      files: files.slice(0, 200),
+      targetHints: inferPullTargetHints(labels, files),
+    };
   }));
+}
+
+function releaseItems(release) {
+  return [
+    ...(release.highlights || []),
+    ...["new", "improved", "fixed"].flatMap((kind) => release.changes?.[kind] || []),
+    ...(release.upgrade || []),
+    ...(release.risks || []),
+  ];
+}
+
+function normalizeReleaseTargets(release) {
+  for (const item of releaseItems(release)) {
+    if (!Array.isArray(item.targets)) continue;
+    item.targets.sort((a, b) => releaseTargetOrder.indexOf(a) - releaseTargetOrder.indexOf(b));
+  }
+  const targets = new Set(releaseItems(release).flatMap((item) => item.targets || []));
+  release.surfaces = [
+    ...releaseTargetOrder.filter((target) => targets.has(target)),
+    ...[...targets].filter((target) => !releaseTargetOrder.includes(target)).sort(),
+  ];
 }
 
 function collectDocLinks(from, repository, to) {
@@ -130,17 +200,17 @@ async function askDeepSeek(payload, retry = true) {
           role: "system",
           content: `You are Reasonix's release editor. Return one JSON object with a \"release\" property. Write factual, user-facing product release notes in equivalent English and Simplified Chinese. Group changes by user outcome, not by commit. Never invent capabilities, migrations, risks, PR numbers, contributors, URLs, or metrics. Every highlight and change must cite one or more supplied PR numbers. Use this exact release shape:
 {
-  \"version\": \"semver\", \"date\": \"YYYY-MM-DD\", \"channel\": \"stable|prerelease\",
+  \"version\": \"semver\", \"date\": \"YYYY-MM-DD\", \"channel\": \"stable|prerelease\", \"targetingVersion\": 1,
   \"title\": {\"en\":\"\",\"zh\":\"\"}, \"summary\": {\"en\":\"\",\"zh\":\"\"},
-  \"surfaces\": [\"desktop\"],
+  \"surfaces\": [\"desktop\",\"cli\"],
   \"guides\": [{\"title\":{\"en\":\"\",\"zh\":\"\"},\"body\":{\"en\":\"\",\"zh\":\"\"},\"href\":\"https://...\"}],
-  \"highlights\": [{\"kind\":\"new|improved|fixed|security\",\"title\":{\"en\":\"\",\"zh\":\"\"},\"body\":{\"en\":\"\",\"zh\":\"\"},\"refs\":[123]}],
+  \"highlights\": [{\"kind\":\"new|improved|fixed|security\",\"targets\":[\"desktop\",\"cli\"],\"title\":{\"en\":\"\",\"zh\":\"\"},\"body\":{\"en\":\"\",\"zh\":\"\"},\"refs\":[123]}],
   \"changes\": {\"new\":[],\"improved\":[],\"fixed\":[]},
-  \"upgrade\": [{\"level\":\"info|warning\",\"title\":{\"en\":\"\",\"zh\":\"\"},\"body\":{\"en\":\"\",\"zh\":\"\"},\"refs\":[123]}],
-  \"risks\": [{\"title\":{\"en\":\"\",\"zh\":\"\"},\"body\":{\"en\":\"\",\"zh\":\"\"},\"refs\":[123]}],
+  \"upgrade\": [{\"level\":\"info|warning\",\"targets\":[\"desktop\"],\"title\":{\"en\":\"\",\"zh\":\"\"},\"body\":{\"en\":\"\",\"zh\":\"\"},\"refs\":[123]}],
+  \"risks\": [{\"targets\":[\"cli\"],\"title\":{\"en\":\"\",\"zh\":\"\"},\"body\":{\"en\":\"\",\"zh\":\"\"},\"refs\":[123]}],
   \"contributors\": [], \"links\": {\"github\":\"https://...\",\"compare\":\"https://...\",\"download\":\"https://...\"}
 }
-Return guides only for supplied documentation URLs. Mention upgrade action or risk only when explicitly supported; otherwise use empty arrays. Output JSON only.`,
+Every highlight, change, upgrade note, and risk must have a non-empty \"targets\" array using only this canonical order: desktop, cli, site, service. Use each PR's targetHints as deterministic candidates, then choose the user-visible delivery target supported by its labels, changed files, title, and body. Shared product-core behavior belongs to both desktop and cli. Website-only work belongs to site; hosted workers and release infrastructure belong to service and must not be marked as a client update merely because a client file accompanies the server change. Set top-level surfaces to the canonical union of all item targets. Return guides only for supplied documentation URLs. Mention upgrade action or risk only when explicitly supported; otherwise use empty arrays. Output JSON only.`,
         },
         { role: "user", content: `Create the release record from these public GitHub sources:\n${JSON.stringify(payload)}` },
       ],
@@ -201,6 +271,7 @@ async function main() {
     documentationUrls: docLinks,
   };
   const release = await askDeepSeek(source);
+  release.targetingVersion = 1;
   release.version = version;
   release.releaseId = version;
   release.baseVersion = baseVersion;
@@ -232,13 +303,16 @@ async function main() {
       : "https://reasonix.io/?download=desktop&channel=stable#start",
   };
   release.guides = (release.guides || []).filter((guide) => docLinks.includes(guide.href));
+  normalizeReleaseTargets(release);
   assertGroundedRefs(release, new Set(pulls.map((pull) => pull.number)));
   validateCatalog({ schemaVersion: 1, releases: [release] });
   await upsertRelease(release);
   console.log(`Generated bilingual release notes for v${version} from ${pulls.length} pull request(s).`);
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exitCode = 1;
-});
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -12,6 +12,8 @@ const changeKinds = ["new", "improved", "fixed"];
 const itemKinds = new Set(["new", "improved", "fixed", "security"]);
 const releaseChannels = new Set(["stable", "prerelease"]);
 const releaseStatuses = new Set(["reviewed", "published"]);
+const releaseTargetOrder = ["desktop", "cli", "site", "service"];
+const releaseTargets = new Set(releaseTargetOrder);
 
 function invariant(condition, message) {
   if (!condition) throw new Error(message);
@@ -34,13 +36,34 @@ function validateRefs(refs, path) {
   for (const ref of refs) invariant(Number.isInteger(ref) && ref > 0, `${path} contains invalid PR number ${ref}`);
 }
 
-function validateItem(item, path, { kind = false, href = false, level = false } = {}) {
+function validateItem(item, path, { kind = false, href = false, level = false, targets = false } = {}) {
   invariant(isObject(item), `${path} must be an object`);
   for (const field of localizedFields) validateLocalized(item[field], `${path}.${field}`);
   if (kind) invariant(itemKinds.has(item.kind), `${path}.kind is invalid`);
   if (href) invariant(typeof item.href === "string" && /^https:\/\//.test(item.href), `${path}.href must be HTTPS`);
   if (level) invariant(item.level === "info" || item.level === "warning", `${path}.level is invalid`);
+  if (targets || item.targets !== undefined) {
+    invariant(Array.isArray(item.targets) && item.targets.length > 0, `${path}.targets must be a non-empty array`);
+    invariant(new Set(item.targets).size === item.targets.length, `${path}.targets contains duplicates`);
+    for (const target of item.targets) invariant(releaseTargets.has(target), `${path}.targets contains invalid target ${target}`);
+    const sorted = releaseTargetOrder.filter((target) => item.targets.includes(target));
+    invariant(sorted.every((target, index) => target === item.targets[index]), `${path}.targets must use canonical order`);
+  }
   validateRefs(item.refs, `${path}.refs`);
+}
+
+function releaseItems(release) {
+  return [
+    ...release.highlights,
+    ...changeKinds.flatMap((kind) => release.changes[kind]),
+    ...release.upgrade,
+    ...release.risks,
+  ];
+}
+
+function itemTargetsUnion(release) {
+  const targets = new Set(releaseItems(release).flatMap((item) => item.targets || []));
+  return releaseTargetOrder.filter((target) => targets.has(target));
 }
 
 function semverParts(version) {
@@ -126,6 +149,10 @@ export function validateCatalog(catalog) {
         );
       }
     }
+    if (release.targetingVersion !== undefined) {
+      invariant(release.targetingVersion === 1, `${path}.targetingVersion is invalid`);
+    }
+    const targetsRequired = release.targetingVersion === 1;
     validateLocalized(release.title, `${path}.title`);
     validateLocalized(release.summary, `${path}.summary`);
     invariant(Array.isArray(release.surfaces) && release.surfaces.length > 0, `${path}.surfaces must not be empty`);
@@ -133,18 +160,36 @@ export function validateCatalog(catalog) {
     invariant(Array.isArray(release.guides), `${path}.guides must be an array`);
     release.guides.forEach((item, itemIndex) => validateItem(item, `${path}.guides[${itemIndex}]`, { href: true }));
     invariant(Array.isArray(release.highlights) && release.highlights.length > 0, `${path}.highlights must not be empty`);
-    release.highlights.forEach((item, itemIndex) => validateItem(item, `${path}.highlights[${itemIndex}]`, { kind: true }));
+    release.highlights.forEach((item, itemIndex) =>
+      validateItem(item, `${path}.highlights[${itemIndex}]`, { kind: true, targets: targetsRequired }),
+    );
     invariant(isObject(release.changes), `${path}.changes must be an object`);
     for (const changeKind of changeKinds) {
       invariant(Array.isArray(release.changes[changeKind]), `${path}.changes.${changeKind} must be an array`);
       release.changes[changeKind].forEach((item, itemIndex) =>
-        validateItem(item, `${path}.changes.${changeKind}[${itemIndex}]`),
+        validateItem(item, `${path}.changes.${changeKind}[${itemIndex}]`, { targets: targetsRequired }),
       );
     }
     invariant(Array.isArray(release.upgrade), `${path}.upgrade must be an array`);
-    release.upgrade.forEach((item, itemIndex) => validateItem(item, `${path}.upgrade[${itemIndex}]`, { level: true }));
+    release.upgrade.forEach((item, itemIndex) =>
+      validateItem(item, `${path}.upgrade[${itemIndex}]`, { level: true, targets: targetsRequired }),
+    );
     invariant(Array.isArray(release.risks), `${path}.risks must be an array`);
-    release.risks.forEach((item, itemIndex) => validateItem(item, `${path}.risks[${itemIndex}]`));
+    release.risks.forEach((item, itemIndex) =>
+      validateItem(item, `${path}.risks[${itemIndex}]`, { targets: targetsRequired }),
+    );
+    if (targetsRequired) {
+      const derivedTargets = itemTargetsUnion(release);
+      invariant(
+        derivedTargets.includes("desktop") || derivedTargets.includes("cli"),
+        `${path} must contain at least one Desktop or CLI update`,
+      );
+      invariant(
+        derivedTargets.length === release.surfaces.length &&
+          derivedTargets.every((target, index) => target === release.surfaces[index]),
+        `${path}.surfaces must equal the canonical union of item targets`,
+      );
+    }
     invariant(Array.isArray(release.contributors), `${path}.contributors must be an array`);
     invariant(isObject(release.links), `${path}.links must be an object`);
     for (const link of ["github", "compare", "download"]) {
@@ -181,10 +226,73 @@ function refsSuffix(refs = []) {
   return ` (${refs.map((ref) => `[#${ref}](https://github.com/esengine/DeepSeek-Reasonix/pull/${ref})`).join(", ")})`;
 }
 
+function targetLabel(target) {
+  return { desktop: "Desktop", cli: "CLI", site: "Site", service: "Service" }[target] || target;
+}
+
+function targetsPrefix(item) {
+  if (!item.targets?.length) return "";
+  return `**[${item.targets.map(targetLabel).join(" · ")}]** `;
+}
+
 function renderItems(items, lang) {
   return items
-    .map((item) => `- **${localized(item.title, lang)}** — ${localized(item.body, lang)}${refsSuffix(item.refs)}`)
+    .map((item) => `- ${targetsPrefix(item)}**${localized(item.title, lang)}** — ${localized(item.body, lang)}${refsSuffix(item.refs)}`)
     .join("\n");
+}
+
+function hasTarget(item, target) {
+  return item.targets?.includes(target) || false;
+}
+
+function targetItemCount(release, target) {
+  return releaseItems(release).filter((item) => hasTarget(item, target)).length;
+}
+
+function appendTargetSection(lines, release, target, lang) {
+  const isZh = lang === "zh";
+  const title = target === "desktop"
+    ? (isZh ? "桌面端更新" : "Desktop updates")
+    : (isZh ? "CLI 端更新" : "CLI updates");
+  lines.push(`## ${title}`, "");
+
+  const highlights = release.highlights.filter((item) => hasTarget(item, target));
+  if (highlights.length) {
+    lines.push(`### ${isZh ? "重点内容" : "Highlights"}`, "", renderItems(highlights, lang), "");
+  }
+  const headings = {
+    new: isZh ? "新增" : "New",
+    improved: isZh ? "改进" : "Improved",
+    fixed: isZh ? "修复" : "Fixed",
+  };
+  for (const kind of changeKinds) {
+    const items = release.changes[kind].filter((item) => hasTarget(item, target));
+    if (items.length) lines.push(`### ${headings[kind]}`, "", renderItems(items, lang), "");
+  }
+
+  if (!highlights.length && !changeKinds.some((kind) => release.changes[kind].some((item) => hasTarget(item, target)))) {
+    const noTargetedItems = targetItemCount(release, target) === 0;
+    lines.push(
+      target === "cli" && noTargetedItems
+        ? (isZh ? "本版本没有 CLI 相关功能、改进或修复，CLI 用户可按需跳过。" : "This release has no CLI features, improvements, or fixes; CLI users may skip it if preferred.")
+        : (isZh ? "此板块没有功能或修复条目；相关说明请查看下方升级提醒和风险提示。" : "No feature or fix entries are listed here; see the upgrade and risk notes below."),
+      "",
+    );
+  }
+}
+
+function appendOtherTargetSection(lines, release, lang) {
+  const isZh = lang === "zh";
+  const isOtherOnly = (item) => item.targets?.length && !hasTarget(item, "desktop") && !hasTarget(item, "cli");
+  const highlights = release.highlights.filter(isOtherOnly);
+  const changes = Object.fromEntries(changeKinds.map((kind) => [kind, release.changes[kind].filter(isOtherOnly)]));
+  if (!highlights.length && !changeKinds.some((kind) => changes[kind].length)) return;
+
+  lines.push(`## ${isZh ? "其他项目更新" : "Other project updates"}`, "");
+  if (highlights.length) lines.push(renderItems(highlights, lang), "");
+  for (const kind of changeKinds) {
+    if (changes[kind].length) lines.push(renderItems(changes[kind], lang), "");
+  }
 }
 
 export function renderGitHubRelease(release, lang = "zh") {
@@ -219,21 +327,28 @@ export function renderGitHubRelease(release, lang = "zh") {
     "",
     `${isZh ? "发布日期" : "Released"}：${release.date}`,
     "",
-    `## ${isZh ? "重点内容" : "Highlights"}`,
-    "",
-    renderItems(release.highlights, lang),
-    "",
   );
 
-  const headings = {
-    new: isZh ? "新功能" : "New",
-    improved: isZh ? "改进" : "Improved",
-    fixed: isZh ? "修复" : "Fixed",
-  };
-  for (const kind of changeKinds) {
-    const items = release.changes[kind];
-    if (!items.length) continue;
-    lines.push(`## ${headings[kind]}`, "", renderItems(items, lang), "");
+  if (release.targetingVersion === 1) {
+    lines.push(
+      `**Desktop ${targetItemCount(release, "desktop")} · CLI ${targetItemCount(release, "cli")}**`,
+      "",
+    );
+    appendTargetSection(lines, release, "desktop", lang);
+    appendTargetSection(lines, release, "cli", lang);
+    appendOtherTargetSection(lines, release, lang);
+  } else {
+    lines.push(`## ${isZh ? "重点内容" : "Highlights"}`, "", renderItems(release.highlights, lang), "");
+    const headings = {
+      new: isZh ? "新功能" : "New",
+      improved: isZh ? "改进" : "Improved",
+      fixed: isZh ? "修复" : "Fixed",
+    };
+    for (const kind of changeKinds) {
+      const items = release.changes[kind];
+      if (!items.length) continue;
+      lines.push(`## ${headings[kind]}`, "", renderItems(items, lang), "");
+    }
   }
 
   lines.push(`## ${isZh ? "升级提醒" : "Upgrade notes"}`, "");

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -14,6 +14,7 @@ const releaseChannels = new Set(["stable", "prerelease"]);
 const releaseStatuses = new Set(["reviewed", "published"]);
 const releaseTargetOrder = ["desktop", "cli", "site", "service"];
 const releaseTargets = new Set(releaseTargetOrder);
+const releaseTargetingRequiredFrom = "1.31.4";
 
 function invariant(condition, message) {
   if (!condition) throw new Error(message);
@@ -70,6 +71,15 @@ function semverParts(version) {
   const match = String(version).match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/);
   invariant(match, `invalid version ${version}`);
   return [Number(match[1]), Number(match[2]), Number(match[3]), match[4] || ""];
+}
+
+function isCoreVersionAtLeast(version, minimum) {
+  const current = semverParts(version);
+  const floor = semverParts(minimum);
+  for (let index = 0; index < 3; index += 1) {
+    if (current[index] !== floor[index]) return current[index] > floor[index];
+  }
+  return true;
 }
 
 export function compareVersionsDesc(a, b) {
@@ -149,7 +159,13 @@ export function validateCatalog(catalog) {
         );
       }
     }
-    if (release.targetingVersion !== undefined) {
+    const targetingRequiredByVersion = isCoreVersionAtLeast(release.version, releaseTargetingRequiredFrom);
+    if (targetingRequiredByVersion) {
+      invariant(
+        release.targetingVersion === 1,
+        `${path}.targetingVersion must be 1 for v${releaseTargetingRequiredFrom} and newer`,
+      );
+    } else if (release.targetingVersion !== undefined) {
       invariant(release.targetingVersion === 1, `${path}.targetingVersion is invalid`);
     }
     const targetsRequired = release.targetingVersion === 1;

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { inferPullTargetHints } from "./generate-release-notes.mjs";
 import { loadCatalog, releaseForVersion, renderGitHubRelease, validateCatalog } from "./release-notes.mjs";
 import { validateReleaseEvent } from "./release-event.mjs";
 
@@ -26,6 +27,71 @@ test("GitHub rendering keeps product sections and source PR links", async () => 
   assert.match(markdown, /## 致谢/);
   assert.match(markdown, /\/pull\/6460/);
   assert.match(markdown, /reasonix\.io\/changelog\/v1\.17\.13/);
+});
+
+test("targeted releases render Desktop and CLI sections from one shared item", async () => {
+  const catalog = await loadCatalog();
+  const markdown = renderGitHubRelease(releaseForVersion(catalog, "1.31.4"), "zh");
+  assert.match(markdown, /## 桌面端更新/);
+  assert.match(markdown, /## CLI 端更新/);
+  assert.match(markdown, /## 其他项目更新/);
+  assert.match(markdown, /\*\*\[Service\]\*\* \*\*降低数据库读取成本\*\*/);
+  assert.equal(markdown.match(/更好的数学渲染/g)?.length, 2);
+});
+
+test("targeted release validation requires canonical item targets and matching surfaces", () => {
+  const release = {
+    version: "2.0.0",
+    targetingVersion: 1,
+    date: "2026-01-01",
+    channel: "stable",
+    title: { en: "Targeted", zh: "分类版本" },
+    summary: { en: "Summary", zh: "摘要" },
+    surfaces: ["desktop", "cli"],
+    guides: [],
+    highlights: [{
+      kind: "fixed",
+      targets: ["desktop", "cli"],
+      title: { en: "Shared fix", zh: "共享修复" },
+      body: { en: "A shared fix.", zh: "一项共享修复。" },
+      refs: [1],
+    }],
+    changes: { new: [], improved: [], fixed: [] },
+    upgrade: [],
+    risks: [],
+    contributors: [],
+    links: {
+      github: "https://example.com/release",
+      compare: "https://example.com/compare",
+      download: "https://example.com/download",
+    },
+  };
+  assert.doesNotThrow(() => validateCatalog({ schemaVersion: 1, releases: [release] }));
+  assert.throws(
+    () => validateCatalog({
+      schemaVersion: 1,
+      releases: [{ ...release, highlights: [{ ...release.highlights[0], targets: undefined }] }],
+    }),
+    /targets must be a non-empty array/,
+  );
+  assert.throws(
+    () => validateCatalog({ schemaVersion: 1, releases: [{ ...release, surfaces: ["desktop"] }] }),
+    /surfaces must equal the canonical union/,
+  );
+  assert.throws(
+    () => validateCatalog({
+      schemaVersion: 1,
+      releases: [{ ...release, highlights: [{ ...release.highlights[0], targets: ["cli", "desktop"] }] }],
+    }),
+    /targets must use canonical order/,
+  );
+});
+
+test("release target hints prefer explicit product labels and identify shared or service paths", () => {
+  assert.deepEqual(inferPullTargetHints(["desktop"], ["internal/sessioncatalog/catalog.go"]), ["desktop"]);
+  assert.deepEqual(inferPullTargetHints(["desktop", "tui"], ["desktop/app.go", "internal/cli/cli.go"]), ["desktop", "cli"]);
+  assert.deepEqual(inferPullTargetHints([], ["internal/agent/agent.go"]), ["desktop", "cli"]);
+  assert.deepEqual(inferPullTargetHints([], ["workers/crash-report/src/index.ts"]), ["service"]);
 });
 
 test("validation rejects bilingual drift", () => {

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -87,6 +87,41 @@ test("targeted release validation requires canonical item targets and matching s
   );
 });
 
+test("targeting adoption boundary preserves historical releases and rejects future legacy records", () => {
+  const release = {
+    version: "1.31.3",
+    date: "2026-01-01",
+    channel: "stable",
+    title: { en: "Legacy", zh: "旧版" },
+    summary: { en: "Summary", zh: "摘要" },
+    surfaces: ["desktop"],
+    guides: [],
+    highlights: [{
+      kind: "fixed",
+      title: { en: "Legacy fix", zh: "旧版修复" },
+      body: { en: "A historical fix.", zh: "一项历史修复。" },
+      refs: [1],
+    }],
+    changes: { new: [], improved: [], fixed: [] },
+    upgrade: [],
+    risks: [],
+    contributors: [],
+    links: {
+      github: "https://example.com/release",
+      compare: "https://example.com/compare",
+      download: "https://example.com/download",
+    },
+  };
+
+  assert.doesNotThrow(() => validateCatalog({ schemaVersion: 1, releases: [release] }));
+  for (const version of ["1.31.4", "1.32.0", "2.0.0-preview.1"]) {
+    assert.throws(
+      () => validateCatalog({ schemaVersion: 1, releases: [{ ...release, version }] }),
+      /targetingVersion must be 1 for v1\.31\.4 and newer/,
+    );
+  }
+});
+
 test("release target hints prefer explicit product labels and identify shared or service paths", () => {
   assert.deepEqual(inferPullTargetHints(["desktop"], ["internal/sessioncatalog/catalog.go"]), ["desktop"]);
   assert.deepEqual(inferPullTargetHints(["desktop", "tui"], ["desktop/app.go", "internal/cli/cli.go"]), ["desktop", "cli"]);

--- a/site/src/components/ChangelogPage.astro
+++ b/site/src/components/ChangelogPage.astro
@@ -1,8 +1,8 @@
 ---
 import Base from '../layouts/Base.astro';
 import SiteHeader from './SiteHeader.astro';
-import type { ReleaseItem, ReleaseRecord } from '../data/releases';
-import { releasePath } from '../data/releases';
+import type { ReleaseItem, ReleaseRecord, ReleaseTarget } from '../data/releases';
+import { releasePath, releaseTargetCount } from '../data/releases';
 import '../styles/changelog.css';
 
 const { release, releases, canonical } = Astro.props as {
@@ -33,15 +33,44 @@ const surfaceLabel = (surface: string) => ({
   security: { en: 'Security', zh: '安全' },
   provider: { en: 'Provider', zh: '模型服务' },
   plugin: { en: 'Plugins', zh: '插件' },
+  site: { en: 'Site', zh: '网站' },
+  service: { en: 'Service', zh: '服务端' },
 }[surface] ?? { en: surface, zh: surface });
+
+const targetingEnabled = release.targetingVersion === 1;
+const changeKinds = ['new', 'improved', 'fixed'] as const;
+const clientTargets: { id: ReleaseTarget; en: string; zh: string }[] = [
+  { id: 'desktop', en: 'Desktop updates', zh: '桌面端更新' },
+  { id: 'cli', en: 'CLI updates', zh: 'CLI 端更新' },
+];
+const hasTarget = (item: ReleaseItem, target: ReleaseTarget) => item.targets?.includes(target) ?? false;
+const clientHighlights = (target: ReleaseTarget) => release.highlights.filter((item) => hasTarget(item, target));
+const clientChanges = (target: ReleaseTarget, kind: typeof changeKinds[number]) =>
+  release.changes[kind].filter((item) => hasTarget(item, target));
+const hasClientChangeContent = (target: ReleaseTarget) =>
+  clientHighlights(target).length > 0 || changeKinds.some((kind) => clientChanges(target, kind).length > 0);
+const isOtherOnly = (item: ReleaseItem) =>
+  Boolean(item.targets?.length) && !hasTarget(item, 'desktop') && !hasTarget(item, 'cli');
+const otherHighlights = release.highlights.filter(isOtherOnly);
+const otherChanges = Object.fromEntries(
+  changeKinds.map((kind) => [kind, release.changes[kind].filter(isOtherOnly)]),
+) as Record<typeof changeKinds[number], ReleaseItem[]>;
+const hasOtherChanges = otherHighlights.length > 0 || changeKinds.some((kind) => otherChanges[kind].length > 0);
 
 /* Sections render only when they have content; numbering is sequential. */
 const sectionDefs = [
   ...(release.guides.length ? [{ id: 'guides', en: 'Guides', zh: '使用攻略' }] : []),
-  { id: 'highlights', en: 'Highlights', zh: '重点内容' },
-  ...(['new', 'improved', 'fixed'] as const)
-    .filter((kind) => release.changes[kind].length)
-    .map((kind) => ({ id: kind, ...kindLabel(kind) })),
+  ...(targetingEnabled
+    ? [
+        ...clientTargets,
+        ...(hasOtherChanges ? [{ id: 'other', en: 'Other project updates', zh: '其他项目更新' }] : []),
+      ]
+    : [
+        { id: 'highlights', en: 'Highlights', zh: '重点内容' },
+        ...changeKinds
+          .filter((kind) => release.changes[kind].length)
+          .map((kind) => ({ id: kind, ...kindLabel(kind) })),
+      ]),
   ...(release.upgrade.length ? [{ id: 'upgrade', en: 'Upgrade notes', zh: '升级提醒' }] : []),
   ...(release.risks.length ? [{ id: 'risks', en: 'Risk notes', zh: '风险提示' }] : []),
   ...(release.contributors.length ? [{ id: 'thanks', en: 'Thanks', zh: '致谢' }] : []),
@@ -136,6 +165,12 @@ const description = release.summary.en;
               <span><strong>npm</strong> {release.builds.npm}</span>
             </div>
           )}
+          {targetingEnabled && (
+            <div class="release-target-summary" aria-label="Updates by product">
+              <span><strong>Desktop</strong> {releaseTargetCount(release, 'desktop')}</span>
+              <span><strong>CLI</strong> {releaseTargetCount(release, 'cli')}</span>
+            </div>
+          )}
           <p class="release-lede"><span class="l-en">{release.summary.en}</span><span class="l-zh">{release.summary.zh}</span></p>
         </header>
 
@@ -154,45 +189,147 @@ const description = release.summary.en;
           </section>
         )}
 
-        <section id="highlights" class="release-section">
-          <div class="release-section__head"><span>{sectionNum.get('highlights')}</span><h2><span class="l-en">Highlights</span><span class="l-zh">重点内容</span></h2></div>
-          <div class="release-highlight-list">
-            {release.highlights.map((item, index) => {
-              const kind = kindLabel(item.kind);
+        {targetingEnabled ? (
+          <>
+            {clientTargets.map((target) => {
+              const highlights = clientHighlights(target.id);
+              const total = releaseTargetCount(release, target.id);
               return (
-                <article class="release-highlight" data-kind={item.kind}>
-                  <div class="release-highlight__index">{String(index + 1).padStart(2, '0')}</div>
-                  <div>
-                    <div class="release-highlight__kind"><span class="l-en">{kind.en}</span><span class="l-zh">{kind.zh}</span></div>
-                    <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
-                    <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
-                    {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}
-                  </div>
-                </article>
+                <section id={target.id} class="release-section release-target-section" data-target={target.id}>
+                  <div class="release-section__head"><span>{sectionNum.get(target.id)}</span><h2><span class="l-en">{target.en}</span><span class="l-zh">{target.zh}</span></h2></div>
+                  <p class="release-target-section__summary">
+                    <span class="l-en">{total} update{total === 1 ? '' : 's'} relevant to {target.id === 'desktop' ? 'Desktop' : 'CLI'}.</span>
+                    <span class="l-zh">与{target.id === 'desktop' ? '桌面端' : ' CLI'}相关的更新共 {total} 项。</span>
+                  </p>
+
+                  {highlights.length > 0 && (
+                    <div class="release-target-group">
+                      <h3 class="release-target-group__title"><span class="l-en">Highlights</span><span class="l-zh">重点内容</span></h3>
+                      <div class="release-highlight-list">
+                        {highlights.map((item, index) => {
+                          const kind = kindLabel(item.kind);
+                          return (
+                            <article class="release-highlight" data-kind={item.kind}>
+                              <div class="release-highlight__index">{String(index + 1).padStart(2, '0')}</div>
+                              <div>
+                                <div class="release-item-meta">
+                                  <div class="release-highlight__kind"><span class="l-en">{kind.en}</span><span class="l-zh">{kind.zh}</span></div>
+                                  <div class="release-item-targets">{item.targets?.map((itemTarget) => {
+                                    const label = surfaceLabel(itemTarget);
+                                    return <span><span class="l-en">{label.en}</span><span class="l-zh">{label.zh}</span></span>;
+                                  })}</div>
+                                </div>
+                                <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
+                                <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
+                                {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}
+                              </div>
+                            </article>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+
+                  {changeKinds.map((kind) => {
+                    const items = clientChanges(target.id, kind);
+                    if (!items.length) return null;
+                    const label = kindLabel(kind);
+                    return (
+                      <div class="release-target-group">
+                        <h3 class="release-target-group__title"><span class="l-en">{label.en}</span><span class="l-zh">{label.zh}</span></h3>
+                        <div class="release-change-list">
+                          {items.map((item: ReleaseItem) => (
+                            <article>
+                              <div class="release-item-targets">{item.targets?.map((itemTarget) => {
+                                const targetLabel = surfaceLabel(itemTarget);
+                                return <span><span class="l-en">{targetLabel.en}</span><span class="l-zh">{targetLabel.zh}</span></span>;
+                              })}</div>
+                              <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
+                              <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
+                              {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}
+                            </article>
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  })}
+
+                  {!hasClientChangeContent(target.id) && (
+                    <div class="release-target-empty">
+                      {target.id === 'cli' && total === 0 ? (
+                        <><strong><span class="l-en">No CLI changes in this release.</span><span class="l-zh">本版本没有 CLI 相关改动。</span></strong><p><span class="l-en">CLI users may skip this version if preferred.</span><span class="l-zh">CLI 用户可按需跳过这个版本。</span></p></>
+                      ) : (
+                        <><strong><span class="l-en">No feature or fix entries in this section.</span><span class="l-zh">此板块没有功能或修复条目。</span></strong><p><span class="l-en">See the upgrade and risk notes below for relevant guidance.</span><span class="l-zh">相关说明请查看下方升级提醒和风险提示。</span></p></>
+                      )}
+                    </div>
+                  )}
+                </section>
               );
             })}
-          </div>
-        </section>
 
-        {(['new', 'improved', 'fixed'] as const).map((kind) => {
-          const items = release.changes[kind];
-          if (!items.length) return null;
-          const label = kindLabel(kind);
-          return (
-            <section id={kind} class="release-section release-change-section">
-              <div class="release-section__head"><span>{sectionNum.get(kind)}</span><h2><span class="l-en">{label.en}</span><span class="l-zh">{label.zh}</span></h2></div>
-              <div class="release-change-list">
-                {items.map((item: ReleaseItem) => (
-                  <article>
-                    <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
-                    <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
-                    {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}
-                  </article>
-                ))}
+            {hasOtherChanges && (
+              <section id="other" class="release-section release-target-section" data-target="other">
+                <div class="release-section__head"><span>{sectionNum.get('other')}</span><h2><span class="l-en">Other project updates</span><span class="l-zh">其他项目更新</span></h2></div>
+                <p class="release-target-section__summary"><span class="l-en">Website and service changes that do not require a Desktop or CLI update.</span><span class="l-zh">不要求更新桌面端或 CLI 的网站与服务端变更。</span></p>
+                <div class="release-change-list">
+                  {[...otherHighlights, ...changeKinds.flatMap((kind) => otherChanges[kind])].map((item) => (
+                    <article>
+                      <div class="release-item-targets">{item.targets?.map((itemTarget) => {
+                        const label = surfaceLabel(itemTarget);
+                        return <span><span class="l-en">{label.en}</span><span class="l-zh">{label.zh}</span></span>;
+                      })}</div>
+                      <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
+                      <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
+                      {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}
+                    </article>
+                  ))}
+                </div>
+              </section>
+            )}
+          </>
+        ) : (
+          <>
+            <section id="highlights" class="release-section">
+              <div class="release-section__head"><span>{sectionNum.get('highlights')}</span><h2><span class="l-en">Highlights</span><span class="l-zh">重点内容</span></h2></div>
+              <div class="release-highlight-list">
+                {release.highlights.map((item, index) => {
+                  const kind = kindLabel(item.kind);
+                  return (
+                    <article class="release-highlight" data-kind={item.kind}>
+                      <div class="release-highlight__index">{String(index + 1).padStart(2, '0')}</div>
+                      <div>
+                        <div class="release-highlight__kind"><span class="l-en">{kind.en}</span><span class="l-zh">{kind.zh}</span></div>
+                        <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
+                        <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
+                        {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}
+                      </div>
+                    </article>
+                  );
+                })}
               </div>
             </section>
-          );
-        })}
+
+            {changeKinds.map((kind) => {
+              const items = release.changes[kind];
+              if (!items.length) return null;
+              const label = kindLabel(kind);
+              return (
+                <section id={kind} class="release-section release-change-section">
+                  <div class="release-section__head"><span>{sectionNum.get(kind)}</span><h2><span class="l-en">{label.en}</span><span class="l-zh">{label.zh}</span></h2></div>
+                  <div class="release-change-list">
+                    {items.map((item: ReleaseItem) => (
+                      <article>
+                        <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
+                        <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
+                        {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+          </>
+        )}
 
         {release.upgrade.length > 0 && (
           <section id="upgrade" class="release-section">
@@ -202,6 +339,10 @@ const description = release.summary.en;
                 <article class:list={["release-notice", `release-notice--${item.level}`]}>
                   <div class="release-notice__icon">{item.level === 'warning' ? '!' : 'i'}</div>
                   <div>
+                    {item.targets?.length && <div class="release-item-targets">{item.targets.map((itemTarget) => {
+                      const label = surfaceLabel(itemTarget);
+                      return <span><span class="l-en">{label.en}</span><span class="l-zh">{label.zh}</span></span>;
+                    })}</div>}
                     <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
                     <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
                     {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}
@@ -218,6 +359,10 @@ const description = release.summary.en;
             <div class="release-change-list">
               {release.risks.map((item) => (
                 <article>
+                  {item.targets?.length && <div class="release-item-targets">{item.targets.map((itemTarget) => {
+                    const label = surfaceLabel(itemTarget);
+                    return <span><span class="l-en">{label.en}</span><span class="l-zh">{label.zh}</span></span>;
+                  })}</div>}
                   <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
                   <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
                   {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}

--- a/site/src/data/releases.ts
+++ b/site/src/data/releases.ts
@@ -3,11 +3,13 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 export type LocalizedText = { en: string; zh: string };
+export type ReleaseTarget = 'desktop' | 'cli' | 'site' | 'service';
 
 export type ReleaseItem = {
   title: LocalizedText;
   body: LocalizedText;
   refs?: number[];
+  targets?: ReleaseTarget[];
 };
 
 export type ReleaseHighlight = ReleaseItem & {
@@ -19,6 +21,7 @@ export type ReleaseUpgrade = ReleaseItem & { level: 'info' | 'warning' };
 
 export type ReleaseRecord = {
   version: string;
+  targetingVersion?: 1;
   releaseId?: string;
   baseVersion?: string;
   date: string;
@@ -67,4 +70,19 @@ export const latestRelease = latestStableRelease;
 
 export function releasePath(version: string): string {
   return `/changelog/v${version}/`;
+}
+
+export function releaseContentItems(release: ReleaseRecord): ReleaseItem[] {
+  return [
+    ...release.highlights,
+    ...release.changes.new,
+    ...release.changes.improved,
+    ...release.changes.fixed,
+    ...release.upgrade,
+    ...release.risks,
+  ];
+}
+
+export function releaseTargetCount(release: ReleaseRecord, target: ReleaseTarget): number {
+  return releaseContentItems(release).filter((item) => item.targets?.includes(target)).length;
 }

--- a/site/src/scripts/changelog-style-contract.test.mjs
+++ b/site/src/scripts/changelog-style-contract.test.mjs
@@ -20,6 +20,17 @@ test("every release uses the version-ledger hero", () => {
   assert.doesNotMatch(css, /\.release-hero--compact|\.release-hero__actions|\.release-hero blockquote/);
 });
 
+test("targeted releases split Desktop and CLI updates without removing legacy sections", () => {
+  assert.match(component, /release\.targetingVersion === 1/);
+  assert.match(component, /id=\{target\.id\}/);
+  assert.match(component, /Desktop updates/);
+  assert.match(component, /CLI updates/);
+  assert.match(component, /CLI users may skip this version if preferred/);
+  assert.match(component, /<section id="highlights"/);
+  assert.match(css, /\.release-target-section__summary/);
+  assert.match(css, /\.release-item-targets/);
+});
+
 test("changelog has one official navigation and marks archives noindex", () => {
   assert.doesNotMatch(component, /release-channel-tabs/);
   assert.match(component, /Historical archive/);

--- a/site/src/styles/changelog.css
+++ b/site/src/styles/changelog.css
@@ -204,6 +204,24 @@ body {
   font-weight: 600;
 }
 
+.release-target-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+.release-target-summary > span {
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: color-mix(in oklch, var(--card) 64%, transparent);
+  color: var(--ink-2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+.release-target-summary strong { color: var(--release-ink); }
+.release-target-summary + .release-lede { margin-top: 20px; }
+
 .release-lede { margin: 28px 0 0; max-width: 720px; color: var(--ink-2); font-size: 16.5px; line-height: 1.75; }
 
 .release-section { padding: 52px 62px 0; scroll-margin-top: 100px; }
@@ -223,6 +241,38 @@ body {
 .release-section h2 { color: var(--release-ink); font-size: 27px; font-weight: 650; letter-spacing: -.02em; }
 .release-section h3 { color: var(--release-ink); font-size: 17px; font-weight: 650; line-height: 1.35; }
 .release-section p { color: var(--ink-2); font-size: 15px; line-height: 1.68; }
+
+.release-target-section__summary { margin: -10px 0 24px; max-width: 700px; }
+.release-target-group + .release-target-group { margin-top: 30px; }
+.release-target-group__title {
+  margin-bottom: 13px;
+  color: var(--ink-3) !important;
+  font-size: 11px !important;
+  font-weight: 800 !important;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.release-target-empty {
+  padding: 22px 24px;
+  border: 1px dashed color-mix(in srgb, var(--release-blue) 26%, var(--line));
+  border-radius: 13px;
+  background: color-mix(in oklch, var(--card) 56%, transparent);
+}
+.release-target-empty strong { color: var(--release-ink); font-size: 15px; }
+.release-target-empty p { margin-top: 6px; font-size: 13.5px; }
+.release-item-meta { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.release-item-targets { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 9px; }
+.release-item-meta .release-item-targets { justify-content: flex-end; margin-bottom: 7px; }
+.release-item-targets > span {
+  padding: 3px 7px;
+  border: 1px solid color-mix(in srgb, var(--release-blue) 18%, var(--line));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--release-blue-soft) 52%, transparent);
+  color: var(--release-blue);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+}
 
 .release-guide-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
 .release-guide {
@@ -383,6 +433,8 @@ body {
   .release-hero h1 { font-size: 34px; }
   .release-highlight { grid-template-columns: 1fr; gap: 8px; padding: 20px; }
   .release-highlight__index { display: none; }
+  .release-item-meta { align-items: flex-start; flex-direction: column; gap: 0; }
+  .release-item-meta .release-item-targets { justify-content: flex-start; }
   .release-section h2 { font-size: 23px; }
   .release-download__actions { align-items: flex-start; flex-direction: column; }
   .release-footer { width: calc(100% - 32px); flex-wrap: wrap; }


### PR DESCRIPTION
## Summary

- Add versioned per-item release targets for Desktop, CLI, site, and service updates.
- Split GitHub release notes, reasonix.io changelog pages, and built-in product docs into Desktop and CLI sections.
- Infer deterministic target hints from pull request labels and changed files, then validate the canonical target union.
- Require targetingVersion 1 for v1.31.4 and newer while preserving the legacy layout for historical releases.

## User impact

CLI users can see whether a release contains CLI-relevant changes before upgrading. Desktop-only releases now say that the CLI version may be skipped, while shared fixes remain visible in both client sections. Website and hosted-service-only work is listed separately without implying a client update.

## Compatibility

- Releases before v1.31.4 remain valid and continue using the legacy Highlights, New, Improved, and Fixed layout.
- v1.31.4 and newer records must include complete target metadata.
- Existing readers can ignore the additive JSON fields.
- No prompt, tool schema, provider serialization, or cache-stable prefix changes.

## Security and performance

- No dependencies, privileges, secrets, startup hooks, or runtime command execution were added.
- The generator reuses authenticated public GitHub metadata and bounds displayed file paths to 200 per pull request.
- The change runs only during release-note generation, validation, static rendering, or built-in document rendering; it adds no user-visible runtime lock, goroutine, or hot-path work.
- A live DeepSeek generation call was not required or run; deterministic target inference, schema validation, and renderer behavior are covered by tests.

## Verification

- node scripts/release-notes.mjs validate
- node --test scripts/release-notes.test.mjs: 10 passed
- go test ./...
- cd site and npm test: 59 passed
- cd site and npm run build: 69 pages built
- bash scripts/release-workflows.test.sh
- node scripts/check-single-release-public-contract.mjs
- go run ./tools/repolint
- actionlint for the release-note workflows
- Browser checks at 1440 px and 390 px: Desktop, CLI, and Other sections render without horizontal overflow

Closes #9394

Documentation-impact: none - release-note presentation is implemented directly in the changelog and built-in release document renderers; no separate docs page or command contract changed.