### PR TITLE
Migrate crash storage to Firebase Spark / 将崩溃存储迁移到 Firebase Spark

### DIFF
--- a/.github/workflows/deploy-crash-worker.yml
+++ b/.github/workflows/deploy-crash-worker.yml
@@ -36,6 +36,28 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: npm run migrate:diagnostics-v2
+      - name: Apply and verify Firebase crash D1 migration
+        working-directory: workers/crash-report
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npm run migrate:firebase-crash
+      - name: Sync Firebase crash secrets
+        working-directory: workers/crash-report
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL }}
+          FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+        run: |
+          configured=0
+          [ -n "$FIREBASE_DATABASE_URL" ] && configured=$((configured + 1))
+          [ -n "$FIREBASE_CLIENT_EMAIL" ] && configured=$((configured + 1))
+          [ -n "$FIREBASE_PRIVATE_KEY" ] && configured=$((configured + 1))
+          if [ "$configured" -ne 0 ] && [ "$configured" -ne 3 ]; then
+            echo "Firebase crash secrets must be either all configured or all absent."
+            exit 1
+          fi
+          node -e 'process.stdout.write(JSON.stringify({FIREBASE_DATABASE_URL:process.env.FIREBASE_DATABASE_URL||null,FIREBASE_CLIENT_EMAIL:process.env.FIREBASE_CLIENT_EMAIL||null,FIREBASE_PRIVATE_KEY:process.env.FIREBASE_PRIVATE_KEY||null}))' | npx wrangler secret bulk
       - name: Deploy
         working-directory: workers/crash-report
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ mem.prof
 .env
 .env.local
 *.local
+**/.firebase-crash-migration-state.json
+**/.firebase-crash-migration-state.json.tmp-*
 /reasonix.toml
 /desktop/.env
 /desktop/reasonix.toml

--- a/desktop/crash_app.go
+++ b/desktop/crash_app.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -62,6 +65,8 @@ type crashBreadcrumb struct {
 }
 
 type crashReport struct {
+	EventID         string                `json:"eventId,omitempty"`
+	DedupKey        string                `json:"dedupKey,omitempty"`
 	InstallID       string                `json:"installId,omitempty"`
 	Kind            string                `json:"kind"`
 	Version         string                `json:"version"`
@@ -159,6 +164,37 @@ func baseCrashReport(kind string) crashReport {
 		Device:  collectDeviceInfo(),
 		Channel: channel,
 	}
+}
+
+func ensureCrashIdentity(report *crashReport) error {
+	if report.EventID == "" {
+		value := make([]byte, 16)
+		if _, err := rand.Read(value); err != nil {
+			return fmt.Errorf("generate crash event id: %w", err)
+		}
+		report.EventID = hex.EncodeToString(value)
+	}
+	if report.DedupKey == "" {
+		basis := strings.Join([]string{
+			report.Kind,
+			report.Version,
+			report.Source,
+			report.Label,
+			report.ErrorType,
+			normalizeCrashFingerprintField(report.ErrorMessage),
+			normalizeCrashFingerprintField(report.TopFrame),
+			normalizeCrashFingerprintField(report.FingerprintHint),
+		}, "\n")
+		sum := sha256.Sum256([]byte(basis))
+		report.DedupKey = hex.EncodeToString(sum[:])
+	}
+	return nil
+}
+
+var crashFingerprintNumber = regexp.MustCompile(`\b\d+\b`)
+
+func normalizeCrashFingerprintField(value string) string {
+	return crashFingerprintNumber.ReplaceAllString(strings.ToLower(strings.TrimSpace(value)), "<n>")
 }
 
 func topFrameFromStack(stack string) string {
@@ -259,6 +295,9 @@ func (a *App) ReportCrash(kind, detail string) error {
 	}
 	c, err := httpClient()
 	if err != nil {
+		return err
+	}
+	if err := ensureCrashIdentity(&r); err != nil {
 		return err
 	}
 	return postCrashReport(a.reqCtx(), c, crashEndpoint, r)

--- a/desktop/crash_pending.go
+++ b/desktop/crash_pending.go
@@ -28,7 +28,7 @@ const (
 	pendingCrashFile     = "crash-pending.json" // legacy single-report path
 	pendingCrashQueueDir = "crash-pending"
 	maxPendingCrashes    = 10
-	currentCrashSchema   = 2
+	currentCrashSchema   = 3
 	crashLedgerFile      = "crash-upload-ledger-v1.json"
 	maxCrashLedger       = 512
 	crashLedgerRetention = 180 * 24 * time.Hour
@@ -105,12 +105,31 @@ func writePendingReport(report crashReport, overwrite bool) bool {
 		_ = os.Remove(path)
 		return false
 	}
+	return prunePendingCrashQueue(path)
+}
+
+func prunePendingCrashQueue(writtenPath string) bool {
 	paths := pendingCrashQueuePaths()
 	for len(paths) > maxPendingCrashes {
-		_ = os.Remove(paths[0])
-		paths = paths[1:]
+		victim := -1
+		for index, candidate := range paths {
+			body, err := os.ReadFile(candidate)
+			var header struct {
+				SchemaVersion int `json:"schemaVersion"`
+			}
+			if err != nil || json.Unmarshal(body, &header) != nil || header.SchemaVersion <= currentCrashSchema {
+				victim = index
+				break
+			}
+		}
+		if victim < 0 {
+			break
+		}
+		_ = os.Remove(paths[victim])
+		paths = append(paths[:victim], paths[victim+1:]...)
 	}
-	return true
+	_, err := os.Stat(writtenPath)
+	return err == nil
 }
 
 type crashUploadLedger struct {

--- a/desktop/crash_pending.go
+++ b/desktop/crash_pending.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -13,6 +14,8 @@ import (
 	"time"
 
 	"reasonix/internal/config"
+	"reasonix/internal/filelock"
+	"reasonix/internal/fileutil"
 )
 
 // crash_pending.go captures Go-side panics to disk and ships them on the next
@@ -25,6 +28,10 @@ const (
 	pendingCrashFile     = "crash-pending.json" // legacy single-report path
 	pendingCrashQueueDir = "crash-pending"
 	maxPendingCrashes    = 10
+	currentCrashSchema   = 2
+	crashLedgerFile      = "crash-upload-ledger-v1.json"
+	maxCrashLedger       = 512
+	crashLedgerRetention = 180 * 24 * time.Hour
 )
 
 var (
@@ -71,6 +78,9 @@ func writePendingCrash(site string, r any, stack []byte) {
 
 func writePendingReport(report crashReport, overwrite bool) bool {
 	_ = overwrite // retained for source compatibility; the queue never overwrites.
+	if ensureCrashIdentity(&report) != nil {
+		return false
+	}
 	body, err := json.Marshal(report)
 	if err != nil {
 		return false
@@ -103,6 +113,57 @@ func writePendingReport(report crashReport, overwrite bool) bool {
 	return true
 }
 
+type crashUploadLedger struct {
+	Version int               `json:"version"`
+	Entries map[string]string `json:"entries"`
+}
+
+func crashLedgerPath() string {
+	return filepath.Join(config.MemoryUserDir(), "diagnostics", crashLedgerFile)
+}
+
+func crashLedgerKey(report crashReport) string {
+	return report.Version + ":" + report.DedupKey
+}
+
+func loadCrashLedger(path string, now time.Time) crashUploadLedger {
+	ledger := crashUploadLedger{Version: 1, Entries: map[string]string{}}
+	body, err := os.ReadFile(path)
+	if err != nil || json.Unmarshal(body, &ledger) != nil || ledger.Version != 1 || ledger.Entries == nil {
+		return crashUploadLedger{Version: 1, Entries: map[string]string{}}
+	}
+	cutoff := now.Add(-crashLedgerRetention)
+	for key, value := range ledger.Entries {
+		at, err := time.Parse(time.RFC3339Nano, value)
+		if err != nil || at.Before(cutoff) {
+			delete(ledger.Entries, key)
+		}
+	}
+	return ledger
+}
+
+func saveCrashLedger(path string, ledger crashUploadLedger) error {
+	if len(ledger.Entries) > maxCrashLedger {
+		type row struct{ key, at string }
+		rows := make([]row, 0, len(ledger.Entries))
+		for key, at := range ledger.Entries {
+			rows = append(rows, row{key: key, at: at})
+		}
+		sort.Slice(rows, func(i, j int) bool { return rows[i].at > rows[j].at })
+		for _, item := range rows[maxCrashLedger:] {
+			delete(ledger.Entries, item.key)
+		}
+	}
+	body, err := json.Marshal(ledger)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return fileutil.AtomicWriteFile(path, body, 0o600)
+}
+
 func pendingCrashQueuePaths() []string {
 	entries, err := os.ReadDir(pendingCrashDir())
 	if err != nil {
@@ -130,6 +191,8 @@ func removeAllPendingCrashes() {
 	_ = os.Remove(pendingCrashPath())
 	_ = os.RemoveAll(pendingCrashDir())
 	_ = os.Remove(fatalCrashCoveredPath())
+	_ = os.Remove(crashLedgerPath())
+	_ = os.Remove(crashLedgerPath() + ".lock")
 }
 
 func (a *App) goSafe(site string, fn func()) {
@@ -162,6 +225,18 @@ func (a *App) flushPendingCrash() {
 	if err != nil {
 		return
 	}
+	lockContext, cancel := context.WithTimeout(a.bootContext(), 3*time.Second)
+	defer cancel()
+	ledgerPath := crashLedgerPath()
+	if os.MkdirAll(filepath.Dir(ledgerPath), 0o700) != nil {
+		return
+	}
+	release, err := filelock.AcquireWithExternalTimeout(lockContext, ledgerPath+".lock", 2*time.Second)
+	if err != nil {
+		return
+	}
+	defer release()
+	ledger := loadCrashLedger(ledgerPath, time.Now().UTC())
 	for _, path := range paths {
 		body, readErr := readFileUTF8(path)
 		if readErr != nil {
@@ -172,7 +247,29 @@ func (a *App) flushPendingCrash() {
 			_ = os.Remove(path)
 			continue
 		}
+		if r.SchemaVersion > currentCrashSchema {
+			continue
+		}
+		identityChanged := r.EventID == "" || r.DedupKey == ""
+		if ensureCrashIdentity(&r) != nil {
+			break
+		}
+		if identityChanged {
+			updated, marshalErr := json.Marshal(r)
+			if marshalErr != nil || fileutil.AtomicWriteFile(path, updated, 0o600) != nil {
+				break
+			}
+		}
+		key := crashLedgerKey(r)
+		if _, alreadySent := ledger.Entries[key]; alreadySent {
+			_ = os.Remove(path)
+			continue
+		}
 		if postCrashReport(a.bootContext(), c, crashEndpoint, r) != nil {
+			break
+		}
+		ledger.Entries[key] = time.Now().UTC().Format(time.RFC3339Nano)
+		if saveCrashLedger(ledgerPath, ledger) != nil {
 			break
 		}
 		_ = os.Remove(path)

--- a/desktop/crash_pending_test.go
+++ b/desktop/crash_pending_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -270,7 +271,9 @@ func TestFlushPendingCrashDeduplicatesSameVersionAndResendsAfterUpgrade(t *testi
 	report.ErrorType = "panic"
 	report.TopFrame = "main.go:12"
 	report.Message = "same crash"
-	if !writePendingReport(report, false) || !writePendingReport(report, false) {
+	firstQueued := writePendingReport(report, false)
+	secondQueued := writePendingReport(report, false)
+	if !firstQueued || !secondQueued {
 		t.Fatal("failed to queue duplicate reports")
 	}
 	NewApp().flushPendingCrash()
@@ -316,12 +319,10 @@ func TestConcurrentFlushPendingCrashUsesOneCrossProcessLedgerOwner(t *testing.T)
 	start := make(chan struct{})
 	var done sync.WaitGroup
 	for range 2 {
-		done.Add(1)
-		go func() {
-			defer done.Done()
+		done.Go(func() {
 			<-start
 			NewApp().flushPendingCrash()
-		}()
+		})
 	}
 	close(start)
 	done.Wait()
@@ -407,5 +408,70 @@ func TestFlushPendingCrashBackfillsOldIdentityAndPreservesFutureSchema(t *testin
 	body, err := os.ReadFile(futurePath)
 	if err != nil || !bytes.Contains(body, []byte(`"futureField":"keep"`)) {
 		t.Fatalf("future schema was not preserved: body=%s err=%v", body, err)
+	}
+}
+
+func TestFlushPendingCrashUploadsCurrentSchemaThree(t *testing.T) {
+	removeAllPendingCrashes()
+	oldVersion, oldEndpoint := version, crashEndpoint
+	t.Cleanup(func() {
+		version, crashEndpoint = oldVersion, oldEndpoint
+		removeAllPendingCrashes()
+	})
+	version = "v9.9.9"
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	crashEndpoint = srv.URL
+
+	report := desktopLifecycleReport(desktopLifecycleObservation{
+		Version: "v9.9.8",
+		Phase:   "ready",
+	})
+	if report.SchemaVersion != currentCrashSchema {
+		t.Fatalf("current producer schema = %d, supported = %d", report.SchemaVersion, currentCrashSchema)
+	}
+	if !writePendingReport(report, false) {
+		t.Fatal("failed to queue current-schema report")
+	}
+	NewApp().flushPendingCrash()
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("current-schema uploads = %d, want 1", got)
+	}
+	if got := len(pendingCrashPaths()); got != 0 {
+		t.Fatalf("pending reports after upload = %d, want 0", got)
+	}
+}
+
+func TestWritePendingReportPrunesKnownReportsWithoutDeletingFutureSchema(t *testing.T) {
+	removeAllPendingCrashes()
+	t.Cleanup(removeAllPendingCrashes)
+	if err := os.MkdirAll(pendingCrashDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	futurePath := filepath.Join(pendingCrashDir(), "000-future.json")
+	futureReport := `{"schemaVersion":99,"futureField":"keep"}`
+	if err := os.WriteFile(futurePath, []byte(futureReport), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for index := range maxPendingCrashes {
+		report := baseCrashReport("crash")
+		report.SchemaVersion = currentCrashSchema
+		report.Source = "go"
+		report.Label = fmt.Sprintf("panic-%d", index)
+		report.Message = "bounded current report"
+		if !writePendingReport(report, false) {
+			t.Fatalf("failed to queue current report %d", index)
+		}
+	}
+	body, err := os.ReadFile(futurePath)
+	if err != nil || !bytes.Contains(body, []byte(`"futureField":"keep"`)) {
+		t.Fatalf("future schema was pruned: body=%s err=%v", body, err)
+	}
+	if got := len(pendingCrashQueuePaths()); got != maxPendingCrashes {
+		t.Fatalf("pending reports = %d, want bounded queue of %d", got, maxPendingCrashes)
 	}
 }

--- a/desktop/crash_pending_test.go
+++ b/desktop/crash_pending_test.go
@@ -6,10 +6,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func readPending(t *testing.T) (crashReport, bool) {
@@ -243,5 +246,166 @@ func TestPendingCrashDoesNotPersistInstallID(t *testing.T) {
 	}
 	if bytes.Contains(body, []byte("installId")) || bytes.Contains(body, []byte("install-id")) {
 		t.Fatalf("pending report persisted an installation identity: %s", body)
+	}
+}
+
+func TestFlushPendingCrashDeduplicatesSameVersionAndResendsAfterUpgrade(t *testing.T) {
+	removeAllPendingCrashes()
+	oldVersion, oldEndpoint := version, crashEndpoint
+	t.Cleanup(func() {
+		version, crashEndpoint = oldVersion, oldEndpoint
+		removeAllPendingCrashes()
+	})
+	version = "v9.9.9"
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	crashEndpoint = srv.URL
+
+	report := baseCrashReport("crash")
+	report.Source = "go"
+	report.ErrorType = "panic"
+	report.TopFrame = "main.go:12"
+	report.Message = "same crash"
+	if !writePendingReport(report, false) || !writePendingReport(report, false) {
+		t.Fatal("failed to queue duplicate reports")
+	}
+	NewApp().flushPendingCrash()
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("same-version uploads = %d, want 1", got)
+	}
+
+	report.Version = "v10.0.0"
+	report.EventID, report.DedupKey = "", ""
+	if !writePendingReport(report, false) {
+		t.Fatal("failed to queue upgraded report")
+	}
+	NewApp().flushPendingCrash()
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("uploads after version upgrade = %d, want 2", got)
+	}
+	info, err := os.Stat(crashLedgerPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("ledger permissions = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestConcurrentFlushPendingCrashUsesOneCrossProcessLedgerOwner(t *testing.T) {
+	removeAllPendingCrashes()
+	oldVersion, oldEndpoint := version, crashEndpoint
+	t.Cleanup(func() {
+		version, crashEndpoint = oldVersion, oldEndpoint
+		removeAllPendingCrashes()
+	})
+	version = "v9.9.9"
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	crashEndpoint = srv.URL
+	writePendingCrash("concurrent", "boom", []byte("stack"))
+
+	start := make(chan struct{})
+	var done sync.WaitGroup
+	for range 2 {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			<-start
+			NewApp().flushPendingCrash()
+		}()
+	}
+	close(start)
+	done.Wait()
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("concurrent uploads = %d, want 1", got)
+	}
+}
+
+func TestFlushPendingCrashFailureDoesNotRecordOrDelete(t *testing.T) {
+	removeAllPendingCrashes()
+	oldVersion, oldEndpoint := version, crashEndpoint
+	t.Cleanup(func() {
+		version, crashEndpoint = oldVersion, oldEndpoint
+		removeAllPendingCrashes()
+	})
+	version = "v9.9.9"
+	status := atomic.Int32{}
+	status.Store(http.StatusServiceUnavailable)
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(int(status.Load()))
+	}))
+	defer srv.Close()
+	crashEndpoint = srv.URL
+	writePendingCrash("retry", "boom", []byte("stack"))
+
+	NewApp().flushPendingCrash()
+	if _, ok := readPending(t); !ok {
+		t.Fatal("failed upload removed pending crash")
+	}
+	if ledger := loadCrashLedger(crashLedgerPath(), time.Now().UTC()); len(ledger.Entries) != 0 {
+		t.Fatalf("failed upload recorded ledger entry: %+v", ledger.Entries)
+	}
+	status.Store(http.StatusAccepted)
+	NewApp().flushPendingCrash()
+	if hits.Load() != 2 {
+		t.Fatalf("retry requests = %d, want 2", hits.Load())
+	}
+	if _, ok := readPending(t); ok {
+		t.Fatal("successful retry left pending crash")
+	}
+}
+
+func TestFlushPendingCrashBackfillsOldIdentityAndPreservesFutureSchema(t *testing.T) {
+	removeAllPendingCrashes()
+	oldVersion, oldEndpoint := version, crashEndpoint
+	t.Cleanup(func() {
+		version, crashEndpoint = oldVersion, oldEndpoint
+		removeAllPendingCrashes()
+	})
+	version = "v9.9.9"
+	if err := os.MkdirAll(pendingCrashDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldPath := filepath.Join(pendingCrashDir(), "001-old.json")
+	futurePath := filepath.Join(pendingCrashDir(), "002-future.json")
+	oldReport := `{"kind":"crash","version":"v9.9.9","os":"linux","arch":"amd64","message":"old","schemaVersion":2,"source":"go","errorType":"panic","topFrame":"main.go:12"}`
+	futureReport := `{"kind":"crash","version":"v10.0.0","os":"linux","arch":"amd64","message":"future","schemaVersion":99,"futureField":"keep"}`
+	if err := os.WriteFile(oldPath, []byte(oldReport), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(futurePath, []byte(futureReport), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var uploaded crashReport
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&uploaded); err != nil {
+			t.Error(err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	crashEndpoint = srv.URL
+
+	NewApp().flushPendingCrash()
+	if len(uploaded.EventID) != 32 || len(uploaded.DedupKey) != 64 {
+		t.Fatalf("old report identity not backfilled: %+v", uploaded)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("old report was not removed after send: %v", err)
+	}
+	body, err := os.ReadFile(futurePath)
+	if err != nil || !bytes.Contains(body, []byte(`"futureField":"keep"`)) {
+		t.Fatalf("future schema was not preserved: body=%s err=%v", body, err)
 	}
 }

--- a/desktop/tray_health_unix_test.go
+++ b/desktop/tray_health_unix_test.go
@@ -244,6 +244,7 @@ func TestConnectStatusNotifierSessionBusCancellationInterruptsAuth(t *testing.T)
 	})
 	t.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	resultCh := make(chan error, 1)
 	go func() {
 		connection, err := connectStatusNotifierSessionBus(ctx)
@@ -320,6 +321,7 @@ func TestConnectStatusNotifierSessionBusCancellationInterruptsHello(t *testing.T
 	})
 	t.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	resultCh := make(chan error, 1)
 	go func() {
 		connection, err := connectStatusNotifierSessionBus(ctx)

--- a/docs/DESKTOP_CRASH_DIAGNOSTICS_RUNBOOK.md
+++ b/docs/DESKTOP_CRASH_DIAGNOSTICS_RUNBOOK.md
@@ -23,16 +23,22 @@ itself resolve a crash issue.
 4. Back up D1 and inspect `PRAGMA table_info` before applying
    `workers/crash-report/migrate-diagnostics-v2.sql`. If draft diagnostics-v2
    columns already exist, stop and create an additive reconciliation migration.
-5. Apply `migrate-firebase-crash.sql`, then verify `firebase_crash_outbox`,
-   `firebase_crash_receipts`, `firebase_crash_group_leases`, and the delivery
-   indexes. The outbox is capped at 5,000 rows and 30 days; idempotency receipts
-   are retained for 90 days.
+5. Run `npm run migrate:firebase-crash`. It records a D1 Time Travel bookmark,
+   applies phase 1 (`migrate-firebase-crash.sql`) and phase 2
+   (`migrate-firebase-crash-capacity.sql`) in order, and fails closed on a
+   partially applied phase. Verify the outbox, receipts, compatibility lease
+   table, `firebase_crash_group_state`, and all delivery/lifecycle indexes. The
+   old lease table remains only for rolling-deployment compatibility.
 6. Verify `report_daily`, `report_installations`,
    `report_event_dimensions`, `diagnostics_meta`, their fingerprint/date
    indexes, and the ping window index. Confirm `installation_linked_since`.
-7. Run `npm run migrate:firebase-data` as a dry run, then rerun with `-- --apply`
-   using service-account environment variables. It imports each group's first
-   and latest five retained samples without logging report bodies or credentials.
+7. Run `npm run migrate:firebase-data` as a dry run. It uses 200-fingerprint
+   keyset pages and must report at most 700 MiB reserved. Then run
+   `npm run migrate:firebase-data -- --apply`; after convergence run
+   `npm run migrate:firebase-data -- --verify-only`. The default checkpoint is
+   `.firebase-crash-migration-state.json` (mode `0600`, gitignored); use
+   `--checkpoint=<path>` to relocate it and `--reset-checkpoint` only to restart
+   deliberately. Logs contain only counts, fingerprint prefixes, and digests.
 8. Deploy the Worker in `dual` mode first. Smoke-test old Report/Ping/Metrics payloads, a
    legacy `webview2` payload, and Windows/Linux `webRuntime` payloads using
    `channel=test`.
@@ -48,6 +54,27 @@ itself resolve a crash issue.
 12. Use the admin UI for the audited historical cleanup: ignore the synthetic
    `[go panic] safe` / `v9.9.9` group; resolve `72daba81` in
    `desktop-v1.19.3`; ignore the legacy `desktop.abnormal_exit` replay group.
+
+## Spark capacity, lifecycle, and rollback
+
+The Worker enforces a fixed 700 MiB reservation budget: active groups reserve
+640 KiB, compacted groups 128 KiB, archiving groups 32 KiB, and archived groups
+zero. At 80% the existing alert webhook and dashboard warn; a new group or
+expansion that would cross the budget returns `503` before creating an outbox
+row. Do not make the budget configurable.
+
+Only resolved/ignored groups are eligible. After 30 inactive days the latest
+five samples become fenced markers and the retained-cycle first sample remains.
+After 60 days all sample paths are tombstoned; 24 hours later the Firebase group
+is conditionally deleted. D1 counts, status, notes, aggregates, and audit remain.
+An archived fingerprint that reappears starts a new sample epoch without
+resetting lifetime count/first-seen. Admin deletion uses the same tombstone
+window while deleting its D1 group data atomically.
+
+Rollback is configuration-only: set `CRASH_STORAGE_MODE=d1` and redeploy. Do not
+delete the outbox, receipts, group state, or Firebase data during rollback. Fix
+the migration/capacity/ETag fault, rerun dry-run and `--verify-only`, then return
+to `dual`. No Desktop or CLI update is required.
 
 ## Privacy and compatibility smoke
 

--- a/docs/DESKTOP_CRASH_DIAGNOSTICS_RUNBOOK.md
+++ b/docs/DESKTOP_CRASH_DIAGNOSTICS_RUNBOOK.md
@@ -9,19 +9,43 @@ itself resolve a crash issue.
 
 ## Release order
 
-1. Freeze one candidate SHA. Do not move or recreate a published tag.
-2. Back up D1 and inspect `PRAGMA table_info` before applying
+1. Keep the Firebase project on Spark with no Cloud Billing account. Create
+   only a Realtime Database in `asia-southeast1`, deploy
+   `workers/crash-report/firebase/database.rules.json`, and confirm both client
+   reads and writes are denied. Do not enable Functions, Firestore, BigQuery,
+   Hosting, Storage, or Secret Manager.
+2. Configure the three repository secrets `FIREBASE_DATABASE_URL`,
+   `FIREBASE_CLIENT_EMAIL`, and `FIREBASE_PRIVATE_KEY`. The service account must
+   be dedicated to crash delivery and limited to Realtime Database. Never use
+   the Firebase Web configuration or ship Firebase SDK/configuration in a
+   Desktop artifact.
+3. Freeze one candidate SHA. Do not move or recreate a published tag.
+4. Back up D1 and inspect `PRAGMA table_info` before applying
    `workers/crash-report/migrate-diagnostics-v2.sql`. If draft diagnostics-v2
    columns already exist, stop and create an additive reconciliation migration.
-3. Verify `report_daily`, `report_installations`,
+5. Apply `migrate-firebase-crash.sql`, then verify `firebase_crash_outbox`,
+   `firebase_crash_receipts`, `firebase_crash_group_leases`, and the delivery
+   indexes. The outbox is capped at 5,000 rows and 30 days; idempotency receipts
+   are retained for 90 days.
+6. Verify `report_daily`, `report_installations`,
    `report_event_dimensions`, `diagnostics_meta`, their fingerprint/date
    indexes, and the ping window index. Confirm `installation_linked_since`.
-4. Deploy the Worker first. Smoke-test old Report/Ping/Metrics payloads, a
+7. Run `npm run migrate:firebase-data` as a dry run, then rerun with `-- --apply`
+   using service-account environment variables. It imports each group's first
+   and latest five retained samples without logging report bodies or credentials.
+8. Deploy the Worker in `dual` mode first. Smoke-test old Report/Ping/Metrics payloads, a
    legacy `webview2` payload, and Windows/Linux `webRuntime` payloads using
    `channel=test`.
-5. Build signed Windows and Linux artifacts from the frozen SHA. Complete the
+9. Compare D1 and Firebase for seven complete UTC days. Switch
+   `CRASH_STORAGE_MODE` from `dual` to `firebase` only after counts,
+   fingerprints, retained samples, and redaction match. In Firebase mode D1
+   keeps aggregates and the bounded outbox but no new raw `reports` rows.
+10. Build signed Windows and Linux artifacts from the frozen SHA. Complete the
    capability matrix and performance gates before a feature release.
-6. Use the admin UI for the audited historical cleanup: ignore the synthetic
+11. After seven more stable days, archive old D1 raw samples. Keep `d1`, `dual`,
+   and `firebase` as rollback modes; a Worker rollback does not require a client
+   update.
+12. Use the admin UI for the audited historical cleanup: ignore the synthetic
    `[go panic] safe` / `v9.9.9` group; resolve `72daba81` in
    `desktop-v1.19.3`; ignore the legacy `desktop.abnormal_exit` replay group.
 
@@ -41,6 +65,12 @@ engine/kind/reason/exit code must share one fingerprint. Then verify:
 - retention removes diagnostic facts, pings, and metric-user rows after 30
   days in bounded chunks;
 - `channel=test` remains in the development namespace.
+- duplicate `eventId` values return `202` without incrementing aggregates;
+- Firebase timeout, 401, 429, or 5xx leaves a projected outbox row for the
+  six-hour retry, while a full outbox returns `503` so clients retain pending;
+- automatic Desktop reports are sent once per version and dedup key, failed
+  sends do not enter the 512-entry/180-day ledger, and explicit Desktop/CLI
+  reports bypass local fingerprint suppression.
 
 ## Normal-experience gates
 

--- a/docs/DESKTOP_CRASH_DIAGNOSTICS_RUNBOOK.zh-CN.md
+++ b/docs/DESKTOP_CRASH_DIAGNOSTICS_RUNBOOK.zh-CN.md
@@ -18,14 +18,20 @@
 4. 备份 D1，并先用 `PRAGMA table_info` 检查生产，再应用
    `workers/crash-report/migrate-diagnostics-v2.sql`。若 draft 字段已提前存在，停止发布，
    另做纯加法 reconciliation migration。
-5. 应用 `migrate-firebase-crash.sql`，验证 `firebase_crash_outbox`、
-   `firebase_crash_receipts`、`firebase_crash_group_leases` 和投递索引。outbox 上限
-   5000 条、保留 30 天；幂等回执保留 90 天。
+5. 运行 `npm run migrate:firebase-crash`。命令先记录 D1 Time Travel bookmark，再依次
+   应用第一阶段 `migrate-firebase-crash.sql` 与第二阶段
+   `migrate-firebase-crash-capacity.sql`；任一阶段部分完成时 fail closed。验证 outbox、
+   receipt、兼容 lease 表、`firebase_crash_group_state` 及全部投递/生命周期索引。旧 lease
+   表只用于滚动部署兼容。
 6. 验证 `report_daily`、`report_installations`、
    `report_event_dimensions`、`diagnostics_meta`、fingerprint/date 索引、ping
    窗口索引，以及 `installation_linked_since`。
-7. 先运行 `npm run migrate:firebase-data` dry-run，再通过 `-- --apply` 配合服务账号环境
-   变量执行导入。脚本仅迁移每组首个和最近 5 个样本，不输出报告正文或凭据。
+7. 先运行 `npm run migrate:firebase-data` dry-run。脚本按每页 200 个 fingerprint 的
+   keyset 分页，预计预留必须不超过 700 MiB。随后执行
+   `npm run migrate:firebase-data -- --apply`，收敛后立即执行
+   `npm run migrate:firebase-data -- --verify-only`。默认 checkpoint 为权限 `0600` 且已
+   gitignore 的 `.firebase-crash-migration-state.json`；可用 `--checkpoint=<path>` 改路径，
+   只有明确重跑时才用 `--reset-checkpoint`。日志只输出计数、fingerprint 前缀和摘要。
 8. Worker 先使用 `dual` 模式；用旧 Report/Ping/Metrics、legacy `webview2`、Windows/Linux
    `webRuntime` payload 做 `channel=test` smoke。
 9. 连续比较 7 个完整 UTC 日；fingerprint、计数、样本和脱敏结果一致后，才将
@@ -38,6 +44,22 @@
 12. 通过管理界面保留审计地整理历史数据：忽略 `[go panic] safe` / `v9.9.9`，将
    `72daba81` 标记为在 `desktop-v1.19.3` 解决，忽略旧
    `desktop.abnormal_exit` replay 分组。
+
+## Spark 容量、生命周期与回滚
+
+Worker 固定执行 700 MiB 预留上限：active 每组 640 KiB、compacted 128 KiB、
+archiving 32 KiB、archived 为 0。达到 80% 时复用现有 webhook 告警并在后台提示；新组或
+扩容会越过上限时，必须在创建 outbox 前返回 `503`。不得把该上限改为可配置项。
+
+只有 resolved/ignored 分组参与生命周期：30 天无新事件后，把最近 5 个样本替换为带
+fencing 的 marker，并保留当前周期首个样本；60 天后 tombstone 全部样本路径，24 小时后
+条件删除 Firebase group。D1 的计数、状态、备注、聚合和审计继续保留。archived
+fingerprint 再出现时进入新 sample epoch，累计 count 与 lifetime first-seen 不重置。管理员
+删除复用同一 tombstone 窗口，并原子删除对应 D1 分组数据。
+
+回滚只改配置：设置 `CRASH_STORAGE_MODE=d1` 并重新部署。回滚时不要删除 outbox、receipt、
+group-state 或 Firebase 数据。修复 migration/容量/ETag 问题后，重新执行 dry-run 与
+`--verify-only`，再切回 `dual`；Desktop/CLI 无需升级。
 
 ## 隐私与兼容 smoke
 

--- a/docs/DESKTOP_CRASH_DIAGNOSTICS_RUNBOOK.zh-CN.md
+++ b/docs/DESKTOP_CRASH_DIAGNOSTICS_RUNBOOK.zh-CN.md
@@ -7,18 +7,35 @@
 
 ## 发布顺序
 
-1. 冻结唯一候选 SHA，已发布 tag 不得移动或重建。
-2. 备份 D1，并先用 `PRAGMA table_info` 检查生产，再应用
+1. Firebase 项目保持 Spark 且不关联 Cloud Billing；只在
+   `asia-southeast1` 创建 Realtime Database，并部署
+   `workers/crash-report/firebase/database.rules.json`，确认客户端读写均被拒绝。不得启用
+   Functions、Firestore、BigQuery、Hosting、Storage 或 Secret Manager。
+2. 配置仓库 Secret：`FIREBASE_DATABASE_URL`、`FIREBASE_CLIENT_EMAIL` 和
+   `FIREBASE_PRIVATE_KEY`。服务账号必须专用于 crash 投递且仅授予 Realtime Database
+   权限。不得使用 Web Firebase 配置，也不得在 Desktop 产物中包含 Firebase SDK 或配置。
+3. 冻结唯一候选 SHA，已发布 tag 不得移动或重建。
+4. 备份 D1，并先用 `PRAGMA table_info` 检查生产，再应用
    `workers/crash-report/migrate-diagnostics-v2.sql`。若 draft 字段已提前存在，停止发布，
    另做纯加法 reconciliation migration。
-3. 验证 `report_daily`、`report_installations`、
+5. 应用 `migrate-firebase-crash.sql`，验证 `firebase_crash_outbox`、
+   `firebase_crash_receipts`、`firebase_crash_group_leases` 和投递索引。outbox 上限
+   5000 条、保留 30 天；幂等回执保留 90 天。
+6. 验证 `report_daily`、`report_installations`、
    `report_event_dimensions`、`diagnostics_meta`、fingerprint/date 索引、ping
    窗口索引，以及 `installation_linked_since`。
-4. 先部署 Worker；用旧 Report/Ping/Metrics、legacy `webview2`、Windows/Linux
+7. 先运行 `npm run migrate:firebase-data` dry-run，再通过 `-- --apply` 配合服务账号环境
+   变量执行导入。脚本仅迁移每组首个和最近 5 个样本，不输出报告正文或凭据。
+8. Worker 先使用 `dual` 模式；用旧 Report/Ping/Metrics、legacy `webview2`、Windows/Linux
    `webRuntime` payload 做 `channel=test` smoke。
-5. 用同一 SHA 生成签名 Windows/Linux 构建；能力矩阵和性能门禁通过后才发布 feature
+9. 连续比较 7 个完整 UTC 日；fingerprint、计数、样本和脱敏结果一致后，才将
+   `CRASH_STORAGE_MODE` 从 `dual` 切换为 `firebase`。Firebase 模式下 D1 只保留聚合、
+   索引和有界 outbox，不再写入新 `reports` 原文。
+10. 用同一 SHA 生成签名 Windows/Linux 构建；能力矩阵和性能门禁通过后才发布 feature
    release。
-6. 通过管理界面保留审计地整理历史数据：忽略 `[go panic] safe` / `v9.9.9`，将
+11. 再稳定观察 7 天后归档 D1 旧原始样本。保留 `d1`、`dual`、`firebase` 三种回滚
+   模式；Worker 回滚不要求客户端升级。
+12. 通过管理界面保留审计地整理历史数据：忽略 `[go panic] safe` / `v9.9.9`，将
    `72daba81` 标记为在 `desktop-v1.19.3` 解决，忽略旧
    `desktop.abnormal_exit` replay 分组。
 
@@ -33,6 +50,11 @@
 - 删除测试分组会删除三张诊断聚合表的对应数据；
 - 诊断事实、ping、metric user 按 30 天分块清理；
 - `channel=test` 始终位于 development namespace。
+- 重复 `eventId` 返回 `202` 且不重复增加聚合；
+- Firebase timeout、401、429 或 5xx 会保留 projected outbox，交给每 6 小时重试；
+  outbox 满时返回 `503`，客户端必须保留 pending；
+- Desktop 自动报告按版本和 dedup key 只成功上传一次，失败不进入 512 条/180 天账本；
+  用户主动提交的 Desktop/CLI 报告不受本地 fingerprint 去重限制。
 
 ## 正常体验门禁
 

--- a/internal/crashreport/cli.go
+++ b/internal/crashreport/cli.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -52,10 +53,13 @@ var (
 	longBase64URLPattern  = regexp.MustCompile(`\b[A-Za-z0-9_-]{48,}\b`)
 	goLocationPattern     = regexp.MustCompile(`[^\s]+\.go:\d+`)
 	reportFilenamePattern = regexp.MustCompile(`^[0-9]{20}-[0-9]+-[0-9a-f]{16}\.json$`)
+	fingerprintNumber     = regexp.MustCompile(`\b\d+\b`)
 )
 
 // Report is the subset of the shared crash ingest protocol emitted by the CLI.
 type Report struct {
+	EventID       string `json:"eventId,omitempty"`
+	DedupKey      string `json:"dedupKey,omitempty"`
 	Kind          string `json:"kind"`
 	Version       string `json:"version"`
 	OS            string `json:"os"`
@@ -133,7 +137,16 @@ func List(home string) ([]Pending, error) {
 		if json.Unmarshal(body, &report) != nil || !valid(report) {
 			continue
 		}
-		out = append(out, Pending{ID: strings.TrimSuffix(entry.Name(), ".json"), Report: sanitizeReport(report)})
+		id := strings.TrimSuffix(entry.Name(), ".json")
+		identityChanged := report.EventID == "" || report.DedupKey == ""
+		ensureReportIdentity(&report, id)
+		report = sanitizeReport(report)
+		if identityChanged {
+			if updated, marshalErr := json.Marshal(report); marshalErr == nil {
+				_ = fileutil.AtomicWriteFile(filepath.Join(dir, entry.Name()), updated, 0o600)
+			}
+		}
+		out = append(out, Pending{ID: id, Report: report})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID > out[j].ID })
 	return out, nil
@@ -223,15 +236,16 @@ func write(home string, report Report) error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
-	body, err := json.Marshal(sanitizeReport(report))
-	if err != nil {
-		return err
-	}
 	nonce := make([]byte, 8)
 	if _, err := rand.Read(nonce); err != nil {
 		return err
 	}
 	id := fmt.Sprintf("%020d-%d-%s", time.Now().UTC().UnixNano(), os.Getpid(), hex.EncodeToString(nonce))
+	ensureReportIdentity(&report, id)
+	body, err := json.Marshal(sanitizeReport(report))
+	if err != nil {
+		return err
+	}
 	queueMu.Lock()
 	defer queueMu.Unlock()
 	if err := fileutil.AtomicWriteFile(filepath.Join(dir, id+".json"), body, 0o600); err != nil {
@@ -239,6 +253,30 @@ func write(home string, report Report) error {
 	}
 	prune(dir)
 	return nil
+}
+
+func ensureReportIdentity(report *Report, stableID string) {
+	if report.EventID == "" {
+		sum := sha256.Sum256([]byte("reasonix-cli-event\n" + stableID))
+		report.EventID = hex.EncodeToString(sum[:16])
+	}
+	if report.DedupKey == "" {
+		basis := strings.Join([]string{
+			report.Kind,
+			report.Version,
+			report.Source,
+			report.Label,
+			report.ErrorType,
+			normalizeFingerprintField(report.ErrorMessage),
+			normalizeFingerprintField(report.TopFrame),
+		}, "\n")
+		sum := sha256.Sum256([]byte(basis))
+		report.DedupKey = hex.EncodeToString(sum[:])
+	}
+}
+
+func normalizeFingerprintField(value string) string {
+	return fingerprintNumber.ReplaceAllString(strings.ToLower(strings.TrimSpace(value)), "<n>")
 }
 
 func prune(dir string) {

--- a/internal/crashreport/cli_test.go
+++ b/internal/crashreport/cli_test.go
@@ -1,6 +1,7 @@
 package crashreport
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -39,6 +40,9 @@ func TestCapturePanicWritesBoundedSanitizedReport(t *testing.T) {
 	report := reports[0].Report
 	if report.Kind != "crash" || report.Source != "cli.go" || report.Label != "panic" || report.SchemaVersion != 2 {
 		t.Fatalf("report metadata = %+v", report)
+	}
+	if len(report.EventID) != 32 || len(report.DedupKey) != 64 {
+		t.Fatalf("report identity = event %q dedup %q", report.EventID, report.DedupKey)
 	}
 	if !strings.Contains(report.Stack, "reasonix/internal/agent.run(...)") || !strings.Contains(report.Stack, "<path>/run.go:42") {
 		t.Fatalf("sanitized stack = %q", report.Stack)
@@ -82,6 +86,36 @@ func TestCapturePanicWritesBoundedSanitizedReport(t *testing.T) {
 	reports, err = List(home)
 	if err != nil || len(reports) != maxReports {
 		t.Fatalf("bounded reports=%d err=%v", len(reports), err)
+	}
+}
+
+func TestListBackfillsStableIdentityForOldPendingReport(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, dirName)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	name := "00000000000000000001-1-0000000000000001.json"
+	path := filepath.Join(dir, name)
+	body := `{"kind":"crash","version":"v1.20.0","os":"linux","arch":"amd64","message":"old","schemaVersion":2,"source":"cli.go","label":"panic"}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first, err := List(home)
+	if err != nil || len(first) != 1 {
+		t.Fatalf("first List reports=%d err=%v", len(first), err)
+	}
+	second, err := List(home)
+	if err != nil || len(second) != 1 {
+		t.Fatalf("second List reports=%d err=%v", len(second), err)
+	}
+	if first[0].Report.EventID == "" || first[0].Report.DedupKey == "" ||
+		first[0].Report.EventID != second[0].Report.EventID || first[0].Report.DedupKey != second[0].Report.DedupKey {
+		t.Fatalf("identity was not stable: first=%+v second=%+v", first[0].Report, second[0].Report)
+	}
+	stored, err := os.ReadFile(path)
+	if err != nil || !bytes.Contains(stored, []byte(`"eventId"`)) || !bytes.Contains(stored, []byte(`"dedupKey"`)) {
+		t.Fatalf("backfilled identity was not persisted: body=%s err=%v", stored, err)
 	}
 }
 

--- a/workers/crash-report/firebase.json
+++ b/workers/crash-report/firebase.json
@@ -1,0 +1,5 @@
+{
+  "database": {
+    "rules": "firebase/database.rules.json"
+  }
+}

--- a/workers/crash-report/firebase/database.rules.json
+++ b/workers/crash-report/firebase/database.rules.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    ".read": false,
+    ".write": false
+  }
+}

--- a/workers/crash-report/migrate-firebase-crash-capacity.sql
+++ b/workers/crash-report/migrate-firebase-crash-capacity.sql
@@ -1,0 +1,54 @@
+-- Phase 2: Spark capacity accounting, lifecycle state, and generation leases.
+-- The phase-1 lease table remains in place for an old Worker during rollout.
+CREATE TABLE IF NOT EXISTS firebase_crash_group_state (
+  fingerprint TEXT PRIMARY KEY,
+  sample_state TEXT NOT NULL DEFAULT 'active'
+    CHECK (sample_state IN ('active', 'compacted', 'archiving', 'archived')),
+  sample_epoch INTEGER NOT NULL DEFAULT 1 CHECK (sample_epoch >= 1),
+  epoch_first_event_id TEXT NOT NULL DEFAULT '',
+  reserved_bytes INTEGER NOT NULL DEFAULT 655360 CHECK (reserved_bytes >= 0),
+  last_seen TEXT NOT NULL,
+  compacted_at TEXT NOT NULL DEFAULT '',
+  archived_at TEXT NOT NULL DEFAULT '',
+  archive_reason TEXT NOT NULL DEFAULT ''
+    CHECK (archive_reason IN ('', 'retention', 'admin')),
+  lease_owner TEXT NOT NULL DEFAULT '',
+  lease_generation INTEGER NOT NULL DEFAULT 0 CHECK (lease_generation >= 0),
+  lease_expires_at TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS firebase_crash_group_state_lifecycle
+  ON firebase_crash_group_state (sample_state, last_seen);
+
+CREATE INDEX IF NOT EXISTS firebase_crash_group_state_lease
+  ON firebase_crash_group_state (lease_expires_at);
+
+-- Seed existing D1 groups with the same 30/60-day classification used by the
+-- migration command. Its preflight enforces the 700 MiB budget before this
+-- statement runs.
+INSERT OR IGNORE INTO firebase_crash_group_state (
+  fingerprint, sample_state, sample_epoch, reserved_bytes, last_seen,
+  compacted_at, archived_at, archive_reason
+)
+SELECT fingerprint,
+  CASE
+    WHEN status IN ('resolved', 'ignored') AND datetime(last_seen) <= datetime('now', '-60 days')
+      THEN 'archived'
+    WHEN status IN ('resolved', 'ignored') AND datetime(last_seen) <= datetime('now', '-30 days')
+      THEN 'compacted'
+    ELSE 'active'
+  END,
+  1,
+  CASE
+    WHEN status IN ('resolved', 'ignored') AND datetime(last_seen) <= datetime('now', '-60 days') THEN 0
+    WHEN status IN ('resolved', 'ignored') AND datetime(last_seen) <= datetime('now', '-30 days') THEN 131072
+    ELSE 655360
+  END,
+  last_seen,
+  CASE WHEN status IN ('resolved', 'ignored') AND datetime(last_seen) <= datetime('now', '-30 days')
+    AND datetime(last_seen) > datetime('now', '-60 days') THEN datetime('now') ELSE '' END,
+  CASE WHEN status IN ('resolved', 'ignored') AND datetime(last_seen) <= datetime('now', '-60 days')
+    THEN datetime('now') ELSE '' END,
+  CASE WHEN status IN ('resolved', 'ignored') AND datetime(last_seen) <= datetime('now', '-60 days')
+    THEN 'retention' ELSE '' END
+FROM groups;

--- a/workers/crash-report/migrate-firebase-crash.sql
+++ b/workers/crash-report/migrate-firebase-crash.sql
@@ -1,0 +1,32 @@
+-- Additive Firebase Spark crash delivery state. Apply before selecting
+-- CRASH_STORAGE_MODE=dual or firebase.
+CREATE TABLE IF NOT EXISTS firebase_crash_outbox (
+  event_id TEXT PRIMARY KEY,
+  fingerprint TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  state TEXT NOT NULL DEFAULT 'queued' CHECK (state IN ('queued', 'processing', 'projected')),
+  attempts INTEGER NOT NULL DEFAULT 0,
+  next_attempt_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS firebase_crash_outbox_retry
+  ON firebase_crash_outbox (state, next_attempt_at, created_at);
+
+CREATE TABLE IF NOT EXISTS firebase_crash_receipts (
+  event_id TEXT PRIMARY KEY,
+  projected_at TEXT NOT NULL,
+  group_count INTEGER NOT NULL,
+  latest_slot INTEGER NOT NULL,
+  first_sample INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS firebase_crash_receipts_projected
+  ON firebase_crash_receipts (projected_at);
+
+CREATE TABLE IF NOT EXISTS firebase_crash_group_leases (
+  fingerprint TEXT PRIMARY KEY,
+  owner TEXT NOT NULL,
+  expires_at TEXT NOT NULL
+);

--- a/workers/crash-report/package.json
+++ b/workers/crash-report/package.json
@@ -6,6 +6,8 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "migrate:diagnostics-v2": "node scripts/apply-diagnostics-v2.mjs",
+    "migrate:firebase-crash": "node scripts/apply-firebase-crash.mjs",
+    "migrate:firebase-data": "node scripts/migrate-firebase-data.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/workers/crash-report/schema.sql
+++ b/workers/crash-report/schema.sql
@@ -92,6 +92,31 @@ CREATE TABLE IF NOT EXISTS firebase_crash_group_leases (
   expires_at TEXT NOT NULL
 );
 
+-- Durable Firebase lifecycle, capacity reservation, and fencing state. The
+-- older lease table above remains for rolling-deployment compatibility only.
+CREATE TABLE IF NOT EXISTS firebase_crash_group_state (
+  fingerprint TEXT PRIMARY KEY,
+  sample_state TEXT NOT NULL DEFAULT 'active'
+    CHECK (sample_state IN ('active', 'compacted', 'archiving', 'archived')),
+  sample_epoch INTEGER NOT NULL DEFAULT 1 CHECK (sample_epoch >= 1),
+  epoch_first_event_id TEXT NOT NULL DEFAULT '',
+  reserved_bytes INTEGER NOT NULL DEFAULT 655360 CHECK (reserved_bytes >= 0),
+  last_seen TEXT NOT NULL,
+  compacted_at TEXT NOT NULL DEFAULT '',
+  archived_at TEXT NOT NULL DEFAULT '',
+  archive_reason TEXT NOT NULL DEFAULT ''
+    CHECK (archive_reason IN ('', 'retention', 'admin')),
+  lease_owner TEXT NOT NULL DEFAULT '',
+  lease_generation INTEGER NOT NULL DEFAULT 0 CHECK (lease_generation >= 0),
+  lease_expires_at TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS firebase_crash_group_state_lifecycle
+  ON firebase_crash_group_state (sample_state, last_seen);
+
+CREATE INDEX IF NOT EXISTS firebase_crash_group_state_lease
+  ON firebase_crash_group_state (lease_expires_at);
+
 CREATE TABLE IF NOT EXISTS pings (
   date TEXT NOT NULL,
   install_id TEXT NOT NULL,

--- a/workers/crash-report/schema.sql
+++ b/workers/crash-report/schema.sql
@@ -54,6 +54,44 @@ CREATE TABLE IF NOT EXISTS reports (
 
 CREATE INDEX IF NOT EXISTS reports_fingerprint ON reports (fingerprint);
 
+-- Firebase Spark delivery is coordinated through D1 so an unavailable or
+-- quota-limited Realtime Database never loses a sanitized report. The payload
+-- is deleted immediately after Firebase accepts the group/sample projection.
+CREATE TABLE IF NOT EXISTS firebase_crash_outbox (
+  event_id TEXT PRIMARY KEY,
+  fingerprint TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  state TEXT NOT NULL DEFAULT 'queued' CHECK (state IN ('queued', 'processing', 'projected')),
+  attempts INTEGER NOT NULL DEFAULT 0,
+  next_attempt_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS firebase_crash_outbox_retry
+  ON firebase_crash_outbox (state, next_attempt_at, created_at);
+
+CREATE TABLE IF NOT EXISTS firebase_crash_receipts (
+  event_id TEXT PRIMARY KEY,
+  projected_at TEXT NOT NULL,
+  group_count INTEGER NOT NULL,
+  latest_slot INTEGER NOT NULL,
+  first_sample INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS firebase_crash_receipts_projected
+  ON firebase_crash_receipts (projected_at);
+
+-- Serializes each group's D1 projection, Firebase ring update, metadata sync,
+-- and administrative deletion across Worker isolates. Expired owners are
+-- recoverable, while owner-checked release prevents an old request from
+-- deleting a newer lease.
+CREATE TABLE IF NOT EXISTS firebase_crash_group_leases (
+  fingerprint TEXT PRIMARY KEY,
+  owner TEXT NOT NULL,
+  expires_at TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS pings (
   date TEXT NOT NULL,
   install_id TEXT NOT NULL,

--- a/workers/crash-report/scripts/apply-firebase-crash.d.mts
+++ b/workers/crash-report/scripts/apply-firebase-crash.d.mts
@@ -4,8 +4,14 @@ export type FirebaseCrashSchemaState = {
 };
 
 export const firebaseCrashSchemaEntries: readonly string[];
+export const firebaseCrashV1SchemaEntries: readonly string[];
+export const firebaseCrashV2SchemaEntries: readonly string[];
 export const firebaseCrashSchemaQuery: string;
+export const firebaseCrashCapacityQuery: string;
 
 export function classifyFirebaseCrashSchema(
   rows: Array<Record<string, unknown>>,
-): FirebaseCrashSchemaState;
+): FirebaseCrashSchemaState & {
+  v1: FirebaseCrashSchemaState;
+  v2: FirebaseCrashSchemaState;
+};

--- a/workers/crash-report/scripts/apply-firebase-crash.d.mts
+++ b/workers/crash-report/scripts/apply-firebase-crash.d.mts
@@ -1,0 +1,11 @@
+export type FirebaseCrashSchemaState = {
+  state: "absent" | "partial" | "complete";
+  missing: string[];
+};
+
+export const firebaseCrashSchemaEntries: readonly string[];
+export const firebaseCrashSchemaQuery: string;
+
+export function classifyFirebaseCrashSchema(
+  rows: Array<Record<string, unknown>>,
+): FirebaseCrashSchemaState;

--- a/workers/crash-report/scripts/apply-firebase-crash.mjs
+++ b/workers/crash-report/scripts/apply-firebase-crash.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { parseWranglerRows } from "./apply-diagnostics-v2.mjs";
 
-export const firebaseCrashSchemaEntries = Object.freeze([
+export const firebaseCrashV1SchemaEntries = Object.freeze([
   "table:firebase_crash_outbox",
   "table:firebase_crash_receipts",
   "index:firebase_crash_outbox_retry",
@@ -13,22 +13,54 @@ export const firebaseCrashSchemaEntries = Object.freeze([
   "table:firebase_crash_group_leases",
 ]);
 
+export const firebaseCrashV2SchemaEntries = Object.freeze([
+  "table:firebase_crash_group_state",
+  "index:firebase_crash_group_state_lifecycle",
+  "index:firebase_crash_group_state_lease",
+]);
+
+export const firebaseCrashSchemaEntries = Object.freeze([
+  ...firebaseCrashV1SchemaEntries,
+  ...firebaseCrashV2SchemaEntries,
+]);
+
 export const firebaseCrashSchemaQuery = `
 SELECT type AS kind, name
 FROM sqlite_master
 WHERE type IN ('table', 'index') AND name IN (
   'firebase_crash_outbox', 'firebase_crash_receipts', 'firebase_crash_group_leases',
-  'firebase_crash_outbox_retry', 'firebase_crash_receipts_projected'
+  'firebase_crash_outbox_retry', 'firebase_crash_receipts_projected',
+  'firebase_crash_group_state', 'firebase_crash_group_state_lifecycle',
+  'firebase_crash_group_state_lease'
 )
 ORDER BY kind, name;
 `.trim();
 
-export function classifyFirebaseCrashSchema(rows) {
+export const firebaseCrashCapacityQuery = `
+SELECT COALESCE(SUM(CASE
+  WHEN status IN ('resolved', 'ignored') AND datetime(last_seen) <= datetime('now', '-60 days') THEN 0
+  WHEN status IN ('resolved', 'ignored') AND datetime(last_seen) <= datetime('now', '-30 days') THEN 131072
+  ELSE 655360
+END), 0) AS reserved_bytes
+FROM groups;
+`.trim();
+
+function classifyEntries(rows, entries) {
   const present = new Set(rows.map((row) => `${String(row.kind)}:${String(row.name)}`));
-  const missing = firebaseCrashSchemaEntries.filter((entry) => !present.has(entry));
+  const missing = entries.filter((entry) => !present.has(entry));
   if (missing.length === 0) return { state: "complete", missing };
-  if (missing.length === firebaseCrashSchemaEntries.length) return { state: "absent", missing };
+  if (missing.length === entries.length) return { state: "absent", missing };
   return { state: "partial", missing };
+}
+
+export function classifyFirebaseCrashSchema(rows) {
+  const v1 = classifyEntries(rows, firebaseCrashV1SchemaEntries);
+  const v2 = classifyEntries(rows, firebaseCrashV2SchemaEntries);
+  const missing = [...v1.missing, ...v2.missing];
+  const state = v1.state === "complete" && v2.state === "complete"
+    ? "complete"
+    : v1.state === "absent" && v2.state === "absent" ? "absent" : "partial";
+  return { state, missing, v1, v2 };
 }
 
 function runWrangler(projectDir, args, captureOutput = false) {
@@ -52,6 +84,17 @@ function inspect(projectDir, database) {
   return classifyFirebaseCrashSchema(parseWranglerRows(output));
 }
 
+function assertSparkCapacity(projectDir, database) {
+  const output = runWrangler(projectDir, [
+    "d1", "execute", database, "--remote", "--json", "--command", firebaseCrashCapacityQuery,
+  ], true);
+  const rows = parseWranglerRows(output);
+  const reserved = Number(rows[0]?.reserved_bytes ?? 0);
+  if (!Number.isFinite(reserved) || reserved > 700 * 1024 * 1024) {
+    throw new Error(`Firebase crash reservation preflight exceeds 700 MiB (${reserved} bytes)`);
+  }
+}
+
 function main() {
   const projectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
   const database = process.env.DIAGNOSTICS_D1_DATABASE || "reasonix-crash";
@@ -60,14 +103,23 @@ function main() {
     console.log("Firebase crash D1 schema is already complete; migration skipped.");
     return;
   }
-  if (before.state === "partial") {
+  if (before.v1.state === "partial" || before.v2.state === "partial" ||
+      (before.v1.state === "absent" && before.v2.state === "complete")) {
     throw new Error(`Firebase crash D1 schema is partial; missing: ${before.missing.join(", ")}`);
   }
   console.log("Recording the current D1 Time Travel bookmark before migration.");
   runWrangler(projectDir, ["d1", "time-travel", "info", database]);
-  runWrangler(projectDir, [
-    "d1", "execute", database, "--remote", "--yes", "--file", "migrate-firebase-crash.sql",
-  ]);
+  if (before.v1.state === "absent") {
+    runWrangler(projectDir, [
+      "d1", "execute", database, "--remote", "--yes", "--file", "migrate-firebase-crash.sql",
+    ]);
+  }
+  if (before.v2.state === "absent") {
+    assertSparkCapacity(projectDir, database);
+    runWrangler(projectDir, [
+      "d1", "execute", database, "--remote", "--yes", "--file", "migrate-firebase-crash-capacity.sql",
+    ]);
+  }
   const after = inspect(projectDir, database);
   if (after.state !== "complete") {
     throw new Error(`Firebase crash D1 migration failed; missing: ${after.missing.join(", ")}`);

--- a/workers/crash-report/scripts/apply-firebase-crash.mjs
+++ b/workers/crash-report/scripts/apply-firebase-crash.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { parseWranglerRows } from "./apply-diagnostics-v2.mjs";
+
+export const firebaseCrashSchemaEntries = Object.freeze([
+  "table:firebase_crash_outbox",
+  "table:firebase_crash_receipts",
+  "index:firebase_crash_outbox_retry",
+  "index:firebase_crash_receipts_projected",
+  "table:firebase_crash_group_leases",
+]);
+
+export const firebaseCrashSchemaQuery = `
+SELECT type AS kind, name
+FROM sqlite_master
+WHERE type IN ('table', 'index') AND name IN (
+  'firebase_crash_outbox', 'firebase_crash_receipts', 'firebase_crash_group_leases',
+  'firebase_crash_outbox_retry', 'firebase_crash_receipts_projected'
+)
+ORDER BY kind, name;
+`.trim();
+
+export function classifyFirebaseCrashSchema(rows) {
+  const present = new Set(rows.map((row) => `${String(row.kind)}:${String(row.name)}`));
+  const missing = firebaseCrashSchemaEntries.filter((entry) => !present.has(entry));
+  if (missing.length === 0) return { state: "complete", missing };
+  if (missing.length === firebaseCrashSchemaEntries.length) return { state: "absent", missing };
+  return { state: "partial", missing };
+}
+
+function runWrangler(projectDir, args, captureOutput = false) {
+  const executable = process.platform === "win32" ? "wrangler.cmd" : "wrangler";
+  const wrangler = path.join(projectDir, "node_modules", ".bin", executable);
+  const result = spawnSync(wrangler, args, {
+    cwd: projectDir,
+    encoding: "utf8",
+    env: process.env,
+    stdio: captureOutput ? ["ignore", "pipe", "inherit"] : "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`wrangler exited with status ${result.status}`);
+  return result.stdout ?? "";
+}
+
+function inspect(projectDir, database) {
+  const output = runWrangler(projectDir, [
+    "d1", "execute", database, "--remote", "--json", "--command", firebaseCrashSchemaQuery,
+  ], true);
+  return classifyFirebaseCrashSchema(parseWranglerRows(output));
+}
+
+function main() {
+  const projectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const database = process.env.DIAGNOSTICS_D1_DATABASE || "reasonix-crash";
+  const before = inspect(projectDir, database);
+  if (before.state === "complete") {
+    console.log("Firebase crash D1 schema is already complete; migration skipped.");
+    return;
+  }
+  if (before.state === "partial") {
+    throw new Error(`Firebase crash D1 schema is partial; missing: ${before.missing.join(", ")}`);
+  }
+  console.log("Recording the current D1 Time Travel bookmark before migration.");
+  runWrangler(projectDir, ["d1", "time-travel", "info", database]);
+  runWrangler(projectDir, [
+    "d1", "execute", database, "--remote", "--yes", "--file", "migrate-firebase-crash.sql",
+  ]);
+  const after = inspect(projectDir, database);
+  if (after.state !== "complete") {
+    throw new Error(`Firebase crash D1 migration failed; missing: ${after.missing.join(", ")}`);
+  }
+  console.log("Firebase crash D1 migration and verification completed.");
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/workers/crash-report/scripts/migrate-firebase-data.d.mts
+++ b/workers/crash-report/scripts/migrate-firebase-data.d.mts
@@ -1,6 +1,20 @@
 export const firebaseOAuthGrantType: string;
 
+export function classifyMigrationGroup(
+  row: Record<string, unknown>,
+  now?: Date,
+): "active" | "compacted" | "archived";
+
+export function canonicalJSONString(value: unknown): string;
+export function contentDigest(value: unknown): string;
+
 export function buildFirebaseGroups(
   groupRows: Array<Record<string, unknown>>,
   reportRows: Array<Record<string, unknown>>,
-): Map<string, Record<string, unknown>>;
+  now?: Date,
+): Map<string, {
+  state: "active" | "compacted" | "archived";
+  value: Record<string, unknown> | null;
+  firstEventId: string;
+  reservedBytes: number;
+}>;

--- a/workers/crash-report/scripts/migrate-firebase-data.d.mts
+++ b/workers/crash-report/scripts/migrate-firebase-data.d.mts
@@ -1,0 +1,6 @@
+export const firebaseOAuthGrantType: string;
+
+export function buildFirebaseGroups(
+  groupRows: Array<Record<string, unknown>>,
+  reportRows: Array<Record<string, unknown>>,
+): Map<string, Record<string, unknown>>;

--- a/workers/crash-report/scripts/migrate-firebase-data.mjs
+++ b/workers/crash-report/scripts/migrate-firebase-data.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+import { createHash, createPrivateKey, createSign } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { parseWranglerRows } from "./apply-diagnostics-v2.mjs";
+
+const tokenURL = "https://oauth2.googleapis.com/token";
+const scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/firebase.database";
+export const firebaseOAuthGrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+function base64url(value) {
+  return Buffer.from(value).toString("base64url");
+}
+
+function text(value) {
+  return typeof value === "string" ? value : value == null ? "" : String(value);
+}
+
+function json(value, fallback) {
+  if (typeof value !== "string" || value === "") return fallback;
+  try { return JSON.parse(value); } catch { return fallback; }
+}
+
+function eventID(fingerprint, id) {
+  return createHash("sha256").update(`firebase-migration\n${fingerprint}\n${id}`).digest("hex").slice(0, 32);
+}
+
+function sample(row) {
+  return {
+    eventId: eventID(text(row.fingerprint), text(row.id)),
+    receivedAt: text(row.created_at),
+    kind: text(row.kind),
+    version: text(row.version),
+    os: text(row.os),
+    arch: text(row.arch),
+    message: text(row.message),
+    device: json(row.device, {}),
+    source: text(row.source),
+    label: text(row.label),
+    errorType: text(row.error_type),
+    errorMessage: text(row.error_message),
+    topFrame: text(row.top_frame),
+    buildCommit: text(row.build_commit),
+    channel: text(row.channel),
+    language: text(row.language),
+    view: text(row.view),
+    breadcrumbs: json(row.breadcrumbs, []),
+    componentStack: text(row.component_stack),
+    stack: text(row.stack),
+    occurredAt: text(row.occurred_at),
+    webview2: json(row.webview2, undefined),
+    webRuntime: json(row.web_runtime, undefined),
+  };
+}
+
+export function buildFirebaseGroups(groupRows, reportRows) {
+  const reports = new Map();
+  for (const row of reportRows) {
+    const fingerprint = text(row.fingerprint);
+    const values = reports.get(fingerprint) ?? [];
+    values.push(row);
+    reports.set(fingerprint, values);
+  }
+  const output = new Map();
+  for (const row of groupRows) {
+    const fingerprint = text(row.fingerprint);
+    const count = Number(row.count) || 0;
+    const retained = (reports.get(fingerprint) ?? []).sort((a, b) => Number(a.id) - Number(b.id));
+    const first = retained[0];
+    const latestRows = retained.slice(-5);
+    const latest = {};
+    latestRows.forEach((report, index) => {
+      latest[(count - latestRows.length + index + 5) % 5] = sample(report);
+    });
+    output.set(fingerprint, {
+      meta: {
+        fingerprint,
+        kind: text(row.kind),
+        count,
+        firstSeen: text(row.first_seen),
+        lastSeen: text(row.last_seen),
+        firstVersion: text(row.first_version),
+        lastVersion: text(row.last_version),
+        status: text(row.status),
+        title: text(row.title),
+        source: text(row.source),
+        label: text(row.label),
+        errorType: text(row.error_type),
+        topFrame: text(row.top_frame),
+        severity: text(row.severity),
+        lastOS: text(row.last_os),
+        lastArch: text(row.last_arch),
+        lastBuildCommit: text(row.last_build_commit),
+        lastChannel: text(row.last_channel),
+        regressedAt: text(row.regressed_at),
+      },
+      samples: {
+        ...(first ? { first: sample(first) } : {}),
+        latest,
+      },
+    });
+  }
+  return output;
+}
+
+function runWrangler(projectDir, database, query) {
+  const executable = process.platform === "win32" ? "wrangler.cmd" : "wrangler";
+  const wrangler = path.join(projectDir, "node_modules", ".bin", executable);
+  const result = spawnSync(wrangler, ["d1", "execute", database, "--remote", "--json", "--command", query], {
+    cwd: projectDir,
+    encoding: "utf8",
+    env: process.env,
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`wrangler exited with status ${result.status}`);
+  return parseWranglerRows(result.stdout ?? "");
+}
+
+async function accessToken(email, privateKey) {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const claims = base64url(JSON.stringify({ iss: email, scope, aud: tokenURL, iat: now, exp: now + 3600 }));
+  const unsigned = `${header}.${claims}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(unsigned);
+  signer.end();
+  const assertion = `${unsigned}.${signer.sign(createPrivateKey(privateKey.replace(/\\n/g, "\n")), "base64url")}`;
+  const response = await fetch(tokenURL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ grant_type: firebaseOAuthGrantType, assertion }),
+  });
+  if (!response.ok) throw new Error(`Firebase OAuth failed with ${response.status}`);
+  const body = await response.json();
+  if (typeof body.access_token !== "string") throw new Error("Firebase OAuth response omitted access_token");
+  return body.access_token;
+}
+
+function databaseURL(raw) {
+  const url = new URL(raw);
+  if (url.protocol !== "https:" || !(url.hostname.endsWith(".firebaseio.com") || url.hostname.endsWith(".firebasedatabase.app"))) {
+    throw new Error("FIREBASE_DATABASE_URL must be an approved Realtime Database host");
+  }
+  return url.toString().replace(/\/$/, "");
+}
+
+async function upload(baseURL, token, groups) {
+  let completed = 0;
+  for (const [fingerprint, value] of groups) {
+    const response = await fetch(`${baseURL}/groups/${encodeURIComponent(fingerprint)}.json`, {
+      method: "PUT",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify(value),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) throw new Error(`Firebase migration write failed with ${response.status} after ${completed} groups`);
+    completed++;
+    if (completed % 100 === 0) console.log(`Migrated ${completed}/${groups.size} groups.`);
+  }
+  console.log(`Migrated and verified HTTP success for ${completed} Firebase groups.`);
+}
+
+async function main() {
+  const projectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const database = process.env.DIAGNOSTICS_D1_DATABASE || "reasonix-crash";
+  const groups = runWrangler(projectDir, database, "SELECT * FROM groups ORDER BY fingerprint");
+  const reports = runWrangler(projectDir, database, "SELECT * FROM reports ORDER BY fingerprint, id");
+  const payloads = buildFirebaseGroups(groups, reports);
+  const bytes = [...payloads.values()].reduce((total, value) => total + Buffer.byteLength(JSON.stringify(value)), 0);
+  console.log(`Prepared ${payloads.size} groups and ${reports.length} retained samples (${bytes} JSON bytes).`);
+  if (!process.argv.includes("--apply")) {
+    console.log("Dry run only. Pass --apply with Firebase service-account environment variables to upload.");
+    return;
+  }
+  const email = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY;
+  const rawURL = process.env.FIREBASE_DATABASE_URL;
+  if (!email || !privateKey || !rawURL) throw new Error("Firebase service-account environment variables are required for --apply");
+  await upload(databaseURL(rawURL), await accessToken(email, privateKey), payloads);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/workers/crash-report/scripts/migrate-firebase-data.mjs
+++ b/workers/crash-report/scripts/migrate-firebase-data.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { createHash, createPrivateKey, createSign } from "node:crypto";
+import { chmodSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -8,6 +9,10 @@ import { parseWranglerRows } from "./apply-diagnostics-v2.mjs";
 
 const tokenURL = "https://oauth2.googleapis.com/token";
 const scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/firebase.database";
+const PAGE_SIZE = 200;
+const MAX_PASSES = 3;
+const STORAGE_BUDGET = 700 * 1024 * 1024;
+const RESERVATIONS = { active: 640 * 1024, compacted: 128 * 1024, archived: 0 };
 export const firebaseOAuthGrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer";
 
 function base64url(value) {
@@ -27,10 +32,13 @@ function eventID(fingerprint, id) {
   return createHash("sha256").update(`firebase-migration\n${fingerprint}\n${id}`).digest("hex").slice(0, 32);
 }
 
-function sample(row) {
+function sample(row, groupCount, sampleEpoch = 1) {
   return {
     eventId: eventID(text(row.fingerprint), text(row.id)),
     receivedAt: text(row.created_at),
+    groupCount,
+    writerGeneration: 0,
+    sampleEpoch,
     kind: text(row.kind),
     version: text(row.version),
     os: text(row.os),
@@ -55,7 +63,26 @@ function sample(row) {
   };
 }
 
-export function buildFirebaseGroups(groupRows, reportRows) {
+export function classifyMigrationGroup(row, now = new Date()) {
+  if (row.status !== "resolved" && row.status !== "ignored") return "active";
+  const age = now.getTime() - new Date(text(row.last_seen)).getTime();
+  if (!Number.isFinite(age) || age < 30 * 86400_000) return "active";
+  return age >= 60 * 86400_000 ? "archived" : "compacted";
+}
+
+export function canonicalJSONString(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJSONString).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJSONString(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function contentDigest(value) {
+  return createHash("sha256").update(canonicalJSONString(value)).digest("hex");
+}
+
+export function buildFirebaseGroups(groupRows, reportRows, now = new Date()) {
   const reports = new Map();
   for (const row of reportRows) {
     const fingerprint = text(row.fingerprint);
@@ -67,14 +94,24 @@ export function buildFirebaseGroups(groupRows, reportRows) {
   for (const row of groupRows) {
     const fingerprint = text(row.fingerprint);
     const count = Number(row.count) || 0;
+    const state = classifyMigrationGroup(row, now);
+    if (state === "archived") {
+      output.set(fingerprint, { state, value: null, firstEventId: "", reservedBytes: 0 });
+      continue;
+    }
     const retained = (reports.get(fingerprint) ?? []).sort((a, b) => Number(a.id) - Number(b.id));
     const first = retained[0];
-    const latestRows = retained.slice(-5);
+    const latestRows = state === "active" ? retained.slice(-5) : [];
     const latest = {};
     latestRows.forEach((report, index) => {
-      latest[(count - latestRows.length + index + 5) % 5] = sample(report);
+      const sampleCount = count - latestRows.length + index + 1;
+      latest[(sampleCount - 1) % 5] = sample(report, sampleCount);
     });
-    output.set(fingerprint, {
+    const samples = {
+      ...(first ? { first: sample(first, 1) } : {}),
+      ...(latestRows.length ? { latest } : {}),
+    };
+    const value = {
       meta: {
         fingerprint,
         kind: text(row.kind),
@@ -95,11 +132,17 @@ export function buildFirebaseGroups(groupRows, reportRows) {
         lastBuildCommit: text(row.last_build_commit),
         lastChannel: text(row.last_channel),
         regressedAt: text(row.regressed_at),
+        writerGeneration: 0,
+        sampleEpoch: 1,
+        sampleState: state,
       },
-      samples: {
-        ...(first ? { first: sample(first) } : {}),
-        latest,
-      },
+      ...(Object.keys(samples).length ? { samples } : {}),
+    };
+    output.set(fingerprint, {
+      state,
+      value,
+      firstEventId: first ? eventID(fingerprint, text(first.id)) : "",
+      reservedBytes: RESERVATIONS[state],
     });
   }
   return output;
@@ -119,6 +162,37 @@ function runWrangler(projectDir, database, query) {
   return parseWranglerRows(result.stdout ?? "");
 }
 
+function sqlText(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function validateFingerprint(value) {
+  if (!/^(?:dev:)?[0-9a-f]{64}$/.test(value)) throw new Error("D1 returned an invalid fingerprint");
+  return value;
+}
+
+function readPage(projectDir, database, cursor) {
+  const rows = runWrangler(
+    projectDir,
+    database,
+    `SELECT * FROM groups WHERE fingerprint > ${sqlText(cursor)} ORDER BY fingerprint LIMIT ${PAGE_SIZE}`,
+  );
+  if (!rows.length) return { groups: [], reports: [], states: [] };
+  const fingerprints = rows.map((row) => validateFingerprint(text(row.fingerprint)));
+  const reports = runWrangler(
+    projectDir,
+    database,
+    `SELECT * FROM reports WHERE fingerprint IN (${fingerprints.map(sqlText).join(",")}) ORDER BY fingerprint, id`,
+  );
+  const states = runWrangler(
+    projectDir,
+    database,
+    `SELECT fingerprint, sample_state, sample_epoch, epoch_first_event_id, reserved_bytes, last_seen
+     FROM firebase_crash_group_state WHERE fingerprint IN (${fingerprints.map(sqlText).join(",")})`,
+  );
+  return { groups: rows, reports, states };
+}
+
 async function accessToken(email, privateKey) {
   const now = Math.floor(Date.now() / 1000);
   const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
@@ -132,6 +206,7 @@ async function accessToken(email, privateKey) {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({ grant_type: firebaseOAuthGrantType, assertion }),
+    signal: AbortSignal.timeout(10_000),
   });
   if (!response.ok) throw new Error(`Firebase OAuth failed with ${response.status}`);
   const body = await response.json();
@@ -144,42 +219,208 @@ function databaseURL(raw) {
   if (url.protocol !== "https:" || !(url.hostname.endsWith(".firebaseio.com") || url.hostname.endsWith(".firebasedatabase.app"))) {
     throw new Error("FIREBASE_DATABASE_URL must be an approved Realtime Database host");
   }
+  url.search = "";
+  url.hash = "";
   return url.toString().replace(/\/$/, "");
 }
 
-async function upload(baseURL, token, groups) {
-  let completed = 0;
-  for (const [fingerprint, value] of groups) {
-    const response = await fetch(`${baseURL}/groups/${encodeURIComponent(fingerprint)}.json`, {
-      method: "PUT",
-      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-      body: JSON.stringify(value),
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!response.ok) throw new Error(`Firebase migration write failed with ${response.status} after ${completed} groups`);
-    completed++;
-    if (completed % 100 === 0) console.log(`Migrated ${completed}/${groups.size} groups.`);
+async function firebaseRequest(baseURL, token, fingerprint, init = {}) {
+  const silent = init.method && init.method !== "GET" ? "?print=silent" : "";
+  return fetch(`${baseURL}/groups/${encodeURIComponent(fingerprint)}.json${silent}`, {
+    ...init,
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json", ...init.headers },
+    signal: AbortSignal.timeout(10_000),
+  });
+}
+
+async function readAndVerify(baseURL, token, fingerprint, expected) {
+  const response = await firebaseRequest(baseURL, token, fingerprint, { method: "GET" });
+  if (!response.ok) throw new Error(`Firebase migration readback failed with ${response.status}`);
+  const actual = await response.json();
+  const actualHash = contentDigest(actual);
+  const expectedHash = contentDigest(expected);
+  if (actualHash !== expectedHash) {
+    throw new Error(`Firebase readback digest mismatch for ${fingerprint.slice(0, 8)} (${actualHash.slice(0, 12)})`);
   }
-  console.log(`Migrated and verified HTTP success for ${completed} Firebase groups.`);
+  return actualHash;
+}
+
+async function reconcileGroup(baseURL, token, fingerprint, entry, apply) {
+  if (apply) {
+    const response = await firebaseRequest(baseURL, token, fingerprint, entry.value === null
+      ? { method: "DELETE" }
+      : { method: "PUT", body: JSON.stringify(entry.value) });
+    if (!response.ok) throw new Error(`Firebase migration write failed with ${response.status}`);
+  }
+  return readAndVerify(baseURL, token, fingerprint, entry.value);
+}
+
+function stateSQL(fingerprint, row, entry, now) {
+  const compactedAt = entry.state === "compacted" ? now : "";
+  const archivedAt = entry.state === "archived" ? now : "";
+  const reason = entry.state === "archived" ? "retention" : "";
+  return `INSERT INTO firebase_crash_group_state (
+    fingerprint, sample_state, sample_epoch, epoch_first_event_id, reserved_bytes,
+    last_seen, compacted_at, archived_at, archive_reason
+  ) VALUES (
+    ${sqlText(fingerprint)}, ${sqlText(entry.state)}, 1, ${sqlText(entry.firstEventId)},
+    ${entry.reservedBytes}, ${sqlText(text(row.last_seen))}, ${sqlText(compactedAt)},
+    ${sqlText(archivedAt)}, ${sqlText(reason)}
+  ) ON CONFLICT (fingerprint) DO UPDATE SET
+    sample_state = excluded.sample_state,
+    sample_epoch = excluded.sample_epoch,
+    epoch_first_event_id = excluded.epoch_first_event_id,
+    reserved_bytes = excluded.reserved_bytes,
+    last_seen = excluded.last_seen,
+    compacted_at = excluded.compacted_at,
+    archived_at = excluded.archived_at,
+    archive_reason = excluded.archive_reason`;
+}
+
+function verifyD1State(row, entry, states) {
+  const state = states.find((candidate) => candidate.fingerprint === row.fingerprint);
+  if (!state || state.sample_state !== entry.state || Number(state.sample_epoch) !== 1 ||
+      text(state.epoch_first_event_id) !== entry.firstEventId ||
+      Number(state.reserved_bytes) !== entry.reservedBytes || text(state.last_seen) !== text(row.last_seen)) {
+    throw new Error(`D1 migration state mismatch for ${text(row.fingerprint).slice(0, 8)}`);
+  }
+}
+
+function emptyCheckpoint(database, targetHash, startedAt) {
+  return { version: 1, database, targetHash, startedAt, pass: 1, cursor: "", changed: 0, groups: {} };
+}
+
+function loadCheckpoint(file, expected) {
+  try {
+    const value = JSON.parse(readFileSync(file, "utf8"));
+    if (value.version !== 1 || value.database !== expected.database || value.targetHash !== expected.targetHash) {
+      throw new Error("checkpoint target does not match this migration");
+    }
+    return value;
+  } catch (error) {
+    if (error?.code === "ENOENT") return expected;
+    throw error;
+  }
+}
+
+function saveCheckpoint(file, value) {
+  const temporary = `${file}.tmp-${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+  chmodSync(temporary, 0o600);
+  renameSync(temporary, file);
+  chmodSync(file, 0o600);
+}
+
+function parseArgs(argv, projectDir) {
+  const apply = argv.includes("--apply");
+  const verifyOnly = argv.includes("--verify-only");
+  if (apply && verifyOnly) throw new Error("--apply and --verify-only are mutually exclusive");
+  const checkpointArg = argv.find((arg) => arg.startsWith("--checkpoint="));
+  return {
+    mode: apply ? "apply" : verifyOnly ? "verify" : "dry-run",
+    reset: argv.includes("--reset-checkpoint"),
+    checkpoint: checkpointArg ? path.resolve(checkpointArg.slice("--checkpoint=".length))
+      : path.join(projectDir, ".firebase-crash-migration-state.json"),
+  };
+}
+
+async function dryRun(projectDir, database, now) {
+  let cursor = "";
+  const counts = { active: 0, compacted: 0, archived: 0 };
+  let estimatedBytes = 0;
+  let contentBytes = 0;
+  while (true) {
+    const page = readPage(projectDir, database, cursor);
+    if (!page.groups.length) break;
+    const entries = buildFirebaseGroups(page.groups, page.reports, now);
+    for (const entry of entries.values()) {
+      counts[entry.state]++;
+      estimatedBytes += entry.reservedBytes;
+      if (entry.value !== null) contentBytes += Buffer.byteLength(canonicalJSONString(entry.value));
+    }
+    cursor = text(page.groups.at(-1).fingerprint);
+  }
+  console.log(`Groups: active=${counts.active}, compacted=${counts.compacted}, archived=${counts.archived}.`);
+  console.log(`Canonical Firebase content estimate: ${(contentBytes / 1048576).toFixed(1)} MiB.`);
+  console.log(`Conservative reservation: ${(estimatedBytes / 1048576).toFixed(1)} MiB / 700 MiB.`);
+  if (estimatedBytes > STORAGE_BUDGET) throw new Error("Estimated Firebase reservation exceeds the 700 MiB safety budget");
+}
+
+async function migrate(projectDir, database, mode, checkpointFile, now) {
+  const email = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY;
+  const rawURL = process.env.FIREBASE_DATABASE_URL;
+  if (!email || !privateKey || !rawURL) throw new Error("Firebase service-account environment variables are required");
+  const baseURL = databaseURL(rawURL);
+  const targetHash = createHash("sha256").update(baseURL).digest("hex");
+  let checkpoint = loadCheckpoint(checkpointFile, emptyCheckpoint(database, targetHash, now.toISOString()));
+  const token = await accessToken(email, privateKey);
+  const apply = mode === "apply";
+  for (; checkpoint.pass <= MAX_PASSES; checkpoint.pass++) {
+    let cursor = checkpoint.cursor;
+    let passChanged = Number(checkpoint.changed ?? 0);
+    while (true) {
+      const page = readPage(projectDir, database, cursor);
+      if (!page.groups.length) break;
+      const values = buildFirebaseGroups(page.groups, page.reports, now);
+      for (const row of page.groups) {
+        const fingerprint = validateFingerprint(text(row.fingerprint));
+        const entry = values.get(fingerprint);
+        const sourceHash = contentDigest({ state: entry.state, value: entry.value });
+        const previous = checkpoint.groups[fingerprint];
+        if (mode === "verify" || previous?.sourceHash !== sourceHash) {
+          const firebaseHash = await reconcileGroup(baseURL, token, fingerprint, entry, apply);
+          if (apply) runWrangler(projectDir, database, stateSQL(fingerprint, row, entry, now.toISOString()));
+          if (mode === "verify") verifyD1State(row, entry, page.states);
+          checkpoint.groups[fingerprint] = { sourceHash, firebaseHash, state: entry.state };
+          passChanged++;
+          console.log(`${mode === "verify" ? "Verified" : "Reconciled"} ${fingerprint.slice(0, 8)} ${sourceHash.slice(0, 12)}.`);
+        } else if (apply) {
+          await readAndVerify(baseURL, token, fingerprint, entry.value);
+        }
+        cursor = fingerprint;
+        checkpoint.cursor = cursor;
+        checkpoint.changed = passChanged;
+        saveCheckpoint(checkpointFile, checkpoint);
+      }
+    }
+    if (mode === "verify") {
+      checkpoint.cursor = "";
+      checkpoint.changed = 0;
+      checkpoint.completedAt = new Date().toISOString();
+      saveCheckpoint(checkpointFile, checkpoint);
+      console.log(`Verified ${Object.keys(checkpoint.groups).length} Firebase groups without writes.`);
+      return;
+    }
+    if (passChanged === 0) {
+      checkpoint.cursor = "";
+      checkpoint.changed = 0;
+      checkpoint.completedAt = new Date().toISOString();
+      saveCheckpoint(checkpointFile, checkpoint);
+      console.log(`Migration converged after ${checkpoint.pass} pass(es).`);
+      return;
+    }
+    checkpoint.cursor = "";
+    checkpoint.changed = 0;
+    saveCheckpoint(checkpointFile, checkpoint);
+  }
+  throw new Error("Firebase migration did not converge after 3 reconciliation passes; keep CRASH_STORAGE_MODE=d1");
 }
 
 async function main() {
   const projectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
   const database = process.env.DIAGNOSTICS_D1_DATABASE || "reasonix-crash";
-  const groups = runWrangler(projectDir, database, "SELECT * FROM groups ORDER BY fingerprint");
-  const reports = runWrangler(projectDir, database, "SELECT * FROM reports ORDER BY fingerprint, id");
-  const payloads = buildFirebaseGroups(groups, reports);
-  const bytes = [...payloads.values()].reduce((total, value) => total + Buffer.byteLength(JSON.stringify(value)), 0);
-  console.log(`Prepared ${payloads.size} groups and ${reports.length} retained samples (${bytes} JSON bytes).`);
-  if (!process.argv.includes("--apply")) {
-    console.log("Dry run only. Pass --apply with Firebase service-account environment variables to upload.");
+  const args = parseArgs(process.argv.slice(2), projectDir);
+  if (args.reset) {
+    try { unlinkSync(args.checkpoint); } catch (error) { if (error?.code !== "ENOENT") throw error; }
+  }
+  const now = new Date();
+  await dryRun(projectDir, database, now);
+  if (args.mode === "dry-run") {
+    console.log("Dry run only. Use --apply to migrate or --verify-only to perform readback verification.");
     return;
   }
-  const email = process.env.FIREBASE_CLIENT_EMAIL;
-  const privateKey = process.env.FIREBASE_PRIVATE_KEY;
-  const rawURL = process.env.FIREBASE_DATABASE_URL;
-  if (!email || !privateKey || !rawURL) throw new Error("Firebase service-account environment variables are required for --apply");
-  await upload(databaseURL(rawURL), await accessToken(email, privateKey), payloads);
+  await migrate(projectDir, database, args.mode, args.checkpoint, now);
 }
 
 const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";

--- a/workers/crash-report/src/crash_delivery.ts
+++ b/workers/crash-report/src/crash_delivery.ts
@@ -4,6 +4,30 @@ import { firebaseConfigured } from "./firebase_rtdb";
 export const FIREBASE_OUTBOX_LIMIT = 5_000;
 export const FIREBASE_OUTBOX_BATCH = 200;
 const FIREBASE_GROUP_LEASE_MS = 60_000;
+export const FIREBASE_STORAGE_BUDGET_BYTES = 700 * 1024 * 1024;
+export const FIREBASE_STORAGE_WARNING_BYTES = Math.floor(FIREBASE_STORAGE_BUDGET_BYTES * 0.8);
+export const FIREBASE_ACTIVE_RESERVATION_BYTES = 640 * 1024;
+export const FIREBASE_COMPACTED_RESERVATION_BYTES = 128 * 1024;
+export const FIREBASE_ARCHIVING_RESERVATION_BYTES = 32 * 1024;
+
+export type FirebaseSampleState = "active" | "compacted" | "archiving" | "archived";
+
+export type FirebaseGroupState = {
+  fingerprint: string;
+  sample_state: FirebaseSampleState;
+  sample_epoch: number;
+  epoch_first_event_id: string;
+  reserved_bytes: number;
+  last_seen: string;
+  compacted_at: string;
+  archived_at: string;
+  archive_reason: "" | "retention" | "admin";
+  lease_owner: string;
+  lease_generation: number;
+  lease_expires_at: string;
+};
+
+export type FirebaseGroupLease = { owner: string; generation: number };
 
 export type CrashStorageMode = "d1" | "dual" | "firebase";
 
@@ -73,14 +97,25 @@ export function projectionCompletionStatements(
   fingerprint: string,
   now: string,
 ): D1PreparedStatement[] {
-  return [
-    db.prepare(
+  const stateWrite = db.prepare(
+      `UPDATE firebase_crash_group_state
+       SET epoch_first_event_id = CASE WHEN epoch_first_event_id = '' THEN ?1 ELSE epoch_first_event_id END,
+           last_seen = CASE WHEN last_seen < ?2 THEN ?2 ELSE last_seen END
+       WHERE fingerprint = ?3 AND sample_state = 'active'`,
+    ).bind(eventId, now, fingerprint);
+  const receipt = db.prepare(
       `INSERT OR IGNORE INTO firebase_crash_receipts (
          event_id, projected_at, group_count, latest_slot, first_sample
        )
-       SELECT ?1, ?2, count, (count - 1) % 5, CASE WHEN count = 1 THEN 1 ELSE 0 END
-       FROM groups WHERE fingerprint = ?3`,
-    ).bind(eventId, now, fingerprint),
+       SELECT ?1, ?2, groups.count, (groups.count - 1) % 5,
+              CASE WHEN state.epoch_first_event_id = ?1 THEN 1 ELSE 0 END
+       FROM groups
+       JOIN firebase_crash_group_state AS state USING (fingerprint)
+       WHERE groups.fingerprint = ?3`,
+    ).bind(eventId, now, fingerprint);
+  return [
+    stateWrite,
+    receipt,
     db.prepare(
       "UPDATE firebase_crash_outbox SET state = 'projected', updated_at = ?2 WHERE event_id = ?1",
     ).bind(eventId, now),
@@ -108,34 +143,116 @@ export async function firebaseOutboxExists(env: Env, eventId: string): Promise<b
   ).bind(eventId).first());
 }
 
+export async function firebaseEventExists(env: Env, eventId: string): Promise<boolean> {
+  return Boolean(await env.DB.prepare(
+    `SELECT event_id FROM firebase_crash_outbox WHERE event_id = ?1
+     UNION ALL SELECT event_id FROM firebase_crash_receipts WHERE event_id = ?1 LIMIT 1`,
+  ).bind(eventId).first());
+}
+
+export async function firebaseGroupState(
+  env: Env,
+  fingerprint: string,
+): Promise<FirebaseGroupState | null> {
+  return env.DB.prepare(
+    `SELECT fingerprint, sample_state, sample_epoch, epoch_first_event_id, reserved_bytes,
+            last_seen, compacted_at, archived_at, archive_reason,
+            lease_owner, lease_generation, lease_expires_at
+     FROM firebase_crash_group_state WHERE fingerprint = ?1`,
+  ).bind(fingerprint).first<FirebaseGroupState>();
+}
+
+export async function reserveFirebaseGroup(
+  env: Env,
+  fingerprint: string,
+  lastSeen: string,
+): Promise<"reserved" | "full"> {
+  const result = await env.DB.prepare(
+    `INSERT INTO firebase_crash_group_state (
+       fingerprint, sample_state, sample_epoch, epoch_first_event_id,
+       reserved_bytes, last_seen, compacted_at, archived_at, archive_reason
+     )
+     SELECT ?1, 'active', 1, '', ?2, ?3, '', '', ''
+     WHERE (SELECT COALESCE(SUM(reserved_bytes), 0) FROM firebase_crash_group_state) + ?2 <= ?4
+       AND (
+         NOT EXISTS (SELECT 1 FROM groups WHERE fingerprint = ?1) OR
+         EXISTS (SELECT 1 FROM firebase_crash_group_state WHERE fingerprint = ?1)
+       )
+     ON CONFLICT (fingerprint) DO UPDATE SET
+       sample_state = 'active',
+       sample_epoch = CASE
+         WHEN firebase_crash_group_state.sample_state IN ('archiving', 'archived')
+           THEN firebase_crash_group_state.sample_epoch + 1
+         ELSE firebase_crash_group_state.sample_epoch
+       END,
+       epoch_first_event_id = CASE
+         WHEN firebase_crash_group_state.sample_state IN ('archiving', 'archived') THEN ''
+         ELSE firebase_crash_group_state.epoch_first_event_id
+       END,
+       reserved_bytes = ?2,
+       last_seen = CASE WHEN firebase_crash_group_state.last_seen < ?3
+         THEN ?3 ELSE firebase_crash_group_state.last_seen END,
+       compacted_at = '', archived_at = '', archive_reason = ''
+     WHERE firebase_crash_group_state.reserved_bytes >= ?2 OR
+       (SELECT COALESCE(SUM(reserved_bytes), 0) FROM firebase_crash_group_state)
+         - firebase_crash_group_state.reserved_bytes + ?2 <= ?4`,
+  ).bind(fingerprint, FIREBASE_ACTIVE_RESERVATION_BYTES, lastSeen, FIREBASE_STORAGE_BUDGET_BYTES).run();
+  return Number(result.meta?.changes ?? 0) > 0 ? "reserved" : "full";
+}
+
+export async function reclaimUnusedFirebaseReservation(env: Env, fingerprint: string): Promise<void> {
+  await env.DB.prepare(
+    `DELETE FROM firebase_crash_group_state
+     WHERE fingerprint = ?1 AND lease_generation = 0
+       AND NOT EXISTS (SELECT 1 FROM groups WHERE fingerprint = ?1)
+       AND NOT EXISTS (SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = ?1)`,
+  ).bind(fingerprint).run();
+}
+
 export async function acquireFirebaseGroupLease(
   env: Env,
   fingerprint: string,
   now = new Date(),
-): Promise<string | null> {
+): Promise<FirebaseGroupLease | null> {
   const owner = crypto.randomUUID();
   const acquiredAt = now.toISOString();
   const expiresAt = new Date(now.getTime() + FIREBASE_GROUP_LEASE_MS).toISOString();
-  await env.DB.prepare(
-    `INSERT INTO firebase_crash_group_leases (fingerprint, owner, expires_at)
-     VALUES (?1, ?2, ?3)
-     ON CONFLICT (fingerprint) DO UPDATE SET owner = ?2, expires_at = ?3
-     WHERE datetime(firebase_crash_group_leases.expires_at) <= datetime(?4)`,
-  ).bind(fingerprint, owner, expiresAt, acquiredAt).run();
-  const current = await env.DB.prepare(
-    "SELECT owner FROM firebase_crash_group_leases WHERE fingerprint = ?1",
-  ).bind(fingerprint).first<{ owner: string }>();
-  return current?.owner === owner ? owner : null;
+  const acquired = await env.DB.prepare(
+    `UPDATE firebase_crash_group_state
+     SET lease_owner = ?2, lease_generation = lease_generation + 1, lease_expires_at = ?3
+     WHERE fingerprint = ?1 AND (
+       lease_owner = '' OR datetime(lease_expires_at) <= datetime(?4)
+     )
+     RETURNING lease_generation`,
+  ).bind(fingerprint, owner, expiresAt, acquiredAt).first<{ lease_generation: number }>();
+  return acquired ? { owner, generation: Number(acquired.lease_generation) } : null;
+}
+
+export async function renewFirebaseGroupLease(
+  env: Env,
+  fingerprint: string,
+  lease: FirebaseGroupLease,
+  now = new Date(),
+): Promise<boolean> {
+  const current = now.toISOString();
+  const expiresAt = new Date(now.getTime() + FIREBASE_GROUP_LEASE_MS).toISOString();
+  const result = await env.DB.prepare(
+    `UPDATE firebase_crash_group_state SET lease_expires_at = ?4
+     WHERE fingerprint = ?1 AND lease_owner = ?2 AND lease_generation = ?3
+       AND datetime(lease_expires_at) > datetime(?5)`,
+  ).bind(fingerprint, lease.owner, lease.generation, expiresAt, current).run();
+  return Number(result.meta?.changes ?? 0) > 0;
 }
 
 export async function releaseFirebaseGroupLease(
   env: Env,
   fingerprint: string,
-  owner: string,
+  lease: FirebaseGroupLease,
 ): Promise<void> {
   await env.DB.prepare(
-    "DELETE FROM firebase_crash_group_leases WHERE fingerprint = ?1 AND owner = ?2",
-  ).bind(fingerprint, owner).run();
+    `UPDATE firebase_crash_group_state SET lease_owner = '', lease_expires_at = ''
+     WHERE fingerprint = ?1 AND lease_owner = ?2 AND lease_generation = ?3`,
+  ).bind(fingerprint, lease.owner, lease.generation).run();
 }
 
 export async function markFirebaseDelivered(env: Env, eventId: string): Promise<void> {
@@ -175,6 +292,9 @@ export async function purgeFirebaseDeliveryState(env: Env): Promise<void> {
   await env.DB.batch([
     env.DB.prepare("DELETE FROM firebase_crash_outbox WHERE datetime(created_at) < datetime('now', '-30 days')"),
     env.DB.prepare("DELETE FROM firebase_crash_receipts WHERE datetime(projected_at) < datetime('now', '-90 days')"),
-    env.DB.prepare("DELETE FROM firebase_crash_group_leases WHERE datetime(expires_at) < datetime('now')"),
+    env.DB.prepare(
+      `UPDATE firebase_crash_group_state SET lease_owner = '', lease_expires_at = ''
+       WHERE lease_owner != '' AND datetime(lease_expires_at) < datetime('now')`,
+    ),
   ]);
 }

--- a/workers/crash-report/src/crash_delivery.ts
+++ b/workers/crash-report/src/crash_delivery.ts
@@ -1,0 +1,180 @@
+import type { Env } from "./env";
+import { firebaseConfigured } from "./firebase_rtdb";
+
+export const FIREBASE_OUTBOX_LIMIT = 5_000;
+export const FIREBASE_OUTBOX_BATCH = 200;
+const FIREBASE_GROUP_LEASE_MS = 60_000;
+
+export type CrashStorageMode = "d1" | "dual" | "firebase";
+
+export type FirebaseOutboxRow = {
+  event_id: string;
+  fingerprint: string;
+  payload: string;
+  state: "queued" | "processing" | "projected";
+  attempts: number;
+  next_attempt_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type FirebaseProjectionReceipt = {
+  group_count: number;
+  latest_slot: number;
+  first_sample: number;
+};
+
+export function crashStorageMode(env: Env): CrashStorageMode {
+  const raw = env.CRASH_STORAGE_MODE?.trim().toLowerCase() || "d1";
+  if (raw === "d1" || raw === "dual" || raw === "firebase") return raw;
+  throw new Error(`invalid crash storage mode ${raw}`);
+}
+
+export function firebaseStorageReady(env: Env): boolean {
+  return crashStorageMode(env) === "d1" || firebaseConfigured(env);
+}
+
+export async function enqueueFirebaseCrash(
+  env: Env,
+  eventId: string,
+  fingerprint: string,
+  payload: string,
+  now: string,
+): Promise<"inserted" | "duplicate" | "full"> {
+  const result = await env.DB.prepare(
+    `INSERT OR IGNORE INTO firebase_crash_outbox (
+       event_id, fingerprint, payload, state, attempts, next_attempt_at, created_at, updated_at
+     )
+     SELECT ?1, ?2, ?3, 'queued', 0, ?4, ?4, ?4
+     WHERE (SELECT COUNT(*) FROM firebase_crash_outbox) < ?5
+       AND NOT EXISTS (SELECT 1 FROM firebase_crash_receipts WHERE event_id = ?1)`,
+  ).bind(eventId, fingerprint, payload, now, FIREBASE_OUTBOX_LIMIT).run();
+  if (Number(result.meta?.changes ?? 0) > 0) return "inserted";
+  const existing = await env.DB.prepare(
+    `SELECT event_id FROM firebase_crash_outbox WHERE event_id = ?1
+     UNION ALL SELECT event_id FROM firebase_crash_receipts WHERE event_id = ?1 LIMIT 1`,
+  ).bind(eventId).first<{ event_id: string }>();
+  return existing ? "duplicate" : "full";
+}
+
+export async function claimFirebaseCrash(env: Env, eventId: string, now: string): Promise<boolean> {
+  const result = await env.DB.prepare(
+    `UPDATE firebase_crash_outbox SET state = 'processing', updated_at = ?2
+     WHERE event_id = ?1 AND (
+       state = 'queued' OR (state = 'processing' AND datetime(updated_at) < datetime('now', '-10 minutes'))
+     )`,
+  ).bind(eventId, now).run();
+  return Number(result.meta?.changes ?? 0) > 0;
+}
+
+export function projectionCompletionStatements(
+  db: D1Database,
+  eventId: string,
+  fingerprint: string,
+  now: string,
+): D1PreparedStatement[] {
+  return [
+    db.prepare(
+      `INSERT OR IGNORE INTO firebase_crash_receipts (
+         event_id, projected_at, group_count, latest_slot, first_sample
+       )
+       SELECT ?1, ?2, count, (count - 1) % 5, CASE WHEN count = 1 THEN 1 ELSE 0 END
+       FROM groups WHERE fingerprint = ?3`,
+    ).bind(eventId, now, fingerprint),
+    db.prepare(
+      "UPDATE firebase_crash_outbox SET state = 'projected', updated_at = ?2 WHERE event_id = ?1",
+    ).bind(eventId, now),
+  ];
+}
+
+export async function firebaseProjectionReceipt(
+  env: Env,
+  eventId: string,
+): Promise<FirebaseProjectionReceipt | null> {
+  return env.DB.prepare(
+    "SELECT group_count, latest_slot, first_sample FROM firebase_crash_receipts WHERE event_id = ?1",
+  ).bind(eventId).first<FirebaseProjectionReceipt>();
+}
+
+export async function firebaseProjectionExists(env: Env, eventId: string): Promise<boolean> {
+  return Boolean(await env.DB.prepare(
+    "SELECT event_id FROM firebase_crash_receipts WHERE event_id = ?1",
+  ).bind(eventId).first());
+}
+
+export async function firebaseOutboxExists(env: Env, eventId: string): Promise<boolean> {
+  return Boolean(await env.DB.prepare(
+    "SELECT event_id FROM firebase_crash_outbox WHERE event_id = ?1",
+  ).bind(eventId).first());
+}
+
+export async function acquireFirebaseGroupLease(
+  env: Env,
+  fingerprint: string,
+  now = new Date(),
+): Promise<string | null> {
+  const owner = crypto.randomUUID();
+  const acquiredAt = now.toISOString();
+  const expiresAt = new Date(now.getTime() + FIREBASE_GROUP_LEASE_MS).toISOString();
+  await env.DB.prepare(
+    `INSERT INTO firebase_crash_group_leases (fingerprint, owner, expires_at)
+     VALUES (?1, ?2, ?3)
+     ON CONFLICT (fingerprint) DO UPDATE SET owner = ?2, expires_at = ?3
+     WHERE datetime(firebase_crash_group_leases.expires_at) <= datetime(?4)`,
+  ).bind(fingerprint, owner, expiresAt, acquiredAt).run();
+  const current = await env.DB.prepare(
+    "SELECT owner FROM firebase_crash_group_leases WHERE fingerprint = ?1",
+  ).bind(fingerprint).first<{ owner: string }>();
+  return current?.owner === owner ? owner : null;
+}
+
+export async function releaseFirebaseGroupLease(
+  env: Env,
+  fingerprint: string,
+  owner: string,
+): Promise<void> {
+  await env.DB.prepare(
+    "DELETE FROM firebase_crash_group_leases WHERE fingerprint = ?1 AND owner = ?2",
+  ).bind(fingerprint, owner).run();
+}
+
+export async function markFirebaseDelivered(env: Env, eventId: string): Promise<void> {
+  await env.DB.prepare("DELETE FROM firebase_crash_outbox WHERE event_id = ?1").bind(eventId).run();
+}
+
+export async function recordFirebaseRetry(
+  env: Env,
+  eventId: string,
+  state: FirebaseOutboxRow["state"],
+  attempts: number,
+): Promise<void> {
+  const delaySeconds = Math.min(24 * 60 * 60, 30 * 2 ** Math.min(attempts, 11));
+  const now = new Date();
+  const next = new Date(now.getTime() + delaySeconds * 1000).toISOString();
+  await env.DB.prepare(
+    `UPDATE firebase_crash_outbox
+     SET state = ?2, attempts = attempts + 1, next_attempt_at = ?3, updated_at = ?4
+     WHERE event_id = ?1`,
+  ).bind(eventId, state, next, now.toISOString()).run();
+}
+
+export async function dueFirebaseCrashes(env: Env): Promise<FirebaseOutboxRow[]> {
+  const result = await env.DB.prepare(
+    `SELECT event_id, fingerprint, payload, state, attempts, next_attempt_at, created_at, updated_at
+     FROM firebase_crash_outbox
+     WHERE next_attempt_at <= ?1 AND (
+       state IN ('queued', 'projected') OR
+       (state = 'processing' AND datetime(updated_at) < datetime('now', '-10 minutes'))
+     )
+     ORDER BY created_at LIMIT ?2`,
+  ).bind(new Date().toISOString(), FIREBASE_OUTBOX_BATCH).all<FirebaseOutboxRow>();
+  return result.results;
+}
+
+export async function purgeFirebaseDeliveryState(env: Env): Promise<void> {
+  await env.DB.batch([
+    env.DB.prepare("DELETE FROM firebase_crash_outbox WHERE datetime(created_at) < datetime('now', '-30 days')"),
+    env.DB.prepare("DELETE FROM firebase_crash_receipts WHERE datetime(projected_at) < datetime('now', '-90 days')"),
+    env.DB.prepare("DELETE FROM firebase_crash_group_leases WHERE datetime(expires_at) < datetime('now')"),
+  ]);
+}

--- a/workers/crash-report/src/diagnostics_v2.test.ts
+++ b/workers/crash-report/src/diagnostics_v2.test.ts
@@ -15,12 +15,17 @@ import {
 import type { Env } from "./env";
 import diagnosticsMigrationSQL from "../migrate-diagnostics-v2.sql?raw";
 import freshSchemaSQL from "../schema.sql?raw";
+import firebaseCrashMigrationSQL from "../migrate-firebase-crash.sql?raw";
 import {
   classifyDiagnosticsV2Schema,
   diagnosticsV2SchemaEntries,
   diagnosticsV2SchemaQuery,
   parseWranglerRows,
 } from "../scripts/apply-diagnostics-v2.mjs";
+import {
+  classifyFirebaseCrashSchema,
+  firebaseCrashSchemaQuery,
+} from "../scripts/apply-firebase-crash.mjs";
 
 const oldReport = {
   kind: "crash",
@@ -172,6 +177,21 @@ describe("diagnostics v2 compatibility and privacy", () => {
       db.close();
     }
   });
+
+  it("keeps the Firebase outbox migration additive and aligned with fresh installs", () => {
+    const migrated = new DatabaseSync(":memory:");
+    const fresh = new DatabaseSync(":memory:");
+    try {
+      migrated.exec(firebaseCrashMigrationSQL);
+      fresh.exec(freshSchemaSQL);
+      expect(classifyFirebaseCrashSchema(migrated.prepare(firebaseCrashSchemaQuery).all()).state).toBe("complete");
+      expect(classifyFirebaseCrashSchema(fresh.prepare(firebaseCrashSchemaQuery).all()).state).toBe("complete");
+      expect(firebaseCrashMigrationSQL).not.toMatch(/\b(?:DROP|ALTER)\b/);
+    } finally {
+      migrated.close();
+      fresh.close();
+    }
+  });
 });
 
 describe("stats window and release baseline", () => {
@@ -233,6 +253,8 @@ describe("diagnostics v2 storage consistency", () => {
       expect.stringContaining("INSERT INTO report_installations"),
       expect.stringContaining("INSERT INTO report_event_dimensions"),
       expect.stringContaining("DELETE FROM reports"),
+      expect.stringContaining("INSERT OR IGNORE INTO firebase_crash_receipts"),
+      expect.stringContaining("UPDATE firebase_crash_outbox SET state = 'projected'"),
     ]);
   });
 

--- a/workers/crash-report/src/diagnostics_v2.test.ts
+++ b/workers/crash-report/src/diagnostics_v2.test.ts
@@ -16,6 +16,7 @@ import type { Env } from "./env";
 import diagnosticsMigrationSQL from "../migrate-diagnostics-v2.sql?raw";
 import freshSchemaSQL from "../schema.sql?raw";
 import firebaseCrashMigrationSQL from "../migrate-firebase-crash.sql?raw";
+import firebaseCrashCapacityMigrationSQL from "../migrate-firebase-crash-capacity.sql?raw";
 import {
   classifyDiagnosticsV2Schema,
   diagnosticsV2SchemaEntries,
@@ -182,11 +183,15 @@ describe("diagnostics v2 compatibility and privacy", () => {
     const migrated = new DatabaseSync(":memory:");
     const fresh = new DatabaseSync(":memory:");
     try {
+      migrated.exec("CREATE TABLE groups (fingerprint TEXT PRIMARY KEY, last_seen TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'open')");
       migrated.exec(firebaseCrashMigrationSQL);
+      expect(classifyFirebaseCrashSchema(migrated.prepare(firebaseCrashSchemaQuery).all()).state).toBe("partial");
+      migrated.exec(firebaseCrashCapacityMigrationSQL);
       fresh.exec(freshSchemaSQL);
       expect(classifyFirebaseCrashSchema(migrated.prepare(firebaseCrashSchemaQuery).all()).state).toBe("complete");
       expect(classifyFirebaseCrashSchema(fresh.prepare(firebaseCrashSchemaQuery).all()).state).toBe("complete");
       expect(firebaseCrashMigrationSQL).not.toMatch(/\b(?:DROP|ALTER)\b/);
+      expect(firebaseCrashCapacityMigrationSQL).not.toMatch(/\b(?:DROP|ALTER)\b/);
     } finally {
       migrated.close();
       fresh.close();
@@ -253,9 +258,8 @@ describe("diagnostics v2 storage consistency", () => {
       expect.stringContaining("INSERT INTO report_installations"),
       expect.stringContaining("INSERT INTO report_event_dimensions"),
       expect.stringContaining("DELETE FROM reports"),
-      expect.stringContaining("INSERT OR IGNORE INTO firebase_crash_receipts"),
-      expect.stringContaining("UPDATE firebase_crash_outbox SET state = 'projected'"),
     ]);
+    expect(committed.every((statement) => !statement.sql.includes("firebase_crash_"))).toBe(true);
   });
 
   it("preserves separate GPU and runtime event dimensions for one installation", () => {

--- a/workers/crash-report/src/env.ts
+++ b/workers/crash-report/src/env.ts
@@ -23,4 +23,11 @@ export interface Env {
   // Lark bot URLs get their native payload shape; any other receiver gets
   // Slack-style {"text": ...}. Unset = log-only.
   ALERT_WEBHOOK?: string;
+  // Crash sample storage rollout. `d1` is the fail-safe default; `dual`
+  // preserves D1 samples while mirroring Firebase; `firebase` keeps only the
+  // D1 query projection and the bounded retry outbox.
+  CRASH_STORAGE_MODE?: string;
+  FIREBASE_DATABASE_URL?: string;
+  FIREBASE_CLIENT_EMAIL?: string;
+  FIREBASE_PRIVATE_KEY?: string;
 }

--- a/workers/crash-report/src/firebase_crash_integration.test.ts
+++ b/workers/crash-report/src/firebase_crash_integration.test.ts
@@ -12,6 +12,8 @@ import {
   releaseFirebaseGroupLease,
 } from "./crash_delivery";
 
+const firebaseOAuthTokenURL = "https://oauth2.googleapis.com/token";
+
 type SQLiteD1Statement = D1PreparedStatement & {
   execute(): D1Result;
 };
@@ -164,7 +166,7 @@ describe("Firebase-primary crash ingest", () => {
     const writes: Array<{ url: string; body: string }> = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url.includes("oauth2.googleapis.com")) {
+      if (url === firebaseOAuthTokenURL) {
         return Response.json({ access_token: "token", expires_in: 3600 });
       }
       writes.push({ url, body: String(init?.body) });
@@ -197,7 +199,7 @@ describe("Firebase-primary crash ingest", () => {
     let databaseAvailable = false;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes("oauth2.googleapis.com")) {
+      if (url === firebaseOAuthTokenURL) {
         return Response.json({ access_token: "token", expires_in: 3600 });
       }
       return databaseAvailable ? Response.json({ ok: true }) : new Response("unavailable", { status: 503 });
@@ -228,7 +230,7 @@ describe("Firebase-primary crash ingest", () => {
     let databaseWrites = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url.includes("oauth2.googleapis.com")) {
+      if (url === firebaseOAuthTokenURL) {
         return Response.json({ access_token: "token", expires_in: 3600 });
       }
       databaseWrites++;
@@ -290,7 +292,7 @@ describe("Firebase-primary crash ingest", () => {
     const successfulBodies: string[] = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url.includes("oauth2.googleapis.com")) {
+      if (url === firebaseOAuthTokenURL) {
         return Response.json({ access_token: "token", expires_in: 3600 });
       }
       databaseWrites++;

--- a/workers/crash-report/src/firebase_crash_integration.test.ts
+++ b/workers/crash-report/src/firebase_crash_integration.test.ts
@@ -6,36 +6,28 @@ import type { Env } from "./env";
 import freshSchemaSQL from "../schema.sql?raw";
 import { resetFirebaseAuthForTests } from "./firebase_rtdb";
 import {
+  FIREBASE_ACTIVE_RESERVATION_BYTES,
+  FIREBASE_STORAGE_BUDGET_BYTES,
   acquireFirebaseGroupLease,
   dueFirebaseCrashes,
   purgeFirebaseDeliveryState,
   releaseFirebaseGroupLease,
+  reserveFirebaseGroup,
 } from "./crash_delivery";
 
-const firebaseOAuthTokenURL = "https://oauth2.googleapis.com/token";
+const oauthURL = "https://oauth2.googleapis.com/token";
 
-type SQLiteD1Statement = D1PreparedStatement & {
-  execute(): D1Result;
-};
+type SQLiteD1Statement = D1PreparedStatement & { execute(): D1Result };
 
 function sqliteD1(db: DatabaseSync): D1Database {
   return {
     prepare(sql: string) {
       let binds: unknown[] = [];
       const statement = {
-        bind(...values: unknown[]) {
-          binds = values;
-          return statement;
-        },
-        async first<T>() {
-          return (db.prepare(sql).get(...binds) ?? null) as T | null;
-        },
-        async all<T>() {
-          return { success: true, results: db.prepare(sql).all(...binds) as T[], meta: {} };
-        },
-        async run() {
-          return statement.execute();
-        },
+        bind(...values: unknown[]) { binds = values; return statement; },
+        async first<T>() { return (db.prepare(sql).get(...binds) ?? null) as T | null; },
+        async all<T>() { return { success: true, results: db.prepare(sql).all(...binds) as T[], meta: {} }; },
+        async run() { return statement.execute(); },
         execute() {
           const result = db.prepare(sql).run(...binds);
           return { success: true, results: [], meta: { changes: Number(result.changes) } } as unknown as D1Result;
@@ -64,18 +56,15 @@ async function privateKeyPEM(): Promise<string> {
     true,
     ["sign", "verify"],
   ) as CryptoKeyPair;
-  const exported = await crypto.subtle.exportKey("pkcs8", pair.privateKey) as ArrayBuffer;
-  const bytes = new Uint8Array(exported);
+  const bytes = new Uint8Array(await crypto.subtle.exportKey("pkcs8", pair.privateKey) as ArrayBuffer);
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
-  const encoded = btoa(binary).match(/.{1,64}/g)?.join("\n") ?? "";
-  return `-----BEGIN PRIVATE KEY-----\n${encoded}\n-----END PRIVATE KEY-----`;
+  return `-----BEGIN PRIVATE KEY-----\n${btoa(binary).match(/.{1,64}/g)?.join("\n") ?? ""}\n-----END PRIVATE KEY-----`;
 }
 
 async function integrationEnv(db: DatabaseSync): Promise<Env> {
   return {
-    DB: sqliteD1(db),
-    RATE_LIMITER: { async limit() { return { success: true }; } },
+    DB: sqliteD1(db), RATE_LIMITER: { async limit() { return { success: true }; } },
     CRASH_STORAGE_MODE: "firebase",
     FIREBASE_DATABASE_URL: "https://reasonix-test.asia-southeast1.firebasedatabase.app",
     FIREBASE_CLIENT_EMAIL: "crash-writer@example.iam.gserviceaccount.com",
@@ -85,93 +74,120 @@ async function integrationEnv(db: DatabaseSync): Promise<Env> {
 
 function reportRequest(eventId = "a".repeat(32)): Request {
   const body = JSON.stringify({
-    eventId,
-    dedupKey: "b".repeat(64),
-    installId: "c".repeat(32),
-    kind: "crash",
-    version: "v1.25.0",
-    os: "linux",
-    arch: "amd64",
-    message: "panic at /home/alice/project/main.go:12",
-    source: "go",
-    label: "panic",
-    errorType: "runtime.error",
-    topFrame: "main.go:12",
+    eventId, dedupKey: "b".repeat(64), installId: "c".repeat(32), kind: "crash",
+    version: "v1.25.0", os: "linux", arch: "amd64",
+    message: "panic at /home/alice/project/main.go:12", source: "go", label: "panic",
+    errorType: "runtime.error", topFrame: "main.go:12",
   });
   return new Request("https://crash.reasonix.io/v1/report", {
     method: "POST",
     headers: {
-      "content-type": "application/json",
-      "content-length": String(new TextEncoder().encode(body).byteLength),
+      "content-type": "application/json", "content-length": String(new TextEncoder().encode(body).byteLength),
       "cf-connecting-ip": "127.0.0.1",
     },
     body,
   });
 }
 
-afterEach(() => {
-  vi.unstubAllGlobals();
-  resetFirebaseAuthForTests();
-});
+function firebaseStub() {
+  const values = new Map<string, unknown>();
+  const etags = new Map<string, number>();
+  const puts: Array<{ path: string; body: string }> = [];
+  let unavailable = false;
+  let beforeFirstPut: (() => Promise<void>) | undefined;
+  const pathOf = (url: string) => new URL(url).pathname.replace(/^\//, "").replace(/\.json$/, "");
+  const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url === oauthURL) return Response.json({ access_token: "token", expires_in: 3600 });
+    if (unavailable) return new Response("unavailable", { status: 503 });
+    const path = pathOf(url);
+    const version = etags.get(path) ?? 1;
+    if ((init?.method ?? "GET") === "GET") {
+      return Response.json(values.get(path) ?? null, { headers: { etag: `"${version}"` } });
+    }
+    if (init?.method === "PUT") {
+      if (beforeFirstPut) { const wait = beforeFirstPut; beforeFirstPut = undefined; await wait(); }
+      const match = new Headers(init.headers).get("If-Match");
+      if (match !== `"${version}"`) return new Response(null, { status: 412 });
+      const body = String(init.body);
+      puts.push({ path, body });
+      values.set(path, JSON.parse(body) as unknown);
+      etags.set(path, version + 1);
+      return new Response(null, { status: 204 });
+    }
+    if (init?.method === "DELETE") { values.delete(path); return new Response(null, { status: 204 }); }
+    return new Response(null, { status: 400 });
+  });
+  return {
+    values, puts, fetcher,
+    setUnavailable(value: boolean) { unavailable = value; },
+    blockFirstPut(waiter: () => Promise<void>) { beforeFirstPut = waiter; },
+  };
+}
+
+afterEach(() => { vi.unstubAllGlobals(); resetFirebaseAuthForTests(); });
 
 describe("Firebase-primary crash ingest", () => {
-  it("serializes each group across isolates and protects a replacement lease from stale release", async () => {
+  it("fences stale lease release with an increasing generation", async () => {
     const db = new DatabaseSync(":memory:");
     db.exec(freshSchemaSQL);
     const env = await integrationEnv(db);
     const fingerprint = "9".repeat(64);
+    db.prepare(`INSERT INTO firebase_crash_group_state (
+      fingerprint, reserved_bytes, last_seen
+    ) VALUES (?, ?, ?)`).run(fingerprint, FIREBASE_ACTIVE_RESERVATION_BYTES, "2026-08-25T00:00:00Z");
     try {
-      const first = await acquireFirebaseGroupLease(env, fingerprint, new Date("2026-08-25T00:00:00Z"));
-      expect(first).toBeTruthy();
-      expect(await acquireFirebaseGroupLease(env, fingerprint, new Date("2026-08-25T00:00:30Z"))).toBeNull();
-      const replacement = await acquireFirebaseGroupLease(env, fingerprint, new Date("2026-08-25T00:01:01Z"));
-      expect(replacement).toBeTruthy();
-      await releaseFirebaseGroupLease(env, fingerprint, first!);
-      expect(db.prepare("SELECT owner FROM firebase_crash_group_leases").get()).toEqual({ owner: replacement });
-      await releaseFirebaseGroupLease(env, fingerprint, replacement!);
-      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_group_leases").get()).toEqual({ count: 0 });
-    } finally {
-      db.close();
-    }
+      const base = new Date("2026-08-25T00:00:00Z").getTime();
+      for (let iteration = 0; iteration < 100; iteration++) {
+        const started = new Date(base + iteration * 180_000);
+        const first = await acquireFirebaseGroupLease(env, fingerprint, started);
+        expect(first?.generation).toBe(iteration * 2 + 1);
+        expect(await acquireFirebaseGroupLease(env, fingerprint, new Date(started.getTime() + 30_000))).toBeNull();
+        const replacement = await acquireFirebaseGroupLease(env, fingerprint, new Date(started.getTime() + 61_000));
+        expect(replacement?.generation).toBe(iteration * 2 + 2);
+        await releaseFirebaseGroupLease(env, fingerprint, first!);
+        expect(db.prepare("SELECT lease_owner FROM firebase_crash_group_state").get())
+          .toEqual({ lease_owner: replacement!.owner });
+        await releaseFirebaseGroupLease(env, fingerprint, replacement!);
+      }
+      expect(db.prepare("SELECT lease_owner, lease_generation FROM firebase_crash_group_state").get())
+        .toEqual({ lease_owner: "", lease_generation: 200 });
+    } finally { db.close(); }
   });
 
-  it("reclaims ISO-timestamped processing rows and purges expired delivery state", async () => {
+  it("reclaims old delivery rows and expired generation leases", async () => {
     const db = new DatabaseSync(":memory:");
     db.exec(freshSchemaSQL);
     const env = await integrationEnv(db);
     try {
       db.prepare(`INSERT INTO firebase_crash_outbox (
         event_id, fingerprint, payload, state, attempts, next_attempt_at, created_at, updated_at
-      ) VALUES (?, ?, '{}', 'processing', 0, ?, ?, ?)`)
-        .run("8".repeat(32), "7".repeat(64), "2000-01-01T00:00:00.000Z", "2000-01-01T00:00:00.000Z", "2000-01-01T00:00:00.000Z");
+      ) VALUES (?, ?, '{}', 'processing', 0, ?, ?, ?)`).run(
+        "8".repeat(32), "7".repeat(64), "2000-01-01T00:00:00Z", "2000-01-01T00:00:00Z", "2000-01-01T00:00:00Z",
+      );
       db.prepare(`INSERT INTO firebase_crash_receipts (
         event_id, projected_at, group_count, latest_slot, first_sample
-      ) VALUES (?, ?, 1, 0, 1)`).run("6".repeat(32), "2000-01-01T00:00:00.000Z");
-      db.prepare("INSERT INTO firebase_crash_group_leases (fingerprint, owner, expires_at) VALUES (?, ?, ?)")
-        .run("5".repeat(64), "expired", "2000-01-01T00:00:00.000Z");
+      ) VALUES (?, ?, 1, 0, 1)`).run("6".repeat(32), "2000-01-01T00:00:00Z");
+      db.prepare(`INSERT INTO firebase_crash_group_state (
+        fingerprint, reserved_bytes, last_seen, lease_owner, lease_generation, lease_expires_at
+      ) VALUES (?, ?, ?, 'expired', 4, ?)`).run(
+        "5".repeat(64), FIREBASE_ACTIVE_RESERVATION_BYTES, "2000-01-01T00:00:00Z", "2000-01-01T00:00:00Z",
+      );
       expect(await dueFirebaseCrashes(env)).toHaveLength(1);
       await purgeFirebaseDeliveryState(env);
       expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_outbox").get()).toEqual({ count: 0 });
       expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_receipts").get()).toEqual({ count: 0 });
-      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_group_leases").get()).toEqual({ count: 0 });
-    } finally {
-      db.close();
-    }
+      expect(db.prepare("SELECT lease_owner, lease_generation FROM firebase_crash_group_state").get())
+        .toEqual({ lease_owner: "", lease_generation: 4 });
+    } finally { db.close(); }
   });
 
   it("stores no long-lived D1 sample and deduplicates a repeated eventId", async () => {
     const db = new DatabaseSync(":memory:");
     db.exec(freshSchemaSQL);
     const env = await integrationEnv(db);
-    const writes: Array<{ url: string; body: string }> = [];
-    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url === firebaseOAuthTokenURL) {
-        return Response.json({ access_token: "token", expires_in: 3600 });
-      }
-      writes.push({ url, body: String(init?.body) });
-      return Response.json({ ok: true });
-    });
+    const firebase = firebaseStub();
+    vi.stubGlobal("fetch", firebase.fetcher);
     try {
       expect((await worker.fetch(reportRequest(), env)).status).toBe(202);
       expect((await worker.fetch(reportRequest(), env)).status).toBe(202);
@@ -179,88 +195,60 @@ describe("Firebase-primary crash ingest", () => {
       expect(db.prepare("SELECT COUNT(*) AS count FROM reports").get()).toEqual({ count: 0 });
       expect(db.prepare("SELECT events FROM report_daily").get()).toEqual({ events: 1 });
       expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_outbox").get()).toEqual({ count: 0 });
-      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_receipts").get()).toEqual({ count: 1 });
       expect(db.prepare("SELECT group_count, latest_slot, first_sample FROM firebase_crash_receipts").get())
         .toEqual({ group_count: 1, latest_slot: 0, first_sample: 1 });
-      expect(writes).toHaveLength(1);
-      const firebaseBody = writes[0].body;
-      expect(firebaseBody).toContain("/home/_/project/main.go:12");
-      expect(firebaseBody).not.toContain("\"installId\"");
-      expect(firebaseBody).not.toContain("alice");
-    } finally {
-      db.close();
-    }
+      expect(firebase.puts).toHaveLength(3);
+      const bodies = firebase.puts.map((write) => write.body).join("\n");
+      expect(bodies).toContain("/home/_/project/main.go:12");
+      expect(bodies).not.toContain("installId");
+      expect(bodies).not.toContain("alice");
+    } finally { db.close(); }
   });
 
-  it("buffers an unavailable Firebase write and retries without double-counting D1", async () => {
+  it("buffers Firebase failure and retries without double-counting D1", async () => {
     const db = new DatabaseSync(":memory:");
     db.exec(freshSchemaSQL);
     const env = await integrationEnv(db);
-    let databaseAvailable = false;
-    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url === firebaseOAuthTokenURL) {
-        return Response.json({ access_token: "token", expires_in: 3600 });
-      }
-      return databaseAvailable ? Response.json({ ok: true }) : new Response("unavailable", { status: 503 });
-    });
+    const firebase = firebaseStub();
+    firebase.setUnavailable(true);
+    vi.stubGlobal("fetch", firebase.fetcher);
     try {
       expect((await worker.fetch(reportRequest("d".repeat(32)), env)).status).toBe(202);
       expect(db.prepare("SELECT state FROM firebase_crash_outbox").get()).toEqual({ state: "projected" });
-      expect(db.prepare("SELECT count FROM groups").get()).toEqual({ count: 1 });
-      db.prepare("UPDATE firebase_crash_outbox SET next_attempt_at = '2000-01-01T00:00:00.000Z'").run();
-      databaseAvailable = true;
+      firebase.setUnavailable(false);
+      db.prepare("UPDATE firebase_crash_outbox SET next_attempt_at = '2000-01-01T00:00:00Z'").run();
       await drainFirebaseCrashOutbox(env);
       expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_outbox").get()).toEqual({ count: 0 });
       expect(db.prepare("SELECT count FROM groups").get()).toEqual({ count: 1 });
-    } finally {
-      db.close();
-    }
+    } finally { db.close(); }
   });
 
-  it("queues a concurrent same-group report until the current projection and Firebase write release the lease", async () => {
+  it("queues a same-group report while the current generation is writing", async () => {
     const db = new DatabaseSync(":memory:");
     db.exec(freshSchemaSQL);
     const env = await integrationEnv(db);
-    const bodies: Array<Record<string, unknown>> = [];
-    let releaseFirstWrite!: () => void;
-    const firstWriteReleased = new Promise<void>((resolve) => { releaseFirstWrite = resolve; });
-    let signalFirstWrite!: () => void;
-    const firstWriteStarted = new Promise<void>((resolve) => { signalFirstWrite = resolve; });
-    let databaseWrites = 0;
-    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url === firebaseOAuthTokenURL) {
-        return Response.json({ access_token: "token", expires_in: 3600 });
-      }
-      databaseWrites++;
-      bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
-      if (databaseWrites === 1) {
-        signalFirstWrite();
-        await firstWriteReleased;
-      }
-      return Response.json({ ok: true });
-    });
+    const firebase = firebaseStub();
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => { release = resolve; });
+    let started!: () => void;
+    const firstPut = new Promise<void>((resolve) => { started = resolve; });
+    firebase.blockFirstPut(async () => { started(); await released; });
+    vi.stubGlobal("fetch", firebase.fetcher);
     try {
       const first = worker.fetch(reportRequest("1".repeat(32)), env);
-      await firstWriteStarted;
+      await firstPut;
       expect((await worker.fetch(reportRequest("2".repeat(32)), env)).status).toBe(202);
-      expect(db.prepare("SELECT count FROM groups").get()).toEqual({ count: 1 });
       expect(db.prepare("SELECT state FROM firebase_crash_outbox WHERE event_id = ?").get("2".repeat(32)))
         .toEqual({ state: "queued" });
-      releaseFirstWrite();
+      release();
       expect((await first).status).toBe(202);
       await drainFirebaseCrashOutbox(env);
-      expect(bodies.map((body) => (body.meta as { count: number }).count)).toEqual([1, 2]);
       expect(db.prepare("SELECT count FROM groups").get()).toEqual({ count: 2 });
       expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_outbox").get()).toEqual({ count: 0 });
-    } finally {
-      releaseFirstWrite();
-      db.close();
-    }
+    } finally { release(); db.close(); }
   });
 
-  it("returns 503 instead of growing beyond the 5000-row outbox cap", async () => {
+  it("returns 503 at the outbox cap and reclaims only the unused new reservation", async () => {
     const db = new DatabaseSync(":memory:");
     db.exec(freshSchemaSQL);
     db.exec(`WITH RECURSIVE n(value) AS (
@@ -268,52 +256,32 @@ describe("Firebase-primary crash ingest", () => {
     ) INSERT INTO firebase_crash_outbox (
       event_id, fingerprint, payload, state, attempts, next_attempt_at, created_at, updated_at
     ) SELECT printf('%032x', value), '${"e".repeat(64)}', '{}', 'queued', 0,
-      '2026-08-25T00:00:00.000Z', '2026-08-25T00:00:00.000Z', '2026-08-25T00:00:00.000Z' FROM n`);
+      '2026-08-25T00:00:00Z', '2026-08-25T00:00:00Z', '2026-08-25T00:00:00Z' FROM n`);
     const env = await integrationEnv(db);
-    let networkCalls = 0;
-    vi.stubGlobal("fetch", async () => {
-      networkCalls++;
-      return Response.json({ ok: true });
-    });
     try {
       expect((await worker.fetch(reportRequest("f".repeat(32)), env)).status).toBe(503);
-      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_outbox").get()).toEqual({ count: 5000 });
-      expect(networkCalls).toBe(0);
-    } finally {
-      db.close();
-    }
+      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_group_state").get()).toEqual({ count: 0 });
+    } finally { db.close(); }
   });
 
-  it("does not let a stale retry overwrite a newer ring-buffer slot", async () => {
+  it("enforces the 700 MiB reservation in the atomic INSERT/UPDATE statement", async () => {
     const db = new DatabaseSync(":memory:");
     db.exec(freshSchemaSQL);
     const env = await integrationEnv(db);
-    let databaseWrites = 0;
-    const successfulBodies: string[] = [];
-    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url === firebaseOAuthTokenURL) {
-        return Response.json({ access_token: "token", expires_in: 3600 });
-      }
-      databaseWrites++;
-      if (databaseWrites === 1) return new Response("unavailable", { status: 503 });
-      successfulBodies.push(String(init?.body));
-      return Response.json({ ok: true });
-    });
+    const padding = FIREBASE_STORAGE_BUDGET_BYTES - FIREBASE_ACTIVE_RESERVATION_BYTES + 1;
+    db.prepare(`INSERT INTO firebase_crash_group_state (
+      fingerprint, reserved_bytes, last_seen
+    ) VALUES (?, ?, ?)`).run("1".repeat(64), padding, "2026-08-25T00:00:00Z");
     try {
-      for (const value of "1234567") {
-        expect((await worker.fetch(reportRequest(value.repeat(32)), env)).status).toBe(202);
-      }
-      expect(db.prepare("SELECT count FROM groups").get()).toEqual({ count: 7 });
-      db.prepare("UPDATE firebase_crash_outbox SET next_attempt_at = '2000-01-01T00:00:00.000Z'").run();
-      await drainFirebaseCrashOutbox(env);
-      const retry = JSON.parse(successfulBodies.at(-1) ?? "{}") as Record<string, unknown>;
-      expect(retry.meta).toMatchObject({ count: 7 });
-      expect(retry["samples/first"]).toMatchObject({ eventId: "1".repeat(32) });
-      expect(Object.keys(retry).some((key) => key.startsWith("samples/latest/"))).toBe(false);
-      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_outbox").get()).toEqual({ count: 0 });
-    } finally {
-      db.close();
-    }
+      expect(await reserveFirebaseGroup(env, "2".repeat(64), "2026-08-25T00:00:00Z")).toBe("full");
+      expect(db.prepare("SELECT SUM(reserved_bytes) AS total FROM firebase_crash_group_state").get())
+        .toEqual({ total: padding });
+      db.prepare(`INSERT INTO groups (
+        fingerprint, kind, count, first_seen, last_seen, last_version
+      ) VALUES (?, 'crash', 1, ?, ?, 'v1')`).run(
+        "3".repeat(64), "2026-08-25T00:00:00Z", "2026-08-25T00:00:00Z",
+      );
+      expect(await reserveFirebaseGroup(env, "3".repeat(64), "2026-08-25T00:00:00Z")).toBe("full");
+    } finally { db.close(); }
   });
 });

--- a/workers/crash-report/src/firebase_crash_integration.test.ts
+++ b/workers/crash-report/src/firebase_crash_integration.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+// @ts-expect-error Node 22+ provides node:sqlite; Worker production code does not import it.
+import { DatabaseSync } from "node:sqlite";
+import worker, { drainFirebaseCrashOutbox } from "./index";
+import type { Env } from "./env";
+import freshSchemaSQL from "../schema.sql?raw";
+import { resetFirebaseAuthForTests } from "./firebase_rtdb";
+import {
+  acquireFirebaseGroupLease,
+  dueFirebaseCrashes,
+  purgeFirebaseDeliveryState,
+  releaseFirebaseGroupLease,
+} from "./crash_delivery";
+
+type SQLiteD1Statement = D1PreparedStatement & {
+  execute(): D1Result;
+};
+
+function sqliteD1(db: DatabaseSync): D1Database {
+  return {
+    prepare(sql: string) {
+      let binds: unknown[] = [];
+      const statement = {
+        bind(...values: unknown[]) {
+          binds = values;
+          return statement;
+        },
+        async first<T>() {
+          return (db.prepare(sql).get(...binds) ?? null) as T | null;
+        },
+        async all<T>() {
+          return { success: true, results: db.prepare(sql).all(...binds) as T[], meta: {} };
+        },
+        async run() {
+          return statement.execute();
+        },
+        execute() {
+          const result = db.prepare(sql).run(...binds);
+          return { success: true, results: [], meta: { changes: Number(result.changes) } } as unknown as D1Result;
+        },
+        raw() { return Promise.resolve([]); },
+      } as unknown as SQLiteD1Statement;
+      return statement;
+    },
+    async batch(statements: D1PreparedStatement[]) {
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        const results = statements.map((statement) => (statement as SQLiteD1Statement).execute());
+        db.exec("COMMIT");
+        return results;
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+    },
+  } as unknown as D1Database;
+}
+
+async function privateKeyPEM(): Promise<string> {
+  const pair = await crypto.subtle.generateKey(
+    { name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const exported = await crypto.subtle.exportKey("pkcs8", pair.privateKey) as ArrayBuffer;
+  const bytes = new Uint8Array(exported);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  const encoded = btoa(binary).match(/.{1,64}/g)?.join("\n") ?? "";
+  return `-----BEGIN PRIVATE KEY-----\n${encoded}\n-----END PRIVATE KEY-----`;
+}
+
+async function integrationEnv(db: DatabaseSync): Promise<Env> {
+  return {
+    DB: sqliteD1(db),
+    RATE_LIMITER: { async limit() { return { success: true }; } },
+    CRASH_STORAGE_MODE: "firebase",
+    FIREBASE_DATABASE_URL: "https://reasonix-test.asia-southeast1.firebasedatabase.app",
+    FIREBASE_CLIENT_EMAIL: "crash-writer@example.iam.gserviceaccount.com",
+    FIREBASE_PRIVATE_KEY: await privateKeyPEM(),
+  } as unknown as Env;
+}
+
+function reportRequest(eventId = "a".repeat(32)): Request {
+  const body = JSON.stringify({
+    eventId,
+    dedupKey: "b".repeat(64),
+    installId: "c".repeat(32),
+    kind: "crash",
+    version: "v1.25.0",
+    os: "linux",
+    arch: "amd64",
+    message: "panic at /home/alice/project/main.go:12",
+    source: "go",
+    label: "panic",
+    errorType: "runtime.error",
+    topFrame: "main.go:12",
+  });
+  return new Request("https://crash.reasonix.io/v1/report", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "content-length": String(new TextEncoder().encode(body).byteLength),
+      "cf-connecting-ip": "127.0.0.1",
+    },
+    body,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetFirebaseAuthForTests();
+});
+
+describe("Firebase-primary crash ingest", () => {
+  it("serializes each group across isolates and protects a replacement lease from stale release", async () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(freshSchemaSQL);
+    const env = await integrationEnv(db);
+    const fingerprint = "9".repeat(64);
+    try {
+      const first = await acquireFirebaseGroupLease(env, fingerprint, new Date("2026-08-25T00:00:00Z"));
+      expect(first).toBeTruthy();
+      expect(await acquireFirebaseGroupLease(env, fingerprint, new Date("2026-08-25T00:00:30Z"))).toBeNull();
+      const replacement = await acquireFirebaseGroupLease(env, fingerprint, new Date("2026-08-25T00:01:01Z"));
+      expect(replacement).toBeTruthy();
+      await releaseFirebaseGroupLease(env, fingerprint, first!);
+      expect(db.prepare("SELECT owner FROM firebase_crash_group_leases").get()).toEqual({ owner: replacement });
+      await releaseFirebaseGroupLease(env, fingerprint, replacement!);
+      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_group_leases").get()).toEqual({ count: 0 });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("reclaims ISO-timestamped processing rows and purges expired delivery state", async () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(freshSchemaSQL);
+    const env = await integrationEnv(db);
+    try {
+      db.prepare(`INSERT INTO firebase_crash_outbox (
+        event_id, fingerprint, payload, state, attempts, next_attempt_at, created_at, updated_at
+      ) VALUES (?, ?, '{}', 'processing', 0, ?, ?, ?)`)
+        .run("8".repeat(32), "7".repeat(64), "2000-01-01T00:00:00.000Z", "2000-01-01T00:00:00.000Z", "2000-01-01T00:00:00.000Z");
+      db.prepare(`INSERT INTO firebase_crash_receipts (
+        event_id, projected_at, group_count, latest_slot, first_sample
+      ) VALUES (?, ?, 1, 0, 1)`).run("6".repeat(32), "2000-01-01T00:00:00.000Z");
+      db.prepare("INSERT INTO firebase_crash_group_leases (fingerprint, owner, expires_at) VALUES (?, ?, ?)")
+        .run("5".repeat(64), "expired", "2000-01-01T00:00:00.000Z");
+      expect(await dueFirebaseCrashes(env)).toHaveLength(1);
+      await purgeFirebaseDeliveryState(env);
+      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_outbox").get()).toEqual({ count: 0 });
+      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_receipts").get()).toEqual({ count: 0 });
+      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_group_leases").get()).toEqual({ count: 0 });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("stores no long-lived D1 sample and deduplicates a repeated eventId", async () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(freshSchemaSQL);
+    const env = await integrationEnv(db);
+    const writes: Array<{ url: string; body: string }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("oauth2.googleapis.com")) {
+        return Response.json({ access_token: "token", expires_in: 3600 });
+      }
+      writes.push({ url, body: String(init?.body) });
+      return Response.json({ ok: true });
+    });
+    try {
+      expect((await worker.fetch(reportRequest(), env)).status).toBe(202);
+      expect((await worker.fetch(reportRequest(), env)).status).toBe(202);
+      expect(db.prepare("SELECT count FROM groups").get()).toEqual({ count: 1 });
+      expect(db.prepare("SELECT COUNT(*) AS count FROM reports").get()).toEqual({ count: 0 });
+      expect(db.prepare("SELECT events FROM report_daily").get()).toEqual({ events: 1 });
+      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_outbox").get()).toEqual({ count: 0 });
+      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_receipts").get()).toEqual({ count: 1 });
+      expect(db.prepare("SELECT group_count, latest_slot, first_sample FROM firebase_crash_receipts").get())
+        .toEqual({ group_count: 1, latest_slot: 0, first_sample: 1 });
+      expect(writes).toHaveLength(1);
+      const firebaseBody = writes[0].body;
+      expect(firebaseBody).toContain("/home/_/project/main.go:12");
+      expect(firebaseBody).not.toContain("\"installId\"");
+      expect(firebaseBody).not.toContain("alice");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("buffers an unavailable Firebase write and retries without double-counting D1", async () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(freshSchemaSQL);
+    const env = await integrationEnv(db);
+    let databaseAvailable = false;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("oauth2.googleapis.com")) {
+        return Response.json({ access_token: "token", expires_in: 3600 });
+      }
+      return databaseAvailable ? Response.json({ ok: true }) : new Response("unavailable", { status: 503 });
+    });
+    try {
+      expect((await worker.fetch(reportRequest("d".repeat(32)), env)).status).toBe(202);
+      expect(db.prepare("SELECT state FROM firebase_crash_outbox").get()).toEqual({ state: "projected" });
+      expect(db.prepare("SELECT count FROM groups").get()).toEqual({ count: 1 });
+      db.prepare("UPDATE firebase_crash_outbox SET next_attempt_at = '2000-01-01T00:00:00.000Z'").run();
+      databaseAvailable = true;
+      await drainFirebaseCrashOutbox(env);
+      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_outbox").get()).toEqual({ count: 0 });
+      expect(db.prepare("SELECT count FROM groups").get()).toEqual({ count: 1 });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("queues a concurrent same-group report until the current projection and Firebase write release the lease", async () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(freshSchemaSQL);
+    const env = await integrationEnv(db);
+    const bodies: Array<Record<string, unknown>> = [];
+    let releaseFirstWrite!: () => void;
+    const firstWriteReleased = new Promise<void>((resolve) => { releaseFirstWrite = resolve; });
+    let signalFirstWrite!: () => void;
+    const firstWriteStarted = new Promise<void>((resolve) => { signalFirstWrite = resolve; });
+    let databaseWrites = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("oauth2.googleapis.com")) {
+        return Response.json({ access_token: "token", expires_in: 3600 });
+      }
+      databaseWrites++;
+      bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      if (databaseWrites === 1) {
+        signalFirstWrite();
+        await firstWriteReleased;
+      }
+      return Response.json({ ok: true });
+    });
+    try {
+      const first = worker.fetch(reportRequest("1".repeat(32)), env);
+      await firstWriteStarted;
+      expect((await worker.fetch(reportRequest("2".repeat(32)), env)).status).toBe(202);
+      expect(db.prepare("SELECT count FROM groups").get()).toEqual({ count: 1 });
+      expect(db.prepare("SELECT state FROM firebase_crash_outbox WHERE event_id = ?").get("2".repeat(32)))
+        .toEqual({ state: "queued" });
+      releaseFirstWrite();
+      expect((await first).status).toBe(202);
+      await drainFirebaseCrashOutbox(env);
+      expect(bodies.map((body) => (body.meta as { count: number }).count)).toEqual([1, 2]);
+      expect(db.prepare("SELECT count FROM groups").get()).toEqual({ count: 2 });
+      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_outbox").get()).toEqual({ count: 0 });
+    } finally {
+      releaseFirstWrite();
+      db.close();
+    }
+  });
+
+  it("returns 503 instead of growing beyond the 5000-row outbox cap", async () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(freshSchemaSQL);
+    db.exec(`WITH RECURSIVE n(value) AS (
+      SELECT 1 UNION ALL SELECT value + 1 FROM n WHERE value < 5000
+    ) INSERT INTO firebase_crash_outbox (
+      event_id, fingerprint, payload, state, attempts, next_attempt_at, created_at, updated_at
+    ) SELECT printf('%032x', value), '${"e".repeat(64)}', '{}', 'queued', 0,
+      '2026-08-25T00:00:00.000Z', '2026-08-25T00:00:00.000Z', '2026-08-25T00:00:00.000Z' FROM n`);
+    const env = await integrationEnv(db);
+    let networkCalls = 0;
+    vi.stubGlobal("fetch", async () => {
+      networkCalls++;
+      return Response.json({ ok: true });
+    });
+    try {
+      expect((await worker.fetch(reportRequest("f".repeat(32)), env)).status).toBe(503);
+      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_outbox").get()).toEqual({ count: 5000 });
+      expect(networkCalls).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not let a stale retry overwrite a newer ring-buffer slot", async () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(freshSchemaSQL);
+    const env = await integrationEnv(db);
+    let databaseWrites = 0;
+    const successfulBodies: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("oauth2.googleapis.com")) {
+        return Response.json({ access_token: "token", expires_in: 3600 });
+      }
+      databaseWrites++;
+      if (databaseWrites === 1) return new Response("unavailable", { status: 503 });
+      successfulBodies.push(String(init?.body));
+      return Response.json({ ok: true });
+    });
+    try {
+      for (const value of "1234567") {
+        expect((await worker.fetch(reportRequest(value.repeat(32)), env)).status).toBe(202);
+      }
+      expect(db.prepare("SELECT count FROM groups").get()).toEqual({ count: 7 });
+      db.prepare("UPDATE firebase_crash_outbox SET next_attempt_at = '2000-01-01T00:00:00.000Z'").run();
+      await drainFirebaseCrashOutbox(env);
+      const retry = JSON.parse(successfulBodies.at(-1) ?? "{}") as Record<string, unknown>;
+      expect(retry.meta).toMatchObject({ count: 7 });
+      expect(retry["samples/first"]).toMatchObject({ eventId: "1".repeat(32) });
+      expect(Object.keys(retry).some((key) => key.startsWith("samples/latest/"))).toBe(false);
+      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_outbox").get()).toEqual({ count: 0 });
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/workers/crash-report/src/firebase_crash_view.ts
+++ b/workers/crash-report/src/firebase_crash_view.ts
@@ -60,16 +60,25 @@ export function firebaseMeta(group: FirebaseGroupRow): FirebaseCrashGroupMeta {
     lastBuildCommit: group.last_build_commit,
     lastChannel: group.last_channel,
     regressedAt: group.regressed_at,
+    writerGeneration: 0,
+    sampleEpoch: 1,
+    sampleState: "active",
   };
 }
 
 export function firebaseSamples(
-  samples?: { first?: FirebaseCrashSample; latest?: Record<string, FirebaseCrashSample> | FirebaseCrashSample[] },
+  samples?: {
+    first?: FirebaseCrashSample;
+    latest?: Record<string, FirebaseCrashSample | { marker?: unknown }> |
+      Array<FirebaseCrashSample | { marker?: unknown }>;
+  },
 ): ReportSample[] {
   if (!samples) return [];
+  const isSample = (value: FirebaseCrashSample | { marker?: unknown }): value is FirebaseCrashSample =>
+    typeof (value as Partial<FirebaseCrashSample>).eventId === "string";
   const latest = Array.isArray(samples.latest)
-    ? samples.latest.filter((value): value is FirebaseCrashSample => Boolean(value))
-    : Object.values(samples.latest ?? {});
+    ? samples.latest.filter(isSample)
+    : Object.values(samples.latest ?? {}).filter(isSample);
   const unique = new Map<string, FirebaseCrashSample>();
   for (const sample of [...latest, ...(samples.first ? [samples.first] : [])]) {
     if (sample && typeof sample.eventId === "string") unique.set(sample.eventId, sample);

--- a/workers/crash-report/src/firebase_crash_view.ts
+++ b/workers/crash-report/src/firebase_crash_view.ts
@@ -1,0 +1,108 @@
+import type { Env } from "./env";
+import type { ReportSample } from "./group";
+import type {
+  FirebaseCrashGroupMeta,
+  FirebaseCrashSample,
+} from "./firebase_rtdb";
+
+export type FirebaseGroupRow = {
+  fingerprint: string;
+  kind: string;
+  count: number;
+  first_seen: string;
+  last_seen: string;
+  first_version: string;
+  last_version: string;
+  status: string;
+  title: string;
+  source: string;
+  label: string;
+  error_type: string;
+  top_frame: string;
+  severity: string;
+  last_os: string;
+  last_arch: string;
+  last_build_commit: string;
+  last_channel: string;
+  regressed_at: string;
+};
+
+export async function loadFirebaseGroupMeta(
+  env: Env,
+  fingerprint: string,
+): Promise<FirebaseGroupRow | null> {
+  return env.DB.prepare(
+    `SELECT fingerprint, kind, count, first_seen, last_seen, first_version, last_version,
+            status, title, source, label, error_type, top_frame, severity, last_os, last_arch,
+            last_build_commit, last_channel, regressed_at
+     FROM groups WHERE fingerprint = ?1`,
+  ).bind(fingerprint).first<FirebaseGroupRow>();
+}
+
+export function firebaseMeta(group: FirebaseGroupRow): FirebaseCrashGroupMeta {
+  return {
+    fingerprint: group.fingerprint,
+    kind: group.kind,
+    count: Number(group.count),
+    firstSeen: group.first_seen,
+    lastSeen: group.last_seen,
+    firstVersion: group.first_version,
+    lastVersion: group.last_version,
+    status: group.status,
+    title: group.title,
+    source: group.source,
+    label: group.label,
+    errorType: group.error_type,
+    topFrame: group.top_frame,
+    severity: group.severity,
+    lastOS: group.last_os,
+    lastArch: group.last_arch,
+    lastBuildCommit: group.last_build_commit,
+    lastChannel: group.last_channel,
+    regressedAt: group.regressed_at,
+  };
+}
+
+export function firebaseSamples(
+  samples?: { first?: FirebaseCrashSample; latest?: Record<string, FirebaseCrashSample> | FirebaseCrashSample[] },
+): ReportSample[] {
+  if (!samples) return [];
+  const latest = Array.isArray(samples.latest)
+    ? samples.latest.filter((value): value is FirebaseCrashSample => Boolean(value))
+    : Object.values(samples.latest ?? {});
+  const unique = new Map<string, FirebaseCrashSample>();
+  for (const sample of [...latest, ...(samples.first ? [samples.first] : [])]) {
+    if (sample && typeof sample.eventId === "string") unique.set(sample.eventId, sample);
+  }
+  return [...unique.values()]
+    .sort((left, right) => String(right.receivedAt).localeCompare(String(left.receivedAt)))
+    .map(firebaseSampleToReport);
+}
+
+function firebaseSampleToReport(sample: FirebaseCrashSample): ReportSample {
+  const string = (key: string) => typeof sample[key] === "string" ? sample[key] as string : "";
+  const json = (key: string, fallback: unknown) => JSON.stringify(sample[key] ?? fallback);
+  return {
+    version: string("version"),
+    os: string("os"),
+    arch: string("arch"),
+    message: string("message"),
+    device: json("device", {}),
+    created_at: string("receivedAt"),
+    source: string("source"),
+    label: string("label"),
+    error_type: string("errorType"),
+    error_message: string("errorMessage"),
+    top_frame: string("topFrame"),
+    build_commit: string("buildCommit"),
+    channel: string("channel"),
+    language: string("language"),
+    view: string("view"),
+    breadcrumbs: json("breadcrumbs", []),
+    component_stack: string("componentStack"),
+    stack: string("stack"),
+    occurred_at: string("occurredAt"),
+    webview2: sample.webview2 ? json("webview2", {}) : "",
+    web_runtime: sample.webRuntime ? json("webRuntime", {}) : "",
+  };
+}

--- a/workers/crash-report/src/firebase_delivery.ts
+++ b/workers/crash-report/src/firebase_delivery.ts
@@ -1,0 +1,118 @@
+import type { Env } from "./env";
+import { Report, type ReportPayload } from "./report_schema";
+import {
+  acquireFirebaseGroupLease,
+  claimFirebaseCrash,
+  crashStorageMode,
+  dueFirebaseCrashes,
+  firebaseGroupState,
+  firebaseOutboxExists,
+  firebaseProjectionReceipt,
+  firebaseStorageReady,
+  markFirebaseDelivered,
+  recordFirebaseRetry,
+  releaseFirebaseGroupLease,
+  renewFirebaseGroupLease,
+  type FirebaseGroupLease,
+  type FirebaseOutboxRow,
+} from "./crash_delivery";
+import { firebaseMeta, loadFirebaseGroupMeta } from "./firebase_crash_view";
+import { writeFirebaseCrashGroup } from "./firebase_rtdb";
+
+const LATEST_SAMPLES_PER_GROUP = 5;
+
+export type StoredCrashEvent = {
+  eventId: string;
+  fingerprint: string;
+  receivedAt: string;
+  keepD1Sample: boolean;
+  report: ReportPayload;
+};
+
+export async function deliverCrashEventToFirebase(
+  env: Env,
+  event: StoredCrashEvent,
+  attempts: number,
+  lease: FirebaseGroupLease,
+): Promise<boolean> {
+  try {
+    const [group, receipt, state] = await Promise.all([
+      loadFirebaseGroupMeta(env, event.fingerprint),
+      firebaseProjectionReceipt(env, event.eventId),
+      firebaseGroupState(env, event.fingerprint),
+    ]);
+    if (!group || !receipt || !state || state.sample_state !== "active") {
+      throw new Error("firebase projection state is missing");
+    }
+    const { installId: _installId, ...publicReport } = event.report;
+    const stillLatest = Number(receipt.group_count) > Number(group.count) - LATEST_SAMPLES_PER_GROUP;
+    const renew = () => renewFirebaseGroupLease(env, event.fingerprint, lease);
+    await writeFirebaseCrashGroup(
+      env,
+      firebaseMeta(group),
+      { ...publicReport, eventId: event.eventId, receivedAt: event.receivedAt },
+      stillLatest ? Number(receipt.latest_slot) : null,
+      Number(receipt.first_sample) === 1,
+      lease.generation,
+      Number(state.sample_epoch),
+      renew,
+    );
+    if (!await renew()) throw new Error("firebase crash group lease was fenced before delivery completion");
+    await markFirebaseDelivered(env, event.eventId);
+    return true;
+  } catch (error) {
+    console.error("firebase crash delivery failed", error);
+    await recordFirebaseRetry(env, event.eventId, "projected", attempts);
+    return false;
+  }
+}
+
+function parseStoredCrash(row: FirebaseOutboxRow): StoredCrashEvent | undefined {
+  try {
+    const value = JSON.parse(row.payload) as Partial<StoredCrashEvent>;
+    const report = Report.safeParse(value.report);
+    if (
+      !report.success || value.eventId !== row.event_id || value.fingerprint !== row.fingerprint ||
+      !/^(?:dev:)?[0-9a-f]{64}$/.test(value.fingerprint ?? "") ||
+      typeof value.receivedAt !== "string" || typeof value.keepD1Sample !== "boolean"
+    ) return undefined;
+    return { ...value, report: report.data } as StoredCrashEvent;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function drainFirebaseCrashOutbox(
+  env: Env,
+  projectCrashEvent: (env: Env, event: StoredCrashEvent) => Promise<void>,
+): Promise<void> {
+  if (crashStorageMode(env) === "d1" || !firebaseStorageReady(env)) return;
+  for (const row of await dueFirebaseCrashes(env)) {
+    const event = parseStoredCrash(row);
+    if (!event) {
+      console.error(`firebase crash outbox row ${row.event_id} is invalid`);
+      await recordFirebaseRetry(env, row.event_id, "queued", row.attempts);
+      continue;
+    }
+    const lease = await acquireFirebaseGroupLease(env, row.fingerprint);
+    if (!lease) continue;
+    try {
+      if (!await firebaseOutboxExists(env, row.event_id)) continue;
+      if (row.state !== "projected") {
+        if (!await claimFirebaseCrash(env, row.event_id, new Date().toISOString())) continue;
+        try {
+          await projectCrashEvent(env, event);
+        } catch (error) {
+          console.error("firebase crash projection failed", error);
+          await recordFirebaseRetry(env, row.event_id, "queued", row.attempts);
+          continue;
+        }
+      }
+      if (!await deliverCrashEventToFirebase(env, event, row.attempts, lease)) break;
+    } finally {
+      await releaseFirebaseGroupLease(env, row.fingerprint, lease).catch((error) => {
+        console.error("firebase crash group lease release failed", error);
+      });
+    }
+  }
+}

--- a/workers/crash-report/src/firebase_lifecycle.test.ts
+++ b/workers/crash-report/src/firebase_lifecycle.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+// @ts-expect-error Node 22+ provides node:sqlite; Worker production code does not import it.
+import { DatabaseSync } from "node:sqlite";
+import freshSchemaSQL from "../schema.sql?raw";
+import type { Env } from "./env";
+import {
+  FIREBASE_ACTIVE_RESERVATION_BYTES,
+  FIREBASE_ARCHIVING_RESERVATION_BYTES,
+  FIREBASE_COMPACTED_RESERVATION_BYTES,
+  reserveFirebaseGroup,
+} from "./crash_delivery";
+import { runFirebaseCrashLifecycle } from "./firebase_lifecycle";
+import { resetFirebaseAuthForTests } from "./firebase_rtdb";
+
+type SQLiteStatement = D1PreparedStatement & { execute(): D1Result };
+
+function sqliteD1(db: DatabaseSync): D1Database {
+  return {
+    prepare(sql: string) {
+      let binds: unknown[] = [];
+      const statement = {
+        bind(...values: unknown[]) { binds = values; return statement; },
+        async first<T>() { return (db.prepare(sql).get(...binds) ?? null) as T | null; },
+        async all<T>() { return { success: true, results: db.prepare(sql).all(...binds) as T[], meta: {} }; },
+        async run() { return statement.execute(); },
+        execute() {
+          const result = db.prepare(sql).run(...binds);
+          return { success: true, results: [], meta: { changes: Number(result.changes) } } as unknown as D1Result;
+        },
+        raw() { return Promise.resolve([]); },
+      } as unknown as SQLiteStatement;
+      return statement;
+    },
+    async batch(statements: D1PreparedStatement[]) {
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        const results = statements.map((statement) => (statement as SQLiteStatement).execute());
+        db.exec("COMMIT");
+        return results;
+      } catch (error) { db.exec("ROLLBACK"); throw error; }
+    },
+  } as unknown as D1Database;
+}
+
+async function privateKeyPEM(): Promise<string> {
+  const pair = await crypto.subtle.generateKey(
+    { name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const bytes = new Uint8Array(await crypto.subtle.exportKey("pkcs8", pair.privateKey) as ArrayBuffer);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return `-----BEGIN PRIVATE KEY-----\n${btoa(binary).match(/.{1,64}/g)?.join("\n") ?? ""}\n-----END PRIVATE KEY-----`;
+}
+
+async function envFor(db: DatabaseSync): Promise<Env> {
+  return {
+    DB: sqliteD1(db), CRASH_STORAGE_MODE: "firebase",
+    FIREBASE_DATABASE_URL: "https://reasonix-test.asia-southeast1.firebasedatabase.app",
+    FIREBASE_CLIENT_EMAIL: "writer@example.iam.gserviceaccount.com",
+    FIREBASE_PRIVATE_KEY: await privateKeyPEM(),
+  } as Env;
+}
+
+function firebaseStore(initial: Record<string, unknown>) {
+  const values = new Map(Object.entries(initial));
+  const versions = new Map<string, number>();
+  const pathOf = (url: string) => new URL(url).pathname.replace(/^\//, "").replace(/\.json$/, "");
+  const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url === "https://oauth2.googleapis.com/token") {
+      return Response.json({ access_token: "token", expires_in: 3600 });
+    }
+    const path = pathOf(url);
+    const method = init?.method ?? "GET";
+    const version = versions.get(path) ?? 1;
+    if (method === "GET") return Response.json(values.get(path) ?? null, { headers: { etag: `"${version}"` } });
+    if (new Headers(init?.headers).get("If-Match") !== `"${version}"`) return new Response(null, { status: 412 });
+    if (method === "DELETE") {
+      for (const key of [...values.keys()]) if (key === path || key.startsWith(`${path}/`)) values.delete(key);
+    } else {
+      values.set(path, JSON.parse(String(init?.body)) as unknown);
+    }
+    versions.set(path, version + 1);
+    return new Response(null, { status: 204 });
+  });
+  return { values, fetcher };
+}
+
+function insertGroup(db: DatabaseSync, fingerprint: string, status: string, lastSeen: string) {
+  db.prepare(`INSERT INTO groups (
+    fingerprint, kind, count, first_seen, last_seen, first_version, last_version,
+    status, title, source, severity
+  ) VALUES (?, 'crash', 8, '2026-01-01T00:00:00Z', ?, 'v1', 'v2', ?, 'boom', 'go', 'high')`)
+    .run(fingerprint, lastSeen, status);
+  db.prepare(`INSERT INTO firebase_crash_group_state (
+    fingerprint, reserved_bytes, last_seen
+  ) VALUES (?, ?, ?)`).run(fingerprint, FIREBASE_ACTIVE_RESERVATION_BYTES, lastSeen);
+}
+
+afterEach(() => { vi.unstubAllGlobals(); resetFirebaseAuthForTests(); });
+
+describe("Firebase sample lifecycle", () => {
+  it("compacts at 30 days, tombstones at 60 days, and deletes after 24 hours", async () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(freshSchemaSQL);
+    const fingerprint = "a".repeat(64);
+    insertGroup(db, fingerprint, "resolved", "2026-07-10T00:00:00Z");
+    const root = `groups/${fingerprint}`;
+    const old = { eventId: "1".repeat(32), receivedAt: "2026-01-01T00:00:00Z", groupCount: 1, writerGeneration: 0, sampleEpoch: 1 };
+    const firebase = firebaseStore({
+      [`${root}/meta`]: { count: 8, writerGeneration: 0, sampleEpoch: 1 },
+      [`${root}/samples/first`]: old,
+      ...Object.fromEntries(Array.from({ length: 5 }, (_, slot) => [`${root}/samples/latest/${slot}`, old])),
+      [root]: { present: true },
+    });
+    vi.stubGlobal("fetch", firebase.fetcher);
+    const env = await envFor(db);
+    try {
+      await runFirebaseCrashLifecycle(env, new Date("2026-08-25T00:00:00Z"));
+      expect(db.prepare("SELECT sample_state, reserved_bytes FROM firebase_crash_group_state").get())
+        .toEqual({ sample_state: "compacted", reserved_bytes: FIREBASE_COMPACTED_RESERVATION_BYTES });
+      expect(firebase.values.get(`${root}/samples/latest/0`)).toMatchObject({ marker: "compacted" });
+      expect(firebase.values.get(`${root}/samples/first`)).toEqual(old);
+
+      db.prepare("UPDATE groups SET last_seen = '2026-06-01T00:00:00Z' WHERE fingerprint = ?").run(fingerprint);
+      await runFirebaseCrashLifecycle(env, new Date("2026-08-25T01:00:00Z"));
+      expect(db.prepare("SELECT sample_state, reserved_bytes FROM firebase_crash_group_state").get())
+        .toEqual({ sample_state: "archiving", reserved_bytes: FIREBASE_ARCHIVING_RESERVATION_BYTES });
+      expect(firebase.values.get(`${root}/samples/first`)).toMatchObject({ marker: "archiving" });
+
+      await runFirebaseCrashLifecycle(env, new Date("2026-08-26T02:00:00Z"));
+      expect(db.prepare("SELECT sample_state, reserved_bytes FROM firebase_crash_group_state").get())
+        .toEqual({ sample_state: "archived", reserved_bytes: 0 });
+      expect([...firebase.values.keys()].some((key) => key === root || key.startsWith(`${root}/`))).toBe(false);
+    } finally { db.close(); }
+  });
+
+  it("never cleans open groups or groups with pending outbox, and reactivates an archived epoch", async () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(freshSchemaSQL);
+    const open = "b".repeat(64);
+    const pending = "c".repeat(64);
+    insertGroup(db, open, "open", "2020-01-01T00:00:00Z");
+    insertGroup(db, pending, "ignored", "2020-01-01T00:00:00Z");
+    db.prepare(`INSERT INTO firebase_crash_outbox (
+      event_id, fingerprint, payload, state, attempts, next_attempt_at, created_at, updated_at
+    ) VALUES (?, ?, '{}', 'queued', 0, ?, ?, ?)`).run(
+      "9".repeat(32), pending, "2026-08-25T00:00:00Z", "2026-08-25T00:00:00Z", "2026-08-25T00:00:00Z",
+    );
+    const env = await envFor(db);
+    vi.stubGlobal("fetch", firebaseStore({}).fetcher);
+    try {
+      await runFirebaseCrashLifecycle(env, new Date("2026-08-25T00:00:00Z"));
+      expect(db.prepare("SELECT COUNT(*) AS count FROM firebase_crash_group_state WHERE sample_state = 'active'").get())
+        .toEqual({ count: 2 });
+      db.prepare(`UPDATE firebase_crash_group_state SET
+        sample_state = 'archived', reserved_bytes = 0, sample_epoch = 3
+        WHERE fingerprint = ?`).run(open);
+      expect(await reserveFirebaseGroup(env, open, "2026-08-25T01:00:00Z")).toBe("reserved");
+      expect(db.prepare("SELECT sample_state, sample_epoch, reserved_bytes FROM firebase_crash_group_state WHERE fingerprint = ?").get(open))
+        .toEqual({ sample_state: "active", sample_epoch: 4, reserved_bytes: FIREBASE_ACTIVE_RESERVATION_BYTES });
+    } finally { db.close(); }
+  });
+});

--- a/workers/crash-report/src/firebase_lifecycle.ts
+++ b/workers/crash-report/src/firebase_lifecycle.ts
@@ -1,0 +1,259 @@
+import type { Env } from "./env";
+import {
+  FIREBASE_ARCHIVING_RESERVATION_BYTES,
+  FIREBASE_ACTIVE_RESERVATION_BYTES,
+  FIREBASE_COMPACTED_RESERVATION_BYTES,
+  FIREBASE_OUTBOX_LIMIT,
+  FIREBASE_STORAGE_BUDGET_BYTES,
+  acquireFirebaseGroupLease,
+  firebaseGroupState,
+  releaseFirebaseGroupLease,
+  renewFirebaseGroupLease,
+  type FirebaseGroupLease,
+  type FirebaseSampleState,
+} from "./crash_delivery";
+import { firebaseMeta, loadFirebaseGroupMeta } from "./firebase_crash_view";
+import {
+  deleteFirebaseCrashGroupConditional,
+  writeFirebaseGroupMeta,
+  writeFirebaseSampleMarkers,
+} from "./firebase_rtdb";
+
+const LIFECYCLE_BATCH = 20;
+
+export type FirebaseStorageSummary = {
+  active: number;
+  compacted: number;
+  archiving: number;
+  archived: number;
+  reservedBytes: number;
+  budgetBytes: number;
+  outboxCount: number;
+  oldestOutboxSeconds: number;
+  stuckArchiving: number;
+};
+
+type LifecycleCandidate = {
+  fingerprint: string;
+  sample_state: FirebaseSampleState;
+};
+
+function renewer(env: Env, fingerprint: string, lease: FirebaseGroupLease) {
+  return () => renewFirebaseGroupLease(env, fingerprint, lease);
+}
+
+async function pendingOutbox(env: Env, fingerprint: string): Promise<boolean> {
+  return Boolean(await env.DB.prepare(
+    "SELECT event_id FROM firebase_crash_outbox WHERE fingerprint = ?1 LIMIT 1",
+  ).bind(fingerprint).first());
+}
+
+async function compactGroup(env: Env, fingerprint: string, lease: FirebaseGroupLease, now: string): Promise<void> {
+  const [group, state] = await Promise.all([
+    loadFirebaseGroupMeta(env, fingerprint), firebaseGroupState(env, fingerprint),
+  ]);
+  if (!group || !state || state.sample_state !== "active" || await pendingOutbox(env, fingerprint)) return;
+  const renew = renewer(env, fingerprint, lease);
+  await writeFirebaseSampleMarkers(
+    env, fingerprint, Number(group.count), lease.generation, Number(state.sample_epoch),
+    "compacted", false, renew,
+  );
+  await writeFirebaseGroupMeta(
+    env, fingerprint, firebaseMeta(group), lease.generation, Number(state.sample_epoch),
+    "compacted", renew,
+  );
+  await env.DB.prepare(
+    `UPDATE firebase_crash_group_state
+     SET sample_state = 'compacted', reserved_bytes = ?4, compacted_at = ?5
+     WHERE fingerprint = ?1 AND sample_state = 'active'
+       AND lease_owner = ?2 AND lease_generation = ?3
+       AND NOT EXISTS (SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = ?1)`,
+  ).bind(fingerprint, lease.owner, lease.generation, FIREBASE_COMPACTED_RESERVATION_BYTES, now).run();
+}
+
+async function beginArchive(
+  env: Env,
+  fingerprint: string,
+  lease: FirebaseGroupLease,
+  now: string,
+  reason: "retention" | "admin",
+): Promise<void> {
+  const [group, state] = await Promise.all([
+    loadFirebaseGroupMeta(env, fingerprint), firebaseGroupState(env, fingerprint),
+  ]);
+  if (!group || !state || !["active", "compacted"].includes(state.sample_state)) {
+    if (reason === "admin") throw new Error("firebase crash group lifecycle state is missing");
+    return;
+  }
+  if (reason === "retention" && await pendingOutbox(env, fingerprint)) return;
+  const renew = renewer(env, fingerprint, lease);
+  await writeFirebaseSampleMarkers(
+    env, fingerprint, Number(group.count), lease.generation, Number(state.sample_epoch),
+    "archiving", true, renew,
+  );
+  await writeFirebaseGroupMeta(
+    env, fingerprint, firebaseMeta(group), lease.generation, Number(state.sample_epoch),
+    "archiving", renew,
+  );
+  if (reason === "admin") {
+    await env.DB.batch([
+      env.DB.prepare("DELETE FROM reports WHERE fingerprint = ?1").bind(fingerprint),
+      env.DB.prepare("DELETE FROM report_daily WHERE fingerprint = ?1").bind(fingerprint),
+      env.DB.prepare("DELETE FROM report_installations WHERE fingerprint = ?1").bind(fingerprint),
+      env.DB.prepare("DELETE FROM report_event_dimensions WHERE fingerprint = ?1").bind(fingerprint),
+      env.DB.prepare(
+        "DELETE FROM firebase_crash_outbox WHERE fingerprint = ?1 AND datetime(created_at) <= datetime(?2)",
+      ).bind(fingerprint, now),
+      env.DB.prepare("DELETE FROM groups WHERE fingerprint = ?1").bind(fingerprint),
+      env.DB.prepare(
+        `UPDATE firebase_crash_group_state
+         SET sample_state = CASE WHEN EXISTS (
+               SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = ?1
+             ) THEN 'active' ELSE 'archiving' END,
+             sample_epoch = sample_epoch + CASE WHEN EXISTS (
+               SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = ?1
+             ) THEN 1 ELSE 0 END,
+             epoch_first_event_id = CASE WHEN EXISTS (
+               SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = ?1
+             ) THEN '' ELSE epoch_first_event_id END,
+             reserved_bytes = CASE WHEN EXISTS (
+               SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = ?1
+             ) THEN ?4 ELSE ?5 END,
+             archived_at = CASE WHEN EXISTS (
+               SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = ?1
+             ) THEN '' ELSE ?6 END,
+             archive_reason = CASE WHEN EXISTS (
+               SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = ?1
+             ) THEN '' ELSE 'admin' END
+         WHERE fingerprint = ?1 AND lease_owner = ?2 AND lease_generation = ?3`,
+      ).bind(
+        fingerprint, lease.owner, lease.generation,
+        FIREBASE_ACTIVE_RESERVATION_BYTES, FIREBASE_ARCHIVING_RESERVATION_BYTES, now,
+      ),
+    ]);
+    return;
+  }
+  await env.DB.prepare(
+    `UPDATE firebase_crash_group_state
+     SET sample_state = 'archiving', reserved_bytes = ?4, archived_at = ?5, archive_reason = 'retention'
+     WHERE fingerprint = ?1 AND sample_state IN ('active', 'compacted')
+       AND lease_owner = ?2 AND lease_generation = ?3
+       AND NOT EXISTS (SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = ?1)`,
+  ).bind(fingerprint, lease.owner, lease.generation, FIREBASE_ARCHIVING_RESERVATION_BYTES, now).run();
+}
+
+async function finishArchive(env: Env, fingerprint: string, lease: FirebaseGroupLease): Promise<void> {
+  const state = await firebaseGroupState(env, fingerprint);
+  if (!state || state.sample_state !== "archiving" || await pendingOutbox(env, fingerprint)) return;
+  await deleteFirebaseCrashGroupConditional(env, fingerprint, renewer(env, fingerprint, lease));
+  if (state.archive_reason === "admin") {
+    await env.DB.prepare(
+      `DELETE FROM firebase_crash_group_state
+       WHERE fingerprint = ?1 AND sample_state = 'archiving'
+         AND lease_owner = ?2 AND lease_generation = ?3
+         AND NOT EXISTS (SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = ?1)`,
+    ).bind(fingerprint, lease.owner, lease.generation).run();
+  } else {
+    await env.DB.prepare(
+      `UPDATE firebase_crash_group_state
+       SET sample_state = 'archived', reserved_bytes = 0, lease_owner = '', lease_expires_at = ''
+       WHERE fingerprint = ?1 AND sample_state = 'archiving'
+         AND lease_owner = ?2 AND lease_generation = ?3
+         AND NOT EXISTS (SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = ?1)`,
+    ).bind(fingerprint, lease.owner, lease.generation).run();
+  }
+}
+
+async function withLease(
+  env: Env,
+  candidate: LifecycleCandidate,
+  operation: (lease: FirebaseGroupLease) => Promise<void>,
+): Promise<boolean> {
+  const lease = await acquireFirebaseGroupLease(env, candidate.fingerprint);
+  if (!lease) return false;
+  try {
+    await operation(lease);
+    return true;
+  } finally {
+    await releaseFirebaseGroupLease(env, candidate.fingerprint, lease);
+  }
+}
+
+export async function archiveFirebaseGroupForAdmin(env: Env, fingerprint: string): Promise<void> {
+  const lease = await acquireFirebaseGroupLease(env, fingerprint);
+  if (!lease) throw new Error("firebase crash group is busy");
+  try {
+    await beginArchive(env, fingerprint, lease, new Date().toISOString(), "admin");
+  } finally {
+    await releaseFirebaseGroupLease(env, fingerprint, lease);
+  }
+}
+
+export async function runFirebaseCrashLifecycle(env: Env, now = new Date()): Promise<void> {
+  const iso = now.toISOString();
+  let remaining = LIFECYCLE_BATCH;
+  const queries = [
+    `SELECT fingerprint, sample_state FROM firebase_crash_group_state
+     WHERE sample_state = 'archiving' AND datetime(archived_at) <= datetime(?1, '-24 hours')
+     ORDER BY archived_at LIMIT ?2`,
+    `SELECT state.fingerprint, state.sample_state FROM firebase_crash_group_state AS state
+     JOIN groups USING (fingerprint)
+     WHERE state.sample_state IN ('active', 'compacted') AND groups.status IN ('resolved', 'ignored')
+       AND datetime(groups.last_seen) <= datetime(?1, '-60 days')
+       AND NOT EXISTS (SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = state.fingerprint)
+     ORDER BY groups.last_seen LIMIT ?2`,
+    `SELECT state.fingerprint, state.sample_state FROM firebase_crash_group_state AS state
+     JOIN groups USING (fingerprint)
+     WHERE state.sample_state = 'active' AND groups.status IN ('resolved', 'ignored')
+       AND datetime(groups.last_seen) <= datetime(?1, '-30 days')
+       AND NOT EXISTS (SELECT 1 FROM firebase_crash_outbox WHERE fingerprint = state.fingerprint)
+     ORDER BY groups.last_seen LIMIT ?2`,
+  ];
+  for (let phase = 0; phase < queries.length && remaining > 0; phase++) {
+    const candidates = await env.DB.prepare(queries[phase]).bind(iso, remaining).all<LifecycleCandidate>();
+    for (const candidate of candidates.results) {
+      const processed = await withLease(env, candidate, async (lease) => {
+        if (phase === 0) await finishArchive(env, candidate.fingerprint, lease);
+        else if (phase === 1) await beginArchive(env, candidate.fingerprint, lease, iso, "retention");
+        else await compactGroup(env, candidate.fingerprint, lease, iso);
+      });
+      if (processed) remaining--;
+      if (remaining === 0) break;
+    }
+  }
+}
+
+export async function firebaseStorageSummary(env: Env): Promise<FirebaseStorageSummary> {
+  const [state, outbox] = await Promise.all([
+    env.DB.prepare(
+      `SELECT
+         SUM(CASE WHEN sample_state = 'active' THEN 1 ELSE 0 END) AS active,
+         SUM(CASE WHEN sample_state = 'compacted' THEN 1 ELSE 0 END) AS compacted,
+         SUM(CASE WHEN sample_state = 'archiving' THEN 1 ELSE 0 END) AS archiving,
+         SUM(CASE WHEN sample_state = 'archived' THEN 1 ELSE 0 END) AS archived,
+         COALESCE(SUM(reserved_bytes), 0) AS reserved_bytes,
+         SUM(CASE WHEN sample_state = 'archiving' AND datetime(archived_at) < datetime('now', '-48 hours')
+           THEN 1 ELSE 0 END) AS stuck_archiving
+       FROM firebase_crash_group_state`,
+    ).first<Record<string, number>>(),
+    env.DB.prepare(
+      `SELECT COUNT(*) AS outbox_count,
+              COALESCE(CAST((julianday('now') - julianday(MIN(created_at))) * 86400 AS INTEGER), 0)
+                AS oldest_outbox_seconds
+       FROM firebase_crash_outbox`,
+    ).first<Record<string, number>>(),
+  ]);
+  return {
+    active: Number(state?.active ?? 0),
+    compacted: Number(state?.compacted ?? 0),
+    archiving: Number(state?.archiving ?? 0),
+    archived: Number(state?.archived ?? 0),
+    reservedBytes: Number(state?.reserved_bytes ?? 0),
+    budgetBytes: FIREBASE_STORAGE_BUDGET_BYTES,
+    outboxCount: Number(outbox?.outbox_count ?? 0),
+    oldestOutboxSeconds: Number(outbox?.oldest_outbox_seconds ?? 0),
+    stuckArchiving: Number(state?.stuck_archiving ?? 0),
+  };
+}
+
+export const FIREBASE_OUTBOX_WARNING = Math.floor(FIREBASE_OUTBOX_LIMIT * 0.8);

--- a/workers/crash-report/src/firebase_migration.test.ts
+++ b/workers/crash-report/src/firebase_migration.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildFirebaseGroups,
+  canonicalJSONString,
+  classifyMigrationGroup,
+  contentDigest,
   firebaseOAuthGrantType,
 } from "../scripts/migrate-firebase-data.mjs";
 
@@ -33,17 +36,30 @@ describe("Firebase retained-sample migration", () => {
       device: "{}",
       breadcrumbs: "[]",
     })));
-    const value = groups.get(fingerprint) as {
+    const entry = groups.get(fingerprint) as unknown as { state: string; value: {
       meta: { count: number };
-      samples: { first: { message: string }; latest: Record<string, { message: string; eventId: string }> };
-    };
+      samples: { first: { message: string; groupCount: number }; latest: Record<string, { message: string; eventId: string; sampleEpoch: number }> };
+    } };
+    const value = entry.value;
+    expect(entry.state).toBe("active");
     expect(value.meta.count).toBe(8);
     expect(value.samples.first.message).toBe("sample-1");
+    expect(value.samples.first.groupCount).toBe(1);
     expect(Object.values(value.samples.latest).map((sample) => sample.message).sort()).toEqual([
       "sample-4", "sample-5", "sample-6", "sample-7", "sample-8",
     ]);
     expect(value.samples.latest[2].message).toBe("sample-8");
     expect(value.samples.latest[2].eventId).toMatch(/^[0-9a-f]{32}$/);
+    expect(value.samples.latest[2]).toMatchObject({ groupCount: 8, sampleEpoch: 1 });
     expect(JSON.stringify(value)).not.toContain("installId");
+  });
+
+  it("classifies resolved retention windows and canonicalizes readback digests", () => {
+    const now = new Date("2026-08-25T00:00:00Z");
+    expect(classifyMigrationGroup({ status: "open", last_seen: "2020-01-01T00:00:00Z" }, now)).toBe("active");
+    expect(classifyMigrationGroup({ status: "resolved", last_seen: "2026-07-10T00:00:00Z" }, now)).toBe("compacted");
+    expect(classifyMigrationGroup({ status: "ignored", last_seen: "2026-06-01T00:00:00Z" }, now)).toBe("archived");
+    expect(canonicalJSONString({ b: 2, a: { d: 4, c: 3 } })).toBe('{"a":{"c":3,"d":4},"b":2}');
+    expect(contentDigest({ b: 2, a: 1 })).toBe(contentDigest({ a: 1, b: 2 }));
   });
 });

--- a/workers/crash-report/src/firebase_migration.test.ts
+++ b/workers/crash-report/src/firebase_migration.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFirebaseGroups,
+  firebaseOAuthGrantType,
+} from "../scripts/migrate-firebase-data.mjs";
+
+describe("Firebase retained-sample migration", () => {
+  it("uses the OAuth JWT bearer grant expected by Google's token endpoint", () => {
+    expect(firebaseOAuthGrantType).toBe("urn:ietf:params:oauth:grant-type:jwt-bearer");
+  });
+
+  it("keeps the first sample and maps the newest five into absolute ring slots", () => {
+    const fingerprint = "a".repeat(64);
+    const groups = buildFirebaseGroups([{
+      fingerprint,
+      kind: "crash",
+      count: 8,
+      first_seen: "2026-08-01T00:00:00Z",
+      last_seen: "2026-08-08T00:00:00Z",
+      first_version: "v1",
+      last_version: "v2",
+      status: "open",
+      severity: "high",
+    }], [1, 4, 5, 6, 7, 8].map((id) => ({
+      id,
+      fingerprint,
+      kind: "crash",
+      version: id === 1 ? "v1" : "v2",
+      os: "linux",
+      arch: "amd64",
+      message: `sample-${id}`,
+      created_at: `2026-08-0${id}T00:00:00Z`,
+      device: "{}",
+      breadcrumbs: "[]",
+    })));
+    const value = groups.get(fingerprint) as {
+      meta: { count: number };
+      samples: { first: { message: string }; latest: Record<string, { message: string; eventId: string }> };
+    };
+    expect(value.meta.count).toBe(8);
+    expect(value.samples.first.message).toBe("sample-1");
+    expect(Object.values(value.samples.latest).map((sample) => sample.message).sort()).toEqual([
+      "sample-4", "sample-5", "sample-6", "sample-7", "sample-8",
+    ]);
+    expect(value.samples.latest[2].message).toBe("sample-8");
+    expect(value.samples.latest[2].eventId).toMatch(/^[0-9a-f]{32}$/);
+    expect(JSON.stringify(value)).not.toContain("installId");
+  });
+});

--- a/workers/crash-report/src/firebase_rtdb.test.ts
+++ b/workers/crash-report/src/firebase_rtdb.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "./env";
+import {
+  deleteFirebaseCrashGroup,
+  readFirebaseCrashGroup,
+  resetFirebaseAuthForTests,
+  writeFirebaseCrashGroup,
+  writeFirebaseGroupMeta,
+  type FirebaseCrashGroupMeta,
+} from "./firebase_rtdb";
+
+async function privateKeyPEM(): Promise<string> {
+  const pair = await crypto.subtle.generateKey(
+    { name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const exported = await crypto.subtle.exportKey("pkcs8", pair.privateKey) as ArrayBuffer;
+  const bytes = new Uint8Array(exported);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  const encoded = btoa(binary).match(/.{1,64}/g)?.join("\n") ?? "";
+  return `-----BEGIN PRIVATE KEY-----\n${encoded}\n-----END PRIVATE KEY-----`;
+}
+
+const meta: FirebaseCrashGroupMeta = {
+  fingerprint: "a".repeat(64),
+  kind: "crash",
+  count: 1,
+  firstSeen: "2026-08-25T00:00:00.000Z",
+  lastSeen: "2026-08-25T00:00:00.000Z",
+  firstVersion: "v1.0.0",
+  lastVersion: "v1.0.0",
+  status: "open",
+  title: "boom",
+  source: "go",
+  label: "panic",
+  errorType: "error",
+  topFrame: "main.go:<n>",
+  severity: "high",
+  lastOS: "linux",
+  lastArch: "amd64",
+  lastBuildCommit: "",
+  lastChannel: "stable",
+  regressedAt: "",
+};
+
+async function firebaseEnv(): Promise<Env> {
+  return {
+    FIREBASE_DATABASE_URL: "https://reasonix-test.asia-southeast1.firebasedatabase.app",
+    FIREBASE_CLIENT_EMAIL: "crash-writer@example.iam.gserviceaccount.com",
+    FIREBASE_PRIVATE_KEY: await privateKeyPEM(),
+  } as Env;
+}
+
+describe("Firebase Realtime Database delivery", () => {
+  beforeEach(() => resetFirebaseAuthForTests());
+  afterEach(() => vi.useRealTimers());
+
+  it("coalesces OAuth requests and writes only fixed group/sample paths", async () => {
+    const env = await firebaseEnv();
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetcher: typeof fetch = async (input, init) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url === "https://oauth2.googleapis.com/token") {
+        return Response.json({ access_token: "short-lived-token", expires_in: 3600 });
+      }
+      return Response.json({ ok: true });
+    };
+    const sample = { eventId: "b".repeat(32), receivedAt: meta.firstSeen, message: "sanitized" };
+    await Promise.all([
+      writeFirebaseCrashGroup(env, meta, sample, 0, true, fetcher),
+      writeFirebaseCrashGroup(env, { ...meta, count: 2 }, sample, 1, false, fetcher),
+    ]);
+    expect(calls.filter((call) => call.url.includes("oauth2.googleapis.com"))).toHaveLength(1);
+    const writes = calls.filter((call) => call.url.includes("firebasedatabase.app"));
+    expect(writes).toHaveLength(2);
+    expect(writes[0].init?.headers).toMatchObject({ authorization: "Bearer short-lived-token" });
+    const firstBody = JSON.parse(String(writes[0].init?.body));
+    expect(firstBody).toMatchObject({ meta, "samples/first": sample, "samples/latest/0": sample });
+    expect(JSON.stringify(firstBody)).not.toContain("installId");
+  });
+
+  it("refreshes once after a 401 without exposing credential response bodies", async () => {
+    const env = await firebaseEnv();
+    let tokenRequests = 0;
+    const fetcher: typeof fetch = async (input, init) => {
+      const url = String(input);
+      if (url.includes("oauth2.googleapis.com")) {
+        tokenRequests++;
+        return Response.json({ access_token: `token-${tokenRequests}`, expires_in: 3600 });
+      }
+      const authorization = (init?.headers as Record<string, string>).authorization;
+      return authorization === "Bearer token-1" ? new Response("expired", { status: 401 }) : Response.json({ ok: true });
+    };
+    await writeFirebaseCrashGroup(
+      env,
+      meta,
+      { eventId: "c".repeat(32), receivedAt: meta.firstSeen },
+      0,
+      true,
+      fetcher,
+    );
+    expect(tokenRequests).toBe(2);
+
+    resetFirebaseAuthForTests();
+    const secretBody = "private-key-material-must-not-leak";
+    const failing: typeof fetch = async () => new Response(secretBody, { status: 403 });
+    await expect(writeFirebaseCrashGroup(
+      env,
+      meta,
+      { eventId: "d".repeat(32), receivedAt: meta.firstSeen },
+      0,
+      true,
+      failing,
+    )).rejects.not.toThrow(secretBody);
+  });
+
+  it("bounds an unresponsive OAuth token request", async () => {
+    vi.useFakeTimers();
+    const env = await firebaseEnv();
+    let signalRequest!: () => void;
+    const requestStarted = new Promise<void>((resolve) => { signalRequest = resolve; });
+    const fetcher: typeof fetch = async (_input, init) => {
+      signalRequest();
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+      });
+    };
+    const pending = writeFirebaseCrashGroup(
+      env,
+      meta,
+      { eventId: "1".repeat(32), receivedAt: meta.firstSeen },
+      0,
+      true,
+      fetcher,
+    );
+    const rejected = expect(pending).rejects.toThrow("aborted");
+    await requestStarted;
+    await vi.advanceTimersByTimeAsync(5_001);
+    await rejected;
+  });
+
+  it("rejects non-Firebase database hosts before transmitting a sample", async () => {
+    const env = { ...await firebaseEnv(), FIREBASE_DATABASE_URL: "https://example.com" } as Env;
+    let databaseCalls = 0;
+    const fetcher: typeof fetch = async (input) => {
+      if (String(input).includes("oauth2.googleapis.com")) {
+        return Response.json({ access_token: "token", expires_in: 3600 });
+      }
+      databaseCalls++;
+      return Response.json({ ok: true });
+    };
+    await expect(writeFirebaseCrashGroup(
+      env,
+      meta,
+      { eventId: "e".repeat(32), receivedAt: meta.firstSeen },
+      0,
+      true,
+      fetcher,
+    )).rejects.toThrow("approved Realtime Database host");
+    expect(databaseCalls).toBe(0);
+  });
+
+  it("reads, replaces metadata, and deletes a group through authenticated REST calls", async () => {
+    const env = await firebaseEnv();
+    const calls: Array<{ url: string; method: string; body?: BodyInit | null }> = [];
+    const sample = { eventId: "f".repeat(32), receivedAt: meta.firstSeen, message: "sample" };
+    const fetcher: typeof fetch = async (input, init) => {
+      const url = String(input);
+      if (url.includes("oauth2.googleapis.com")) {
+        return Response.json({ access_token: "dashboard-token", expires_in: 3600 });
+      }
+      calls.push({ url, method: init?.method ?? "GET", body: init?.body });
+      if ((init?.method ?? "GET") === "GET") {
+        return Response.json({ meta, samples: { first: sample, latest: { 0: sample } } });
+      }
+      return Response.json({ ok: true });
+    };
+    const group = await readFirebaseCrashGroup(env, meta.fingerprint, fetcher);
+    expect(group?.samples?.first).toEqual(sample);
+    await writeFirebaseGroupMeta(env, meta.fingerprint, { ...meta, severity: "critical" }, fetcher);
+    await deleteFirebaseCrashGroup(env, meta.fingerprint, fetcher);
+    expect(calls.map((call) => call.method)).toEqual(["GET", "PUT", "DELETE"]);
+    expect(calls[1].url.endsWith(`/groups/${meta.fingerprint}/meta.json`)).toBe(true);
+    expect(JSON.parse(String(calls[1].body))).toMatchObject({ severity: "critical" });
+  });
+});

--- a/workers/crash-report/src/firebase_rtdb.test.ts
+++ b/workers/crash-report/src/firebase_rtdb.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "./env";
 import {
+  FirebaseFenceError,
   deleteFirebaseCrashGroup,
   readFirebaseCrashGroup,
   resetFirebaseAuthForTests,
@@ -9,8 +10,8 @@ import {
   type FirebaseCrashGroupMeta,
 } from "./firebase_rtdb";
 
-const firebaseOAuthTokenURL = "https://oauth2.googleapis.com/token";
-const firebaseTestDatabaseHost = "reasonix-test.asia-southeast1.firebasedatabase.app";
+const oauthURL = "https://oauth2.googleapis.com/token";
+const databaseHost = "reasonix-test.asia-southeast1.firebasedatabase.app";
 
 async function privateKeyPEM(): Promise<string> {
   const pair = await crypto.subtle.generateKey(
@@ -18,8 +19,7 @@ async function privateKeyPEM(): Promise<string> {
     true,
     ["sign", "verify"],
   ) as CryptoKeyPair;
-  const exported = await crypto.subtle.exportKey("pkcs8", pair.privateKey) as ArrayBuffer;
-  const bytes = new Uint8Array(exported);
+  const bytes = new Uint8Array(await crypto.subtle.exportKey("pkcs8", pair.privateKey) as ArrayBuffer);
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
   const encoded = btoa(binary).match(/.{1,64}/g)?.join("\n") ?? "";
@@ -27,166 +27,168 @@ async function privateKeyPEM(): Promise<string> {
 }
 
 const meta: FirebaseCrashGroupMeta = {
-  fingerprint: "a".repeat(64),
-  kind: "crash",
-  count: 1,
-  firstSeen: "2026-08-25T00:00:00.000Z",
-  lastSeen: "2026-08-25T00:00:00.000Z",
-  firstVersion: "v1.0.0",
-  lastVersion: "v1.0.0",
-  status: "open",
-  title: "boom",
-  source: "go",
-  label: "panic",
-  errorType: "error",
-  topFrame: "main.go:<n>",
-  severity: "high",
-  lastOS: "linux",
-  lastArch: "amd64",
-  lastBuildCommit: "",
-  lastChannel: "stable",
-  regressedAt: "",
+  fingerprint: "a".repeat(64), kind: "crash", count: 1,
+  firstSeen: "2026-08-25T00:00:00.000Z", lastSeen: "2026-08-25T00:00:00.000Z",
+  firstVersion: "v1.0.0", lastVersion: "v1.0.0", status: "open", title: "boom",
+  source: "go", label: "panic", errorType: "error", topFrame: "main.go:<n>", severity: "high",
+  lastOS: "linux", lastArch: "amd64", lastBuildCommit: "", lastChannel: "stable", regressedAt: "",
 };
 
 async function firebaseEnv(): Promise<Env> {
   return {
-    FIREBASE_DATABASE_URL: "https://reasonix-test.asia-southeast1.firebasedatabase.app",
+    FIREBASE_DATABASE_URL: `https://${databaseHost}`,
     FIREBASE_CLIENT_EMAIL: "crash-writer@example.iam.gserviceaccount.com",
     FIREBASE_PRIVATE_KEY: await privateKeyPEM(),
   } as Env;
 }
 
-describe("Firebase Realtime Database delivery", () => {
-  beforeEach(() => resetFirebaseAuthForTests());
-  afterEach(() => vi.useRealTimers());
+type Call = { url: string; init?: RequestInit };
 
-  it("coalesces OAuth requests and writes only fixed group/sample paths", async () => {
+function storeFetcher(initial: Record<string, unknown> = {}) {
+  const values = new Map(Object.entries(initial));
+  const versions = new Map<string, number>();
+  const calls: Call[] = [];
+  const pathOf = (url: string) => new URL(url).pathname.replace(/^\//, "").replace(/\.json$/, "");
+  const fetcher: typeof fetch = async (input, init) => {
+    const url = String(input);
+    calls.push({ url, init });
+    if (url === oauthURL) return Response.json({ access_token: "token", expires_in: 3600 });
+    const path = pathOf(url);
+    const method = init?.method ?? "GET";
+    const version = versions.get(path) ?? 1;
+    if (method === "GET") {
+      return Response.json(values.get(path) ?? null, { headers: { etag: `"${version}"` } });
+    }
+    const headers = new Headers(init?.headers);
+    if (headers.has("If-Match") && headers.get("If-Match") !== `"${version}"`) {
+      return Response.json(values.get(path) ?? null, { status: 412, headers: { etag: `"${version}"` } });
+    }
+    if (method === "DELETE") values.delete(path);
+    else values.set(path, JSON.parse(String(init?.body)) as unknown);
+    versions.set(path, version + 1);
+    return new Response(null, { status: 204 });
+  };
+  return { fetcher, calls, values, versions };
+}
+
+describe("Firebase Realtime Database conditional delivery", () => {
+  beforeEach(() => resetFirebaseAuthForTests());
+  afterEach(() => { vi.useRealTimers(); resetFirebaseAuthForTests(); });
+
+  it("coalesces OAuth and writes only meta, first, and one ring slot with ETags", async () => {
     const env = await firebaseEnv();
-    const calls: Array<{ url: string; init?: RequestInit }> = [];
-    const fetcher: typeof fetch = async (input, init) => {
-      const url = String(input);
-      calls.push({ url, init });
-      if (url === "https://oauth2.googleapis.com/token") {
-        return Response.json({ access_token: "short-lived-token", expires_in: 3600 });
-      }
-      return Response.json({ ok: true });
-    };
+    const store = storeFetcher();
     const sample = { eventId: "b".repeat(32), receivedAt: meta.firstSeen, message: "sanitized" };
     await Promise.all([
-      writeFirebaseCrashGroup(env, meta, sample, 0, true, fetcher),
-      writeFirebaseCrashGroup(env, { ...meta, count: 2 }, sample, 1, false, fetcher),
+      writeFirebaseCrashGroup(env, meta, sample, 0, true, 1, 1, undefined, store.fetcher),
+      writeFirebaseCrashGroup(env, { ...meta, count: 2 }, sample, 1, false, 2, 1, undefined, store.fetcher),
     ]);
-    expect(calls.filter((call) => call.url === firebaseOAuthTokenURL)).toHaveLength(1);
-    const writes = calls.filter((call) => new URL(call.url).hostname === firebaseTestDatabaseHost);
-    expect(writes).toHaveLength(2);
-    expect(writes[0].init?.headers).toMatchObject({ authorization: "Bearer short-lived-token" });
-    const firstBody = JSON.parse(String(writes[0].init?.body));
-    expect(firstBody).toMatchObject({ meta, "samples/first": sample, "samples/latest/0": sample });
-    expect(JSON.stringify(firstBody)).not.toContain("installId");
+    expect(store.calls.filter((call) => call.url === oauthURL)).toHaveLength(1);
+    const databaseCalls = store.calls.filter((call) => new URL(call.url).hostname === databaseHost);
+    expect(databaseCalls.every((call) => !call.url.includes(`/groups/${meta.fingerprint}.json`))).toBe(true);
+    const puts = databaseCalls.filter((call) => call.init?.method === "PUT");
+    expect(puts.length).toBeGreaterThanOrEqual(4);
+    expect(puts.every((call) => new Headers(call.init?.headers).has("If-Match"))).toBe(true);
+    expect(puts.every((call) => call.url.endsWith("?print=silent"))).toBe(true);
+    expect(JSON.stringify([...store.values.values()])).not.toContain("installId");
   });
 
-  it("refreshes once after a 401 without exposing credential response bodies", async () => {
+  it("retries a 412 at most through a fresh ETag and fences a stale generation", async () => {
+    const env = await firebaseEnv();
+    const store = storeFetcher();
+    let injected = false;
+    const fetcher: typeof fetch = async (input, init) => {
+      if (String(input) !== oauthURL && init?.method === "PUT" && !injected) {
+        injected = true;
+        return Response.json({ writerGeneration: 0 }, { status: 412, headers: { etag: '"2"' } });
+      }
+      return store.fetcher(input, init);
+    };
+    await writeFirebaseCrashGroup(
+      env, meta, { eventId: "c".repeat(32), receivedAt: meta.firstSeen }, 0, true, 2, 1, undefined, fetcher,
+    );
+    expect(injected).toBe(true);
+
+    resetFirebaseAuthForTests();
+    const metaPath = `groups/${meta.fingerprint}/meta`;
+    const fenced = storeFetcher({ [metaPath]: { ...meta, writerGeneration: 11, sampleEpoch: 1 } });
+    await expect(writeFirebaseCrashGroup(
+      env, meta, { eventId: "d".repeat(32), receivedAt: meta.firstSeen }, 0, false, 10, 1, undefined,
+      fenced.fetcher,
+    )).rejects.toBeInstanceOf(FirebaseFenceError);
+    expect(fenced.calls.filter((call) => call.init?.method === "PUT")).toHaveLength(0);
+  });
+
+  it("refreshes once after 401 and never includes credential bodies in errors", async () => {
     const env = await firebaseEnv();
     let tokenRequests = 0;
+    const store = storeFetcher();
+    let rejected = false;
     const fetcher: typeof fetch = async (input, init) => {
-      const url = String(input);
-      if (url === firebaseOAuthTokenURL) {
+      if (String(input) === oauthURL) {
         tokenRequests++;
         return Response.json({ access_token: `token-${tokenRequests}`, expires_in: 3600 });
       }
-      const authorization = (init?.headers as Record<string, string>).authorization;
-      return authorization === "Bearer token-1" ? new Response("expired", { status: 401 }) : Response.json({ ok: true });
+      if (!rejected) { rejected = true; return new Response("expired", { status: 401 }); }
+      return store.fetcher(input, init);
     };
     await writeFirebaseCrashGroup(
-      env,
-      meta,
-      { eventId: "c".repeat(32), receivedAt: meta.firstSeen },
-      0,
-      true,
-      fetcher,
+      env, meta, { eventId: "e".repeat(32), receivedAt: meta.firstSeen }, 0, true, 1, 1, undefined, fetcher,
     );
     expect(tokenRequests).toBe(2);
 
     resetFirebaseAuthForTests();
-    const secretBody = "private-key-material-must-not-leak";
-    const failing: typeof fetch = async () => new Response(secretBody, { status: 403 });
+    const secret = "private-key-material-must-not-leak";
+    const failing: typeof fetch = async () => new Response(secret, { status: 403 });
     await expect(writeFirebaseCrashGroup(
-      env,
-      meta,
-      { eventId: "d".repeat(32), receivedAt: meta.firstSeen },
-      0,
-      true,
-      failing,
-    )).rejects.not.toThrow(secretBody);
+      env, meta, { eventId: "f".repeat(32), receivedAt: meta.firstSeen }, 0, true, 1, 1, undefined, failing,
+    )).rejects.not.toThrow(secret);
   });
 
-  it("bounds an unresponsive OAuth token request", async () => {
+  it("bounds OAuth and rejects non-Firebase hosts before sample transmission", async () => {
     vi.useFakeTimers();
     const env = await firebaseEnv();
-    let signalRequest!: () => void;
-    const requestStarted = new Promise<void>((resolve) => { signalRequest = resolve; });
-    const fetcher: typeof fetch = async (_input, init) => {
-      signalRequest();
+    let started!: () => void;
+    const requestStarted = new Promise<void>((resolve) => { started = resolve; });
+    const hanging: typeof fetch = async (_input, init) => {
+      started();
       return new Promise<Response>((_resolve, reject) => {
         init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
       });
     };
     const pending = writeFirebaseCrashGroup(
-      env,
-      meta,
-      { eventId: "1".repeat(32), receivedAt: meta.firstSeen },
-      0,
-      true,
-      fetcher,
+      env, meta, { eventId: "1".repeat(32), receivedAt: meta.firstSeen }, 0, true, 1, 1, undefined, hanging,
     );
-    const rejected = expect(pending).rejects.toThrow("aborted");
+    const rejection = expect(pending).rejects.toThrow("aborted");
     await requestStarted;
     await vi.advanceTimersByTimeAsync(5_001);
-    await rejected;
-  });
+    await rejection;
+    vi.useRealTimers();
 
-  it("rejects non-Firebase database hosts before transmitting a sample", async () => {
-    const env = { ...await firebaseEnv(), FIREBASE_DATABASE_URL: "https://example.com" } as Env;
+    resetFirebaseAuthForTests();
+    const invalid = { ...await firebaseEnv(), FIREBASE_DATABASE_URL: "https://example.com" } as Env;
     let databaseCalls = 0;
     const fetcher: typeof fetch = async (input) => {
-      if (String(input) === firebaseOAuthTokenURL) {
-        return Response.json({ access_token: "token", expires_in: 3600 });
-      }
+      if (String(input) === oauthURL) return Response.json({ access_token: "token", expires_in: 3600 });
       databaseCalls++;
-      return Response.json({ ok: true });
+      return Response.json(null);
     };
     await expect(writeFirebaseCrashGroup(
-      env,
-      meta,
-      { eventId: "e".repeat(32), receivedAt: meta.firstSeen },
-      0,
-      true,
-      fetcher,
+      invalid, meta, { eventId: "2".repeat(32), receivedAt: meta.firstSeen }, 0, true, 1, 1, undefined, fetcher,
     )).rejects.toThrow("approved Realtime Database host");
     expect(databaseCalls).toBe(0);
   });
 
-  it("reads, replaces metadata, and deletes a group through authenticated REST calls", async () => {
+  it("reads groups and conditionally replaces metadata while legacy delete remains available", async () => {
     const env = await firebaseEnv();
-    const calls: Array<{ url: string; method: string; body?: BodyInit | null }> = [];
-    const sample = { eventId: "f".repeat(32), receivedAt: meta.firstSeen, message: "sample" };
-    const fetcher: typeof fetch = async (input, init) => {
-      const url = String(input);
-      if (url === firebaseOAuthTokenURL) {
-        return Response.json({ access_token: "dashboard-token", expires_in: 3600 });
-      }
-      calls.push({ url, method: init?.method ?? "GET", body: init?.body });
-      if ((init?.method ?? "GET") === "GET") {
-        return Response.json({ meta, samples: { first: sample, latest: { 0: sample } } });
-      }
-      return Response.json({ ok: true });
-    };
-    const group = await readFirebaseCrashGroup(env, meta.fingerprint, fetcher);
-    expect(group?.samples?.first).toEqual(sample);
-    await writeFirebaseGroupMeta(env, meta.fingerprint, { ...meta, severity: "critical" }, fetcher);
-    await deleteFirebaseCrashGroup(env, meta.fingerprint, fetcher);
-    expect(calls.map((call) => call.method)).toEqual(["GET", "PUT", "DELETE"]);
-    expect(calls[1].url.endsWith(`/groups/${meta.fingerprint}/meta.json`)).toBe(true);
-    expect(JSON.parse(String(calls[1].body))).toMatchObject({ severity: "critical" });
+    const root = `groups/${meta.fingerprint}`;
+    const sample = { eventId: "3".repeat(32), receivedAt: meta.firstSeen, groupCount: 1, writerGeneration: 1, sampleEpoch: 1 };
+    const store = storeFetcher({ [root]: { meta, samples: { first: sample, latest: { 0: sample } } } });
+    expect((await readFirebaseCrashGroup(env, meta.fingerprint, store.fetcher))?.samples?.first).toEqual(sample);
+    await writeFirebaseGroupMeta(env, meta.fingerprint, { ...meta, severity: "critical" }, 2, 1, "active", undefined, store.fetcher);
+    await deleteFirebaseCrashGroup(env, meta.fingerprint, store.fetcher);
+    expect(store.calls.map((call) => call.init?.method ?? "GET")).toEqual([
+      "POST", "GET", "GET", "PUT", "DELETE",
+    ]);
   });
 });

--- a/workers/crash-report/src/firebase_rtdb.test.ts
+++ b/workers/crash-report/src/firebase_rtdb.test.ts
@@ -9,6 +9,9 @@ import {
   type FirebaseCrashGroupMeta,
 } from "./firebase_rtdb";
 
+const firebaseOAuthTokenURL = "https://oauth2.googleapis.com/token";
+const firebaseTestDatabaseHost = "reasonix-test.asia-southeast1.firebasedatabase.app";
+
 async function privateKeyPEM(): Promise<string> {
   const pair = await crypto.subtle.generateKey(
     { name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
@@ -73,8 +76,8 @@ describe("Firebase Realtime Database delivery", () => {
       writeFirebaseCrashGroup(env, meta, sample, 0, true, fetcher),
       writeFirebaseCrashGroup(env, { ...meta, count: 2 }, sample, 1, false, fetcher),
     ]);
-    expect(calls.filter((call) => call.url.includes("oauth2.googleapis.com"))).toHaveLength(1);
-    const writes = calls.filter((call) => call.url.includes("firebasedatabase.app"));
+    expect(calls.filter((call) => call.url === firebaseOAuthTokenURL)).toHaveLength(1);
+    const writes = calls.filter((call) => new URL(call.url).hostname === firebaseTestDatabaseHost);
     expect(writes).toHaveLength(2);
     expect(writes[0].init?.headers).toMatchObject({ authorization: "Bearer short-lived-token" });
     const firstBody = JSON.parse(String(writes[0].init?.body));
@@ -87,7 +90,7 @@ describe("Firebase Realtime Database delivery", () => {
     let tokenRequests = 0;
     const fetcher: typeof fetch = async (input, init) => {
       const url = String(input);
-      if (url.includes("oauth2.googleapis.com")) {
+      if (url === firebaseOAuthTokenURL) {
         tokenRequests++;
         return Response.json({ access_token: `token-${tokenRequests}`, expires_in: 3600 });
       }
@@ -146,7 +149,7 @@ describe("Firebase Realtime Database delivery", () => {
     const env = { ...await firebaseEnv(), FIREBASE_DATABASE_URL: "https://example.com" } as Env;
     let databaseCalls = 0;
     const fetcher: typeof fetch = async (input) => {
-      if (String(input).includes("oauth2.googleapis.com")) {
+      if (String(input) === firebaseOAuthTokenURL) {
         return Response.json({ access_token: "token", expires_in: 3600 });
       }
       databaseCalls++;
@@ -169,7 +172,7 @@ describe("Firebase Realtime Database delivery", () => {
     const sample = { eventId: "f".repeat(32), receivedAt: meta.firstSeen, message: "sample" };
     const fetcher: typeof fetch = async (input, init) => {
       const url = String(input);
-      if (url.includes("oauth2.googleapis.com")) {
+      if (url === firebaseOAuthTokenURL) {
         return Response.json({ access_token: "dashboard-token", expires_in: 3600 });
       }
       calls.push({ url, method: init?.method ?? "GET", body: init?.body });

--- a/workers/crash-report/src/firebase_rtdb.ts
+++ b/workers/crash-report/src/firebase_rtdb.ts
@@ -1,0 +1,285 @@
+import type { Env } from "./env";
+
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const TOKEN_SCOPE = [
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/firebase.database",
+].join(" ");
+const TOKEN_REFRESH_SKEW_MS = 5 * 60 * 1000;
+const REQUEST_TIMEOUT_MS = 5_000;
+
+type Fetcher = typeof fetch;
+
+type CachedToken = {
+  clientEmail: string;
+  value: string;
+  expiresAt: number;
+};
+
+let cachedToken: CachedToken | undefined;
+let tokenRequest: Promise<CachedToken> | undefined;
+
+export type FirebaseCrashSample = Record<string, unknown> & {
+  eventId: string;
+  receivedAt: string;
+};
+
+export type FirebaseCrashGroupMeta = {
+  fingerprint: string;
+  kind: string;
+  count: number;
+  firstSeen: string;
+  lastSeen: string;
+  firstVersion: string;
+  lastVersion: string;
+  status: string;
+  title: string;
+  source: string;
+  label: string;
+  errorType: string;
+  topFrame: string;
+  severity: string;
+  lastOS: string;
+  lastArch: string;
+  lastBuildCommit: string;
+  lastChannel: string;
+  regressedAt: string;
+};
+
+export type FirebaseCrashGroup = {
+  meta?: FirebaseCrashGroupMeta;
+  samples?: {
+    first?: FirebaseCrashSample;
+    latest?: Record<string, FirebaseCrashSample> | FirebaseCrashSample[];
+  };
+};
+
+function base64url(data: Uint8Array | string): string {
+  const bytes = typeof data === "string" ? new TextEncoder().encode(data) : data;
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  }
+  return btoa(binary).replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+function privateKeyBytes(pem: string): Uint8Array {
+  const normalized = pem.replace(/\\n/g, "\n").trim();
+  const encoded = normalized
+    .replace("-----BEGIN PRIVATE KEY-----", "")
+    .replace("-----END PRIVATE KEY-----", "")
+    .replace(/\s/g, "");
+  if (!encoded) throw new Error("firebase private key is empty");
+  const binary = atob(encoded);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+async function serviceAccountAssertion(env: Env, now: number): Promise<string> {
+  const clientEmail = env.FIREBASE_CLIENT_EMAIL?.trim();
+  const privateKey = env.FIREBASE_PRIVATE_KEY;
+  if (!clientEmail || !privateKey) throw new Error("firebase service account is not configured");
+  const issuedAt = Math.floor(now / 1000);
+  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const claims = base64url(JSON.stringify({
+    iss: clientEmail,
+    scope: TOKEN_SCOPE,
+    aud: TOKEN_URL,
+    iat: issuedAt,
+    exp: issuedAt + 3600,
+  }));
+  const unsigned = `${header}.${claims}`;
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    privateKeyBytes(privateKey),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    new TextEncoder().encode(unsigned),
+  );
+  return `${unsigned}.${base64url(new Uint8Array(signature))}`;
+}
+
+async function requestAccessToken(env: Env, fetcher: Fetcher, now: number): Promise<CachedToken> {
+  const assertion = await serviceAccountAssertion(env, now);
+  const body = new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion,
+  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetcher(TOKEN_URL, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body,
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new Error(`firebase oauth failed with ${response.status}`);
+    const payload = await response.json() as { access_token?: unknown; expires_in?: unknown };
+    if (typeof payload.access_token !== "string" || !payload.access_token) {
+      throw new Error("firebase oauth response omitted access_token");
+    }
+    const expiresIn = typeof payload.expires_in === "number" ? payload.expires_in : 3600;
+    return {
+      clientEmail: env.FIREBASE_CLIENT_EMAIL!.trim(),
+      value: payload.access_token,
+      expiresAt: now + Math.max(60, expiresIn) * 1000,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function accessToken(env: Env, fetcher: Fetcher, now = Date.now()): Promise<string> {
+  const clientEmail = env.FIREBASE_CLIENT_EMAIL?.trim() ?? "";
+  if (
+    cachedToken?.clientEmail === clientEmail &&
+    cachedToken.expiresAt - TOKEN_REFRESH_SKEW_MS > now
+  ) {
+    return cachedToken.value;
+  }
+  if (!tokenRequest) {
+    tokenRequest = requestAccessToken(env, fetcher, now).finally(() => {
+      tokenRequest = undefined;
+    });
+  }
+  cachedToken = await tokenRequest;
+  return cachedToken.value;
+}
+
+function databaseURL(env: Env): string {
+  const raw = env.FIREBASE_DATABASE_URL?.trim();
+  if (!raw) throw new Error("firebase database URL is not configured");
+  const url = new URL(raw);
+  if (url.protocol !== "https:" || !(
+    url.hostname.endsWith(".firebaseio.com") ||
+    url.hostname.endsWith(".firebasedatabase.app")
+  )) {
+    throw new Error("firebase database URL is not an approved Realtime Database host");
+  }
+  url.pathname = url.pathname.replace(/\/$/, "");
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
+}
+
+async function firebaseFetch(
+  env: Env,
+  path: string,
+  init: RequestInit,
+  fetcher: Fetcher,
+  retryAuth = true,
+): Promise<Response> {
+  const token = await accessToken(env, fetcher);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetcher(`${databaseURL(env)}/${path}.json`, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        "content-type": "application/json",
+        ...init.headers,
+        authorization: `Bearer ${token}`,
+      },
+    });
+    if (response.status === 401 && retryAuth) {
+      cachedToken = undefined;
+      return firebaseFetch(env, path, init, fetcher, false);
+    }
+    return response;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function firebaseConfigured(env: Env): boolean {
+  return Boolean(
+    env.FIREBASE_DATABASE_URL?.trim() &&
+    env.FIREBASE_CLIENT_EMAIL?.trim() &&
+    env.FIREBASE_PRIVATE_KEY,
+  );
+}
+
+export async function writeFirebaseCrashGroup(
+  env: Env,
+  meta: FirebaseCrashGroupMeta,
+  sample: FirebaseCrashSample,
+  latestSlot: number | null,
+  firstSample: boolean,
+  fetcher: Fetcher = fetch,
+): Promise<void> {
+  if (latestSlot !== null && (!Number.isInteger(latestSlot) || latestSlot < 0 || latestSlot > 4)) {
+    throw new Error("firebase latest sample slot is invalid");
+  }
+  const body: Record<string, unknown> = {
+    meta,
+  };
+  if (latestSlot !== null) body[`samples/latest/${latestSlot}`] = sample;
+  if (firstSample) body["samples/first"] = sample;
+  const response = await firebaseFetch(
+    env,
+    `groups/${encodeURIComponent(meta.fingerprint)}`,
+    { method: "PATCH", body: JSON.stringify(body) },
+    fetcher,
+  );
+  if (!response.ok) throw new Error(`firebase database write failed with ${response.status}`);
+}
+
+export async function readFirebaseCrashGroup(
+  env: Env,
+  fingerprint: string,
+  fetcher: Fetcher = fetch,
+): Promise<FirebaseCrashGroup | null> {
+  const response = await firebaseFetch(
+    env,
+    `groups/${encodeURIComponent(fingerprint)}`,
+    { method: "GET" },
+    fetcher,
+  );
+  if (!response.ok) throw new Error(`firebase database read failed with ${response.status}`);
+  const value = await response.json() as unknown;
+  if (value === null) return null;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("firebase database group response is invalid");
+  }
+  return value as FirebaseCrashGroup;
+}
+
+export async function writeFirebaseGroupMeta(
+  env: Env,
+  fingerprint: string,
+  meta: FirebaseCrashGroupMeta,
+  fetcher: Fetcher = fetch,
+): Promise<void> {
+  const response = await firebaseFetch(
+    env,
+    `groups/${encodeURIComponent(fingerprint)}/meta`,
+    { method: "PUT", body: JSON.stringify(meta) },
+    fetcher,
+  );
+  if (!response.ok) throw new Error(`firebase database metadata write failed with ${response.status}`);
+}
+
+export async function deleteFirebaseCrashGroup(
+  env: Env,
+  fingerprint: string,
+  fetcher: Fetcher = fetch,
+): Promise<void> {
+  const response = await firebaseFetch(
+    env,
+    `groups/${encodeURIComponent(fingerprint)}`,
+    { method: "DELETE" },
+    fetcher,
+  );
+  if (!response.ok) throw new Error(`firebase database delete failed with ${response.status}`);
+}
+
+export function resetFirebaseAuthForTests(): void {
+  cachedToken = undefined;
+  tokenRequest = undefined;
+}

--- a/workers/crash-report/src/firebase_rtdb.ts
+++ b/workers/crash-report/src/firebase_rtdb.ts
@@ -22,6 +22,21 @@ let tokenRequest: Promise<CachedToken> | undefined;
 export type FirebaseCrashSample = Record<string, unknown> & {
   eventId: string;
   receivedAt: string;
+  groupCount: number;
+  writerGeneration: number;
+  sampleEpoch: number;
+};
+
+export type FirebaseCrashSampleInput = Record<string, unknown> & {
+  eventId: string;
+  receivedAt: string;
+};
+
+export type FirebaseSampleMarker = {
+  marker: "compacted" | "archiving";
+  groupCount: number;
+  writerGeneration: number;
+  sampleEpoch: number;
 };
 
 export type FirebaseCrashGroupMeta = {
@@ -44,13 +59,23 @@ export type FirebaseCrashGroupMeta = {
   lastBuildCommit: string;
   lastChannel: string;
   regressedAt: string;
+  writerGeneration?: number;
+  sampleEpoch?: number;
+  sampleState?: "active" | "compacted" | "archiving" | "archived";
+};
+
+type FirebaseFencedMeta = FirebaseCrashGroupMeta & {
+  writerGeneration: number;
+  sampleEpoch: number;
+  sampleState: "active" | "compacted" | "archiving" | "archived";
 };
 
 export type FirebaseCrashGroup = {
   meta?: FirebaseCrashGroupMeta;
   samples?: {
     first?: FirebaseCrashSample;
-    latest?: Record<string, FirebaseCrashSample> | FirebaseCrashSample[];
+    latest?: Record<string, FirebaseCrashSample | FirebaseSampleMarker> |
+      Array<FirebaseCrashSample | FirebaseSampleMarker>;
   };
 };
 
@@ -178,7 +203,10 @@ async function firebaseFetch(
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   try {
-    const response = await fetcher(`${databaseURL(env)}/${path}.json`, {
+    const queryOffset = path.indexOf("?");
+    const resource = queryOffset === -1 ? path : path.slice(0, queryOffset);
+    const query = queryOffset === -1 ? "" : path.slice(queryOffset);
+    const response = await fetcher(`${databaseURL(env)}/${resource}.json${query}`, {
       ...init,
       signal: controller.signal,
       headers: {
@@ -205,29 +233,135 @@ export function firebaseConfigured(env: Env): boolean {
   );
 }
 
+export class FirebaseFenceError extends Error {
+  constructor() {
+    super("firebase conditional write was fenced by a newer writer");
+    this.name = "FirebaseFenceError";
+  }
+}
+
+type FencedValue = {
+  writerGeneration?: unknown;
+  sampleEpoch?: unknown;
+  groupCount?: unknown;
+  count?: unknown;
+  marker?: unknown;
+};
+
+function numberField(value: FencedValue | null, field: keyof FencedValue): number {
+  const raw = value?.[field];
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : -1;
+}
+
+async function conditionalPut(
+  env: Env,
+  path: string,
+  candidate: FencedValue,
+  mayWrite: (current: FencedValue | null) => "write" | "complete" | "fenced",
+  fetcher: Fetcher,
+  beforeWrite: () => Promise<boolean>,
+): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const currentResponse = await firebaseFetch(env, path, {
+      method: "GET",
+      headers: { "X-Firebase-ETag": "true" },
+    }, fetcher);
+    if (!currentResponse.ok) {
+      throw new Error(`firebase database conditional read failed with ${currentResponse.status}`);
+    }
+    const etag = currentResponse.headers.get("etag");
+    if (!etag) throw new Error("firebase database conditional read omitted ETag");
+    const raw = await currentResponse.json() as unknown;
+    const current = raw && typeof raw === "object" && !Array.isArray(raw) ? raw as FencedValue : null;
+    const decision = mayWrite(current);
+    if (decision === "complete") return;
+    if (decision === "fenced") throw new FirebaseFenceError();
+    if (!await beforeWrite()) throw new FirebaseFenceError();
+    const write = await firebaseFetch(env, `${path}?print=silent`, {
+      method: "PUT",
+      headers: { "If-Match": etag },
+      body: JSON.stringify(candidate),
+    }, fetcher);
+    if (write.status === 412) continue;
+    if (!write.ok) throw new Error(`firebase database conditional write failed with ${write.status}`);
+    return;
+  }
+  throw new Error("firebase database conditional write retry limit reached");
+}
+
+function metaDecision(candidate: FirebaseFencedMeta) {
+  return (current: FencedValue | null): "write" | "complete" | "fenced" => {
+    if (!current) return "write";
+    const generation = numberField(current, "writerGeneration");
+    const epoch = numberField(current, "sampleEpoch");
+    const count = numberField(current, "count");
+    if (generation > candidate.writerGeneration || epoch > candidate.sampleEpoch) return "fenced";
+    if (
+      generation === candidate.writerGeneration && epoch === candidate.sampleEpoch &&
+      count >= candidate.count
+    ) return "complete";
+    return "write";
+  };
+}
+
+function sampleDecision(candidate: FirebaseCrashSample | FirebaseSampleMarker, first: boolean) {
+  return (current: FencedValue | null): "write" | "complete" | "fenced" => {
+    if (!current) return "write";
+    const generation = numberField(current, "writerGeneration");
+    const epoch = numberField(current, "sampleEpoch");
+    const count = numberField(current, "groupCount");
+    if (epoch > candidate.sampleEpoch || generation > candidate.writerGeneration) return "fenced";
+    if (epoch < candidate.sampleEpoch) return "write";
+    if ("marker" in candidate) {
+      return generation === candidate.writerGeneration && current.marker === candidate.marker
+        ? "complete" : "write";
+    }
+    if (first && current.marker === undefined) return "complete";
+    if (generation === candidate.writerGeneration && count >= candidate.groupCount) return "complete";
+    if (!first && current.marker === undefined && count >= candidate.groupCount) return "complete";
+    return "write";
+  };
+}
+
 export async function writeFirebaseCrashGroup(
   env: Env,
   meta: FirebaseCrashGroupMeta,
-  sample: FirebaseCrashSample,
+  sample: FirebaseCrashSampleInput,
   latestSlot: number | null,
   firstSample: boolean,
+  writerGeneration: number,
+  sampleEpoch: number,
+  beforeWrite: () => Promise<boolean> = async () => true,
   fetcher: Fetcher = fetch,
 ): Promise<void> {
   if (latestSlot !== null && (!Number.isInteger(latestSlot) || latestSlot < 0 || latestSlot > 4)) {
     throw new Error("firebase latest sample slot is invalid");
   }
-  const body: Record<string, unknown> = {
-    meta,
+  const fencedMeta: FirebaseFencedMeta = {
+    ...meta,
+    writerGeneration,
+    sampleEpoch,
+    sampleState: "active",
   };
-  if (latestSlot !== null) body[`samples/latest/${latestSlot}`] = sample;
-  if (firstSample) body["samples/first"] = sample;
-  const response = await firebaseFetch(
-    env,
-    `groups/${encodeURIComponent(meta.fingerprint)}`,
-    { method: "PATCH", body: JSON.stringify(body) },
-    fetcher,
-  );
-  if (!response.ok) throw new Error(`firebase database write failed with ${response.status}`);
+  const fencedSample: FirebaseCrashSample = {
+    ...sample,
+    groupCount: meta.count,
+    writerGeneration,
+    sampleEpoch,
+  };
+  const root = `groups/${encodeURIComponent(meta.fingerprint)}`;
+  await conditionalPut(env, `${root}/meta`, fencedMeta, metaDecision(fencedMeta), fetcher, beforeWrite);
+  if (firstSample) {
+    await conditionalPut(
+      env, `${root}/samples/first`, fencedSample, sampleDecision(fencedSample, true), fetcher, beforeWrite,
+    );
+  }
+  if (latestSlot !== null) {
+    await conditionalPut(
+      env, `${root}/samples/latest/${latestSlot}`, fencedSample, sampleDecision(fencedSample, false), fetcher,
+      beforeWrite,
+    );
+  }
 }
 
 export async function readFirebaseCrashGroup(
@@ -254,15 +388,43 @@ export async function writeFirebaseGroupMeta(
   env: Env,
   fingerprint: string,
   meta: FirebaseCrashGroupMeta,
+  writerGeneration: number,
+  sampleEpoch: number,
+  sampleState: FirebaseFencedMeta["sampleState"],
+  beforeWrite: () => Promise<boolean> = async () => true,
   fetcher: Fetcher = fetch,
 ): Promise<void> {
-  const response = await firebaseFetch(
+  const candidate: FirebaseFencedMeta = { ...meta, writerGeneration, sampleEpoch, sampleState };
+  await conditionalPut(
     env,
     `groups/${encodeURIComponent(fingerprint)}/meta`,
-    { method: "PUT", body: JSON.stringify(meta) },
+    candidate,
+    metaDecision(candidate),
     fetcher,
+    beforeWrite,
   );
-  if (!response.ok) throw new Error(`firebase database metadata write failed with ${response.status}`);
+}
+
+export async function writeFirebaseSampleMarkers(
+  env: Env,
+  fingerprint: string,
+  groupCount: number,
+  writerGeneration: number,
+  sampleEpoch: number,
+  marker: FirebaseSampleMarker["marker"],
+  includeFirst: boolean,
+  beforeWrite: () => Promise<boolean> = async () => true,
+  fetcher: Fetcher = fetch,
+): Promise<void> {
+  const candidate: FirebaseSampleMarker = {
+    marker, groupCount, writerGeneration, sampleEpoch,
+  };
+  const root = `groups/${encodeURIComponent(fingerprint)}/samples`;
+  const paths = Array.from({ length: 5 }, (_, slot) => `${root}/latest/${slot}`);
+  if (includeFirst) paths.unshift(`${root}/first`);
+  for (const path of paths) {
+    await conditionalPut(env, path, candidate, sampleDecision(candidate, false), fetcher, beforeWrite);
+  }
 }
 
 export async function deleteFirebaseCrashGroup(
@@ -277,6 +439,33 @@ export async function deleteFirebaseCrashGroup(
     fetcher,
   );
   if (!response.ok) throw new Error(`firebase database delete failed with ${response.status}`);
+}
+
+export async function deleteFirebaseCrashGroupConditional(
+  env: Env,
+  fingerprint: string,
+  beforeDelete: () => Promise<boolean>,
+  fetcher: Fetcher = fetch,
+): Promise<void> {
+  const path = `groups/${encodeURIComponent(fingerprint)}`;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const current = await firebaseFetch(env, path, {
+      method: "GET",
+      headers: { "X-Firebase-ETag": "true" },
+    }, fetcher);
+    if (!current.ok) throw new Error(`firebase database delete precondition read failed with ${current.status}`);
+    const etag = current.headers.get("etag");
+    if (!etag) throw new Error("firebase database delete precondition read omitted ETag");
+    if (!await beforeDelete()) throw new FirebaseFenceError();
+    const response = await firebaseFetch(env, `${path}?print=silent`, {
+      method: "DELETE",
+      headers: { "If-Match": etag },
+    }, fetcher);
+    if (response.status === 412) continue;
+    if (!response.ok) throw new Error(`firebase database conditional delete failed with ${response.status}`);
+    return;
+  }
+  throw new Error("firebase database conditional delete retry limit reached");
 }
 
 export function resetFirebaseAuthForTests(): void {

--- a/workers/crash-report/src/group.ts
+++ b/workers/crash-report/src/group.ts
@@ -153,7 +153,13 @@ function sampleReports(reports: ReportSample[], options: { limit?: number } = {}
   return `<div class="sample-list">${visibleSamples}${history}</div>`;
 }
 
-export function renderGroup(group: Group, reports: ReportSample[], user: User, diagnostics?: GroupDiagnosticSummary): string {
+export function renderGroup(
+  group: Group,
+  reports: ReportSample[],
+  user: User,
+  diagnostics?: GroupDiagnosticSummary,
+  lifecycle?: { state: "active" | "compacted" | "archiving" | "archived"; epoch: number },
+): string {
   const samples = sampleReports(reports);
   const platform = [group.last_os, group.last_arch].filter(Boolean).join("/");
   const status = statusPill(group.status) || `<span class="pill open">${i18n("open", "未处理")}</span>`;
@@ -184,6 +190,15 @@ export function renderGroup(group: Group, reports: ReportSample[], user: User, d
         .map((row) => `<div><span>${esc(row.facet)} · ${esc(row.value)}</span><b>${row.installs} ${i18n("installs", "安装")} · ${row.events} ${i18n("events", "事件")}</b></div>`)
         .join("")}</div></div>`
     : "";
+  const lifecycleNotice = lifecycle?.state === "compacted"
+    ? `<div class="card full"><p>${i18n("Recent samples were removed by the 30-day policy; only the first retained-cycle sample remains.", "最近样本已按 30 天策略清理；仅保留当前保留周期的首个样本。")}</p></div>`
+    : lifecycle?.state === "archiving"
+      ? `<div class="card full"><p>${i18n("This group is completing its 60-day Firebase sample archive.", "该分组正在执行 60 天 Firebase 样本归档。")}</p></div>`
+      : lifecycle?.state === "archived"
+        ? `<div class="card full"><p>${i18n("Firebase raw samples were removed; D1 aggregates, status, notes, and audit history remain.", "Firebase 原始样本已清理；D1 聚合、状态、备注和审计仍保留。")}</p></div>`
+        : lifecycle && lifecycle.epoch > 1
+          ? `<div class="card full"><p>${i18nHTML(`Samples belong to retained cycle ${lifecycle.epoch}; Lifetime First Seen remains the D1 value above.`, `样本属于第 ${lifecycle.epoch} 个保留周期；Lifetime First Seen 仍以上方 D1 值为准。`)}</p></div>`
+          : "";
   return page(
     `Reasonix · ${group.fingerprint.slice(0, 8)}`,
     `stats / ${group.fingerprint.slice(0, 8)}`,
@@ -193,7 +208,8 @@ ${group.title ? `<p class="summary group-summary">${esc(group.title)}</p>` : ""}
 <div class="group-tags">${tags}</div>
 <div class="group-metrics">${metrics}</div>
 ${group.note ? `<p class="group-note">${i18n("Note", "备注")}: ${esc(group.note)}</p>` : ""}</section>
-<div class="card full sample-card"><h2>${i18nHTML("Samples <b>— newest first, first sample plus latest 5 kept</b>", "样本 <b>— 最新优先，保留首个样本和最近 5 个</b>")}</h2>${samples}</div>
+${lifecycleNotice}
+<div class="card full sample-card"><h2>${i18nHTML("Samples <b>— newest first, retained-cycle first plus latest 5 kept</b>", "样本 <b>— 最新优先，保留当前周期首个样本和最近 5 个</b>")}</h2>${samples}</div>
 ${distributions}
 ${user.role === "admin" ? manageGroup(group) : ""}
 <a class="back" href="/stats">${i18n("Back to stats", "返回统计")}</a>`,

--- a/workers/crash-report/src/group.ts
+++ b/workers/crash-report/src/group.ts
@@ -38,7 +38,7 @@ export type Group = {
   regressed_at: string;
 };
 
-type ReportSample = {
+export type ReportSample = {
   version: string;
   os: string;
   arch: string;

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -50,25 +50,36 @@ import {
   acquireFirebaseGroupLease,
   claimFirebaseCrash,
   crashStorageMode,
-  dueFirebaseCrashes,
   enqueueFirebaseCrash,
-  firebaseOutboxExists,
-  firebaseProjectionReceipt,
+  firebaseEventExists,
+  firebaseGroupState,
   firebaseProjectionExists,
   firebaseStorageReady,
-  markFirebaseDelivered,
   projectionCompletionStatements,
   purgeFirebaseDeliveryState,
   recordFirebaseRetry,
+  reclaimUnusedFirebaseReservation,
   releaseFirebaseGroupLease,
-  type FirebaseOutboxRow,
+  renewFirebaseGroupLease,
+  reserveFirebaseGroup,
+  type FirebaseGroupLease,
 } from "./crash_delivery";
 import {
-  deleteFirebaseCrashGroup,
   readFirebaseCrashGroup,
-  writeFirebaseCrashGroup,
   writeFirebaseGroupMeta,
 } from "./firebase_rtdb";
+import {
+  deliverCrashEventToFirebase,
+  drainFirebaseCrashOutbox as drainFirebaseOutbox,
+  type StoredCrashEvent,
+} from "./firebase_delivery";
+import {
+  archiveFirebaseGroupForAdmin,
+  firebaseStorageSummary,
+  runFirebaseCrashLifecycle,
+  FIREBASE_OUTBOX_WARNING,
+  type FirebaseStorageSummary,
+} from "./firebase_lifecycle";
 import {
   firebaseMeta,
   firebaseSamples,
@@ -549,14 +560,6 @@ function storageUnavailable(op: string, err: unknown): Response {
   return new Response("storage unavailable", { status: 503 });
 }
 
-type StoredCrashEvent = {
-  eventId: string;
-  fingerprint: string;
-  receivedAt: string;
-  keepD1Sample: boolean;
-  report: ReportPayload;
-};
-
 async function prepareCrashEvent(r: ReportPayload, keepD1Sample: boolean): Promise<StoredCrashEvent> {
   const message = scrubSensitiveText(r.message);
   const errorMessage = scrubSensitiveText(r.errorMessage ?? "");
@@ -629,7 +632,8 @@ async function prepareCrashEvent(r: ReportPayload, keepD1Sample: boolean): Promi
 }
 
 async function projectCrashEvent(env: Env, event: StoredCrashEvent): Promise<void> {
-  if (await firebaseProjectionExists(env, event.eventId)) {
+  const firebaseDelivery = crashStorageMode(env) !== "d1";
+  if (firebaseDelivery && await firebaseProjectionExists(env, event.eventId)) {
     await env.DB.prepare(
       "UPDATE firebase_crash_outbox SET state = 'projected', updated_at = ?2 WHERE event_id = ?1",
     ).bind(event.eventId, new Date().toISOString()).run();
@@ -716,80 +720,16 @@ async function projectCrashEvent(env: Env, event: StoredCrashEvent): Promise<voi
        )`,
     ).bind(event.fingerprint, LATEST_SAMPLES_PER_GROUP));
   }
-  statements.push(...projectionCompletionStatements(env.DB, event.eventId, event.fingerprint, event.receivedAt));
+  if (firebaseDelivery) {
+    statements.push(...projectionCompletionStatements(
+      env.DB, event.eventId, event.fingerprint, event.receivedAt,
+    ));
+  }
   await env.DB.batch(statements);
 }
 
-async function deliverCrashEventToFirebase(env: Env, event: StoredCrashEvent, attempts: number): Promise<boolean> {
-  try {
-    const [group, receipt] = await Promise.all([
-      loadFirebaseGroupMeta(env, event.fingerprint),
-      firebaseProjectionReceipt(env, event.eventId),
-    ]);
-    if (!group || !receipt) throw new Error("firebase projection state is missing");
-    const { installId: _installId, ...publicReport } = event.report;
-    const stillLatest = Number(receipt.group_count) > Number(group.count) - LATEST_SAMPLES_PER_GROUP;
-    await writeFirebaseCrashGroup(
-      env,
-      firebaseMeta(group),
-      { ...publicReport, eventId: event.eventId, receivedAt: event.receivedAt },
-      stillLatest ? Number(receipt.latest_slot) : null,
-      Number(receipt.first_sample) === 1,
-    );
-    await markFirebaseDelivered(env, event.eventId);
-    return true;
-  } catch (error) {
-    console.error("firebase crash delivery failed", error);
-    await recordFirebaseRetry(env, event.eventId, "projected", attempts);
-    return false;
-  }
-}
-
-function parseStoredCrash(row: FirebaseOutboxRow): StoredCrashEvent | undefined {
-  try {
-    const value = JSON.parse(row.payload) as Partial<StoredCrashEvent>;
-    const report = Report.safeParse(value.report);
-    if (
-      !report.success || value.eventId !== row.event_id || value.fingerprint !== row.fingerprint ||
-      !/^(?:dev:)?[0-9a-f]{64}$/.test(value.fingerprint ?? "") ||
-      typeof value.receivedAt !== "string" || typeof value.keepD1Sample !== "boolean"
-    ) return undefined;
-    return { ...value, report: report.data } as StoredCrashEvent;
-  } catch {
-    return undefined;
-  }
-}
-
 export async function drainFirebaseCrashOutbox(env: Env): Promise<void> {
-  if (crashStorageMode(env) === "d1" || !firebaseStorageReady(env)) return;
-  for (const row of await dueFirebaseCrashes(env)) {
-    const event = parseStoredCrash(row);
-    if (!event) {
-      console.error(`firebase crash outbox row ${row.event_id} is invalid`);
-      await recordFirebaseRetry(env, row.event_id, "queued", row.attempts);
-      continue;
-    }
-    const leaseOwner = await acquireFirebaseGroupLease(env, row.fingerprint);
-    if (!leaseOwner) continue;
-    try {
-      if (!await firebaseOutboxExists(env, row.event_id)) continue;
-      if (row.state !== "projected") {
-        if (!await claimFirebaseCrash(env, row.event_id, new Date().toISOString())) continue;
-        try {
-          await projectCrashEvent(env, event);
-        } catch (error) {
-          console.error("firebase crash projection failed", error);
-          await recordFirebaseRetry(env, row.event_id, "queued", row.attempts);
-          continue;
-        }
-      }
-      if (!await deliverCrashEventToFirebase(env, event, row.attempts)) break;
-    } finally {
-      await releaseFirebaseGroupLease(env, row.fingerprint, leaseOwner).catch((error) => {
-        console.error("firebase crash group lease release failed", error);
-      });
-    }
-  }
+  return drainFirebaseOutbox(env, projectCrashEvent);
 }
 
 async function handleReport(request: Request, env: Env): Promise<Response> {
@@ -811,18 +751,25 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
   }
   const event = await prepareCrashEvent(parsed.data, mode !== "firebase");
   if (mode !== "d1") {
-    let leaseOwner: string | null = null;
+    let lease: FirebaseGroupLease | null = null;
     try {
+      if (await firebaseEventExists(env, event.eventId)) return new Response("ok", { status: 202 });
+      if (await reserveFirebaseGroup(env, event.fingerprint, event.receivedAt) === "full") {
+        return new Response("storage unavailable", { status: 503 });
+      }
       const enqueued = await enqueueFirebaseCrash(
         env, event.eventId, event.fingerprint, JSON.stringify(event), event.receivedAt,
       );
       if (enqueued === "duplicate") return new Response("ok", { status: 202 });
-      if (enqueued === "full") return new Response("storage unavailable", { status: 503 });
-      leaseOwner = await acquireFirebaseGroupLease(env, event.fingerprint);
+      if (enqueued === "full") {
+        await reclaimUnusedFirebaseReservation(env, event.fingerprint);
+        return new Response("storage unavailable", { status: 503 });
+      }
+      lease = await acquireFirebaseGroupLease(env, event.fingerprint);
     } catch (err) {
       return storageUnavailable("report outbox", err);
     }
-    if (!leaseOwner) return new Response("ok", { status: 202 });
+    if (!lease) return new Response("ok", { status: 202 });
     try {
       if (!await claimFirebaseCrash(env, event.eventId, new Date().toISOString())) {
         return new Response("ok", { status: 202 });
@@ -834,16 +781,13 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
         await recordFirebaseRetry(env, event.eventId, "queued", 0);
         return new Response("ok", { status: 202 });
       }
-      await deliverCrashEventToFirebase(env, event, 0);
+      await deliverCrashEventToFirebase(env, event, 0, lease);
       return new Response("ok", { status: 202 });
     } finally {
-      await releaseFirebaseGroupLease(env, event.fingerprint, leaseOwner).catch((error) => {
+      await releaseFirebaseGroupLease(env, event.fingerprint, lease).catch((error) => {
         console.error("firebase crash group lease release failed", error);
       });
     }
-  }
-  if (await firebaseProjectionExists(env, event.eventId)) {
-    return new Response("ok", { status: 202 });
   }
   try {
     await projectCrashEvent(env, event);
@@ -1127,6 +1071,7 @@ async function handleStats(request: Request, env: Env, user: User, activeModule:
     criticalOpenReports: 0,
   };
   let latestVersion = "";
+  let firebaseStorage: FirebaseStorageSummary | undefined;
 
   if (activeModule === "usage") {
     latestVersion = await latestObservedVersion(env, surface);
@@ -1158,6 +1103,7 @@ async function handleStats(request: Request, env: Env, user: User, activeModule:
     platforms = facets.platforms;
     diagnosticFacets = facets;
     installationLinkedSince = linkedSince?.value ?? "";
+    if (crashStorageMode(env) !== "d1") firebaseStorage = await firebaseStorageSummary(env);
   } else if (activeModule === "preferences") {
     metrics = await metricRows(env, days, surface);
   } else {
@@ -1171,7 +1117,8 @@ async function handleStats(request: Request, env: Env, user: User, activeModule:
 
   return html(
     renderStats(
-      { daily, versions, platforms, crashes, metrics, previousMetrics, sources, diagnosticFacets, installationLinkedSince, overview, latestVersion, filters },
+      { daily, versions, platforms, crashes, metrics, previousMetrics, sources, diagnosticFacets,
+        installationLinkedSince, overview, latestVersion, filters, firebaseStorage },
       user,
       activeModule,
     ),
@@ -1182,13 +1129,18 @@ async function handleGroup(env: Env, fingerprint: string, user: User): Promise<R
   const group = await env.DB.prepare("SELECT * FROM groups WHERE fingerprint = ?1").bind(fingerprint).first<Group>();
   if (!group) return new Response("not found", { status: 404 });
   group.severity = effectiveGroupSeverity(group);
+  const state = crashStorageMode(env) === "d1" ? null : await firebaseGroupState(env, fingerprint);
   let reports: ReportSample[];
   if (crashStorageMode(env) === "firebase") {
-    try {
-      const stored = await readFirebaseCrashGroup(env, fingerprint);
-      reports = firebaseSamples(stored?.samples);
-    } catch (error) {
-      return storageUnavailable("firebase group detail", error);
+    if (state?.sample_state === "archived") {
+      reports = [];
+    } else {
+      try {
+        const stored = await readFirebaseCrashGroup(env, fingerprint);
+        reports = firebaseSamples(stored?.samples);
+      } catch (error) {
+        return storageUnavailable("firebase group detail", error);
+      }
     }
   } else {
     const stored = await env.DB.prepare(
@@ -1198,28 +1150,43 @@ async function handleGroup(env: Env, fingerprint: string, user: User): Promise<R
     ).bind(fingerprint).all<ReportSample>();
     reports = stored.results;
   }
-  return html(renderGroup(group, reports, user, await groupDiagnosticSummary(env, fingerprint)));
+  return html(renderGroup(
+    group, reports, user, await groupDiagnosticSummary(env, fingerprint),
+    state ? { state: state.sample_state, epoch: Number(state.sample_epoch) } : undefined,
+  ));
 }
 
-async function syncFirebaseGroupMetaLocked(env: Env, fingerprint: string): Promise<void> {
+async function syncFirebaseGroupMetaLocked(
+  env: Env,
+  fingerprint: string,
+  lease?: FirebaseGroupLease,
+): Promise<void> {
   if (crashStorageMode(env) === "d1") return;
-  const group = await loadFirebaseGroupMeta(env, fingerprint);
-  if (!group) return;
-  await writeFirebaseGroupMeta(env, fingerprint, firebaseMeta(group));
+  if (!lease) throw new Error("firebase crash group lease is missing");
+  const [group, state] = await Promise.all([
+    loadFirebaseGroupMeta(env, fingerprint),
+    firebaseGroupState(env, fingerprint),
+  ]);
+  if (!group || !state) return;
+  if (state.sample_state === "archived") return;
+  await writeFirebaseGroupMeta(
+    env, fingerprint, firebaseMeta(group), lease.generation, Number(state.sample_epoch),
+    state.sample_state, () => renewFirebaseGroupLease(env, fingerprint, lease),
+  );
 }
 
 async function withFirebaseGroupLease<T>(
   env: Env,
   fingerprint: string,
-  operation: () => Promise<T>,
+  operation: (lease?: FirebaseGroupLease) => Promise<T>,
 ): Promise<T> {
   if (crashStorageMode(env) === "d1") return operation();
-  const owner = await acquireFirebaseGroupLease(env, fingerprint);
-  if (!owner) throw new Error("firebase crash group is busy");
+  const lease = await acquireFirebaseGroupLease(env, fingerprint);
+  if (!lease) throw new Error("firebase crash group is busy");
   try {
-    return await operation();
+    return await operation(lease);
   } finally {
-    await releaseFirebaseGroupLease(env, fingerprint, owner).catch((error) => {
+    await releaseFirebaseGroupLease(env, fingerprint, lease).catch((error) => {
       console.error("firebase crash group lease release failed", error);
     });
   }
@@ -1233,10 +1200,9 @@ async function handleGroupAction(request: Request, env: Env, admin: User, finger
 
   if (a.action === "delete") {
     try {
-      await withFirebaseGroupLease(env, fingerprint, async () => {
-        if (crashStorageMode(env) !== "d1") {
-          await deleteFirebaseCrashGroup(env, fingerprint);
-        }
+      if (crashStorageMode(env) !== "d1") {
+        await archiveFirebaseGroupForAdmin(env, fingerprint);
+      } else {
         await env.DB.batch([
           env.DB.prepare("DELETE FROM reports WHERE fingerprint = ?1").bind(fingerprint),
           env.DB.prepare("DELETE FROM report_daily WHERE fingerprint = ?1").bind(fingerprint),
@@ -1245,7 +1211,7 @@ async function handleGroupAction(request: Request, env: Env, admin: User, finger
           env.DB.prepare("DELETE FROM firebase_crash_outbox WHERE fingerprint = ?1").bind(fingerprint),
           env.DB.prepare("DELETE FROM groups WHERE fingerprint = ?1").bind(fingerprint),
         ]);
-      });
+      }
     } catch (error) {
       return storageUnavailable("firebase group deletion", error);
     }
@@ -1255,11 +1221,11 @@ async function handleGroupAction(request: Request, env: Env, admin: User, finger
   if (a.action === "status") {
     const status = a.status ?? "open";
     try {
-      await withFirebaseGroupLease(env, fingerprint, async () => {
+      await withFirebaseGroupLease(env, fingerprint, async (lease) => {
         await env.DB.prepare(
           "UPDATE groups SET status = ?1, resolved_at = CASE WHEN ?1 = 'resolved' THEN ?3 ELSE resolved_at END WHERE fingerprint = ?2",
         ).bind(status, fingerprint, new Date().toISOString()).run();
-        await syncFirebaseGroupMetaLocked(env, fingerprint);
+        await syncFirebaseGroupMetaLocked(env, fingerprint, lease);
       });
     } catch (error) {
       return storageUnavailable("firebase group metadata", error);
@@ -1277,11 +1243,11 @@ async function handleGroupAction(request: Request, env: Env, admin: User, finger
   if (a.action === "severity") {
     const severity = a.severity ?? "medium";
     try {
-      await withFirebaseGroupLease(env, fingerprint, async () => {
+      await withFirebaseGroupLease(env, fingerprint, async (lease) => {
         await env.DB.prepare("UPDATE groups SET severity = ?1 WHERE fingerprint = ?2")
           .bind(severity, fingerprint)
           .run();
-        await syncFirebaseGroupMetaLocked(env, fingerprint);
+        await syncFirebaseGroupMetaLocked(env, fingerprint, lease);
       });
     } catch (error) {
       return storageUnavailable("firebase group metadata", error);
@@ -1488,6 +1454,20 @@ async function sendAlert(env: Env, text: string): Promise<void> {
 
 async function runIngestSentinel(env: Env): Promise<void> {
   const problems: string[] = [];
+  if (crashStorageMode(env) !== "d1") {
+    try {
+      const storage = await firebaseStorageSummary(env);
+      if (storage.reservedBytes >= storage.budgetBytes * 0.8) {
+        problems.push(`Firebase reserved storage is ${Math.round(storage.reservedBytes / 1048576)} MiB`);
+      }
+      if (storage.stuckArchiving > 0) problems.push(`${storage.stuckArchiving} Firebase archives are stuck`);
+      if (storage.outboxCount >= FIREBASE_OUTBOX_WARNING) {
+        problems.push(`Firebase outbox contains ${storage.outboxCount} rows`);
+      }
+    } catch (err) {
+      problems.push(`Firebase storage sentinel failed: ${errText(err)}`);
+    }
+  }
   try {
     await env.DB.prepare(
       `INSERT INTO pings (date, install_id, version, os, arch, opens)
@@ -1686,8 +1666,9 @@ export default {
     }
     ctx.waitUntil(Promise.all([
       purgeExpiredStatsRows(env),
-      purgeFirebaseDeliveryState(env),
+      crashStorageMode(env) === "d1" ? Promise.resolve() : purgeFirebaseDeliveryState(env),
       drainFirebaseCrashOutbox(env),
+      crashStorageMode(env) === "d1" ? Promise.resolve() : runFirebaseCrashLifecycle(env),
     ]).then(() => undefined));
   },
 };

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import type { Env } from "./env";
 import { html, redirect } from "./shell";
 import { renderStats, type StatsModule } from "./stats";
-import { renderGroup, type Group } from "./group";
+import { renderGroup, type Group, type ReportSample } from "./group";
 import { renderAccount } from "./auth_pages";
 import { renderUsers, renderAudit, type UserRow, type AuditRow } from "./admin";
 import {
@@ -46,6 +46,35 @@ import {
 } from "./diagnostics_v2";
 import { Report, WebRuntimeDiagnostic, type ReportPayload } from "./report_schema";
 import { statsFilters, type StatsFilters } from "./stats_filters";
+import {
+  acquireFirebaseGroupLease,
+  claimFirebaseCrash,
+  crashStorageMode,
+  dueFirebaseCrashes,
+  enqueueFirebaseCrash,
+  firebaseOutboxExists,
+  firebaseProjectionReceipt,
+  firebaseProjectionExists,
+  firebaseStorageReady,
+  markFirebaseDelivered,
+  projectionCompletionStatements,
+  purgeFirebaseDeliveryState,
+  recordFirebaseRetry,
+  releaseFirebaseGroupLease,
+  type FirebaseOutboxRow,
+} from "./crash_delivery";
+import {
+  deleteFirebaseCrashGroup,
+  readFirebaseCrashGroup,
+  writeFirebaseCrashGroup,
+  writeFirebaseGroupMeta,
+} from "./firebase_rtdb";
+import {
+  firebaseMeta,
+  firebaseSamples,
+  loadFirebaseGroupMeta,
+  type FirebaseGroupRow,
+} from "./firebase_crash_view";
 export { Report } from "./report_schema";
 export { diagnosticWindowWhere, effectiveGroupSeverity, isDevelopmentGroup } from "./diagnostics_v2";
 const MAX_BODY_BYTES = 96 * 1024;
@@ -513,14 +542,254 @@ async function readJSON(request: Request): Promise<unknown | Response> {
   }
 }
 
-// Ingest writes fail together when the database is unhealthy (e.g. the D1
-// size cap: every INSERT throws while reads stay fine). Surface that as a
-// deliberate 503 with a loud log instead of an opaque worker exception, so
-// `wrangler tail` / observability show the root cause and clients see a
-// retryable status.
+// Storage operations surface a deliberate 503 with a loud but credential-free
+// log instead of an opaque worker exception, so clients retain retryable state.
 function storageUnavailable(op: string, err: unknown): Response {
-  console.error(`${op}: D1 write failed`, err);
+  console.error(`${op}: storage unavailable`, err);
   return new Response("storage unavailable", { status: 503 });
+}
+
+type StoredCrashEvent = {
+  eventId: string;
+  fingerprint: string;
+  receivedAt: string;
+  keepD1Sample: boolean;
+  report: ReportPayload;
+};
+
+async function prepareCrashEvent(r: ReportPayload, keepD1Sample: boolean): Promise<StoredCrashEvent> {
+  const message = scrubSensitiveText(r.message);
+  const errorMessage = scrubSensitiveText(r.errorMessage ?? "");
+  const stack = scrubSensitiveText(r.stack ?? "");
+  const componentStack = scrubSensitiveText(r.componentStack ?? "");
+  const topFrame = scrubSensitiveText(r.topFrame ?? "");
+  const fingerprintHint = scrubSensitiveText(r.fingerprintHint ?? "");
+  const view = scrubSensitiveText(r.view ?? "");
+  const breadcrumbs = (r.breadcrumbs ?? []).map((breadcrumb) => ({
+    ...breadcrumb,
+    msg: breadcrumb.msg ? scrubSensitiveText(breadcrumb.msg) : breadcrumb.msg,
+  }));
+  const webRuntime = normalizedWebRuntime(r);
+  const webview2 = r.webview2
+    ? {
+        ...r.webview2,
+        processDescription: scrubSensitiveText(r.webview2.processDescription ?? "").slice(0, 255),
+        failureSourceModule: basenameOnly(r.webview2.failureSourceModule),
+      }
+    : undefined;
+  const report: ReportPayload = {
+    ...r,
+    eventId: r.eventId ?? crypto.randomUUID().replaceAll("-", ""),
+    message,
+    errorMessage,
+    stack,
+    componentStack,
+    topFrame,
+    fingerprintHint,
+    view,
+    breadcrumbs,
+    webRuntime,
+    webview2,
+  };
+  const fingerprintBasis = (
+    report.source === "web.runtime.native" || report.source === "webview2.process.native"
+  ) && webRuntime
+    ? nativeWebRuntimeFingerprintBasis(webRuntime)
+    : hasStructuredCrashFields(report)
+      ? normalizeForFingerprint({
+        kind: report.kind,
+        message,
+        source: report.source,
+        label: report.label,
+        errorType: report.errorType,
+        errorMessage,
+        topFrame,
+        fingerprintHint,
+      })
+      : normalizeForFingerprint(report.kind, message);
+  const severityInput = {
+    kind: report.kind,
+    version: report.version,
+    source: report.source ?? "legacy",
+    label: report.label ?? "",
+    errorType: report.errorType ?? "",
+    errorMessage,
+    topFrame,
+    channel: report.channel ?? "",
+    recovery: webRuntime?.recovery,
+  };
+  const development = isDevelopmentReport(severityInput);
+  return {
+    eventId: report.eventId!,
+    fingerprint: namespaceReportFingerprint(await sha256Hex(fingerprintBasis), development),
+    receivedAt: new Date().toISOString(),
+    keepD1Sample,
+    report,
+  };
+}
+
+async function projectCrashEvent(env: Env, event: StoredCrashEvent): Promise<void> {
+  if (await firebaseProjectionExists(env, event.eventId)) {
+    await env.DB.prepare(
+      "UPDATE firebase_crash_outbox SET state = 'projected', updated_at = ?2 WHERE event_id = ?1",
+    ).bind(event.eventId, new Date().toISOString()).run();
+    return;
+  }
+  const r = event.report;
+  const webRuntime = normalizedWebRuntime(r);
+  const webview2 = r.webview2;
+  const message = r.message;
+  const errorMessage = r.errorMessage ?? "";
+  const topFrame = r.topFrame ?? "";
+  const source = r.source ?? "legacy";
+  const label = r.label ?? "";
+  const errorType = r.errorType ?? "";
+  const buildCommit = r.buildCommit ?? "";
+  const channel = r.channel ?? "";
+  const severity = severityForReport({
+    kind: r.kind,
+    version: r.version,
+    source,
+    label,
+    errorType,
+    errorMessage,
+    topFrame,
+    channel,
+    recovery: webRuntime?.recovery,
+  });
+  const prior = await env.DB.prepare("SELECT status FROM groups WHERE fingerprint = ?1")
+    .bind(event.fingerprint)
+    .first<{ status: string }>();
+  const regressedAt = prior?.status === "resolved" ? event.receivedAt : "";
+  const groupWrite = env.DB.prepare(
+    `INSERT INTO groups (
+       fingerprint, kind, count, first_seen, last_seen, first_version, last_version,
+       status, title, source, label, error_type, top_frame, severity,
+       last_os, last_arch, last_build_commit, last_channel, last_sample_at, regressed_at
+     )
+     VALUES (?1, ?2, 1, ?3, ?3, ?4, ?4, 'open', ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?3, ?15)
+     ON CONFLICT (fingerprint) DO UPDATE SET
+       kind = CASE
+         WHEN severity = 'critical' THEN kind
+         WHEN (CASE ?10 WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 ELSE 1 END) >
+              (CASE severity WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 ELSE 1 END)
+           THEN ?2 ELSE kind END,
+       count = count + 1, last_seen = ?3, last_version = ?4, title = ?5,
+       source = ?6, label = ?7, error_type = ?8, top_frame = ?9,
+       severity = CASE
+         WHEN severity = 'critical' THEN severity
+         WHEN (CASE ?10 WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 ELSE 1 END) >
+              (CASE severity WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 ELSE 1 END)
+           THEN ?10 ELSE severity END,
+       last_os = ?11, last_arch = ?12, last_build_commit = ?13, last_channel = ?14,
+       last_sample_at = ?3,
+       status = CASE WHEN status = 'resolved' THEN 'open' ELSE status END,
+       regressed_at = CASE WHEN status = 'resolved' THEN ?3 ELSE regressed_at END`,
+  ).bind(
+    event.fingerprint, r.kind, event.receivedAt, r.version, crashTitle(message), source,
+    label, errorType, topFrame, severity, r.os, r.arch, buildCommit, channel, regressedAt,
+  );
+  const statements: D1PreparedStatement[] = [groupWrite];
+  if (event.keepD1Sample) {
+    statements.push(env.DB.prepare(
+      `INSERT INTO reports (
+         fingerprint, kind, version, os, arch, message, device, created_at,
+         source, label, error_type, error_message, top_frame, build_commit, channel,
+         language, view, breadcrumbs, component_stack, stack, occurred_at, webview2, web_runtime
+       ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23)`,
+    ).bind(
+      event.fingerprint, r.kind, r.version, r.os, r.arch, message,
+      JSON.stringify(r.device ?? {}), event.receivedAt, source, label, errorType, errorMessage,
+      topFrame, buildCommit, channel, r.language ?? "", r.view ?? "",
+      JSON.stringify(r.breadcrumbs ?? []), r.componentStack ?? "", r.stack ?? "",
+      r.occurredAt ?? "", webview2 ? JSON.stringify(webview2) : "",
+      webRuntime ? JSON.stringify(webRuntime) : "",
+    ));
+  }
+  statements.push(...reportAggregateStatements(env.DB, r, event.fingerprint, channel, webRuntime));
+  if (event.keepD1Sample) {
+    statements.push(env.DB.prepare(
+      `DELETE FROM reports WHERE fingerprint = ?1 AND id NOT IN (
+         SELECT id FROM (SELECT id FROM reports WHERE fingerprint = ?1 ORDER BY id ASC LIMIT 1)
+         UNION
+         SELECT id FROM (SELECT id FROM reports WHERE fingerprint = ?1 ORDER BY id DESC LIMIT ?2)
+       )`,
+    ).bind(event.fingerprint, LATEST_SAMPLES_PER_GROUP));
+  }
+  statements.push(...projectionCompletionStatements(env.DB, event.eventId, event.fingerprint, event.receivedAt));
+  await env.DB.batch(statements);
+}
+
+async function deliverCrashEventToFirebase(env: Env, event: StoredCrashEvent, attempts: number): Promise<boolean> {
+  try {
+    const [group, receipt] = await Promise.all([
+      loadFirebaseGroupMeta(env, event.fingerprint),
+      firebaseProjectionReceipt(env, event.eventId),
+    ]);
+    if (!group || !receipt) throw new Error("firebase projection state is missing");
+    const { installId: _installId, ...publicReport } = event.report;
+    const stillLatest = Number(receipt.group_count) > Number(group.count) - LATEST_SAMPLES_PER_GROUP;
+    await writeFirebaseCrashGroup(
+      env,
+      firebaseMeta(group),
+      { ...publicReport, eventId: event.eventId, receivedAt: event.receivedAt },
+      stillLatest ? Number(receipt.latest_slot) : null,
+      Number(receipt.first_sample) === 1,
+    );
+    await markFirebaseDelivered(env, event.eventId);
+    return true;
+  } catch (error) {
+    console.error("firebase crash delivery failed", error);
+    await recordFirebaseRetry(env, event.eventId, "projected", attempts);
+    return false;
+  }
+}
+
+function parseStoredCrash(row: FirebaseOutboxRow): StoredCrashEvent | undefined {
+  try {
+    const value = JSON.parse(row.payload) as Partial<StoredCrashEvent>;
+    const report = Report.safeParse(value.report);
+    if (
+      !report.success || value.eventId !== row.event_id || value.fingerprint !== row.fingerprint ||
+      !/^(?:dev:)?[0-9a-f]{64}$/.test(value.fingerprint ?? "") ||
+      typeof value.receivedAt !== "string" || typeof value.keepD1Sample !== "boolean"
+    ) return undefined;
+    return { ...value, report: report.data } as StoredCrashEvent;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function drainFirebaseCrashOutbox(env: Env): Promise<void> {
+  if (crashStorageMode(env) === "d1" || !firebaseStorageReady(env)) return;
+  for (const row of await dueFirebaseCrashes(env)) {
+    const event = parseStoredCrash(row);
+    if (!event) {
+      console.error(`firebase crash outbox row ${row.event_id} is invalid`);
+      await recordFirebaseRetry(env, row.event_id, "queued", row.attempts);
+      continue;
+    }
+    const leaseOwner = await acquireFirebaseGroupLease(env, row.fingerprint);
+    if (!leaseOwner) continue;
+    try {
+      if (!await firebaseOutboxExists(env, row.event_id)) continue;
+      if (row.state !== "projected") {
+        if (!await claimFirebaseCrash(env, row.event_id, new Date().toISOString())) continue;
+        try {
+          await projectCrashEvent(env, event);
+        } catch (error) {
+          console.error("firebase crash projection failed", error);
+          await recordFirebaseRetry(env, row.event_id, "queued", row.attempts);
+          continue;
+        }
+      }
+      if (!await deliverCrashEventToFirebase(env, event, row.attempts)) break;
+    } finally {
+      await releaseFirebaseGroupLease(env, row.fingerprint, leaseOwner).catch((error) => {
+        console.error("firebase crash group lease release failed", error);
+      });
+    }
+  }
 }
 
 async function handleReport(request: Request, env: Env): Promise<Response> {
@@ -532,158 +801,55 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
   if (raw instanceof Response) return raw;
   const parsed = Report.safeParse(raw);
   if (!parsed.success) return new Response("bad request", { status: 400 });
-  const r = parsed.data;
-  const message = scrubSensitiveText(r.message);
-  const errorMessage = scrubSensitiveText(r.errorMessage ?? "");
-  const stack = scrubSensitiveText(r.stack ?? "");
-  const componentStack = scrubSensitiveText(r.componentStack ?? "");
-  const topFrame = scrubSensitiveText(r.topFrame ?? "");
-  const fingerprintHint = scrubSensitiveText(r.fingerprintHint ?? "");
-  const view = scrubSensitiveText(r.view ?? "");
-  const breadcrumbs = (r.breadcrumbs ?? []).map((b) => ({
-    ...b,
-    msg: b.msg ? scrubSensitiveText(b.msg) : b.msg,
-  }));
-  const webRuntime = normalizedWebRuntime(r);
-  const webview2 = r.webview2
-    ? {
-        ...r.webview2,
-        processDescription: scrubSensitiveText(r.webview2.processDescription ?? "").slice(0, 255),
-        failureSourceModule: basenameOnly(r.webview2.failureSourceModule),
-      }
-    : undefined;
-
-  const fingerprintBasis = (r.source === "web.runtime.native" || r.source === "webview2.process.native") && webRuntime
-    ? nativeWebRuntimeFingerprintBasis(webRuntime)
-    : hasStructuredCrashFields(r)
-      ? normalizeForFingerprint({
-        kind: r.kind,
-        message,
-        source: r.source,
-        label: r.label,
-        errorType: r.errorType,
-        errorMessage,
-        topFrame,
-        fingerprintHint,
-        })
-      : normalizeForFingerprint(r.kind, message);
-  const now = new Date().toISOString();
-  const title = crashTitle(message);
-  const source = r.source ?? "legacy";
-  const label = r.label ?? "";
-  const errorType = r.errorType ?? "";
-  const buildCommit = r.buildCommit ?? "";
-  const channel = r.channel ?? "";
-  const severityInput = {
-    kind: r.kind,
-    version: r.version,
-    source,
-    label,
-    errorType,
-    errorMessage,
-    topFrame,
-    channel,
-    recovery: webRuntime?.recovery,
-  };
-  const development = isDevelopmentReport(severityInput);
-  const fingerprint = namespaceReportFingerprint(await sha256Hex(fingerprintBasis), development);
-  const severity = severityForReport(severityInput);
+  let mode;
   try {
-    const prior = await env.DB.prepare("SELECT status FROM groups WHERE fingerprint = ?1")
-      .bind(fingerprint)
-      .first<{ status: string }>();
-    const regressedAt = prior?.status === "resolved" ? now : "";
-
-    const groupWrite = env.DB.prepare(
-      `INSERT INTO groups (
-         fingerprint, kind, count, first_seen, last_seen, first_version, last_version,
-         status, title, source, label, error_type, top_frame, severity,
-         last_os, last_arch, last_build_commit, last_channel, last_sample_at, regressed_at
-       )
-       VALUES (?1, ?2, 1, ?3, ?3, ?4, ?4, 'open', ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?3, ?15)
-       ON CONFLICT (fingerprint) DO UPDATE SET
-         kind = CASE
-           WHEN severity = 'critical' THEN kind
-           WHEN (CASE ?10 WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 ELSE 1 END) >
-                (CASE severity WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 ELSE 1 END)
-             THEN ?2 ELSE kind END,
-         count = count + 1,
-         last_seen = ?3,
-         last_version = ?4,
-         title = ?5,
-         source = ?6,
-         label = ?7,
-         error_type = ?8,
-         top_frame = ?9,
-         severity = CASE
-           WHEN severity = 'critical' THEN severity
-           WHEN (CASE ?10 WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 ELSE 1 END) >
-                (CASE severity WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 ELSE 1 END)
-             THEN ?10 ELSE severity END,
-         last_os = ?11,
-         last_arch = ?12,
-         last_build_commit = ?13,
-         last_channel = ?14,
-         last_sample_at = ?3,
-         status = CASE WHEN status = 'resolved' THEN 'open' ELSE status END,
-         regressed_at = CASE WHEN status = 'resolved' THEN ?3 ELSE regressed_at END`,
-    )
-      .bind(fingerprint, r.kind, now, r.version, title, source, label, errorType, topFrame, severity, r.os, r.arch, buildCommit, channel, regressedAt);
-
-    const sampleWrite = env.DB.prepare(
-      `INSERT INTO reports (
-         fingerprint, kind, version, os, arch, message, device, created_at,
-         source, label, error_type, error_message, top_frame, build_commit, channel,
-         language, view, breadcrumbs, component_stack, stack, occurred_at, webview2, web_runtime
-       )
-       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23)`,
-    )
-      .bind(
-        fingerprint,
-        r.kind,
-        r.version,
-        r.os,
-        r.arch,
-        message,
-        JSON.stringify(r.device ?? {}),
-        now,
-        source,
-        label,
-        errorType,
-        errorMessage,
-        topFrame,
-        buildCommit,
-        channel,
-        r.language ?? "",
-        view,
-        JSON.stringify(breadcrumbs),
-        componentStack,
-        stack,
-        r.occurredAt ?? "",
-        webview2 ? JSON.stringify(webview2) : "",
-        webRuntime ? JSON.stringify(webRuntime) : "",
+    mode = crashStorageMode(env);
+    if (!firebaseStorageReady(env)) throw new Error("firebase crash storage is not configured");
+  } catch (err) {
+    console.error("report: crash storage configuration failed", err);
+    return new Response("storage unavailable", { status: 503 });
+  }
+  const event = await prepareCrashEvent(parsed.data, mode !== "firebase");
+  if (mode !== "d1") {
+    let leaseOwner: string | null = null;
+    try {
+      const enqueued = await enqueueFirebaseCrash(
+        env, event.eventId, event.fingerprint, JSON.stringify(event), event.receivedAt,
       );
-
-    const pruneSamples = env.DB.prepare(
-      `DELETE FROM reports
-       WHERE fingerprint = ?1
-         AND id NOT IN (
-           SELECT id FROM (SELECT id FROM reports WHERE fingerprint = ?1 ORDER BY id ASC LIMIT 1)
-           UNION
-           SELECT id FROM (SELECT id FROM reports WHERE fingerprint = ?1 ORDER BY id DESC LIMIT ?2)
-         )`,
-    ).bind(fingerprint, LATEST_SAMPLES_PER_GROUP);
-
-    await env.DB.batch([
-      groupWrite,
-      sampleWrite,
-      ...reportAggregateStatements(env.DB, r, fingerprint, channel, webRuntime),
-      pruneSamples,
-    ]);
+      if (enqueued === "duplicate") return new Response("ok", { status: 202 });
+      if (enqueued === "full") return new Response("storage unavailable", { status: 503 });
+      leaseOwner = await acquireFirebaseGroupLease(env, event.fingerprint);
+    } catch (err) {
+      return storageUnavailable("report outbox", err);
+    }
+    if (!leaseOwner) return new Response("ok", { status: 202 });
+    try {
+      if (!await claimFirebaseCrash(env, event.eventId, new Date().toISOString())) {
+        return new Response("ok", { status: 202 });
+      }
+      try {
+        await projectCrashEvent(env, event);
+      } catch (err) {
+        console.error("report: buffered D1 projection failed", err);
+        await recordFirebaseRetry(env, event.eventId, "queued", 0);
+        return new Response("ok", { status: 202 });
+      }
+      await deliverCrashEventToFirebase(env, event, 0);
+      return new Response("ok", { status: 202 });
+    } finally {
+      await releaseFirebaseGroupLease(env, event.fingerprint, leaseOwner).catch((error) => {
+        console.error("firebase crash group lease release failed", error);
+      });
+    }
+  }
+  if (await firebaseProjectionExists(env, event.eventId)) {
+    return new Response("ok", { status: 202 });
+  }
+  try {
+    await projectCrashEvent(env, event);
   } catch (err) {
     return storageUnavailable("report", err);
   }
-
   return new Response("ok", { status: 202 });
 }
 
@@ -1016,36 +1182,47 @@ async function handleGroup(env: Env, fingerprint: string, user: User): Promise<R
   const group = await env.DB.prepare("SELECT * FROM groups WHERE fingerprint = ?1").bind(fingerprint).first<Group>();
   if (!group) return new Response("not found", { status: 404 });
   group.severity = effectiveGroupSeverity(group);
-  const reports = await env.DB.prepare(
-    `SELECT version, os, arch, message, device, created_at, source, label, error_type, error_message,
-      top_frame, build_commit, channel, language, view, breadcrumbs, component_stack, stack, occurred_at, webview2, web_runtime
-     FROM reports WHERE fingerprint = ?1 ORDER BY id DESC`,
-  )
-    .bind(fingerprint)
-    .all<{
-      version: string;
-      os: string;
-      arch: string;
-      message: string;
-      device: string;
-      created_at: string;
-      source: string;
-      label: string;
-      error_type: string;
-      error_message: string;
-      top_frame: string;
-      build_commit: string;
-      channel: string;
-      language: string;
-      view: string;
-      breadcrumbs: string;
-      component_stack: string;
-      stack: string;
-      occurred_at: string;
-      webview2: string;
-      web_runtime: string;
-    }>();
-  return html(renderGroup(group, reports.results, user, await groupDiagnosticSummary(env, fingerprint)));
+  let reports: ReportSample[];
+  if (crashStorageMode(env) === "firebase") {
+    try {
+      const stored = await readFirebaseCrashGroup(env, fingerprint);
+      reports = firebaseSamples(stored?.samples);
+    } catch (error) {
+      return storageUnavailable("firebase group detail", error);
+    }
+  } else {
+    const stored = await env.DB.prepare(
+      `SELECT version, os, arch, message, device, created_at, source, label, error_type, error_message,
+        top_frame, build_commit, channel, language, view, breadcrumbs, component_stack, stack, occurred_at, webview2, web_runtime
+       FROM reports WHERE fingerprint = ?1 ORDER BY id DESC`,
+    ).bind(fingerprint).all<ReportSample>();
+    reports = stored.results;
+  }
+  return html(renderGroup(group, reports, user, await groupDiagnosticSummary(env, fingerprint)));
+}
+
+async function syncFirebaseGroupMetaLocked(env: Env, fingerprint: string): Promise<void> {
+  if (crashStorageMode(env) === "d1") return;
+  const group = await loadFirebaseGroupMeta(env, fingerprint);
+  if (!group) return;
+  await writeFirebaseGroupMeta(env, fingerprint, firebaseMeta(group));
+}
+
+async function withFirebaseGroupLease<T>(
+  env: Env,
+  fingerprint: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (crashStorageMode(env) === "d1") return operation();
+  const owner = await acquireFirebaseGroupLease(env, fingerprint);
+  if (!owner) throw new Error("firebase crash group is busy");
+  try {
+    return await operation();
+  } finally {
+    await releaseFirebaseGroupLease(env, fingerprint, owner).catch((error) => {
+      console.error("firebase crash group lease release failed", error);
+    });
+  }
 }
 
 async function handleGroupAction(request: Request, env: Env, admin: User, fingerprint: string): Promise<Response> {
@@ -1055,23 +1232,38 @@ async function handleGroupAction(request: Request, env: Env, admin: User, finger
   const a = parsed.data;
 
   if (a.action === "delete") {
-    await env.DB.batch([
-      env.DB.prepare("DELETE FROM reports WHERE fingerprint = ?1").bind(fingerprint),
-      env.DB.prepare("DELETE FROM report_daily WHERE fingerprint = ?1").bind(fingerprint),
-      env.DB.prepare("DELETE FROM report_installations WHERE fingerprint = ?1").bind(fingerprint),
-      env.DB.prepare("DELETE FROM report_event_dimensions WHERE fingerprint = ?1").bind(fingerprint),
-      env.DB.prepare("DELETE FROM groups WHERE fingerprint = ?1").bind(fingerprint),
-    ]);
+    try {
+      await withFirebaseGroupLease(env, fingerprint, async () => {
+        if (crashStorageMode(env) !== "d1") {
+          await deleteFirebaseCrashGroup(env, fingerprint);
+        }
+        await env.DB.batch([
+          env.DB.prepare("DELETE FROM reports WHERE fingerprint = ?1").bind(fingerprint),
+          env.DB.prepare("DELETE FROM report_daily WHERE fingerprint = ?1").bind(fingerprint),
+          env.DB.prepare("DELETE FROM report_installations WHERE fingerprint = ?1").bind(fingerprint),
+          env.DB.prepare("DELETE FROM report_event_dimensions WHERE fingerprint = ?1").bind(fingerprint),
+          env.DB.prepare("DELETE FROM firebase_crash_outbox WHERE fingerprint = ?1").bind(fingerprint),
+          env.DB.prepare("DELETE FROM groups WHERE fingerprint = ?1").bind(fingerprint),
+        ]);
+      });
+    } catch (error) {
+      return storageUnavailable("firebase group deletion", error);
+    }
     await logAction(env, admin, "delete_group", fingerprint.slice(0, 8));
     return redirect("/stats");
   }
   if (a.action === "status") {
     const status = a.status ?? "open";
-    await env.DB.prepare(
-      "UPDATE groups SET status = ?1, resolved_at = CASE WHEN ?1 = 'resolved' THEN ?3 ELSE resolved_at END WHERE fingerprint = ?2",
-    )
-      .bind(status, fingerprint, new Date().toISOString())
-      .run();
+    try {
+      await withFirebaseGroupLease(env, fingerprint, async () => {
+        await env.DB.prepare(
+          "UPDATE groups SET status = ?1, resolved_at = CASE WHEN ?1 = 'resolved' THEN ?3 ELSE resolved_at END WHERE fingerprint = ?2",
+        ).bind(status, fingerprint, new Date().toISOString()).run();
+        await syncFirebaseGroupMetaLocked(env, fingerprint);
+      });
+    } catch (error) {
+      return storageUnavailable("firebase group metadata", error);
+    }
     await logAction(env, admin, "set_status", fingerprint.slice(0, 8), status);
     return redirect(`/stats/group/${fingerprint}`);
   }
@@ -1083,10 +1275,18 @@ async function handleGroupAction(request: Request, env: Env, admin: User, finger
     return redirect(`/stats/group/${fingerprint}`);
   }
   if (a.action === "severity") {
-    await env.DB.prepare("UPDATE groups SET severity = ?1 WHERE fingerprint = ?2")
-      .bind(a.severity ?? "medium", fingerprint)
-      .run();
-    await logAction(env, admin, "set_severity", fingerprint.slice(0, 8), a.severity ?? "medium");
+    const severity = a.severity ?? "medium";
+    try {
+      await withFirebaseGroupLease(env, fingerprint, async () => {
+        await env.DB.prepare("UPDATE groups SET severity = ?1 WHERE fingerprint = ?2")
+          .bind(severity, fingerprint)
+          .run();
+        await syncFirebaseGroupMetaLocked(env, fingerprint);
+      });
+    } catch (error) {
+      return storageUnavailable("firebase group metadata", error);
+    }
+    await logAction(env, admin, "set_severity", fingerprint.slice(0, 8), severity);
     return redirect(`/stats/group/${fingerprint}`);
   }
   await env.DB.prepare("UPDATE groups SET note = ?1 WHERE fingerprint = ?2").bind(a.note ?? "", fingerprint).run();
@@ -1478,9 +1678,16 @@ export default {
 
   async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
     if (controller.cron === SENTINEL_CRON) {
-      ctx.waitUntil(runIngestSentinel(env));
+      ctx.waitUntil(Promise.all([
+        runIngestSentinel(env),
+        drainFirebaseCrashOutbox(env),
+      ]).then(() => undefined));
       return;
     }
-    ctx.waitUntil(purgeExpiredStatsRows(env));
+    ctx.waitUntil(Promise.all([
+      purgeExpiredStatsRows(env),
+      purgeFirebaseDeliveryState(env),
+      drainFirebaseCrashOutbox(env),
+    ]).then(() => undefined));
   },
 };

--- a/workers/crash-report/src/report_schema.ts
+++ b/workers/crash-report/src/report_schema.ts
@@ -40,6 +40,8 @@ export const WebRuntimeDiagnostic = z.object({
 });
 
 export const Report = z.object({
+  eventId: z.string().regex(/^[0-9a-f]{32}$/).optional(),
+  dedupKey: z.string().regex(/^[0-9a-f]{64}$/).optional(),
   installId: z.string().regex(/^[0-9a-f]{32}$/).optional(),
   kind: z.enum(["crash", "exception", "feedback", "performance", "bot"]),
   version: z.string().min(1).max(64),

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -614,6 +614,16 @@ export function renderStats(
       gpuStates: BarRow[];
     };
     installationLinkedSince?: string;
+    firebaseStorage?: {
+      active: number;
+      compacted: number;
+      archiving: number;
+      archived: number;
+      reservedBytes: number;
+      budgetBytes: number;
+      outboxCount: number;
+      oldestOutboxSeconds: number;
+    };
     overview: OverviewCounts;
     latestVersion: string;
     filters: {
@@ -734,6 +744,20 @@ export function renderStats(
     (row) => row.kind === "performance" && !isDevelopmentDiagnostic(row),
   );
   const developmentDiagnostics = data.crashes.filter(isDevelopmentDiagnostic);
+  const firebaseStorage = data.firebaseStorage ? (() => {
+    const storage = data.firebaseStorage;
+    const percent = storage.budgetBytes > 0 ? storage.reservedBytes / storage.budgetBytes * 100 : 0;
+    const tone = percent >= 100 ? "bad" : percent >= 80 ? "warn" : "good";
+    const waiting = storage.oldestOutboxSeconds > 0
+      ? `${Math.floor(storage.oldestOutboxSeconds / 3600)}h ${Math.floor(storage.oldestOutboxSeconds % 3600 / 60)}m`
+      : "none";
+    return `<section class="module-panel"><h3>${i18n("Firebase Spark storage", "Firebase Spark 存储")}</h3>
+<div class="overview-grid">
+${statCard({ en: "Reserved", zh: "已预留" }, `${(storage.reservedBytes / 1048576).toFixed(1)} MiB`, `${percent.toFixed(1)}% / 700 MiB`, "#", tone)}
+${statCard({ en: "Lifecycle", zh: "生命周期" }, `${storage.active}/${storage.compacted}/${storage.archiving}/${storage.archived}`, i18n("active / compacted / archiving / archived", "活跃 / 已压缩 / 归档中 / 已归档"), "#")}
+${statCard({ en: "Outbox", zh: "待投递" }, String(storage.outboxCount), i18nHTML(`oldest ${waiting}`, `最老 ${waiting === "none" ? "无" : waiting}`), "#", storage.outboxCount >= 4000 ? "warn" : "good")}
+</div></section>`;
+  })() : "";
   const overview = `<section class="overview-grid">
 ${statCard({ en: "Active today", zh: "今日活跃" }, String(totalUsers), i18n("anonymous installs", "匿名安装"), filterQS({}, "usage"))}
 ${statCard({ en: "Latest adoption", zh: "最新版本占比" }, latestVersionShare(data.overview.latestAdoptionPct), i18nHTML(`latest ${esc(data.latestVersion || "n/a")}`, `最新 ${esc(data.latestVersion || "n/a")}`), filterQS({}, "usage"))}
@@ -781,6 +805,7 @@ ${anyPing ? dailyChart(days) : `<div class="empty">${i18n("No pings yet — data
 </div></section>`;
   const diagnosticsModule = `<section id="diagnostics" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Diagnostic triage", "诊断分诊")}</h2></div><a class="module-action" href="#top">${i18n("Back to overview", "回到概览")}</a></div>
 <p class="sub">${i18n("Installation-linked data is available only from the diagnostics-v2 deployment date; historical device counts are not backfilled.", "可关联安装的数据仅从 diagnostics-v2 部署日起提供；历史设备数不回填。")}</p>
+${firebaseStorage}
 <section class="module-panel"><h3>${i18nHTML("Needs attention <b>— top 10 release crashes and exceptions</b>", "优先处理 <b>— 正式版崩溃与异常 Top 10</b>")}</h3>${reportGroups(releaseCrashes.slice(0, 10), true)}</section>
 ${performanceDiagnostics.length ? `<section class="module-panel"><h3>${i18nHTML("Performance signals <b>— tracked separately from crashes</b>", "性能信号 <b>— 与崩溃分开统计</b>")}</h3>${reportGroups(performanceDiagnostics.slice(0, 5), true)}</section>` : ""}
 ${developmentDiagnostics.length ? `<section class="module-panel"><h3>${i18nHTML("Development diagnostics <b>— excluded from release priority</b>", "开发版诊断 <b>— 不计入正式版优先级</b>")}</h3>${reportGroups(developmentDiagnostics.slice(0, 5), true)}</section>` : ""}

--- a/workers/crash-report/wrangler.toml
+++ b/workers/crash-report/wrangler.toml
@@ -18,6 +18,10 @@ routes = [{ pattern = "crash.reasonix.io", custom_domain = true }]
 crons = ["47 19 * * *", "17 1,7,13,19 * * *"]
 
 [vars]
+# Safe rollout default. Change to `dual` only after the Firebase database URL
+# and service-account secrets have been installed; use `firebase` after the
+# seven-day shadow comparison completes.
+CRASH_STORAGE_MODE = "d1"
 # Emails force-promoted to dashboard admin — the owner is never locked out even
 # if the role migration misses them.
 ADMIN_EMAILS = "359807859@qq.com"


### PR DESCRIPTION
## Summary

- add optional `eventId` and `dedupKey` fields plus a version-scoped Desktop ledger so automatic crashes upload once per version
- keep production on `CRASH_STORAGE_MODE=d1`; this PR adds the safe rollout path but does not enable Firebase in production
- add a bounded D1 outbox, idempotency receipts, fixed Spark capacity reservations, generation leases, and ETag-fenced Realtime Database writes
- retain D1 aggregates, status, notes, audit, and dashboard indexes while Firebase stores the retained-cycle first sample plus latest five samples
- add lifecycle-aware historical migration, management visibility, bilingual runbooks, and the two narrow Desktop DBus `lostcancel` fixes

## Spark capacity and lifecycle

- enforce a non-configurable 700 MiB budget: active 640 KiB/group, compacted 128 KiB/group, archiving 32 KiB/group, archived 0
- perform reservation changes atomically in D1; additions or expansions that would exceed the budget return `503` before an outbox row is created
- warn through the existing webhook and dashboard at 80%, for stuck archives, and when the 5,000-row outbox approaches capacity
- compact resolved/ignored groups after 30 inactive days by retaining the first sample and replacing latest slots with fenced markers
- tombstone resolved/ignored groups after 60 inactive days, then conditionally delete Firebase content after 24 hours while preserving D1 control-plane data
- reactivate archived fingerprints in a new sample epoch without resetting lifetime count or first-seen

## Fencing and delivery semantics

- phase-2 additive D1 state stores sample state/epoch, reservations, lease owner/generation, and expiry; the phase-1 lease table remains for rolling-deployment compatibility only
- every successful lease acquisition increments a durable generation; stale renew/release operations cannot affect a replacement owner
- normal delivery reads only `meta` and the target sample path, then uses Firebase ETags, `If-Match`, and `print=silent` conditional PUTs
- stale generation, epoch, or ring-slot writers cannot overwrite newer absolute state; 412s retry at most three times and leave the outbox intact on failure
- Firebase timeout, auth, quota, or 5xx failures keep a sanitized outbox row and return `202`; a full outbox returns `503` so clients retain pending data
- `d1` mode does not require or access Firebase configuration or Firebase control tables

## Migration and rollout

- `migrate:firebase-crash` records a D1 Time Travel bookmark, applies phase 1 and phase 2 in order, rejects partial phases, and preflights the 700 MiB budget
- `migrate:firebase-data` defaults to dry-run, uses 200-fingerprint keyset pages, classifies active/compacted/archived history, and writes a gitignored mode-0600 atomic checkpoint
- `--apply` performs canonical SHA-256 readback verification and D1 state updates; up to three reconciliation passes rewrite only changed groups
- `--verify-only` checks Firebase content, archived absence, D1 group state, and checkpoint consistency without writes
- after merge, deployment remains `d1`; operators explicitly run dry-run/apply/verify, then observe seven UTC days in `dual` before considering `firebase`

## Security and compatibility

- clients receive no Firebase SDK, web configuration, database URL, or service-account credentials
- Realtime Database rules deny client reads/writes; the Worker uses repository secrets and short-lived OAuth tokens
- old payloads may omit new fields, current schema-3 pending reports upload, and unknown future pending schemas remain untouched
- user-initiated Desktop/CLI reports bypass local fingerprint suppression while keeping stable event IDs
- `/v1/ping`, `/v1/metrics`, accounts, registry, release gateway, prompts, providers, tool order, and cache keys are unchanged

## Verification

- Worker: `npm run typecheck && npm test` (12 files, 107 tests)
- Worker bundle: `npx wrangler deploy --dry-run`
- root: `go test ./...`, `go vet ./...`, and CI-version `golangci-lint`
- Desktop: `go test ./...`, `go vet ./...`, and `golangci-lint`
- focused Desktop pending/ledger race suite
- 100 deterministic lease-generation interleavings, same-fingerprint concurrent ingest, capacity boundary, ETag/412, lifecycle, migration, and compatibility coverage
- `go run ./tools/repolint` and `git diff --check`
- latest `origin/main-v2` merge-tree is conflict-free

Documentation-impact: updated - English and Chinese crash diagnostics runbooks with schema ordering, capacity/lifecycle behavior, checkpointed migration, rollout, and rollback.
