### PR TITLE
ci(crash): Gate Firebase history migration / 为 Firebase 历史迁移增加审批门禁

### DIFF
--- a/.github/workflows/deploy-crash-worker.yml
+++ b/.github/workflows/deploy-crash-worker.yml
@@ -7,6 +7,22 @@ on:
       - 'workers/crash-report/**'
       - '.github/workflows/deploy-crash-worker.yml'
   workflow_dispatch:
+    inputs:
+      firebase_data_action:
+        description: Firebase crash history operation (migration actions do not deploy the Worker)
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - dry-run
+          - apply
+          - verify-only
+      confirmation:
+        description: Enter APPLY_FIREBASE_CRASH_DATA when selecting apply
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -17,6 +33,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.event_name == 'push' || inputs.firebase_data_action == 'none'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -80,3 +97,67 @@ jobs:
             exit 0
           fi
           printf '%s' "$ALERT_WEBHOOK" | npx wrangler secret put ALERT_WEBHOOK
+
+  migrate-firebase-data:
+    if: github.event_name == 'workflow_dispatch' && inputs.firebase_data_action != 'none'
+    runs-on: ubuntu-latest
+    environment: canary
+    steps:
+      - uses: actions/checkout@v7
+      - name: Require the protected production branch
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main-v2" ]; then
+            echo "Firebase crash data migration must run from main-v2."
+            exit 1
+          fi
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: workers/crash-report/package-lock.json
+      - name: Validate
+        working-directory: workers/crash-report
+        run: |
+          npm ci
+          npm run typecheck
+          npm test
+      - name: Run Firebase crash history operation
+        working-directory: workers/crash-report
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL }}
+          FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+          FIREBASE_DATA_ACTION: ${{ inputs.firebase_data_action }}
+          FIREBASE_DATA_CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          configured=0
+          [ -n "$CLOUDFLARE_API_TOKEN" ] && configured=$((configured + 1))
+          [ -n "$FIREBASE_DATABASE_URL" ] && configured=$((configured + 1))
+          [ -n "$FIREBASE_CLIENT_EMAIL" ] && configured=$((configured + 1))
+          [ -n "$FIREBASE_PRIVATE_KEY" ] && configured=$((configured + 1))
+          if [ "$configured" -ne 4 ]; then
+            echo "Cloudflare and Firebase migration secrets must all be configured."
+            exit 1
+          fi
+
+          case "$FIREBASE_DATA_ACTION" in
+            dry-run)
+              npm run migrate:firebase-data
+              ;;
+            apply)
+              if [ "$FIREBASE_DATA_CONFIRMATION" != "APPLY_FIREBASE_CRASH_DATA" ]; then
+                echo "Apply requires the exact confirmation APPLY_FIREBASE_CRASH_DATA."
+                exit 1
+              fi
+              npm run migrate:firebase-data -- --apply
+              npm run migrate:firebase-data -- --verify-only
+              ;;
+            verify-only)
+              npm run migrate:firebase-data -- --verify-only
+              ;;
+            *)
+              echo "Unsupported Firebase crash data action."
+              exit 1
+              ;;
+          esac

--- a/docs/DESKTOP_CRASH_DIAGNOSTICS_RUNBOOK.md
+++ b/docs/DESKTOP_CRASH_DIAGNOSTICS_RUNBOOK.md
@@ -33,13 +33,20 @@ itself resolve a crash issue.
 6. Verify `report_daily`, `report_installations`,
    `report_event_dimensions`, `diagnostics_meta`, their fingerprint/date
    indexes, and the ping window index. Confirm `installation_linked_since`.
-7. Run `npm run migrate:firebase-data` as a dry run. It uses 200-fingerprint
-   keyset pages and must report at most 700 MiB reserved. Then run
-   `npm run migrate:firebase-data -- --apply`; after convergence run
-   `npm run migrate:firebase-data -- --verify-only`. The default checkpoint is
-   `.firebase-crash-migration-state.json` (mode `0600`, gitignored); use
-   `--checkpoint=<path>` to relocate it and `--reset-checkpoint` only to restart
-   deliberately. Logs contain only counts, fingerprint prefixes, and digests.
+7. In **Actions > Deploy crash worker > Run workflow**, select `main-v2` and
+   choose `dry-run` for **Firebase crash history operation**. This uses the
+   existing repository secrets, runs behind the `canary` environment approval,
+   does not deploy the Worker, and must report at most 700 MiB reserved. After
+   reviewing the result, choose `apply` and enter the exact confirmation
+   `APPLY_FIREBASE_CRASH_DATA`; the job runs `--apply` followed immediately by
+   `--verify-only` on the same runner. Choose `verify-only` for later
+   independent audits. Authenticated operators may still run
+   `npm run migrate:firebase-data`, `npm run migrate:firebase-data -- --apply`,
+   and `npm run migrate:firebase-data -- --verify-only` locally. The default
+   checkpoint is `.firebase-crash-migration-state.json` (mode `0600`,
+   gitignored); use `--checkpoint=<path>` to relocate it and
+   `--reset-checkpoint` only to restart deliberately. Logs contain only counts,
+   fingerprint prefixes, and digests.
 8. Deploy the Worker in `dual` mode first. Smoke-test old Report/Ping/Metrics payloads, a
    legacy `webview2` payload, and Windows/Linux `webRuntime` payloads using
    `channel=test`.

--- a/docs/DESKTOP_CRASH_DIAGNOSTICS_RUNBOOK.zh-CN.md
+++ b/docs/DESKTOP_CRASH_DIAGNOSTICS_RUNBOOK.zh-CN.md
@@ -26,9 +26,13 @@
 6. 验证 `report_daily`、`report_installations`、
    `report_event_dimensions`、`diagnostics_meta`、fingerprint/date 索引、ping
    窗口索引，以及 `installation_linked_since`。
-7. 先运行 `npm run migrate:firebase-data` dry-run。脚本按每页 200 个 fingerprint 的
-   keyset 分页，预计预留必须不超过 700 MiB。随后执行
-   `npm run migrate:firebase-data -- --apply`，收敛后立即执行
+7. 在 **Actions > Deploy crash worker > Run workflow** 中选择 `main-v2`，并将
+   **Firebase crash history operation** 设为 `dry-run`。该任务使用现有仓库 Secret，经过
+   `canary` environment 审批，不会部署 Worker；脚本按每页 200 个 fingerprint 的 keyset
+   分页，预计预留必须不超过 700 MiB。确认结果后选择 `apply`，并输入精确确认短语
+   `APPLY_FIREBASE_CRASH_DATA`；任务会在同一 runner 内依次执行 `--apply` 和
+   `--verify-only`。后续独立核验可选择 `verify-only`。已认证的运维人员仍可在本机运行
+   `npm run migrate:firebase-data`、`npm run migrate:firebase-data -- --apply` 和
    `npm run migrate:firebase-data -- --verify-only`。默认 checkpoint 为权限 `0600` 且已
    gitignore 的 `.firebase-crash-migration-state.json`；可用 `--checkpoint=<path>` 改路径，
    只有明确重跑时才用 `--reset-checkpoint`。日志只输出计数、fingerprint 前缀和摘要。

--- a/workers/crash-report/src/deploy_workflow_contract.test.ts
+++ b/workers/crash-report/src/deploy_workflow_contract.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error Test code uses Node to inspect the repository workflow.
+import { readFileSync } from "node:fs";
+
+const workflow = readFileSync("../../.github/workflows/deploy-crash-worker.yml", "utf8");
+
+describe("Firebase crash data migration workflow", () => {
+  it("keeps manual migration separate from Worker deployment", () => {
+    expect(workflow).toContain("firebase_data_action:");
+    expect(workflow).toContain("- dry-run");
+    expect(workflow).toContain("- apply");
+    expect(workflow).toContain("- verify-only");
+    expect(workflow).toContain(
+      "if: github.event_name == 'push' || inputs.firebase_data_action == 'none'",
+    );
+    expect(workflow).toContain(
+      "if: github.event_name == 'workflow_dispatch' && inputs.firebase_data_action != 'none'",
+    );
+
+    const migrationJob = workflow.slice(workflow.indexOf("  migrate-firebase-data:"));
+    expect(migrationJob).not.toContain("wrangler deploy");
+  });
+
+  it("requires the protected branch, environment approval, and all secrets", () => {
+    const migrationJob = workflow.slice(workflow.indexOf("  migrate-firebase-data:"));
+    expect(migrationJob).toContain("environment: canary");
+    expect(migrationJob).toContain('"refs/heads/main-v2"');
+    expect(migrationJob).toContain("CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}");
+    expect(migrationJob).toContain("FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL }}");
+    expect(migrationJob).toContain("FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}");
+    expect(migrationJob).toContain("FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}");
+  });
+
+  it("guards apply and verifies immediately on the same runner", () => {
+    const migrationJob = workflow.slice(workflow.indexOf("  migrate-firebase-data:"));
+    expect(migrationJob).toContain(
+      'if [ "$FIREBASE_DATA_CONFIRMATION" != "APPLY_FIREBASE_CRASH_DATA" ]; then',
+    );
+    const apply = migrationJob.indexOf("npm run migrate:firebase-data -- --apply");
+    const verify = migrationJob.indexOf("npm run migrate:firebase-data -- --verify-only");
+    expect(apply).toBeGreaterThan(0);
+    expect(verify).toBeGreaterThan(apply);
+  });
+});


### PR DESCRIPTION
## Summary

- add a guarded `dry-run | apply | verify-only` dispatch path for Firebase crash history migration
- keep migration mutually exclusive with Worker deployment and locked to `main-v2`
- require `canary` environment approval, all existing Cloudflare/Firebase Secrets, and an exact apply confirmation
- run `verify-only` immediately after apply on the same runner and document the bilingual operator flow
- add workflow contract tests for branch, approval, secret, confirmation, and no-deploy invariants

## Issues

No linked issue. This completes the post-merge operational path for the Firebase Spark crash migration.

## Verification

- `cd workers/crash-report && npm run typecheck`
- `cd workers/crash-report && npm test` (13 files, 110 tests)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/deploy-crash-worker.yml`
- `go run ./tools/repolint`
- `bash scripts/release-workflows.test.sh`
- `git diff --check`

The workflow was not dispatched from this PR because GitHub Actions Secrets are intentionally available only after the change lands on `main-v2`. The first production operation remains a read-only dry run.

## Documentation impact

Documentation-impact: updated - documented the approved Actions dry-run/apply/verify flow in the English and Chinese crash diagnostics runbooks

## Cache impact

Cache-impact: none - workflow, tests, and operator documentation only; no prompt, provider, tool, or runtime request changes
Cache-guard: workflow contract tests assert migration/deploy separation and all production gates
System-prompt-review: N/A
