### PR TITLE
fix(desktop): commit session navigation after target paint / 会话导航在目标绘制后提交

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,7 +394,7 @@ jobs:
           pnpm --dir frontend test:motion-browser
           pnpm --dir frontend test:composer
           pnpm --dir frontend test:transcript
-          pnpm --dir frontend test:transcript-browser
+          xvfb-run -a env REASONIX_TRANSCRIPT_NATIVE_THUMB=1 pnpm --dir frontend test:transcript-browser
 
       - name: Test usage statistics frontend
         run: pnpm --dir frontend test:usage-stats

--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -903,7 +903,7 @@ try {
     element.dispatchEvent(new Event("scroll"));
   });
   await page.waitForFunction(() => document.querySelector(".transcript__row"));
-  const nativeThumbProbe = await transcript.evaluate(async (element) => {
+  let nativeThumbProbe = await transcript.evaluate(async (element) => {
     // The scroll-to-top event can leave a recycled Virtuoso node mounted or a
     // delayed layout owner can move the viewport again for a few frames.
     // Starting the drag in either state can hit the scrollbar track instead of
@@ -964,6 +964,77 @@ try {
     process.stdout.write("  SKIP  native thumb drag (headless macOS Chromium has no deterministic native track)\n");
   } else {
     assert(nativeThumbProbe && nativeThumbProbe.gutter > 1, `workbench exposes a native scrollbar gutter (${nativeThumbProbe?.gutter ?? 0}px)`);
+    const trackTop = nativeThumbProbe.y - 5;
+    const thumbCandidateOffsets = [4, 8, 12, 16, 20, 24, 28, 32];
+    const thumbCandidateMotions = [];
+    let nativeThumbY = null;
+    for (const offset of thumbCandidateOffsets) {
+      await transcript.evaluate((element) => {
+        element.scrollTop = 0;
+        element.dispatchEvent(new Event("scroll"));
+      });
+      await page.waitForFunction(() => (document.querySelector(".transcript")?.scrollTop ?? Number.POSITIVE_INFINITY) <= 1);
+      const candidateY = trackTop + offset;
+      await page.mouse.move(nativeThumbProbe.x, candidateY);
+      await page.mouse.down();
+      await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.nativeScrollbarDrag === "true");
+      await page.mouse.move(nativeThumbProbe.x, candidateY + 48, { steps: 2 });
+      await page.waitForTimeout(150);
+      const motion = await transcript.evaluate((element) => ({
+        scrollTop: element.scrollTop,
+        clientHeight: element.clientHeight,
+      }));
+      thumbCandidateMotions.push({ offset, scrollTop: motion.scrollTop });
+      await page.mouse.up();
+      await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.nativeScrollbarDrag !== "true");
+      // A 48px thumb move traverses several viewports in this fixture. A
+      // track/button press moves at most one page and is not a valid drag hit.
+      if (motion.scrollTop > motion.clientHeight * 2.5) {
+        nativeThumbY = candidateY;
+        break;
+      }
+    }
+    assert(nativeThumbY !== null, `native scrollbar exposes a pointer-draggable thumb (${JSON.stringify(thumbCandidateMotions)})`);
+    await transcript.evaluate((element) => {
+      element.scrollTop = 0;
+      element.dispatchEvent(new Event("scroll"));
+    });
+    nativeThumbProbe = await transcript.evaluate(async (element, input) => {
+      let stableFrames = 0;
+      let previousIdentity = "";
+      for (let frame = 0; frame < 120 && stableFrames < 4; frame += 1) {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        if (element.scrollTop > 1) {
+          element.scrollTop = 0;
+          element.dispatchEvent(new Event("scroll"));
+          stableFrames = 0;
+          previousIdentity = "";
+          continue;
+        }
+        const candidate = element.querySelector(".transcript__row");
+        const identity = candidate instanceof HTMLElement
+          ? `${candidate.dataset.rowKey ?? ""}:${candidate.dataset.knownSize ?? ""}`
+          : "";
+        stableFrames = identity && identity === previousIdentity ? stableFrames + 1 : 0;
+        previousIdentity = identity;
+      }
+      element.querySelectorAll('[data-native-scrollbar-probe="true"]').forEach((node) => {
+        if (node instanceof HTMLElement) delete node.dataset.nativeScrollbarProbe;
+      });
+      const row = element.querySelector(".transcript__row");
+      if (!(row instanceof HTMLElement)) return null;
+      row.dataset.nativeScrollbarProbe = "true";
+      return {
+        ...input.probe,
+        y: input.y,
+        scrollTop: element.scrollTop,
+        rowKey: row.dataset.rowKey ?? "",
+        knownSize: Number.parseFloat(row.dataset.knownSize || "0"),
+        scrollHeight: element.scrollHeight,
+      };
+    }, { probe: nativeThumbProbe, y: nativeThumbY });
+    assert(nativeThumbProbe, "native scrollbar probe remains available after draggable-thumb discovery");
+    assert(true, `native scrollbar exposes a pointer-draggable thumb (${Math.round(nativeThumbY - trackTop)}px from track start)`);
     assert(nativeThumbProbe.scrollTop <= 1, `native scrollbar probe starts at the physical top (${nativeThumbProbe.scrollTop}px)`);
     assert(nativeThumbProbe.knownSize > 0, `native scrollbar probe starts from a measured row (${nativeThumbProbe.knownSize}px)`);
     await page.mouse.move(nativeThumbProbe.x, nativeThumbProbe.y);

--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -978,25 +978,21 @@ try {
     });
     assert(nativeDragStart.scrollTop <= 1, `native thumb press keeps the viewport at the physical top (${nativeDragStart.scrollTop}px)`);
     assert(nativeDragStart.rowKey === nativeThumbProbe.rowKey, `native thumb press keeps the probed logical row (${nativeDragStart.rowKey || "missing"})`);
-    const nativeDragBaseline = await transcript.evaluate(async (element) => {
-      let stableFrames = 0;
-      let previousGeometry = "";
-      let geometry = null;
-      for (let frame = 0; frame < 120 && stableFrames < 4; frame += 1) {
-        await new Promise((resolve) => requestAnimationFrame(resolve));
-        const row = element.querySelector('[data-native-scrollbar-probe="true"]');
-        geometry = {
-          knownSize: row instanceof HTMLElement ? Number.parseFloat(row.dataset.knownSize || "0") : 0,
-          fixedHeight: row instanceof HTMLElement ? row.style.height : "",
-          rowHeight: row instanceof HTMLElement ? row.getBoundingClientRect().height : 0,
-          listHeight: element.querySelector('[data-testid="virtuoso-item-list"]')?.getBoundingClientRect().height ?? 0,
-          scrollHeight: element.scrollHeight,
-        };
-        const identity = JSON.stringify(geometry);
-        stableFrames = identity === previousGeometry ? stableFrames + 1 : 0;
-        previousGeometry = identity;
-      }
-      return geometry;
+    await page.waitForFunction(({ knownSize, rowKey }) => {
+      const row = document.querySelector('[data-native-scrollbar-probe="true"]');
+      return row instanceof HTMLElement
+        && row.dataset.rowKey === rowKey
+        && row.style.height === `${knownSize}px`;
+    }, { knownSize: nativeThumbProbe.knownSize, rowKey: nativeThumbProbe.rowKey });
+    const nativeDragBaseline = await transcript.evaluate((element) => {
+      const row = element.querySelector('[data-native-scrollbar-probe="true"]');
+      return {
+        knownSize: row instanceof HTMLElement ? Number.parseFloat(row.dataset.knownSize || "0") : 0,
+        fixedHeight: row instanceof HTMLElement ? row.style.height : "",
+        rowHeight: row instanceof HTMLElement ? row.getBoundingClientRect().height : 0,
+        listHeight: element.querySelector('[data-testid="virtuoso-item-list"]')?.getBoundingClientRect().height ?? 0,
+        scrollHeight: element.scrollHeight,
+      };
     });
     assert(nativeDragBaseline?.knownSize > 0, `native thumb drag starts from a measured logical row (${nativeDragBaseline?.knownSize ?? 0}px)`);
     assert(nativeDragBaseline.fixedHeight === `${nativeDragBaseline.knownSize}px`, `native thumb drag fixes mounted row layout (${nativeDragBaseline.fixedHeight})`);

--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -904,15 +904,23 @@ try {
   });
   await page.waitForFunction(() => document.querySelector(".transcript__row"));
   const nativeThumbProbe = await transcript.evaluate(async (element) => {
-    // The scroll-to-top event can leave a recycled Virtuoso node mounted for
-    // a few frames. Starting the drag from that node races its old
-    // data-known-size against the newly assigned logical row and makes the
-    // geometry-freeze assertion nondeterministic. Require the logical row and
-    // its measured size to settle before marking the probe.
+    // The scroll-to-top event can leave a recycled Virtuoso node mounted or a
+    // delayed layout owner can move the viewport again for a few frames.
+    // Starting the drag in either state can hit the scrollbar track instead of
+    // the top-positioned thumb, recycling the marked node before the geometry
+    // freeze begins. Require both the physical top and the logical row identity
+    // to settle before marking the probe.
     let stableFrames = 0;
     let previousIdentity = "";
     for (let frame = 0; frame < 120 && stableFrames < 4; frame += 1) {
       await new Promise((resolve) => requestAnimationFrame(resolve));
+      if (element.scrollTop > 1) {
+        element.scrollTop = 0;
+        element.dispatchEvent(new Event("scroll"));
+        stableFrames = 0;
+        previousIdentity = "";
+        continue;
+      }
       const candidate = element.querySelector(".transcript__row");
       const identity = candidate instanceof HTMLElement
         ? `${candidate.dataset.rowKey ?? ""}:${candidate.dataset.knownSize ?? ""}`
@@ -933,6 +941,8 @@ try {
       // the track end, so the target deliberately overshoots the visible
       // gutter where a native thumb is available.
       bottomY: Math.min(window.innerHeight - 1, rect.bottom + Math.max(24, rect.height * 0.1)),
+      scrollTop: element.scrollTop,
+      rowKey: row.dataset.rowKey ?? "",
       knownSize: Number.parseFloat(row.dataset.knownSize || "0"),
       gutter: rect.right - contentRight,
       scrollHeight: element.scrollHeight,
@@ -954,10 +964,20 @@ try {
     process.stdout.write("  SKIP  native thumb drag (headless macOS Chromium has no deterministic native track)\n");
   } else {
     assert(nativeThumbProbe && nativeThumbProbe.gutter > 1, `workbench exposes a native scrollbar gutter (${nativeThumbProbe?.gutter ?? 0}px)`);
+    assert(nativeThumbProbe.scrollTop <= 1, `native scrollbar probe starts at the physical top (${nativeThumbProbe.scrollTop}px)`);
     assert(nativeThumbProbe.knownSize > 0, `native scrollbar probe starts from a measured row (${nativeThumbProbe.knownSize}px)`);
     await page.mouse.move(nativeThumbProbe.x, nativeThumbProbe.y);
     await page.mouse.down();
     await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.nativeScrollbarDrag === "true");
+    const nativeDragStart = await transcript.evaluate((element) => {
+      const row = element.querySelector('[data-native-scrollbar-probe="true"]');
+      return {
+        scrollTop: element.scrollTop,
+        rowKey: row instanceof HTMLElement ? row.dataset.rowKey ?? "" : "",
+      };
+    });
+    assert(nativeDragStart.scrollTop <= 1, `native thumb press keeps the viewport at the physical top (${nativeDragStart.scrollTop}px)`);
+    assert(nativeDragStart.rowKey === nativeThumbProbe.rowKey, `native thumb press keeps the probed logical row (${nativeDragStart.rowKey || "missing"})`);
     const nativeDragBaseline = await transcript.evaluate(async (element) => {
       let stableFrames = 0;
       let previousGeometry = "";

--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -16,6 +16,8 @@ const maxFrameGapMs = Number(process.env.REASONIX_TRANSCRIPT_MAX_FRAME_GAP_MS ??
 const p95FrameGapMs = Number(process.env.REASONIX_TRANSCRIPT_P95_FRAME_GAP_MS ?? 80);
 const maxLongTaskMs = Number(process.env.REASONIX_TRANSCRIPT_MAX_LONG_TASK_MS ?? 250);
 const totalLongTaskMs = Number(process.env.REASONIX_TRANSCRIPT_TOTAL_LONG_TASK_MS ?? 750);
+const nativeThumbReplay = process.platform === "linux"
+  && process.env.REASONIX_TRANSCRIPT_NATIVE_THUMB === "1";
 
 function assert(condition, message) {
   if (!condition) throw new Error(message);
@@ -288,7 +290,11 @@ let browser;
 try {
   await waitForServer();
   browser = await chromium.launch({
-    headless: true,
+    // Chromium's headless compositor reserves the native scrollbar gutter on
+    // Linux but does not expose its thumb to pointer input. CI runs this replay
+    // in Xvfb so the real browser-owned thumb remains draggable; other hosts
+    // keep the deterministic headless path and their platform-specific gates.
+    headless: !nativeThumbReplay,
     ...(process.env.PLAYWRIGHT_EXECUTABLE_PATH ? { executablePath: process.env.PLAYWRIGHT_EXECUTABLE_PATH } : {}),
   });
   const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });

--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -443,6 +443,7 @@ try {
   await page.click('.project-tree__topic-main:has-text("bench:tools-38t")');
   await page.waitForFunction(() => document.querySelector(".project-tree__topic--active .project-tree__topic-label")?.textContent?.includes("bench:tools-38t"));
   await page.waitForFunction(() => document.querySelector(".transcript")?.textContent?.includes("pkg-41/mod.go"), undefined, { timeout: 30_000 });
+  await page.waitForFunction(() => !document.querySelector(".transcript-navigation-overlay"), undefined, { timeout: 30_000 });
   const markdownVisibility = await page.evaluate(() => {
     const row = document.querySelector(".transcript__row");
     if (!(row instanceof HTMLElement)) return { inside: null, outside: null };
@@ -902,7 +903,23 @@ try {
     element.dispatchEvent(new Event("scroll"));
   });
   await page.waitForFunction(() => document.querySelector(".transcript__row"));
-  const nativeThumbProbe = await transcript.evaluate((element) => {
+  const nativeThumbProbe = await transcript.evaluate(async (element) => {
+    // The scroll-to-top event can leave a recycled Virtuoso node mounted for
+    // a few frames. Starting the drag from that node races its old
+    // data-known-size against the newly assigned logical row and makes the
+    // geometry-freeze assertion nondeterministic. Require the logical row and
+    // its measured size to settle before marking the probe.
+    let stableFrames = 0;
+    let previousIdentity = "";
+    for (let frame = 0; frame < 120 && stableFrames < 4; frame += 1) {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      const candidate = element.querySelector(".transcript__row");
+      const identity = candidate instanceof HTMLElement
+        ? `${candidate.dataset.rowKey ?? ""}:${candidate.dataset.knownSize ?? ""}`
+        : "";
+      stableFrames = identity && identity === previousIdentity ? stableFrames + 1 : 0;
+      previousIdentity = identity;
+    }
     const rect = element.getBoundingClientRect();
     const scaleX = rect.width / element.offsetWidth;
     const contentRight = rect.left + (element.clientLeft + element.clientWidth) * scaleX;
@@ -928,22 +945,41 @@ try {
     // WebView2 path is covered by the Windows native smoke job; the geometry
     // lock itself is covered by transcript-native-scrollbar.test.ts.
     process.stdout.write("  SKIP  native thumb drag (headless Windows Chromium has no draggable native track)\n");
-  } else if (process.platform === "darwin" && (!nativeThumbProbe || nativeThumbProbe.gutter <= 1)) {
-    // macOS Chromium inherits system overlay scrollbars, so there is no
-    // pointer-addressable native gutter. Linux CI exercises the complete
-    // thumb ownership and measurement-freeze path below; Windows WebView2
-    // coverage is provided by the native smoke job.
-    process.stdout.write("  SKIP  native thumb drag (host uses overlay scrollbars)\n");
+  } else if (process.platform === "darwin") {
+    // Headless macOS Chromium does not expose a deterministic pointer-draggable
+    // thumb: hosts with overlay scrollbars have no gutter, while hosts with a
+    // reserved gutter accept pointer-down but do not reliably move the thumb.
+    // Linux CI exercises the full drag/freeze path; Windows WebView2 coverage
+    // is provided by the native smoke job.
+    process.stdout.write("  SKIP  native thumb drag (headless macOS Chromium has no deterministic native track)\n");
   } else {
     assert(nativeThumbProbe && nativeThumbProbe.gutter > 1, `workbench exposes a native scrollbar gutter (${nativeThumbProbe?.gutter ?? 0}px)`);
     assert(nativeThumbProbe.knownSize > 0, `native scrollbar probe starts from a measured row (${nativeThumbProbe.knownSize}px)`);
     await page.mouse.move(nativeThumbProbe.x, nativeThumbProbe.y);
     await page.mouse.down();
     await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.nativeScrollbarDrag === "true");
-    await page.waitForFunction(
-      (knownSize) => document.querySelector('[data-native-scrollbar-probe="true"]')?.style.height === `${knownSize}px`,
-      nativeThumbProbe.knownSize,
-    );
+    const nativeDragBaseline = await transcript.evaluate(async (element) => {
+      let stableFrames = 0;
+      let previousGeometry = "";
+      let geometry = null;
+      for (let frame = 0; frame < 120 && stableFrames < 4; frame += 1) {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        const row = element.querySelector('[data-native-scrollbar-probe="true"]');
+        geometry = {
+          knownSize: row instanceof HTMLElement ? Number.parseFloat(row.dataset.knownSize || "0") : 0,
+          fixedHeight: row instanceof HTMLElement ? row.style.height : "",
+          rowHeight: row instanceof HTMLElement ? row.getBoundingClientRect().height : 0,
+          listHeight: element.querySelector('[data-testid="virtuoso-item-list"]')?.getBoundingClientRect().height ?? 0,
+          scrollHeight: element.scrollHeight,
+        };
+        const identity = JSON.stringify(geometry);
+        stableFrames = identity === previousGeometry ? stableFrames + 1 : 0;
+        previousGeometry = identity;
+      }
+      return geometry;
+    });
+    assert(nativeDragBaseline?.knownSize > 0, `native thumb drag starts from a measured logical row (${nativeDragBaseline?.knownSize ?? 0}px)`);
+    assert(nativeDragBaseline.fixedHeight === `${nativeDragBaseline.knownSize}px`, `native thumb drag fixes mounted row layout (${nativeDragBaseline.fixedHeight})`);
     await transcript.evaluate((element) => {
       const row = element.querySelector('[data-native-scrollbar-probe="true"]');
       const content = row?.firstElementChild;
@@ -960,9 +996,9 @@ try {
         scrollHeight: element.scrollHeight,
       };
     });
-    assert(duringNativeThumbDrag.knownSize === nativeThumbProbe.knownSize, `native thumb drag freezes new row measurements (${duringNativeThumbDrag.knownSize}px)`);
-    assert(duringNativeThumbDrag.fixedHeight === `${nativeThumbProbe.knownSize}px`, `native thumb drag fixes mounted row layout (${duringNativeThumbDrag.fixedHeight})`);
-    assert(Math.abs(duringNativeThumbDrag.scrollHeight - nativeThumbProbe.scrollHeight) <= 8, `native thumb drag keeps the physical scroll range stable (${nativeThumbProbe.scrollHeight} → ${duringNativeThumbDrag.scrollHeight}; row ${duringNativeThumbDrag.rowHeight}; list ${duringNativeThumbDrag.listHeight})`);
+    assert(duringNativeThumbDrag.knownSize === nativeDragBaseline.knownSize, `native thumb drag freezes new row measurements (${duringNativeThumbDrag.knownSize}px)`);
+    assert(duringNativeThumbDrag.fixedHeight === nativeDragBaseline.fixedHeight, `native thumb drag fixes mounted row layout (${duringNativeThumbDrag.fixedHeight})`);
+    assert(Math.abs(duringNativeThumbDrag.scrollHeight - nativeDragBaseline.scrollHeight) <= 8, `native thumb drag keeps the physical scroll range stable (${nativeDragBaseline.scrollHeight} → ${duringNativeThumbDrag.scrollHeight}; row ${duringNativeThumbDrag.rowHeight}; list ${duringNativeThumbDrag.listHeight})`);
     await page.mouse.move(nativeThumbProbe.x, nativeThumbProbe.bottomY, { steps: 8 });
     await page.waitForFunction(() => {
       const element = document.querySelector(".transcript");

--- a/desktop/frontend/bench/transcript-selection.mjs
+++ b/desktop/frontend/bench/transcript-selection.mjs
@@ -167,15 +167,27 @@ try {
     document.querySelector(".project-tree__topic--active .project-tree__topic-label")?.textContent?.includes("bench:tools-38t")
       && document.querySelector(".transcript")?.textContent?.includes("pkg-41/mod.go")
   ), undefined, { timeout: 30_000 });
+  await page.waitForFunction(
+    () => !document.querySelector(".transcript-navigation-overlay"),
+    undefined,
+    { timeout: 30_000 },
+  );
   await page.waitForTimeout(300);
-  for (let pageIndex = 0; pageIndex < 8; pageIndex += 1) {
-    await page.evaluate(() => {
+  // Preload the selection fixture with real upward wheel intent. Directly
+  // assigning scrollTop used to make Virtuoso's startReached callback page in
+  // the background, but viewport paging now requires one permit per page.
+  for (let pageIndex = 0; pageIndex < 32; pageIndex += 1) {
+    const before = Number(await page.locator(".transcript").getAttribute("data-transcript-row-count") ?? 0);
+    const box = await page.locator(".transcript").boundingBox();
+    if (!box) break;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.wheel(0, -100_000);
+    const loaded = await page.waitForFunction((previous) => {
       const transcript = document.querySelector(".transcript");
-      if (transcript) transcript.scrollTop = 0;
-    });
-    await page.waitForTimeout(100);
-    if (!(await clickIfPresent(page, ".transcript__older"))) break;
-    await page.waitForTimeout(350);
+      const current = Number(transcript?.getAttribute("data-transcript-row-count") ?? 0);
+      return current > previous;
+    }, before, { timeout: 2_000 }).then(() => true, () => false);
+    if (!loaded) break;
   }
   await clickIfPresent(page, ".transcript__jump-bottom");
   try {

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -100,7 +100,10 @@ console.log("\nbundle budgets");
 // The navigation surface transaction adds target identity checks, data/paint
 // terminals, and bounded history permits to the initial transcript path. The
 // measured build is 434.2 KiB gzip; retain 0.3 KiB for toolchain drift.
-const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 434.5 : 434.5;
+// Failure-atomic source restoration, terminal surface promises, and the
+// one-page viewport permit raise the measured path to 434.8 KiB. Keep 0.2 KiB
+// of headroom without widening unrelated lazy chunks.
+const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 435.0 : 435.0;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -170,6 +173,9 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // Keep only 0.21 KiB of raw headroom so this remains a narrow, measured ratchet.
 // The navigation transaction measures 2365.8 KiB raw; keep the corresponding
 // raw allowance as narrow as the gzip ratchet above.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_366.2 : 2_366.2;
+// Its failure-atomic completion paths plus the fixed navigation footer
+// footprint measure 2369.1 KiB raw after minifying; retain 0.5 KiB
+// for build metadata and toolchain drift.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_369.6 : 2_369.6;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -97,7 +97,10 @@ console.log("\nbundle budgets");
 // Remote onboarding [0.5/3] adds project-group and credential-chain wiring on
 // top of the lazy wizard. Production and test-channel builds both measure
 // 432.28 KiB gzip; keep 0.22 KiB for build-SHA/toolchain drift.
-const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 432.5 : 432.5;
+// The navigation surface transaction adds target identity checks, data/paint
+// terminals, and bounded history permits to the initial transcript path. The
+// measured build is 434.2 KiB gzip; retain 0.3 KiB for toolchain drift.
+const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 434.5 : 434.5;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -116,7 +119,9 @@ if (initialCSS.length > 0) {
 // the retained-transcript navigation allowance; keep the ratchet explicit.
 // The remote-project badge and static session rows move the shell stylesheet
 // to 114.48 KiB gzip. Keep a narrow 0.22 KiB ratchet.
-assertBudget("deferred app-shell CSS gzip", appShellCSSGzip, 114.7 * 1024);
+// The navigation mask's stable composer footprint measures 114.73 KiB; retain
+// less than 0.1 KiB of additional headroom.
+assertBudget("deferred app-shell CSS gzip", appShellCSSGzip, 114.8 * 1024);
 if (localeChunks.length !== 2) {
   throw new Error(`expected 2 on-demand Chinese locale chunks, found ${localeChunks.length}`);
 }
@@ -163,6 +168,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // The complete theme-token contract and one shared operational-overlay recipe
 // add 1.09 KiB raw CSS while remaining inside the existing gzip CSS ceiling.
 // Keep only 0.21 KiB of raw headroom so this remains a narrow, measured ratchet.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_359.5 : 2_359.5;
+// The navigation transaction measures 2365.8 KiB raw; keep the corresponding
+// raw allowance as narrow as the gzip ratchet above.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_366.2 : 2_366.2;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,5 +1,4 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent } from "react";
-import { flushSync } from "react-dom";
 import { ShellExpandProvider, useShellExpand } from "./lib/shellExpand";
 import {
   Activity,
@@ -173,12 +172,9 @@ import { DEFAULT_STATUS_BAR_ITEMS, normalizeStatusBarItems, type StatusBarItemId
 import { paletteSessionDisplayTitle, paletteSessionHint, paletteSessionKeywords, sessionActivityTime } from "./lib/session";
 import { enqueueNavigationRequest, type PendingNavigationRequest } from "./lib/openTopicCoalescing";
 import {
-  beginNavigationSurfaceState,
   guardBackendNavigationResult,
-  markNavigationTargetMasked,
-  settleNavigationSurfaceState,
-  type NavigationSurfaceState,
 } from "./lib/navigationSurfaceTransition";
+import { useNavigationSurface } from "./lib/useNavigationSurface";
 import {
   applyTheme,
   clearLegacyThemePreference,
@@ -1124,40 +1120,12 @@ export default function App() {
   const userPlanModeByTabRef = useRef<UserPlanModeIntents>({});
   const [tabMetas, setTabMetas] = useState<TabMeta[]>([]);
   const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
-  const [navigationSurface, setNavigationSurface] = useState<NavigationSurfaceState>(null);
-  const navigationSurfaceIntent = navigationSurface?.intent ?? null;
-  type PreservedTranscriptSurface = {
-    tabId?: string;
-    items: Item[];
-    geometrySessionKey?: string;
-  };
-  const [preservedTranscriptSurface, setPreservedTranscriptSurface] = useState<PreservedTranscriptSurface | null>(null);
-  const renderedTranscriptSurfaceRef = useRef<PreservedTranscriptSurface | null>(null);
-  const beginNavigationSurface = useCallback((intent: number) => {
-    recordFrontendDiagnostic("navigation", "navigation.begin", { intent, phase: "begin" });
-    const rendered = renderedTranscriptSurfaceRef.current;
-    flushSync(() => {
-      if (rendered && rendered.items.length > 0) {
-        setPreservedTranscriptSurface(rendered);
-      } else {
-        setPreservedTranscriptSurface(null);
-      }
-      setNavigationSurface(beginNavigationSurfaceState(intent));
-    });
-  }, []);
-  const settleNavigationSurface = useCallback((intent: number) => {
-    setNavigationSurface((current) => markNavigationTargetMasked(current, intent));
-  }, []);
-  const commitNavigationSurfacePaint = useCallback((intent: number, outcome: "ready" | "degraded") => {
-    recordFrontendDiagnostic("navigation", "navigation.paint-ready", { intent, outcome });
-    recordFrontendDiagnostic("navigation", "navigation.terminal", { intent, outcome });
-    recordFrontendDiagnostic("navigation", "navigation.settle", { intent, phase: "paint-ready", outcome });
-    setNavigationSurface((current) => {
-      const next = settleNavigationSurfaceState(current, intent);
-      if (next === null) setPreservedTranscriptSurface(null);
-      return next;
-    });
-  }, []);
+  const {
+    surface: navigationSurface, intent: navigationSurfaceIntent, transitioning: runtimeTransitioning, dataReady: navigationTargetDataReady,
+    preserved: preservedTranscriptSurface, renderedRef: renderedTranscriptSurfaceRef, begin: beginNavigationSurface, maskTarget: settleNavigationSurface, commitPaint: commitNavigationSurfacePaint,
+  } = useNavigationSurface({
+    activeTabId, ready: state.meta?.ready === true, backendActivationPending: Boolean(state.backendActivationPending), hydrating: Boolean(state.hydrating), hydrateError: state.hydrateError,
+  });
   const [tabRevealSignal, setTabRevealSignal] = useState(0);
   const [transcriptRevealSignal, setTranscriptRevealSignal] = useState(0);
   const startupSplashVisible = useOverlayStore((s) => s.startupSplashVisible);
@@ -1785,27 +1753,6 @@ export default function App() {
   const goal = composerProfile.goal;
   const collaborationMode = displayedComposerProfileCollaborationMode(composerProfile);
   const toolApprovalMode = composerProfile.toolApprovalMode;
-  const runtimeTransitioning = navigationSurfaceIntent !== null;
-  const navigationTargetDataReady = Boolean(
-    navigationSurface?.phase === "target-masked" &&
-    activeTabId &&
-    state.meta?.ready === true &&
-    !state.backendActivationPending &&
-    !state.hydrating,
-  );
-  const navigationDataReadyIntentRef = useRef<number | null>(null);
-  useEffect(() => {
-    if (!navigationTargetDataReady || navigationSurfaceIntent === null) return;
-    if (navigationDataReadyIntentRef.current === navigationSurfaceIntent) return;
-    navigationDataReadyIntentRef.current = navigationSurfaceIntent;
-    recordFrontendDiagnostic("navigation", "navigation.target-mounted", {
-      intent: navigationSurfaceIntent,
-    });
-    recordFrontendDiagnostic("navigation", "navigation.data-ready", {
-      intent: navigationSurfaceIntent,
-      outcome: "ready",
-    });
-  }, [navigationSurfaceIntent, navigationTargetDataReady]);
   const controllerReady =
     state.meta?.ready === true &&
     (!state.meta.runtime || state.meta.runtime.phase === "ready") &&
@@ -1835,7 +1782,7 @@ export default function App() {
     if (clearContextPending) return "clear_context";
     return null;
   }, [clearContextPending, pendingClose, state.approval, state.ask, state.extensionForm, workspaceConflict]);
-  const visibleDecisionSurface = runtimeTransitioning ? null : decisionSurface;
+  const visibleDecisionSurface = decisionSurface;
   const composerSurfaceHidden = runtimeTransitioning || Boolean(decisionSurface);
   decisionSurfaceRef.current = decisionSurface;
   useEffect(() => {
@@ -3519,7 +3466,6 @@ export default function App() {
     !hydratePlaceholderActive;
   const transcriptItems = hydratePlaceholderActive ? state.hydratePlaceholderItems! : state.items;
   const handleLoadOlderHistory = useCallback((targetTurn?: number, trigger: HistoryLoadTrigger = "retry") => {
-    recordFrontendDiagnostic("history", "history.older-request", { trigger });
     return activeTabId ? loadOlderHistory(activeTabId, targetTurn, trigger) : Promise.resolve(false);
   }, [activeTabId, loadOlderHistory]);
 
@@ -4995,8 +4941,10 @@ export default function App() {
           </main>
 
           {!sidebarImDetailConnection && (
-          <footer className={["footer", terminalPanelOpen && !sidebarCreation ? "footer--compact" : "", visibleDecisionSurface ? "footer--decision" : ""].filter(Boolean).join(" ")} ref={footerRef}>
-            {!runtimeTransitioning && showTodos && (
+          <footer
+            className={["footer", terminalPanelOpen && !sidebarCreation ? "footer--compact" : "", visibleDecisionSurface ? "footer--decision" : "", runtimeTransitioning ? "footer--navigation-hidden" : ""].filter(Boolean).join(" ")} ref={footerRef} style={navigationSurface?.phase === "source-retained" && footerHeight > 0 ? { height: footerHeight, minHeight: footerHeight, boxSizing: "border-box" } : undefined} inert={runtimeTransitioning || undefined} aria-hidden={runtimeTransitioning || undefined}
+          >
+            {showTodos && (
               <TodoPanel
                 key={scopedTodoBatch}
                 stateKey={scopedTodoBatch}
@@ -5004,7 +4952,7 @@ export default function App() {
                 onDismiss={dismissTodos}
               />
             )}
-            {!runtimeTransitioning && rewindState && (
+            {rewindState && (
               <Suspense fallback={null}><UndoRewindBanner
                 meta={{
                   turns: rewindState.turnDiff,
@@ -5170,7 +5118,7 @@ export default function App() {
                     : "",
                 creationEmptyHero ? "composer-decision-host--creation-hero" : "",
               ].filter(Boolean).join(" ")}
-              hidden={(!runtimeTransitioning && composerSurfaceHidden) || undefined}
+              hidden={Boolean(decisionSurface) || undefined}
               inert={composerSurfaceHidden ? true : undefined}
               aria-hidden={composerSurfaceHidden ? true : undefined}
             >

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -33,7 +33,7 @@ import { useWailsResizeFix } from "./lib/useWailsResizeFix";
 import { asArray } from "./lib/array";
 import { createBoundedRefreshCoordinator, sameTabMetaLists, shouldRefreshTabMetaForEvent, TAB_META_MAX_IN_FLIGHT } from "./lib/tabMetaRefresh";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, t, useI18n, useT, type Translator } from "./lib/i18n";
-import { localizedNoticeText, useController, type Item, type LiveStream } from "./lib/useController";
+import { localizedNoticeText, useController, type HistoryLoadTrigger, type Item, type LiveStream } from "./lib/useController";
 import { app, onEvent, onProjectTreeChanged, onReady, onRemoteForwards, onRemoteServer, onRemoteStatus, onRuntimeRebuilt, onSessionRecovered, openExternal } from "./lib/bridge";
 import { useConfigLoadWarnings } from "./lib/useConfigLoadWarnings";
 import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
@@ -172,7 +172,13 @@ import { recordFrontendDiagnostic } from "./lib/frontendDiagnosticBridge";
 import { DEFAULT_STATUS_BAR_ITEMS, normalizeStatusBarItems, type StatusBarItemId } from "./lib/statusBarItems";
 import { paletteSessionDisplayTitle, paletteSessionHint, paletteSessionKeywords, sessionActivityTime } from "./lib/session";
 import { enqueueNavigationRequest, type PendingNavigationRequest } from "./lib/openTopicCoalescing";
-import { guardBackendNavigationResult, settleNavigationSurfaceIntent } from "./lib/navigationSurfaceTransition";
+import {
+  beginNavigationSurfaceState,
+  guardBackendNavigationResult,
+  markNavigationTargetMasked,
+  settleNavigationSurfaceState,
+  type NavigationSurfaceState,
+} from "./lib/navigationSurfaceTransition";
 import {
   applyTheme,
   clearLegacyThemePreference,
@@ -1109,6 +1115,7 @@ export default function App() {
     syncActiveTab,
     ensureBlankTab,
     ensureBlankSurface,
+    commitSingleSurfaceNavigation,
   } = useController();
   const { locale, setPref: setLocalePref } = useI18n();
   const t = useT();
@@ -1117,7 +1124,8 @@ export default function App() {
   const userPlanModeByTabRef = useRef<UserPlanModeIntents>({});
   const [tabMetas, setTabMetas] = useState<TabMeta[]>([]);
   const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
-  const [navigationSurfaceIntent, setNavigationSurfaceIntent] = useState<number | null>(null);
+  const [navigationSurface, setNavigationSurface] = useState<NavigationSurfaceState>(null);
+  const navigationSurfaceIntent = navigationSurface?.intent ?? null;
   type PreservedTranscriptSurface = {
     tabId?: string;
     items: Item[];
@@ -1126,7 +1134,7 @@ export default function App() {
   const [preservedTranscriptSurface, setPreservedTranscriptSurface] = useState<PreservedTranscriptSurface | null>(null);
   const renderedTranscriptSurfaceRef = useRef<PreservedTranscriptSurface | null>(null);
   const beginNavigationSurface = useCallback((intent: number) => {
-    recordFrontendDiagnostic("navigation", "navigation.begin", { phase: "begin" });
+    recordFrontendDiagnostic("navigation", "navigation.begin", { intent, phase: "begin" });
     const rendered = renderedTranscriptSurfaceRef.current;
     flushSync(() => {
       if (rendered && rendered.items.length > 0) {
@@ -1134,13 +1142,18 @@ export default function App() {
       } else {
         setPreservedTranscriptSurface(null);
       }
-      setNavigationSurfaceIntent(intent);
+      setNavigationSurface(beginNavigationSurfaceState(intent));
     });
   }, []);
   const settleNavigationSurface = useCallback((intent: number) => {
-    recordFrontendDiagnostic("navigation", "navigation.settle", { phase: "settle" });
-    setNavigationSurfaceIntent((current) => {
-      const next = settleNavigationSurfaceIntent(current, intent);
+    setNavigationSurface((current) => markNavigationTargetMasked(current, intent));
+  }, []);
+  const commitNavigationSurfacePaint = useCallback((intent: number, outcome: "ready" | "degraded") => {
+    recordFrontendDiagnostic("navigation", "navigation.paint-ready", { intent, outcome });
+    recordFrontendDiagnostic("navigation", "navigation.terminal", { intent, outcome });
+    recordFrontendDiagnostic("navigation", "navigation.settle", { intent, phase: "paint-ready", outcome });
+    setNavigationSurface((current) => {
+      const next = settleNavigationSurfaceState(current, intent);
       if (next === null) setPreservedTranscriptSurface(null);
       return next;
     });
@@ -1773,6 +1786,26 @@ export default function App() {
   const collaborationMode = displayedComposerProfileCollaborationMode(composerProfile);
   const toolApprovalMode = composerProfile.toolApprovalMode;
   const runtimeTransitioning = navigationSurfaceIntent !== null;
+  const navigationTargetDataReady = Boolean(
+    navigationSurface?.phase === "target-masked" &&
+    activeTabId &&
+    state.meta?.ready === true &&
+    !state.backendActivationPending &&
+    !state.hydrating,
+  );
+  const navigationDataReadyIntentRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!navigationTargetDataReady || navigationSurfaceIntent === null) return;
+    if (navigationDataReadyIntentRef.current === navigationSurfaceIntent) return;
+    navigationDataReadyIntentRef.current = navigationSurfaceIntent;
+    recordFrontendDiagnostic("navigation", "navigation.target-mounted", {
+      intent: navigationSurfaceIntent,
+    });
+    recordFrontendDiagnostic("navigation", "navigation.data-ready", {
+      intent: navigationSurfaceIntent,
+      outcome: "ready",
+    });
+  }, [navigationSurfaceIntent, navigationTargetDataReady]);
   const controllerReady =
     state.meta?.ready === true &&
     (!state.meta.runtime || state.meta.runtime.phase === "ready") &&
@@ -3485,9 +3518,10 @@ export default function App() {
     !transcriptHydrating &&
     !hydratePlaceholderActive;
   const transcriptItems = hydratePlaceholderActive ? state.hydratePlaceholderItems! : state.items;
-  const handleLoadOlderHistory = useCallback((targetTurn?: number) => (
-    activeTabId ? loadOlderHistory(activeTabId, targetTurn) : Promise.resolve(false)
-  ), [activeTabId, loadOlderHistory]);
+  const handleLoadOlderHistory = useCallback((targetTurn?: number, trigger: HistoryLoadTrigger = "retry") => {
+    recordFrontendDiagnostic("history", "history.older-request", { trigger });
+    return activeTabId ? loadOlderHistory(activeTabId, targetTurn, trigger) : Promise.resolve(false);
+  }, [activeTabId, loadOlderHistory]);
 
   // Display items: backend history is authoritative after immediate commit.
   // rewindState only drives the undo banner, not optimistic truncation.
@@ -3503,12 +3537,23 @@ export default function App() {
       geometrySessionKey: transcriptGeometrySessionKey,
     };
   }
-  const visibleTranscriptSurface = runtimeTransitioning && preservedTranscriptSurface
+  const visibleTranscriptSurface = runtimeTransitioning && !navigationTargetDataReady && preservedTranscriptSurface
     ? preservedTranscriptSurface
     : null;
   const visibleTranscriptItems = visibleTranscriptSurface?.items ?? displayItems;
   const visibleTranscriptTabId = visibleTranscriptSurface?.tabId ?? activeTabId;
   const visibleTranscriptGeometryKey = visibleTranscriptSurface?.geometrySessionKey ?? transcriptGeometrySessionKey;
+  const surfaceCommitToken = navigationTargetDataReady && navigationSurfaceIntent !== null
+    ? `navigation-${navigationSurfaceIntent}-${activeTabId ?? "blank"}`
+    : undefined;
+  const handleSurfacePaintReady = useCallback((token: string, outcome: "ready" | "degraded") => {
+    const match = /^navigation-(\d+)-/.exec(token);
+    if (!match) return;
+    const intent = Number(match[1]);
+    if (navigationSurface?.intent !== intent) return;
+    if (singleSurfaceLayout && activeTabId) commitSingleSurfaceNavigation(activeTabId);
+    commitNavigationSurfacePaint(intent, outcome);
+  }, [activeTabId, commitNavigationSurfacePaint, commitSingleSurfaceNavigation, navigationSurface?.intent, singleSurfaceLayout]);
   const latestGuidanceConsumed = useMemo(() => {
     for (let i = state.items.length - 1; i >= 0; i--) {
       const item = state.items[i];
@@ -4919,12 +4964,13 @@ export default function App() {
                       running={state.running || rewindCommitting}
                       turnStartAt={state.turnStartAt}
                       contentRevision={state.historyLayoutRevision}
+                      historyMutation={state.historyMutation}
                       welcomeVariant={sidebarCreation ? "creation" : "default"}
                       creationMode={sidebarCreation}
                       actionHoverMenus={sidebarCreation && !hydratePlaceholderActive && !runtimeTransitioning}
                       rewindSignal={rewindSignal}
                       revealSignal={transcriptRevealSignal}
-                      hydrating={runtimeTransitioning || transcriptHydrating}
+                      hydrating={transcriptHydrating || (runtimeTransitioning && !navigationTargetDataReady)}
                       hasOlderHistory={!runtimeTransitioning && state.historyHasOlder && !rewindState}
                       historyStartTurn={state.historyStartTurn}
                       historyTotalTurns={state.historyTotalTurns}
@@ -4932,6 +4978,8 @@ export default function App() {
                       olderHistoryError={state.historyOlderError}
                       onLoadOlderHistory={handleLoadOlderHistory}
                       invocationMetadata={visibleTranscriptTabId ? invocationMetadataByTab[visibleTranscriptTabId] : undefined}
+                      surfaceCommitToken={surfaceCommitToken}
+                      onSurfacePaintReady={handleSurfacePaintReady}
                     />
                   </div>
                   {runtimeTransitioning ? (
@@ -5115,10 +5163,14 @@ export default function App() {
             <div
               className={[
                 "composer-decision-host",
-                composerSurfaceHidden ? "composer-decision-host--hidden" : "",
+                runtimeTransitioning
+                  ? "composer-decision-host--footprint-hidden"
+                  : composerSurfaceHidden
+                    ? "composer-decision-host--hidden"
+                    : "",
                 creationEmptyHero ? "composer-decision-host--creation-hero" : "",
               ].filter(Boolean).join(" ")}
-              hidden={composerSurfaceHidden || undefined}
+              hidden={(!runtimeTransitioning && composerSurfaceHidden) || undefined}
               inert={composerSurfaceHidden ? true : undefined}
               aria-hidden={composerSurfaceHidden ? true : undefined}
             >

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -500,11 +500,9 @@ ok(
   "rewind previews warn on incomplete coverage and only authorize file overwrite after a conflict confirmation",
 );
 
-ok(
-  /const transcriptHydrating = state\.hydrating && !state\.hydrateHistoryLoaded;/.test(appSource) &&
+ok(/const transcriptHydrating = state\.hydrating && !state\.hydrateHistoryLoaded;/.test(appSource) &&
     /hydrating=\{transcriptHydrating \|\| \(runtimeTransitioning && !navigationTargetDataReady\)\}/.test(appSource) &&
-    /surfaceCommitToken=\{surfaceCommitToken\}/.test(appSource) &&
-    /onSurfacePaintReady=\{handleSurfacePaintReady\}/.test(appSource),
+    /surfaceCommitToken=\{surfaceCommitToken\}/.test(appSource) && /onSurfacePaintReady=\{handleSurfacePaintReady\}/.test(appSource),
   "Welcome stays suppressed through target data commit and navigation settles only after paint readiness",
 );
 

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -502,8 +502,10 @@ ok(
 
 ok(
   /const transcriptHydrating = state\.hydrating && !state\.hydrateHistoryLoaded;/.test(appSource) &&
-    /hydrating=\{runtimeTransitioning \|\| transcriptHydrating\}/.test(appSource),
-  "Welcome is suppressed only until transcript history has loaded",
+    /hydrating=\{transcriptHydrating \|\| \(runtimeTransitioning && !navigationTargetDataReady\)\}/.test(appSource) &&
+    /surfaceCommitToken=\{surfaceCommitToken\}/.test(appSource) &&
+    /onSurfacePaintReady=\{handleSurfacePaintReady\}/.test(appSource),
+  "Welcome stays suppressed through target data commit and navigation settles only after paint readiness",
 );
 
 ok(

--- a/desktop/frontend/src/__tests__/capability-busy-notice.test.ts
+++ b/desktop/frontend/src/__tests__/capability-busy-notice.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { activeWorkBusyNoticeText } from "../lib/capabilityMutations";
 import { t } from "../lib/i18n";
-import { effortSwitchNoticeText, modelSwitchNoticeText } from "../lib/useController";
+import { effortSwitchNoticeText, modelSwitchNoticeText } from "../lib/controllerSwitchNotices";
 
 function ok(value: unknown, message: string) {
   if (!value) throw new Error(message);

--- a/desktop/frontend/src/__tests__/frontend-diagnostics.test.ts
+++ b/desktop/frontend/src/__tests__/frontend-diagnostics.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  analyzeFrontendDiagnosticAnomalies,
   createFrontendDiagnostics,
   isFrontendDiagnosticsBuild,
 } from "../lib/frontendDiagnostics";
@@ -112,6 +113,7 @@ assert.equal(serialized.includes("layoutVariant"), true, "row layout variant rem
 assert.equal(serialized.includes("estimateSource"), true, "height estimate source remains available for analysis");
 assert.equal(serialized.includes("workspace.session-directory"), true, "sidebar directory event remains available for analysis");
 assert.equal(serialized.includes("workspaceSessions"), true, "sidebar session counts remain available for analysis");
+assert.ok(Array.isArray(payload.summary.anomalies), "payload includes automatic anomaly analysis");
 for (const forbidden of ["PRIVATE_TEXT", "PRIVATE_TOKEN", "private-user", "private-tab", "path", "token", "tabId"]) {
   assert.equal(serialized.includes(forbidden), false, `payload excludes ${forbidden}`);
 }
@@ -125,5 +127,24 @@ assert.equal(isFrontendDiagnosticsBuild("canary", false), true);
 assert.equal(isFrontendDiagnosticsBuild("preview", false), true);
 assert.equal(isFrontendDiagnosticsBuild("stable", true), true);
 assert.equal(isFrontendDiagnosticsBuild("stable", false), false);
+
+assert.deepEqual(analyzeFrontendDiagnosticAnomalies([
+  { t: 0, type: "navigation.begin", intent: 7 },
+  { t: 1, type: "workspace.session-directory", workspaceSessions: 8 },
+  { t: 2, type: "workspace.session-directory", workspaceSessions: 7 },
+  { t: 3, type: "navigation.settle", intent: 7 },
+  { t: 4, type: "history.older-request", trigger: "viewport-user" },
+  { t: 5, type: "transcript.scroll-write", owner: "unknown-writer" },
+]), [
+  { code: "settle-before-paint-ready", intent: 7 },
+  { code: "navigation-session-count-changed", intent: 7, count: 2 },
+  { code: "viewport-older-without-user-input", count: 1 },
+  { code: "unknown-scroll-writer", count: 1 },
+], "automatic analysis reports ordering, paging, catalog, and writer anomalies");
+
+assert.deepEqual(analyzeFrontendDiagnosticAnomalies([
+  { t: 0, type: "history.viewport-permit" },
+  { t: 1, type: "history.older-request", trigger: "viewport-user" },
+]), [], "a viewport page request consumes one explicit user permit without a false anomaly");
 
 console.log("frontend diagnostics tests passed");

--- a/desktop/frontend/src/__tests__/frontend-diagnostics.test.ts
+++ b/desktop/frontend/src/__tests__/frontend-diagnostics.test.ts
@@ -146,5 +146,9 @@ assert.deepEqual(analyzeFrontendDiagnosticAnomalies([
   { t: 0, type: "history.viewport-permit" },
   { t: 1, type: "history.older-request", trigger: "viewport-user" },
 ]), [], "a viewport page request consumes one explicit user permit without a false anomaly");
+assert.deepEqual(analyzeFrontendDiagnosticAnomalies([
+  { t: 0, type: "navigation.begin", intent: 9 },
+  { t: 1, type: "navigation.settle", intent: 9, outcome: "failed" },
+]), [], "a failed data terminal may release its mask without a paint-ready false positive");
 
 console.log("frontend diagnostics tests passed");

--- a/desktop/frontend/src/__tests__/navigation-surface-transition.test.ts
+++ b/desktop/frontend/src/__tests__/navigation-surface-transition.test.ts
@@ -42,11 +42,15 @@ surface = settleNavigationSurfaceState(surface, 9);
 ok(surface === null, "the matching paint terminal releases the mask");
 
 let paint = advanceSurfacePaintCommit({ attempts: 0, stableFrames: 0 }, {
-  rendered: true, placementReady: true, geometryReady: true,
+  rendered: true, placementReady: true, geometryReady: true, geometryKey: "755:1200:445",
 });
 ok(paint.outcome === undefined, "one paint frame cannot expose the target");
 paint = advanceSurfacePaintCommit(paint.progress, {
-  rendered: true, placementReady: true, geometryReady: true,
+  rendered: true, placementReady: true, geometryReady: true, geometryKey: "859:1200:341",
+});
+ok(paint.outcome === undefined, "a changed viewport geometry restarts the stability gate");
+paint = advanceSurfacePaintCommit(paint.progress, {
+  rendered: true, placementReady: true, geometryReady: true, geometryKey: "859:1200:341",
 });
 ok(paint.outcome === "ready", "two stable geometry frames commit the target");
 let stalled = { attempts: 0, stableFrames: 0 };
@@ -54,7 +58,7 @@ let recoveryRequests = 0;
 let degraded: string | undefined;
 for (let frame = 0; frame < 180; frame += 1) {
   const decision = advanceSurfacePaintCommit(stalled, {
-    rendered: true, placementReady: false, geometryReady: false,
+    rendered: true, placementReady: false, geometryReady: false, geometryKey: "755:0:0",
   });
   stalled = decision.progress;
   if (decision.requestRecovery) recoveryRequests += 1;
@@ -95,9 +99,10 @@ ok(await staleAcceptedPromise === false, "a stale backend-activating result is r
 ok(reasserted === "tab.reveal-background:tab-stale", "stale reassertion receives the mutating target identity");
 
 const appSource = readFileSync(new URL("../App.tsx", import.meta.url), "utf8");
+const surfaceHookSource = readFileSync(new URL("../lib/useNavigationSurface.ts", import.meta.url), "utf8");
 const stylesSource = readFileSync(new URL("../styles.css", import.meta.url), "utf8");
-ok(appSource.includes("flushSync(() => {"), "navigation masking commits synchronously before the Wails await");
-ok(appSource.includes("setPreservedTranscriptSurface(rendered)"), "the last stable transcript is retained during navigation");
+ok(surfaceHookSource.includes("flushSync(() => {"), "navigation masking commits synchronously before the Wails await");
+ok(surfaceHookSource.includes("setPreserved(rendered?.items.length ? rendered : null)"), "the last stable transcript is retained during navigation");
 ok(appSource.includes("items={visibleTranscriptItems}"), "the visible transcript is decoupled from the hydrating target");
 ok(appSource.includes("transcript-navigation-overlay"), "navigation renders a blocking transcript overlay");
 ok(/\.transcript-navigation-overlay\s*\{[\s\S]*?background:\s*var\(--chat-bg, var\(--bg\)\)/.test(stylesSource), "the navigation overlay is opaque while target rows settle");
@@ -105,8 +110,10 @@ ok(appSource.includes("live={runtimeTransitioning ? undefined : state.live}"), "
 ok(appSource.includes("composer-decision-host--footprint-hidden"), "App preserves the composer footprint during navigation");
 ok(!appSource.includes("hidden={composerSurfaceHidden || undefined}"), "navigation no longer collapses the composer footprint");
 ok(appSource.includes("inert={composerSurfaceHidden ? true : undefined}"), "the hidden composer is inert during navigation");
-ok(appSource.includes("!runtimeTransitioning && showTodos"), "source-session Todo content is isolated");
-ok(appSource.includes("!runtimeTransitioning && rewindState"), "source-session rewind content is isolated");
+ok(appSource.includes("{showTodos && ("), "target Todo footprint is laid out below the mask");
+ok(appSource.includes("{rewindState && ("), "target rewind footprint is laid out below the mask");
+ok(/\.footer--navigation-hidden\s*\{[\s\S]*?visibility:\s*hidden;[\s\S]*?pointer-events:\s*none;/.test(stylesSource), "masked target footer cannot paint or receive input");
+ok(appSource.includes('style={navigationSurface?.phase === "source-retained"') && appSource.includes("const visibleDecisionSurface = decisionSurface"), "target-masked paint uses the target footer geometry");
 ok((appSource.match(/guardBackendNavigationResult\(\{/g) ?? []).length === 2, "both Reveal paths guard stale backend activation results");
 const switchFolderSource = appSource.slice(
   appSource.indexOf("const switchFolder = useCallback"),
@@ -117,7 +124,7 @@ ok(switchFolderSource.includes("beginNavigationSurface(navigationIntentSeq)"), "
 ok(switchFolderSource.includes("pickWorkspace(navigationIntentSeq)"), "folder-pick navigation carries the shared intent into the controller");
 ok(switchFolderSource.includes("switchWorkspace(path, navigationIntentSeq)"), "direct workspace navigation carries the shared intent into the controller");
 ok(switchFolderSource.includes("settleNavigationSurface(navigationIntentSeq)"), "workspace request completion advances the target under its surface mask");
-ok(appSource.includes("navigation.paint-ready"), "surface settlement is diagnosed only from target paint readiness");
+ok(surfaceHookSource.includes("navigation.paint-ready"), "surface settlement is diagnosed only from target paint readiness");
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/navigation-surface-transition.test.ts
+++ b/desktop/frontend/src/__tests__/navigation-surface-transition.test.ts
@@ -1,7 +1,14 @@
 // Run: tsx src/__tests__/navigation-surface-transition.test.ts
 
 import { readFileSync } from "node:fs";
-import { guardBackendNavigationResult, settleNavigationSurfaceIntent } from "../lib/navigationSurfaceTransition";
+import {
+  advanceSurfacePaintCommit,
+  beginNavigationSurfaceState,
+  guardBackendNavigationResult,
+  markNavigationTargetMasked,
+  settleNavigationSurfaceIntent,
+  settleNavigationSurfaceState,
+} from "../lib/navigationSurfaceTransition";
 
 let passed = 0;
 let failed = 0;
@@ -23,6 +30,38 @@ active = settleNavigationSurfaceIntent(active, 2);
 ok(active === 3, "coalesced B completion cannot release C's mask");
 active = settleNavigationSurfaceIntent(active, 3);
 ok(active === null, "the latest completion releases its own mask");
+
+let surface = beginNavigationSurfaceState(9);
+surface = markNavigationTargetMasked(surface, 8);
+ok(surface?.phase === "source-retained", "a stale request cannot replace the retained source");
+surface = markNavigationTargetMasked(surface, 9, "tab-target");
+ok(surface?.phase === "target-masked", "the latest request mounts its target under the mask");
+surface = settleNavigationSurfaceState(surface, 8);
+ok(surface?.intent === 9, "a stale paint terminal cannot release the latest mask");
+surface = settleNavigationSurfaceState(surface, 9);
+ok(surface === null, "the matching paint terminal releases the mask");
+
+let paint = advanceSurfacePaintCommit({ attempts: 0, stableFrames: 0 }, {
+  rendered: true, placementReady: true, geometryReady: true,
+});
+ok(paint.outcome === undefined, "one paint frame cannot expose the target");
+paint = advanceSurfacePaintCommit(paint.progress, {
+  rendered: true, placementReady: true, geometryReady: true,
+});
+ok(paint.outcome === "ready", "two stable geometry frames commit the target");
+let stalled = { attempts: 0, stableFrames: 0 };
+let recoveryRequests = 0;
+let degraded: string | undefined;
+for (let frame = 0; frame < 180; frame += 1) {
+  const decision = advanceSurfacePaintCommit(stalled, {
+    rendered: true, placementReady: false, geometryReady: false,
+  });
+  stalled = decision.progress;
+  if (decision.requestRecovery) recoveryRequests += 1;
+  degraded = decision.outcome;
+}
+ok(recoveryRequests === 2, "stalled placement receives two bounded recovery opportunities");
+ok(degraded === "degraded", "the second failed placement terminates without permanent loading");
 
 let reasserted = "";
 const currentAccepted = await guardBackendNavigationResult({
@@ -56,12 +95,15 @@ ok(await staleAcceptedPromise === false, "a stale backend-activating result is r
 ok(reasserted === "tab.reveal-background:tab-stale", "stale reassertion receives the mutating target identity");
 
 const appSource = readFileSync(new URL("../App.tsx", import.meta.url), "utf8");
+const stylesSource = readFileSync(new URL("../styles.css", import.meta.url), "utf8");
 ok(appSource.includes("flushSync(() => {"), "navigation masking commits synchronously before the Wails await");
 ok(appSource.includes("setPreservedTranscriptSurface(rendered)"), "the last stable transcript is retained during navigation");
 ok(appSource.includes("items={visibleTranscriptItems}"), "the visible transcript is decoupled from the hydrating target");
 ok(appSource.includes("transcript-navigation-overlay"), "navigation renders a blocking transcript overlay");
+ok(/\.transcript-navigation-overlay\s*\{[\s\S]*?background:\s*var\(--chat-bg, var\(--bg\)\)/.test(stylesSource), "the navigation overlay is opaque while target rows settle");
 ok(appSource.includes("live={runtimeTransitioning ? undefined : state.live}"), "App removes source live output during navigation");
-ok(appSource.includes("hidden={composerSurfaceHidden || undefined}"), "App keeps the composer mounted but hidden during navigation");
+ok(appSource.includes("composer-decision-host--footprint-hidden"), "App preserves the composer footprint during navigation");
+ok(!appSource.includes("hidden={composerSurfaceHidden || undefined}"), "navigation no longer collapses the composer footprint");
 ok(appSource.includes("inert={composerSurfaceHidden ? true : undefined}"), "the hidden composer is inert during navigation");
 ok(appSource.includes("!runtimeTransitioning && showTodos"), "source-session Todo content is isolated");
 ok(appSource.includes("!runtimeTransitioning && rewindState"), "source-session rewind content is isolated");
@@ -74,7 +116,8 @@ ok(switchFolderSource.includes("const navigationIntentSeq = noteNavigationIntent
 ok(switchFolderSource.includes("beginNavigationSurface(navigationIntentSeq)"), "workspace navigation masks the source surface before Wails");
 ok(switchFolderSource.includes("pickWorkspace(navigationIntentSeq)"), "folder-pick navigation carries the shared intent into the controller");
 ok(switchFolderSource.includes("switchWorkspace(path, navigationIntentSeq)"), "direct workspace navigation carries the shared intent into the controller");
-ok(switchFolderSource.includes("settleNavigationSurface(navigationIntentSeq)"), "workspace navigation compare-clears its surface mask");
+ok(switchFolderSource.includes("settleNavigationSurface(navigationIntentSeq)"), "workspace request completion advances the target under its surface mask");
+ok(appSource.includes("navigation.paint-ready"), "surface settlement is diagnosed only from target paint readiness");
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/new-session-load-race.test.tsx
+++ b/desktop/frontend/src/__tests__/new-session-load-race.test.tsx
@@ -4,6 +4,7 @@ import { JSDOM } from "jsdom";
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { initialState, reducer, useController, type Item } from "../lib/useController";
+import type { NavigationResult } from "../lib/navigationSurfaceTransition";
 import { historySliceFromMessages } from "./mockHistorySlice";
 import type { AppBindings } from "../lib/bridge";
 import type { BalanceInfo, CheckpointMeta, ContextInfo, EffortInfo, HistoryMessage, HistorySliceRequest, JobView, Meta, TabMeta, WireEvent } from "../lib/types";
@@ -335,17 +336,21 @@ await act(async () => {
 
 eq(controller?.state.items.length, 0, "stale history load cannot repopulate a new blank session");
 
-let resumePromise: Promise<void> | undefined;
+let resumeNavigation: NavigationResult<void> | undefined;
+let resumeSurfaceSettled = false;
 await act(async () => {
-  resumePromise = controller?.resumeSession("/sessions/restored.jsonl", "tab-a");
+  resumeNavigation = controller?.resumeSession("/sessions/restored.jsonl", "tab-a");
+  void resumeNavigation?.surfaceReady.then(() => { resumeSurfaceSettled = true; });
   await flushPromises();
 });
+eq(resumeSurfaceSettled, false, "Resume releases navigation acquisition before target history settles");
 eq(controller?.state.ask?.id, "pre-response-resume", "Resume accepts the new-epoch ask and rejects the interleaved old-epoch ask before returning");
 await act(async () => {
   resumeRPCGate.resolve();
-  await resumePromise;
+  await resumeNavigation?.surfaceReady;
   await flushPromises();
 });
+eq(resumeSurfaceSettled, true, "Resume surfaceReady resolves after authoritative history and reconciliation");
 eq(controller?.state.meta?.canonicalTodos?.[0]?.status, "completed", "resuming a session refreshes its authoritative canonical todo state");
 eq(controller?.state.ask?.id, "replayed-runtime-resumed", "Resume RPC ask emitted before return is restored after reset/history hydration");
 ok(promptReplayCalls > 0, "Resume completion performs a tab-scoped pending-prompt replay");
@@ -356,15 +361,15 @@ await act(async () => {
   await flushPromises();
 });
 const replayCallsBeforeChannelOpen = promptReplayCalls;
-let channelPromise: Promise<void> | undefined;
+let channelNavigation: NavigationResult<void> | undefined;
 await act(async () => {
-  channelPromise = controller?.openChannelSession("/sessions/channel.jsonl", "tab-a");
+  channelNavigation = controller?.openChannelSession("/sessions/channel.jsonl", "tab-a");
   await flushPromises();
 });
 eq(controller?.state.ask?.id, "pre-response-channel", "channel-open accepts the new-epoch ask and rejects the interleaved old-epoch ask before returning");
 await act(async () => {
   channelRPCGate.resolve();
-  await channelPromise;
+  await channelNavigation?.surfaceReady;
   await flushPromises();
 });
 eq(controller?.state.ask?.id, "replayed-runtime-channel", "channel-open ask emitted before return is restored after reset/history hydration");

--- a/desktop/frontend/src/__tests__/recovery-quiet-notifications.test.ts
+++ b/desktop/frontend/src/__tests__/recovery-quiet-notifications.test.ts
@@ -28,6 +28,7 @@ function ok(cond: boolean, label: string) {
 const here = dirname(fileURLToPath(import.meta.url));
 const appSource = readFileSync(resolve(here, "../App.tsx"), "utf8");
 const controllerSource = readFileSync(resolve(here, "../lib/useController.ts"), "utf8");
+const noticesSource = readFileSync(resolve(here, "../lib/controllerNotices.ts"), "utf8");
 
 console.log("\nquiet recovery notifications");
 
@@ -38,7 +39,7 @@ ok(!appSource.includes("AcknowledgeTabRecovery"), "App does not expose recovery 
 ok(!appSource.includes("OpenTabRecoveryParent"), "App does not expose recovery compare controls");
 ok(!appSource.includes("recovery.openOriginalFailed"), "App does not carry recovery compare failure text");
 
-ok(controllerSource.includes("function quietTranscriptNoticeKey"), "controller centralizes quiet transcript notices");
+ok(noticesSource.includes("function quietTranscriptNoticeKey"), "controller centralizes quiet transcript notices");
 ok(controllerSource.includes("if (quietTranscriptNoticeKey(rawText, code))"), "raw quiet notices are skipped before localization");
 ok(controllerSource.includes("if (quietTranscriptNoticeKey(text, code))"), "localized quiet notices are skipped before rendering");
 

--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -785,6 +785,10 @@ await waitFor("single-surface activation replaces visible tab", () =>
   (controller.state.items.some((item) => item.kind === "user" && item.text === "history G") ?? false)
 );
 await act(async () => {
+  controller?.commitSingleSurfaceNavigation("tab-g");
+  await flushPromises();
+});
+await act(async () => {
   metaH.resolve({ ...metaFor(tabH), label: "stale-model-tab-h" });
   await metaH.promise;
   await flushPromises();

--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -144,6 +144,7 @@ const tabK = tabMeta("tab-k", { sessionRevision: 1, sessionDigest: "digest-k-v1"
 const tabL = tabMeta("tab-l", { sessionRevision: 1, sessionDigest: "digest-l-v1" });
 const tabM = tabMeta("tab-m", { sessionRevision: 2, sessionDigest: "digest-m-v2" });
 const tabN = tabMeta("tab-n", { sessionRevision: 2, sessionDigest: "digest-n-v2" });
+const tabO = tabMeta("tab-o");
 let backendActiveId = "tab-a";
 const historyB = deferred<HistoryMessage[]>();
 const historyD = deferred<HistoryMessage[]>();
@@ -187,7 +188,7 @@ let staleForkStarted = false;
 let holdStaleForkReassertG = false;
 let staleForkReassertGStarted = false;
 const runningTabs = new Set<string>();
-const tabsById = new Map([tabA, tabB, tabC, tabD, tabE, tabF, tabG, tabH, tabI, tabK, tabL, tabM, tabN].map((tab) => [tab.id, tab]));
+const tabsById = new Map([tabA, tabB, tabC, tabD, tabE, tabF, tabG, tabH, tabI, tabK, tabL, tabM, tabN, tabO].map((tab) => [tab.id, tab]));
 const eventHandlers: Array<(e: WireEvent) => void> = [];
 const readyHandlers: Array<(tabId?: string) => void> = [];
 const topicActivationHandlers: Array<(e: TopicActivationEvent) => void> = [];
@@ -240,6 +241,7 @@ window.go = {
       CheckpointsForTab: async () => checkpoints,
       HistoryForTab: async (tabID: string) => {
         historyCalls.push(tabID);
+        if (tabID === "tab-o") { failSetActiveFor = "tab-a"; throw new Error("history failed at /private/session.jsonl"); }
         if (tabID === "tab-b") return historyB.promise;
         if (tabID === "tab-d") return historyD.promise;
         if (tabID === "tab-e") return [userMessage("fork E")];
@@ -597,6 +599,14 @@ ok(controller?.state.items.some((item) => item.kind === "user" && item.text === 
 eq(historyCalls.length, historyCallsBeforeFailedSwitch, "failed backend tab switch does not hydrate the rejected target");
 failSetActiveFor = "";
 
+await act(async () => { await controller?.switchTab("tab-o", tabO); await flushPromises(); });
+await waitFor("failed history and failed source restore settle on target", () => controller?.activeTabId === "tab-o" && Boolean(controller.state.hydrateError));
+eq(controller?.activeTabId, "tab-o", "failed source rebind does not falsely restore the frontend source");
+eq(backendActiveId, "tab-o", "failed source rebind keeps frontend and backend on the same target");
+failSetActiveFor = "";
+await act(async () => { await controller?.switchTab("tab-a", tabA); await flushPromises(); });
+await waitFor("tab-a restored after failed source rebind", () => controller?.activeTabId === "tab-a");
+
 await act(async () => {
   for (const handler of eventHandlers) handler({ kind: "phase", text: "Planner is thinking", tabId: "tab-a" });
   for (const handler of eventHandlers) handler({ kind: "message", text: "Planner kept", reasoning: "Planner notes", tabId: "tab-a" });
@@ -784,10 +794,7 @@ await waitFor("single-surface activation replaces visible tab", () =>
   controller?.activeTabId === "tab-g" &&
   (controller.state.items.some((item) => item.kind === "user" && item.text === "history G") ?? false)
 );
-await act(async () => {
-  controller?.commitSingleSurfaceNavigation("tab-g");
-  await flushPromises();
-});
+await act(async () => { controller?.commitSingleSurfaceNavigation("tab-g"); await flushPromises(); });
 await act(async () => {
   metaH.resolve({ ...metaFor(tabH), label: "stale-model-tab-h" });
   await metaH.promise;
@@ -815,8 +822,7 @@ await waitFor("reopened tab-h finishes after stale meta discard", () =>
   (controller.state.items.some((item) => item.kind === "user" && item.text === "history H after stale meta") ?? false)
 );
 
-// A stale repair is itself asynchronous. Force a third navigation to complete
-// while that repair is pending and verify the repair follows the newest tab.
+// A third navigation must remain authoritative while stale repair is pending.
 holdStaleSwitchF = true;
 holdStaleSwitchReassertG = true;
 let threeWaySwitchToF: Promise<TabMeta[] | undefined> | undefined;
@@ -861,10 +867,7 @@ eq(controller?.activeTabId, "tab-h", "third navigation remains visible after sta
 eq(backendActiveId, "tab-h", "third navigation remains backend-active after stale fork repair");
 runningTabs.delete("tab-j");
 
-// A same-path session can advance while this tab is inactive (another runtime,
-// crash recovery, or a completed turn). Matching only the path would reuse the
-// old transcript and hide the newer durable suffix. The persisted fingerprint
-// must force one fresh history read, then allow reuse once the cache is current.
+// A changed durable fingerprint must defeat same-path cache reuse, then become reusable.
 await act(async () => {
   await controller?.openProjectTab(tabK.workspaceRoot, tabK.topicId || "");
   await flushPromises();
@@ -894,9 +897,7 @@ await act(async () => {
 await waitFor("matching fingerprint reuses tab history", () => controller?.activeTabId === "tab-k");
 eq(historyCalls.length, historyCallsAfterFingerprintRefresh, "matching fingerprint reuses the hydrated transcript after navigation");
 
-// Older-page hydration must use the same canonical fingerprint as the visible
-// page. A session can advance while the tab is open; an older response must be
-// discarded instead of being prepended to the newer transcript.
+// An older response with a stale fingerprint must not prepend into the newer page.
 await act(async () => {
   await controller?.openProjectTab(tabL.workspaceRoot, tabL.topicId || "");
   await flushPromises();
@@ -926,9 +927,7 @@ await verifyDeferredHistoryCloseRace({
   historyCalls: () => historyLCalls, waitFor, flushPromises, equal: eq, sessionPath: tabL.sessionPath,
 });
 
-// The backend transcript and sidecar are separate durable files. If a save
-// advances between those reads, hydration must reconcile the pair instead of
-// caching an older page under the newer metadata fingerprint.
+// Transcript and sidecar reads must reconcile when a save advances between them.
 await act(async () => {
   await controller?.openProjectTab(tabM.workspaceRoot, tabM.topicId || "");
   await flushPromises();
@@ -940,9 +939,7 @@ await waitFor("split transcript/meta read reconciles", () =>
 eq(historyMCalls, 2, "mismatched page and metadata trigger one bounded history reload");
 ok(!(controller?.state.items.some((item) => item.kind === "user" && item.text === "stale M v1") ?? false), "reconciled hydration does not retain the stale page");
 
-// A live turn may start after the first durable page returns but before the
-// metadata fingerprint is sampled. That live state owns the transcript; the
-// bounded durable reconciliation must stop instead of replacing it.
+// A live turn that starts between durable page and metadata reads owns the transcript.
 startTabNDuringMeta = true;
 await act(async () => {
   await controller?.openProjectTab(tabN.workspaceRoot, tabN.topicId || "");

--- a/desktop/frontend/src/__tests__/topic-activation.test.tsx
+++ b/desktop/frontend/src/__tests__/topic-activation.test.tsx
@@ -146,6 +146,9 @@ const requestIdByTab = new Map<string, string>();
 // When true, the mock emits starting+ready synchronously BEFORE returning the
 // ticket (exercises the terminal-event stash path).
 let eagerActivationEvents = false;
+let failedHistoryTabId = "";
+let failSetActiveTabId = "";
+let restoredTabSeq = 0;
 
 function emitActivation(event: TopicActivationEvent): void {
   for (const handler of topicActivationHandlers) handler(event);
@@ -153,6 +156,7 @@ function emitActivation(event: TopicActivationEvent): void {
 
 function historyFor(tabID: string): HistoryMessage[] {
   if (tabID === "tab-r") return [{ role: "user", content: "帮我查询，现在我链接的 deep" }];
+  if (tabID.startsWith("tab-c-restored-")) return [{ role: "user", content: "history tab-c" }];
   return [{ role: "user", content: `history ${tabID}` }];
 }
 
@@ -181,7 +185,10 @@ window.go = {
       JobsForTab: async () => jobs,
       CheckpointsForTab: async () => checkpoints,
       HistoryForTab: async (tabID: string) => historyFor(tabID),
-      HistorySliceForTab: async (tabID: string, req: HistorySliceRequest) => historySliceFromMessages(tabID, historyFor(tabID), req),
+      HistorySliceForTab: async (tabID: string, req: HistorySliceRequest) => {
+        if (tabID === failedHistoryTabId) throw new Error(`/private/${tabID}/history.jsonl could not be read`);
+        return historySliceFromMessages(tabID, historyFor(tabID), req);
+      },
       HistoryCheckpointTurnsForTab: async () => [],
       StartTopicActivation: async (req: TopicActivationRequest) => {
         const target = Array.from(tabsById.values()).find((tab) => tab.workspaceRoot === req.workspaceRoot && tab.topicId === req.topicId) ?? tabA;
@@ -195,7 +202,19 @@ window.go = {
         return { requestId, tabId: target.id, meta: { ...target, active: true } };
       },
       SetActiveTab: async (tabID: string) => {
+        if (tabID === failSetActiveTabId) throw new Error("source tab was already pruned");
         backendActiveId = tabID;
+      },
+      OpenTopicSession: async (_scope: string, _workspaceRoot: string, _topicID: string, sessionPath: string) => {
+        const source = Array.from(tabsById.values()).find((tab) => tab.sessionPath === sessionPath) ?? tabA;
+        const restored = tabMeta(`${source.id}-restored-${++restoredTabSeq}`, {
+          ...source,
+          id: `${source.id}-restored-${restoredTabSeq}`,
+          active: true,
+        });
+        tabsById.set(restored.id, restored);
+        backendActiveId = restored.id;
+        return restored;
       },
       ReplayPendingPrompts: async () => {},
     } as Partial<AppBindings> as AppBindings,
@@ -257,7 +276,7 @@ await act(async () => {
 await waitFor("C hydrates on its ready", () => hasHistory("tab-c") && controller?.state.hydrating === false);
 ok(!hasHistory("tab-b"), "only the last click's history is visible");
 
-// ── terminal failed surfaces the hydrate-error UI ───────────────────────────
+// ── terminal failure restores the committed source surface ─────────────────
 await act(async () => {
   await controller?.activateTopic("project", tabA.workspaceRoot, tabA.topicId ?? "");
   await flushPromises();
@@ -267,8 +286,27 @@ await act(async () => {
   emitActivation({ requestId: requestIdByTab.get("tab-a") ?? "", tabId: "tab-a", phase: "failed", error: "session failed to start" });
   await flushPromises();
 });
-eq(controller?.state.hydrating, false, "failed activation stops the hydrating surface");
-eq(controller?.state.hydrateError, "session failed to start", "failed activation surfaces the sanitized error");
+eq(controller?.activeTabId, "tab-c", "failed activation restores the previously committed source tab");
+eq(controller?.state.hydrating, false, "restored source is immediately usable");
+ok(hasHistory("tab-c"), "failed activation retains the source transcript");
+const failureNotice = controller?.state.items.findLast((item) => item.kind === "notice");
+ok(Boolean(failureNotice && failureNotice.kind === "notice" && !failureNotice.text.includes("session failed to start")), "failure notice is sanitized before it reaches the restored source");
+
+// ── activation succeeds but target history fails: source still wins ─────────
+failedHistoryTabId = "tab-a";
+failSetActiveTabId = "tab-c";
+await act(async () => {
+  await controller?.activateTopic("project", tabA.workspaceRoot, tabA.topicId ?? "");
+  await flushPromises();
+  emitActivation({ requestId: requestIdByTab.get("tab-a") ?? "", tabId: "tab-a", phase: "ready" });
+  await flushPromises();
+});
+await waitFor("history failure rebinds the pruned committed source", () => controller?.activeTabId?.startsWith("tab-c-restored-") ?? false);
+ok(hasHistory("tab-c"), "target history failure retains the source controller transcript");
+const historyFailureNotice = controller?.state.items.findLast((item) => item.kind === "notice");
+ok(!(historyFailureNotice?.kind === "notice" && historyFailureNotice.text.includes("/private/")), "target history failure does not expose a local path");
+failedHistoryTabId = "";
+failSetActiveTabId = "";
 
 // ── a terminal event that beats the ticket is stashed and replayed ──────────
 eagerActivationEvents = true;

--- a/desktop/frontend/src/__tests__/transcript-native-scrollbar.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-native-scrollbar.test.ts
@@ -8,6 +8,7 @@ import {
   measureTranscriptVirtuosoItem,
 } from "../lib/transcriptNativeScrollbar";
 import { noteTranscriptRowMeasurement, setTranscriptScrollDiagnosticSink } from "../lib/transcriptScrollProbe";
+import { advanceViewportPagePermit, grantsNativeScrollbarPagePermit } from "../lib/useTranscriptNavigationSurface";
 
 let passed = 0;
 function check(actual: unknown, expected: unknown, label: string) {
@@ -42,6 +43,17 @@ process.stdout.write("\ntranscript native scrollbar\n");
 check(isNativeVerticalScrollbarPointer(transcript, { button: 0, clientX: 1095 }), true, "left-button in the right native gutter starts the lock");
 check(isNativeVerticalScrollbarPointer(transcript, { button: 0, clientX: 1085 }), false, "left-button in chat content does not start the lock");
 check(isNativeVerticalScrollbarPointer(transcript, { button: 1, clientX: 1095 }), false, "middle-button autoscroll is not classified as thumb dragging");
+check(grantsNativeScrollbarPagePermit(400, 300, true, false), true, "an observed upward native drag grants one page permit");
+check(grantsNativeScrollbarPagePermit(300, 200, true, true), false, "the same native drag cannot grant a second page permit");
+check(grantsNativeScrollbarPagePermit(400, 300, false, false), false, "scroll movement without a native drag grants no permit");
+let viewportPermit = advanceViewportPagePermit(0, 0);
+check(viewportPermit, 1, "one upward gesture grants a viewport page permit");
+viewportPermit = advanceViewportPagePermit(viewportPermit, 1);
+check(viewportPermit, 2, "startReached consumes the granted viewport page permit");
+check(advanceViewportPagePermit(viewportPermit, 0), 2, "wheel burst events cannot queue another page while the request is active");
+viewportPermit = advanceViewportPagePermit(viewportPermit, 2);
+check(advanceViewportPagePermit(viewportPermit, 1), 0, "request completion clears burst permits before prepend reaches the start");
+check(advanceViewportPagePermit(advanceViewportPagePermit(viewportPermit, 0), 1), 2, "a later user gesture can request one new page");
 
 Object.defineProperty(transcript, "scrollHeight", { configurable: true, value: 600 });
 check(isNativeVerticalScrollbarPointer(transcript, { button: 0, clientX: 1095 }), false, "an empty native gutter without overflow does not start the lock");

--- a/desktop/frontend/src/__tests__/transcript-native-scrollbar.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-native-scrollbar.test.ts
@@ -72,7 +72,10 @@ row.getBoundingClientRect = () => ({
 check(measureTranscriptVirtuosoItem(row, "offsetHeight", false), 640, "ordinary wheel path keeps real dynamic measurement");
 check(measureTranscriptVirtuosoItem(row, "offsetHeight", true), 160, "native thumb drag keeps the existing Virtuoso size");
 row.dataset.transcriptEstimate = "180";
-check(measureTranscriptVirtuosoItem(row, "offsetHeight", true), 180, "native thumb drag keeps the logical row estimate");
+check(measureTranscriptVirtuosoItem(row, "offsetHeight", true), 160, "native thumb drag prefers the measured size over a stale estimate");
+delete row.dataset.knownSize;
+check(measureTranscriptVirtuosoItem(row, "offsetHeight", true), 180, "native thumb drag falls back to the logical row estimate before measurement");
+row.dataset.knownSize = "160";
 delete row.dataset.transcriptEstimate;
 check(measureTranscriptVirtuosoItem(row, "offsetHeight", false), 640, "real measurement resumes after thumb release");
 

--- a/desktop/frontend/src/__tests__/transcript-question-jump.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-question-jump.test.tsx
@@ -238,26 +238,58 @@ console.log("\ntranscript question jump landing");
   }
 }
 
-// ── A one-turn remainder auto-loads without restoring the old fold button ───
+// ── Auto-fill runs only after a stable, genuinely short first page ──────────
 {
-  const harness = await createTranscriptHarness({ viewportHeight: 200, rowHeight: 100 });
+  // Keep the viewport deliberately larger than every estimate Virtuoso may
+  // use before its first measured row. This exercises the auto-fill branch
+  // itself instead of depending on estimate tuning in the virtualizer.
+  const harness = await createTranscriptHarness({ viewportHeight: 100_000, rowHeight: 100 });
   try {
     HTMLElement.prototype.scrollIntoView = () => {};
     let loads = 0;
-    await harness.render(historyTurns(2, 61), {
+    const triggers: string[] = [];
+    await harness.render(historyTurns(61, 61), {
       running: false,
       questionNavigator: true,
       hasOlderHistory: true,
-      historyStartTurn: 2,
+      historyStartTurn: 61,
       historyTotalTurns: 61,
+      surfaceCommitToken: "navigation-1-short-surface",
+      onSurfacePaintReady: () => {},
+      onLoadOlderHistory: async (_targetTurn, trigger) => {
+        loads += 1;
+        triggers.push(trigger ?? "");
+        return true;
+      },
+    });
+    await harness.waitFor(() => loads > 0, "a short stable first page to auto-fill");
+    ok(triggers[0] === "auto-fill", "short-page loading is labeled as auto-fill");
+    ok(harness.container.querySelectorAll(".jump-item").length === 61, "the first page renders a marker for every session question");
+    ok(!harness.container.querySelector(".transcript__older"), "the ordinary show-earlier fold button is absent");
+  } finally {
+    await harness.unmount();
+    await harness.close();
+  }
+}
+
+// ── Initial Virtuoso startReached cannot cascade a full first page ──────────
+{
+  const harness = await createTranscriptHarness({ viewportHeight: 200, rowHeight: 100 });
+  try {
+    let loads = 0;
+    await harness.render(historyTurns(1, 120), {
+      running: false,
+      questionNavigator: true,
+      hasOlderHistory: true,
+      historyStartTurn: 1,
+      historyTotalTurns: 120,
       onLoadOlderHistory: async () => {
         loads += 1;
         return true;
       },
     });
-    await harness.waitFor(() => loads > 0, "the final missing history turn to auto-load");
-    ok(harness.container.querySelectorAll(".jump-item").length === 61, "the first page renders a marker for every session question");
-    ok(!harness.container.querySelector(".transcript__older"), "the ordinary show-earlier fold button is absent");
+    await harness.settle();
+    ok(loads === 0, "mounting a scrollable 120-turn page requests no older history without user intent");
   } finally {
     await harness.unmount();
     await harness.close();

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -1,6 +1,7 @@
 // Run: tsx src/__tests__/use-controller-meta.test.ts
 
-import { currentTurnWaitMs, effortSwitchNoticeText, foregroundRunningFromRuntimeMeta, historyMessagesToItems, initialState, localizedBackendNoticeText, localizedNoticeText, metaFromTab, modelSwitchNoticeText, reducer, sameMeta, type Item } from "../lib/useController";
+import { currentTurnWaitMs, foregroundRunningFromRuntimeMeta, historyMessagesToItems, initialState, localizedBackendNoticeText, localizedNoticeText, metaFromTab, reducer, sameMeta, type Item } from "../lib/useController";
+import { effortSwitchNoticeText, modelSwitchNoticeText } from "../lib/controllerSwitchNotices";
 import { historyPageRequestBudget, historyTurnsToLoad } from "../lib/historyPaging";
 import { shouldReconcileStaleTurn } from "../lib/useStaleTurnWatchdog";
 import { parseTodos } from "../lib/tools";

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type TouchEvent as ReactTouchEvent, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type WheelEvent as ReactWheelEvent } from "react";
 import { Virtuoso, type ListItem } from "react-virtuoso";
-import type { ControllerLiveStore, Item, LiveStream } from "../lib/useController";
+import type { ControllerLiveStore, HistoryLoadTrigger, HistoryMutation, Item, LiveStream } from "../lib/useController";
 import type { CheckpointMeta, WireCompletionSummary } from "../lib/types";
 import type { InvocationMetadataMap } from "../lib/invocationDisplay";
 import { useT } from "../lib/i18n";
@@ -60,6 +60,7 @@ import { TranscriptLayoutIntentProvider, TranscriptScrollWriteProvider } from ".
 import { MarkdownImageTabContext } from "./MarkdownImageContext";
 import { recordTranscriptScrollDiagnostic } from "../lib/transcriptScrollProbe";
 import { recordFrontendDiagnostic } from "../lib/frontendDiagnosticBridge";
+import { advanceSurfacePaintCommit, type SurfacePaintProgress } from "../lib/navigationSurfaceTransition";
 import { useTranscriptQuestionJump, useTranscriptQuestions } from "../lib/useTranscriptQuestionNavigation";
 import {
   LiveAssistantMessage,
@@ -129,6 +130,9 @@ export function Transcript({
   turnStartAt,
   contentRevision = 0,
   invocationMetadata = EMPTY_INVOCATION_METADATA,
+  historyMutation,
+  surfaceCommitToken,
+  onSurfacePaintReady,
 }: {
   items: Item[];
   live?: LiveStream;
@@ -160,10 +164,13 @@ export function Transcript({
   historyTotalTurns?: number;
   loadingOlderHistory?: boolean;
   olderHistoryError?: string;
-  onLoadOlderHistory?: (targetTurn?: number) => boolean | Promise<boolean>;
+  onLoadOlderHistory?: (targetTurn?: number, trigger?: HistoryLoadTrigger) => boolean | Promise<boolean>;
   turnStartAt?: number;
   contentRevision?: number;
   invocationMetadata?: InvocationMetadataMap;
+  historyMutation?: HistoryMutation;
+  surfaceCommitToken?: string;
+  onSurfacePaintReady?: (token: string, outcome: "ready" | "degraded") => void;
 }) {
   const t = useT();
   const subscribeLive = useCallback(
@@ -177,6 +184,11 @@ export function Transcript({
   const live = useSyncExternalStore(subscribeLive, getLiveSnapshot, getLiveSnapshot);
   const layoutSurfaceKey = `${tabId ?? ""}:${revealSignal}`;
   const resolvedGeometrySessionKey = geometrySessionKey || `tab:${tabId ?? "preview"}`;
+  const surfacePaintRenderedTokenRef = useRef<string | null>(null);
+  const surfacePaintTerminalTokenRef = useRef<string | null>(null);
+  const [surfacePaintRenderSeq, setSurfacePaintRenderSeq] = useState(0);
+  const [surfacePaintReadySurfaceKey, setSurfacePaintReadySurfaceKey] = useState<string | null>(null);
+  useEffect(() => setSurfacePaintReadySurfaceKey(null), [layoutSurfaceKey]);
   // Transcript survives tab switches; the bounded LRU therefore survives
   // reveal resets while the Virtuoso view state still resets independently.
   const measuredSizes = useMemo(() => createTranscriptMeasuredSizes(), []);
@@ -507,6 +519,22 @@ export function Transcript({
     cancelStreamingScroll: cancelStreamingAndFollow,
   });
   const clearTranscriptSelection = selectionRetention.clear;
+  const olderHistoryPermitRef = useRef(0);
+  const autoFillPageCountRef = useRef(0);
+  const autoFillInFlightRef = useRef(false);
+  const touchStartYRef = useRef<number | null>(null);
+  useEffect(() => {
+    olderHistoryPermitRef.current = 0;
+    autoFillPageCountRef.current = 0;
+    autoFillInFlightRef.current = false;
+    touchStartYRef.current = null;
+  }, [layoutSurfaceKey]);
+  const grantOlderHistoryPermit = useCallback(() => {
+    // One unconsumed viewport permit prevents a wheel burst from turning one
+    // gesture into a page cascade after each prepend reaches startReached.
+    olderHistoryPermitRef.current = 1;
+    recordFrontendDiagnostic("history", "history.viewport-permit");
+  }, []);
   // User scroll intent is reported to the layout-integrity hook (idle gating
   // for the blank watchdog) and to the scroll arbiter itself, which preempts
   // any in-flight recovery restore on its own intent events (#8657/#8688
@@ -516,27 +544,42 @@ export function Transcript({
     if (accepted) {
       if (SHOW_SCROLL_DIAGNOSTICS) recordTranscriptScrollDiagnostic("wheel", { deltaY: event.deltaY });
       noteUserScrollIntent();
+      if (event.deltaY < 0) grantOlderHistoryPermit();
     }
     return accepted;
-  }, [noteUserScrollIntent, onWheelIntent]);
+  }, [grantOlderHistoryPermit, noteUserScrollIntent, onWheelIntent]);
   const onTouchStartIntentWithRecovery = useCallback((event: ReactTouchEvent<HTMLElement>) => {
+    touchStartYRef.current = event.touches[0]?.clientY ?? null;
     onTouchStartIntent(event);
   }, [onTouchStartIntent]);
   const onTouchMoveIntentWithRecovery = useCallback((event: ReactTouchEvent<HTMLElement>) => {
     const accepted = onTouchMoveIntent(event);
-    if (accepted) noteUserScrollIntent();
+    if (accepted) {
+      noteUserScrollIntent();
+      const currentY = event.touches[0]?.clientY;
+      if (currentY !== undefined && touchStartYRef.current !== null && currentY > touchStartYRef.current) {
+        grantOlderHistoryPermit();
+      }
+      if (currentY !== undefined) touchStartYRef.current = currentY;
+    }
     return accepted;
-  }, [noteUserScrollIntent, onTouchMoveIntent]);
+  }, [grantOlderHistoryPermit, noteUserScrollIntent, onTouchMoveIntent]);
   const onKeyScrollIntentWithRecovery = useCallback((event: ReactKeyboardEvent<HTMLElement>) => {
     const accepted = onKeyScrollIntent(event);
-    if (accepted) noteUserScrollIntent();
+    if (accepted) {
+      noteUserScrollIntent();
+      if (event.key === "ArrowUp" || event.key === "PageUp" || event.key === "Home") grantOlderHistoryPermit();
+    }
     return accepted;
-  }, [noteUserScrollIntent, onKeyScrollIntent]);
+  }, [grantOlderHistoryPermit, noteUserScrollIntent, onKeyScrollIntent]);
   const onPointerDownIntentWithRecovery = useCallback((event: ReactPointerEvent<HTMLElement>) => {
     const accepted = onPointerDownIntent(event);
-    if (accepted) noteUserScrollIntent();
+    if (accepted) {
+      noteUserScrollIntent();
+      grantOlderHistoryPermit();
+    }
     return accepted;
-  }, [noteUserScrollIntent, onPointerDownIntent]);
+  }, [grantOlderHistoryPermit, noteUserScrollIntent, onPointerDownIntent]);
   const scrollInteractions = useTranscriptScrollInteractions({
     scrollElement,
     cancelStreamingScroll: cancelStreamingAutoScroll,
@@ -634,7 +677,6 @@ export function Transcript({
     loadingOlderHistory,
     olderHistoryError,
     running,
-    suppressAutoComplete: hydrating,
     onLoadOlderHistory,
     clearTranscriptSelection,
     invalidateAnchors,
@@ -642,6 +684,43 @@ export function Transcript({
     setActiveQuestion,
     rewindSignal,
   });
+  const handleViewportEarlierHistoryReached = useCallback(() => {
+    if (hydrating || olderHistoryPermitRef.current <= 0) return;
+    olderHistoryPermitRef.current -= 1;
+    void handleEarlierHistoryReached();
+  }, [handleEarlierHistoryReached, hydrating]);
+  useEffect(() => {
+    if (surfacePaintReadySurfaceKey !== layoutSurfaceKey
+      || hydrating || !hasOlderHistory || loadingOlderHistory || olderHistoryError || running || !onLoadOlderHistory) return;
+    let frame: number | null = null;
+    let cancelled = false;
+    let attempts = 0;
+    const probeStableShortSurface = () => {
+      frame = null;
+      if (cancelled) return;
+      attempts += 1;
+      const element = scrollRef.current;
+      if (!element || !virtuosoReadyRef.current || layoutTransientRef.current) {
+        // The initial placement coordinator may stay transient for several
+        // frames while Virtuoso measures the first page. Wait for its real
+        // terminal geometry instead of treating mount/startReached as intent.
+        if (attempts < 180) frame = requestAnimationFrame(probeStableShortSurface);
+        return;
+      }
+      if (hasTranscriptScrollableRange(element)
+        || autoFillInFlightRef.current || autoFillPageCountRef.current >= 3) return;
+      autoFillInFlightRef.current = true;
+      autoFillPageCountRef.current += 1;
+      void Promise.resolve(onLoadOlderHistory(undefined, "auto-fill")).finally(() => {
+        autoFillInFlightRef.current = false;
+      });
+    };
+    frame = requestAnimationFrame(probeStableShortSurface);
+    return () => {
+      cancelled = true;
+      if (frame !== null) cancelAnimationFrame(frame);
+    };
+  }, [hasOlderHistory, historyStartTurn, hydrating, layoutSurfaceKey, loadingOlderHistory, olderHistoryError, onLoadOlderHistory, running, scrollRef, surfacePaintReadySurfaceKey, surfacePaintRenderSeq, virtualRows.length]);
 
   // The jump-bottom click is explicit user intent: it outranks any in-flight
   // recovery anchor restore and ends a stale selection gesture whose
@@ -873,13 +952,75 @@ export function Transcript({
         setHoldingLiveRegion(false);
       }
     }
-  }, [handleRecoveryItemsRendered, holdingLiveRegion, scheduleActiveQuestionSync, selectionRetention.reconcileLogicalFocus, virtualRows.length]);
+    if (rendered.length > 0 && surfaceCommitToken && surfacePaintRenderedTokenRef.current !== surfaceCommitToken) {
+      surfacePaintRenderedTokenRef.current = surfaceCommitToken;
+      setSurfacePaintRenderSeq((value) => value + 1);
+    }
+  }, [handleRecoveryItemsRendered, holdingLiveRegion, layoutSurfaceKey, scheduleActiveQuestionSync, selectionRetention.reconcileLogicalFocus, surfaceCommitToken, virtualRows.length]);
+
+  const prependLayoutTransientRef = useRef(false);
+  useEffect(() => {
+    if (historyMutation?.kind !== "prepend") return;
+    prependLayoutTransientRef.current = true;
+    let frame = requestAnimationFrame(() => {
+      frame = requestAnimationFrame(() => {
+        prependLayoutTransientRef.current = false;
+      });
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      prependLayoutTransientRef.current = false;
+    };
+  }, [historyMutation?.kind, historyMutation?.seq]);
 
   const handleTotalListHeightChanged = useCallback((height: number) => {
     if (SHOW_SCROLL_DIAGNOSTICS) recordTranscriptScrollDiagnostic("list-height", { listHeight: height });
-    if (hydrating) return;
+    if (hydrating || prependLayoutTransientRef.current) return;
     followGrowingTail();
   }, [followGrowingTail, hydrating]);
+
+  useEffect(() => {
+    const token = surfaceCommitToken;
+    if (!token || hydrating || !onSurfacePaintReady || surfacePaintTerminalTokenRef.current === token) return;
+    let frame: number | null = null;
+    let cancelled = false;
+    let progress: SurfacePaintProgress = { attempts: 0, stableFrames: 0 };
+    const emptySurface = virtualRows.length === 0;
+    const finish = (outcome: "ready" | "degraded") => {
+      if (cancelled || surfacePaintTerminalTokenRef.current === token) return;
+      surfacePaintTerminalTokenRef.current = token;
+      recordFrontendDiagnostic("transcript", "transcript.initial-placement-terminal", {
+        intent: Number(/^navigation-(\d+)-/.exec(token)?.[1] ?? 0),
+        outcome,
+      });
+      setSurfacePaintReadySurfaceKey(layoutSurfaceKey);
+      onSurfacePaintReady(token, outcome);
+    };
+    const tick = () => {
+      frame = null;
+      if (cancelled) return;
+      const element = scrollRef.current;
+      const rendered = emptySurface || surfacePaintRenderedTokenRef.current === token;
+      const placementReady = emptySurface
+        ? Boolean(element)
+        : Boolean(element && virtuosoReadyRef.current && !layoutTransientRef.current);
+      const bottomReady = !element ||
+        element.scrollHeight - element.scrollTop - element.clientHeight <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX;
+      const decision = advanceSurfacePaintCommit(progress, { rendered, placementReady, geometryReady: bottomReady });
+      progress = decision.progress;
+      if (decision.outcome) {
+        finish(decision.outcome);
+        return;
+      }
+      if (decision.requestRecovery) scheduleBlankViewportCheck();
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => {
+      cancelled = true;
+      if (frame !== null) cancelAnimationFrame(frame);
+    };
+  }, [hydrating, layoutSurfaceKey, layoutTransientRef, onSurfacePaintReady, scheduleBlankViewportCheck, scrollRef, surfaceCommitToken, surfacePaintRenderSeq, virtualRows.length]);
 
   const virtuosoContext = useMemo<TranscriptVirtuosoContext>(() => ({
     tabId,
@@ -1001,7 +1142,7 @@ export function Transcript({
               : { top: 480, bottom: 480 }}
             scrollerRef={handleScrollerRef}
             itemsRendered={handleItemsRendered}
-            startReached={handleEarlierHistoryReached}
+            startReached={handleViewportEarlierHistoryReached}
             totalListHeightChanged={handleTotalListHeightChanged}
             itemContent={renderVirtuosoRow}
             onScroll={handleTranscriptScroll}

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type TouchEvent as ReactTouchEvent, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type WheelEvent as ReactWheelEvent } from "react";
+import { lazy, Suspense, type CSSProperties, type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { Virtuoso, type ListItem } from "react-virtuoso";
 import type { ControllerLiveStore, HistoryLoadTrigger, HistoryMutation, Item, LiveStream } from "../lib/useController";
 import type { CheckpointMeta, WireCompletionSummary } from "../lib/types";
@@ -60,8 +60,8 @@ import { TranscriptLayoutIntentProvider, TranscriptScrollWriteProvider } from ".
 import { MarkdownImageTabContext } from "./MarkdownImageContext";
 import { recordTranscriptScrollDiagnostic } from "../lib/transcriptScrollProbe";
 import { recordFrontendDiagnostic } from "../lib/frontendDiagnosticBridge";
-import { advanceSurfacePaintCommit, type SurfacePaintProgress } from "../lib/navigationSurfaceTransition";
 import { useTranscriptQuestionJump, useTranscriptQuestions } from "../lib/useTranscriptQuestionNavigation";
+import { useTranscriptHistoryAutoFill, useTranscriptPagingAuthorization, useTranscriptSurfaceCommit } from "../lib/useTranscriptNavigationSurface";
 import {
   LiveAssistantMessage,
   SHOW_SCROLL_DIAGNOSTICS,
@@ -88,14 +88,9 @@ const FrontendDiagnosticsPanel = SHOW_FRONTEND_DIAGNOSTICS
   : null;
 const VIRTUAL_OVERSCAN_ROWS = 8;
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
 function assistantAnswerOnly(item: AssistantItem): AssistantItem {
   return { ...item, reasoning: "", reasoningComplete: true, reasoningDurationMs: undefined };
 }
-
-// ── Transcript component ──────────────────────────────────────────────────────
-
 export function Transcript({
   items,
   live: liveProp,
@@ -138,7 +133,6 @@ export function Transcript({
   live?: LiveStream;
   liveStore?: ControllerLiveStore;
   tabId?: string;
-  /** Stable, memory-only session identity for safe geometry reuse. */
   geometrySessionKey?: string;
   footerHeight?: number;
   onPrompt: (text: string) => void;
@@ -184,11 +178,6 @@ export function Transcript({
   const live = useSyncExternalStore(subscribeLive, getLiveSnapshot, getLiveSnapshot);
   const layoutSurfaceKey = `${tabId ?? ""}:${revealSignal}`;
   const resolvedGeometrySessionKey = geometrySessionKey || `tab:${tabId ?? "preview"}`;
-  const surfacePaintRenderedTokenRef = useRef<string | null>(null);
-  const surfacePaintTerminalTokenRef = useRef<string | null>(null);
-  const [surfacePaintRenderSeq, setSurfacePaintRenderSeq] = useState(0);
-  const [surfacePaintReadySurfaceKey, setSurfacePaintReadySurfaceKey] = useState<string | null>(null);
-  useEffect(() => setSurfacePaintReadySurfaceKey(null), [layoutSurfaceKey]);
   // Transcript survives tab switches; the bounded LRU therefore survives
   // reveal resets while the Virtuoso view state still resets independently.
   const measuredSizes = useMemo(() => createTranscriptMeasuredSizes(), []);
@@ -308,16 +297,12 @@ export function Transcript({
   ] = useTranscriptQuestions(items, historyStartTurn, historyTotalTurns, scrollElement, scrollToBottom);
   const showQuestionNav = questionNavigator && totalQuestions >= QUESTION_NAV_MIN_COUNT;
 
-  // Reset the auto-scroll pin when switching tabs so the new session always
-  // starts at the bottom. Without this, stick.current from the previous tab
-  // persists across React re-renders (Transcript is not keyed by tabId) and
-  // disables auto-scroll when the user had scrolled up in the old tab (#4584).
+  // Transcript is not keyed by tab, so reset the previous tab's pin and open the new session at its tail (#4584).
   useLayoutEffect(() => {
     resetScroll();
     virtuosoReadyRef.current = false;
   }, [resetScroll, revealSignal, tabId]);
 
-  // Row measurement and footer resize share the same coalesced height path.
   useEffect(() => {
     if (hydrating || !virtuosoReadyRef.current || !stick.current) return;
     followGrowingTail();
@@ -519,75 +504,22 @@ export function Transcript({
     cancelStreamingScroll: cancelStreamingAndFollow,
   });
   const clearTranscriptSelection = selectionRetention.clear;
-  const olderHistoryPermitRef = useRef(0);
-  const autoFillPageCountRef = useRef(0);
-  const autoFillInFlightRef = useRef(false);
-  const touchStartYRef = useRef<number | null>(null);
-  useEffect(() => {
-    olderHistoryPermitRef.current = 0;
-    autoFillPageCountRef.current = 0;
-    autoFillInFlightRef.current = false;
-    touchStartYRef.current = null;
-  }, [layoutSurfaceKey]);
-  const grantOlderHistoryPermit = useCallback(() => {
-    // One unconsumed viewport permit prevents a wheel burst from turning one
-    // gesture into a page cascade after each prepend reaches startReached.
-    olderHistoryPermitRef.current = 1;
-    recordFrontendDiagnostic("history", "history.viewport-permit");
-  }, []);
-  // User scroll intent is reported to the layout-integrity hook (idle gating
-  // for the blank watchdog) and to the scroll arbiter itself, which preempts
-  // any in-flight recovery restore on its own intent events (#8657/#8688
-  // follow-up).
-  const onWheelIntentWithRecovery = useCallback((event: ReactWheelEvent<HTMLElement>) => {
-    const accepted = onWheelIntent(event);
-    if (accepted) {
-      if (SHOW_SCROLL_DIAGNOSTICS) recordTranscriptScrollDiagnostic("wheel", { deltaY: event.deltaY });
-      noteUserScrollIntent();
-      if (event.deltaY < 0) grantOlderHistoryPermit();
-    }
-    return accepted;
-  }, [grantOlderHistoryPermit, noteUserScrollIntent, onWheelIntent]);
-  const onTouchStartIntentWithRecovery = useCallback((event: ReactTouchEvent<HTMLElement>) => {
-    touchStartYRef.current = event.touches[0]?.clientY ?? null;
-    onTouchStartIntent(event);
-  }, [onTouchStartIntent]);
-  const onTouchMoveIntentWithRecovery = useCallback((event: ReactTouchEvent<HTMLElement>) => {
-    const accepted = onTouchMoveIntent(event);
-    if (accepted) {
-      noteUserScrollIntent();
-      const currentY = event.touches[0]?.clientY;
-      if (currentY !== undefined && touchStartYRef.current !== null && currentY > touchStartYRef.current) {
-        grantOlderHistoryPermit();
-      }
-      if (currentY !== undefined) touchStartYRef.current = currentY;
-    }
-    return accepted;
-  }, [grantOlderHistoryPermit, noteUserScrollIntent, onTouchMoveIntent]);
-  const onKeyScrollIntentWithRecovery = useCallback((event: ReactKeyboardEvent<HTMLElement>) => {
-    const accepted = onKeyScrollIntent(event);
-    if (accepted) {
-      noteUserScrollIntent();
-      if (event.key === "ArrowUp" || event.key === "PageUp" || event.key === "Home") grantOlderHistoryPermit();
-    }
-    return accepted;
-  }, [grantOlderHistoryPermit, noteUserScrollIntent, onKeyScrollIntent]);
-  const onPointerDownIntentWithRecovery = useCallback((event: ReactPointerEvent<HTMLElement>) => {
-    const accepted = onPointerDownIntent(event);
-    if (accepted) {
-      noteUserScrollIntent();
-      grantOlderHistoryPermit();
-    }
-    return accepted;
-  }, [grantOlderHistoryPermit, noteUserScrollIntent, onPointerDownIntent]);
+  const { readySurfaceKey: surfacePaintReadySurfaceKey, markItemsRendered: markSurfaceItemsRendered } = useTranscriptSurfaceCommit({
+    token: surfaceCommitToken, hydrating, layoutSurfaceKey, virtualRowCount: virtualRows.length, scrollRef, virtuosoReadyRef,
+    layoutTransientRef, scheduleRecovery: scheduleBlankViewportCheck, onReady: onSurfacePaintReady,
+  });
+  const pagingAuthorization = useTranscriptPagingAuthorization({
+    layoutSurfaceKey, nativeScrollbarDragging, scrollRef, noteUserScrollIntent, onWheelIntent, onWheelAccepted: SHOW_SCROLL_DIAGNOSTICS ? (deltaY) => recordTranscriptScrollDiagnostic("wheel", { deltaY }) : undefined,
+    onTouchStartIntent, onTouchMoveIntent, onKeyScrollIntent, onPointerDownIntent,
+  });
   const scrollInteractions = useTranscriptScrollInteractions({
     scrollElement,
     cancelStreamingScroll: cancelStreamingAutoScroll,
-    onWheelIntent: onWheelIntentWithRecovery,
-    onTouchMoveIntent: onTouchMoveIntentWithRecovery,
+    onWheelIntent: pagingAuthorization.onWheelIntent,
+    onTouchMoveIntent: pagingAuthorization.onTouchMoveIntent,
     onTouchEndIntent,
-    onKeyScrollIntent: onKeyScrollIntentWithRecovery,
-    onPointerDownIntent: onPointerDownIntentWithRecovery,
+    onKeyScrollIntent: pagingAuthorization.onKeyScrollIntent,
+    onPointerDownIntent: pagingAuthorization.onPointerDownIntent,
     onNestedScrollIntent,
     onScrollEnd: finishProgrammaticScroll,
     onSelectionPointerDown: selectionRetention.onPointerDownCapture,
@@ -664,10 +596,11 @@ export function Transcript({
   const handleTranscriptScroll = useCallback(() => {
     deliverScroll();
     noteScrollActivity();
+    pagingAuthorization.noteScrollPosition();
     if (creationMode) handleCreationScroll();
     scheduleActiveQuestionSync();
     scheduleBlankViewportCheck();
-  }, [creationMode, deliverScroll, handleCreationScroll, noteScrollActivity, scheduleActiveQuestionSync, scheduleBlankViewportCheck]);
+  }, [creationMode, deliverScroll, handleCreationScroll, noteScrollActivity, pagingAuthorization, scheduleActiveQuestionSync, scheduleBlankViewportCheck]);
   const [handleJumpToQuestion, handleEarlierHistoryReached, retryOlderHistory] = useTranscriptQuestionJump({
     questions,
     loadedByTurn,
@@ -685,42 +618,14 @@ export function Transcript({
     rewindSignal,
   });
   const handleViewportEarlierHistoryReached = useCallback(() => {
-    if (hydrating || olderHistoryPermitRef.current <= 0) return;
-    olderHistoryPermitRef.current -= 1;
-    void handleEarlierHistoryReached();
-  }, [handleEarlierHistoryReached, hydrating]);
-  useEffect(() => {
-    if (surfacePaintReadySurfaceKey !== layoutSurfaceKey
-      || hydrating || !hasOlderHistory || loadingOlderHistory || olderHistoryError || running || !onLoadOlderHistory) return;
-    let frame: number | null = null;
-    let cancelled = false;
-    let attempts = 0;
-    const probeStableShortSurface = () => {
-      frame = null;
-      if (cancelled) return;
-      attempts += 1;
-      const element = scrollRef.current;
-      if (!element || !virtuosoReadyRef.current || layoutTransientRef.current) {
-        // The initial placement coordinator may stay transient for several
-        // frames while Virtuoso measures the first page. Wait for its real
-        // terminal geometry instead of treating mount/startReached as intent.
-        if (attempts < 180) frame = requestAnimationFrame(probeStableShortSurface);
-        return;
-      }
-      if (hasTranscriptScrollableRange(element)
-        || autoFillInFlightRef.current || autoFillPageCountRef.current >= 3) return;
-      autoFillInFlightRef.current = true;
-      autoFillPageCountRef.current += 1;
-      void Promise.resolve(onLoadOlderHistory(undefined, "auto-fill")).finally(() => {
-        autoFillInFlightRef.current = false;
-      });
-    };
-    frame = requestAnimationFrame(probeStableShortSurface);
-    return () => {
-      cancelled = true;
-      if (frame !== null) cancelAnimationFrame(frame);
-    };
-  }, [hasOlderHistory, historyStartTurn, hydrating, layoutSurfaceKey, loadingOlderHistory, olderHistoryError, onLoadOlderHistory, running, scrollRef, surfacePaintReadySurfaceKey, surfacePaintRenderSeq, virtualRows.length]);
+    if (hydrating || !pagingAuthorization.consume()) return;
+    void Promise.resolve(handleEarlierHistoryReached()).finally(pagingAuthorization.complete);
+  }, [handleEarlierHistoryReached, hydrating, pagingAuthorization]);
+  useTranscriptHistoryAutoFill({
+    readySurfaceKey: surfacePaintReadySurfaceKey, layoutSurfaceKey, hydrating, hasOlderHistory, loadingOlderHistory,
+    olderHistoryError, running, historyStartTurn, virtualRowCount: virtualRows.length, scrollRef, virtuosoReadyRef,
+    layoutTransientRef, onLoadOlderHistory,
+  });
 
   // The jump-bottom click is explicit user intent: it outranks any in-flight
   // recovery anchor restore and ends a stale selection gesture whose
@@ -952,11 +857,8 @@ export function Transcript({
         setHoldingLiveRegion(false);
       }
     }
-    if (rendered.length > 0 && surfaceCommitToken && surfacePaintRenderedTokenRef.current !== surfaceCommitToken) {
-      surfacePaintRenderedTokenRef.current = surfaceCommitToken;
-      setSurfacePaintRenderSeq((value) => value + 1);
-    }
-  }, [handleRecoveryItemsRendered, holdingLiveRegion, layoutSurfaceKey, scheduleActiveQuestionSync, selectionRetention.reconcileLogicalFocus, surfaceCommitToken, virtualRows.length]);
+    markSurfaceItemsRendered(rendered.length);
+  }, [handleRecoveryItemsRendered, holdingLiveRegion, markSurfaceItemsRendered, scheduleActiveQuestionSync, selectionRetention.reconcileLogicalFocus, virtualRows.length]);
 
   const prependLayoutTransientRef = useRef(false);
   useEffect(() => {
@@ -978,49 +880,6 @@ export function Transcript({
     if (hydrating || prependLayoutTransientRef.current) return;
     followGrowingTail();
   }, [followGrowingTail, hydrating]);
-
-  useEffect(() => {
-    const token = surfaceCommitToken;
-    if (!token || hydrating || !onSurfacePaintReady || surfacePaintTerminalTokenRef.current === token) return;
-    let frame: number | null = null;
-    let cancelled = false;
-    let progress: SurfacePaintProgress = { attempts: 0, stableFrames: 0 };
-    const emptySurface = virtualRows.length === 0;
-    const finish = (outcome: "ready" | "degraded") => {
-      if (cancelled || surfacePaintTerminalTokenRef.current === token) return;
-      surfacePaintTerminalTokenRef.current = token;
-      recordFrontendDiagnostic("transcript", "transcript.initial-placement-terminal", {
-        intent: Number(/^navigation-(\d+)-/.exec(token)?.[1] ?? 0),
-        outcome,
-      });
-      setSurfacePaintReadySurfaceKey(layoutSurfaceKey);
-      onSurfacePaintReady(token, outcome);
-    };
-    const tick = () => {
-      frame = null;
-      if (cancelled) return;
-      const element = scrollRef.current;
-      const rendered = emptySurface || surfacePaintRenderedTokenRef.current === token;
-      const placementReady = emptySurface
-        ? Boolean(element)
-        : Boolean(element && virtuosoReadyRef.current && !layoutTransientRef.current);
-      const bottomReady = !element ||
-        element.scrollHeight - element.scrollTop - element.clientHeight <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX;
-      const decision = advanceSurfacePaintCommit(progress, { rendered, placementReady, geometryReady: bottomReady });
-      progress = decision.progress;
-      if (decision.outcome) {
-        finish(decision.outcome);
-        return;
-      }
-      if (decision.requestRecovery) scheduleBlankViewportCheck();
-      frame = requestAnimationFrame(tick);
-    };
-    frame = requestAnimationFrame(tick);
-    return () => {
-      cancelled = true;
-      if (frame !== null) cancelAnimationFrame(frame);
-    };
-  }, [hydrating, layoutSurfaceKey, layoutTransientRef, onSurfacePaintReady, scheduleBlankViewportCheck, scrollRef, surfaceCommitToken, surfacePaintRenderSeq, virtualRows.length]);
 
   const virtuosoContext = useMemo<TranscriptVirtuosoContext>(() => ({
     tabId,
@@ -1147,7 +1006,7 @@ export function Transcript({
             itemContent={renderVirtuosoRow}
             onScroll={handleTranscriptScroll}
             onWheelCapture={scrollInteractions.onWheelCapture}
-            onTouchStartCapture={onTouchStartIntentWithRecovery}
+            onTouchStartCapture={pagingAuthorization.onTouchStartIntent}
             onTouchMoveCapture={scrollInteractions.onTouchMoveCapture}
             onTouchEndCapture={scrollInteractions.onTouchEndCapture}
             onTouchCancelCapture={scrollInteractions.onTouchEndCapture}

--- a/desktop/frontend/src/lib/controllerNotices.ts
+++ b/desktop/frontend/src/lib/controllerNotices.ts
@@ -1,0 +1,151 @@
+import { asArray } from "./array";
+import { t, type DictKey } from "./i18n";
+import type { WireFinalReadiness } from "./types";
+
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return String(err || "");
+}
+
+const noticeCodeKeys: Record<string, DictKey> = {
+  final_readiness: "notice.finalReadiness",
+  empty_final: "notice.emptyFinal",
+  executor_handoff: "notice.executorHandoff",
+  tool_budget: "notice.toolBudget",
+  prompt_queued: "notice.promptQueued",
+  loop_guard: "notice.loopGuard",
+  workspace_lease: "notice.workspaceLease",
+  cancelled_turn_display: "notice.cancelledTurnDisplay",
+  session_recovery_forked: "recovery.noticeSavedCopy",
+  session_recovery_adopted: "recovery.noticeAdopted",
+  session_recovery_adopted_covered: "recovery.noticeAdoptedCovered",
+  session_recovery_depth_cap: "recovery.noticeKeptCurrent",
+  session_shutdown_recovery_forked: "recovery.noticeSavedCopy",
+  decision_receipt: "notice.decisionReceiptTitle",
+  context_editing_fallback: "notice.contextEditingFallback",
+};
+
+export function localizedNoticeText(text: string, code?: string): string {
+  if (code === "unapplied_steer") {
+    const separator = text.indexOf("\n");
+    const guidance = separator >= 0 ? text.slice(separator + 1) : text;
+    return t("notice.unappliedSteer", { guidance });
+  }
+  const key = code ? noticeCodeKeys[code] : undefined;
+  return key ? t(key) : localizedBackendNoticeText(text);
+}
+
+const deliveryRequirementKeys: Record<string, DictKey> = {
+  project_check: "notice.deliveryRequirementProjectCheck",
+  todo: "notice.deliveryRequirementTodo",
+  criteria: "notice.deliveryRequirementCriteria",
+  verification: "notice.deliveryRequirementVerification",
+  review: "notice.deliveryRequirementReview",
+  signoff: "notice.deliveryRequirementSignoff",
+  action: "notice.deliveryRequirementAction",
+  mutation: "notice.deliveryRequirementMutation",
+  task: "notice.deliveryRequirementTask",
+  capability: "notice.deliveryRequirementCapability",
+};
+
+export function readinessMissingIds(readiness: WireFinalReadiness | undefined): string[] {
+  return asArray(readiness?.missing).map((id) => String(id));
+}
+
+export function deliveryReadinessDetail(readiness: WireFinalReadiness | undefined, fallback = ""): string {
+  const labels = asArray(readiness?.missing)
+    .map((id) => deliveryRequirementKeys[id])
+    .filter((key): key is DictKey => Boolean(key))
+    .map((key) => t(key));
+  return labels.length === 0
+    ? fallback
+    : t("notice.deliveryIncompleteMissing", { items: labels.join(t("notice.deliveryRequirementSeparator")) });
+}
+
+function localizedSessionAction(action: string): string {
+  switch (action.trim()) {
+    case "changing model": return t("status.actionChangingModel");
+    case "changing effort": return t("status.actionChangingEffort");
+    case "rebuilding settings": return t("status.actionRebuildingSettings");
+    case "switching sessions": return t("status.actionSwitchingSessions");
+    case "switching tabs": return t("status.actionSwitchingTabs");
+    case "autosave": return t("status.actionAutosave");
+    default: return action.trim() || t("status.actionCurrentSession");
+  }
+}
+
+function backendNoticeKey(msg: string): DictKey | "" {
+  switch (msg) {
+    case "Task status needs one more check; asking the assistant to finish or explain what is blocking it.": return "notice.finalReadiness";
+    case "No visible answer was produced; asking the assistant to respond again.": return "notice.emptyFinal";
+    case "The assistant answered before taking action; asking it to use the required tools.": return "notice.executorHandoff";
+    case "Tool round limit reached; asking the assistant to summarize progress.": return "notice.toolBudget";
+    case "The assistant is stuck retrying a blocked action; asking it to change approach.": return "notice.loopGuard";
+    case "Context is getting large; preserving cache until cleanup is needed.": return "notice.contextLarge";
+    case "Context cleanup skipped for now.": return "notice.contextCleanupSkipped";
+    case "Automatic context cleanup paused because the context window is too small.": return "notice.contextCleanupPaused";
+    case "Context was compacted without a generated summary.": return "notice.compactionNoSummary";
+    case "Goal is not ready to complete yet; continuing the remaining work.": return "notice.goalNotReady";
+    case "Goal still has unfinished task state; continuing the remaining work.": return "notice.goalUnfinished";
+    case "Job artifact migration failed.": return "notice.jobArtifactMigrationFailed";
+    case "Background job teardown timed out.": return "notice.jobTeardownTimeout";
+    case "Some plan-mode tool settings were ignored.": return "notice.planModeToolSettingsIgnored";
+    case "Some plan-mode command settings were ignored.": return "notice.planModeCommandSettingsIgnored";
+    case "Config migration did not complete.": return "notice.configMigrationIncomplete";
+    case "Selected model is missing its API key.": return "notice.modelMissingApiKey";
+    case "An MCP server failed to start.": return "notice.mcpServerFailed";
+    case "Some MCP servers failed to start; run /mcp for details.": return "notice.mcpServersFailed";
+    case "Guardian was disabled because its model was not found.": return "notice.guardianModelMissing";
+    case "Guardian was disabled because it could not start.": return "notice.guardianStartFailed";
+    default: return "";
+  }
+}
+
+export function localizedBackendNoticeText(text: string): string {
+  const msg = text.trim();
+  const autosave = /^Session autosave failed: (.+)$/s.exec(msg);
+  if (autosave) return t("status.sessionAutosaveFailed", { err: autosave[1] });
+  const saveBefore = /^Session save failed before (.+?): (.+)$/s.exec(msg);
+  if (saveBefore) return t("status.sessionSaveFailedBefore", { action: localizedSessionAction(saveBefore[1]), err: saveBefore[2] });
+  const modelFallback = /^model (.+) is no longer available; switched to (.+)$/s.exec(msg);
+  if (modelFallback) return t("status.modelFallbackSwitched", { model: modelFallback[1], fallback: modelFallback[2] });
+  const backgroundJob = /^background (.+) failed: needs attention$/s.exec(msg);
+  if (backgroundJob) return t("notice.backgroundJobFailed", { kind: backgroundJob[1] });
+  const canonical = backendNoticeKey(msg);
+  if (canonical) return t(canonical);
+  if (/^session changed on disk; unsaved local transcript was saved as a conflict copy$/i.test(msg) || /^session changed on disk; unsaved local transcript was saved as recovery branch\b/i.test(msg)) return t("recovery.noticeSavedCopy");
+  if (/^repeated save conflicts were detected; saved the current conflict copy in place$/i.test(msg) || /^repeated save conflicts were detected; saved the current conflict copy in an isolated recovery branch$/i.test(msg) || /^session conflicts kept recurring; kept the transcript on the current recovery branch$/i.test(msg)) return t("recovery.noticeKeptCurrent");
+  if (/^session changed on disk; adopted the newer transcript \(local changes already covered\)$/i.test(msg)) return t("recovery.noticeAdoptedCovered");
+  if (/^session changed on disk; adopted the newer transcript$/i.test(msg)) return t("recovery.noticeAdopted");
+  return msg;
+}
+
+function recoveryNoticeDedupeKey(text: string, code?: string): string {
+  switch (code) {
+    case "session_recovery_forked":
+    case "session_shutdown_recovery_forked": return "recovery:saved-copy";
+    case "session_recovery_depth_cap": return "recovery:kept-current";
+    case "session_recovery_adopted_covered": return "recovery:adopted-covered";
+    case "session_recovery_adopted": return "recovery:adopted";
+  }
+  const msg = text.trim();
+  if (/^session changed on disk; unsaved local transcript was saved as a conflict copy$/i.test(msg) || /^session changed on disk; unsaved local transcript was saved as recovery branch\b/i.test(msg) || msg === t("recovery.noticeSavedCopy")) return "recovery:saved-copy";
+  if (/^repeated save conflicts were detected; saved the current conflict copy in place$/i.test(msg) || /^repeated save conflicts were detected; saved the current conflict copy in an isolated recovery branch$/i.test(msg) || /^session conflicts kept recurring; kept the transcript on the current recovery branch$/i.test(msg) || msg === t("recovery.noticeKeptCurrent")) return "recovery:kept-current";
+  if (/^session changed on disk; adopted the newer transcript \(local changes already covered\)$/i.test(msg) || msg === t("recovery.noticeAdoptedCovered")) return "recovery:adopted-covered";
+  if (/^session changed on disk; adopted the newer transcript$/i.test(msg) || msg === t("recovery.noticeAdopted")) return "recovery:adopted";
+  return "";
+}
+
+export function quietTranscriptNoticeKey(text: string, code?: string): string {
+  const recovery = recoveryNoticeDedupeKey(text, code);
+  if (recovery) return recovery;
+  const msg = text.trim();
+  if (/^guardian enabled · model=.+$/i.test(msg)) return "startup:guardian-enabled";
+  if (/^\d+ MCP server\(s\) failed to start: .+ \u2014 run \/mcp for details$/i.test(msg)) return "startup:mcp-failures";
+  const directMCPFailure = /^mcp\s+([A-Za-z0-9._-]+):\s+.+$/i.exec(msg);
+  if (directMCPFailure && !["add", "auth", "config", "connect", "import", "mode", "remove"].includes(directMCPFailure[1].toLowerCase())) return "startup:mcp-failure";
+  if (/^plugin ".+" has been slow \d+ startups in a row \(last \d+ms, budget \d+ms\); demoting to background startup this session$/i.test(msg)) return "startup:plugin-demote";
+  if (/^.+ applied: session refreshed after the lease was released$/i.test(msg)) return "settings:deferred-refresh-applied";
+  return "";
+}

--- a/desktop/frontend/src/lib/controllerSwitchNotices.ts
+++ b/desktop/frontend/src/lib/controllerSwitchNotices.ts
@@ -1,0 +1,97 @@
+import { t, type DictKey } from "./i18n";
+import { errorMessage } from "./controllerNotices";
+import type { MessageActionScope } from "./useController";
+import { app } from "./bridge";
+import type { TabMeta } from "./types";
+
+export async function restoreNavigationBackend(sourceTabId: string, targetTabId: string, sourceTab?: TabMeta): Promise<{
+  restoredTabId: string;
+  restoredMeta?: TabMeta;
+} | null> {
+  if (sourceTabId !== targetTabId && await app.SetActiveTab(sourceTabId).then(() => true).catch(() => false)) {
+    return { restoredTabId: sourceTabId };
+  }
+  if (!sourceTab?.topicId) return null;
+  try {
+    const restoredMeta = sourceTab.sessionPath
+      ? await app.OpenTopicSession(sourceTab.scope, sourceTab.workspaceRoot, sourceTab.topicId, sourceTab.sessionPath)
+      : await app.ActivateTopic(sourceTab.scope, sourceTab.workspaceRoot, sourceTab.topicId, "");
+    return { restoredTabId: restoredMeta.id, restoredMeta };
+  } catch {
+    return null;
+  }
+}
+
+export function messageActionBusyText(scope: MessageActionScope): string {
+  switch (scope) {
+    case "fork": return t("rewind.busyFork");
+    case "summ-from": return t("rewind.busySummFrom");
+    case "summ-upto": return t("rewind.busySummUpto");
+    case "conversation": return t("rewind.busyConversation");
+    case "code": return t("rewind.busyCode");
+    default: return t("rewind.busyBoth");
+  }
+}
+
+type SettingNoticeKeys = {
+  busy: DictKey;
+  busyRunning: DictKey;
+  busyPrompt: DictKey;
+  busyJobs: DictKey;
+  leaseHeld: DictKey;
+  starting: DictKey;
+  startupFailed: DictKey;
+  retry: DictKey;
+  failed: DictKey;
+};
+
+function settingSwitchNoticeText(err: unknown, setting: "effort" | "model" | "token mode", keys: SettingNoticeKeys): string {
+  const msg = errorMessage(err).trim() || "unknown error";
+  const lower = msg.toLowerCase();
+  if (lower.includes("finish or cancel") && lower.includes(`before changing ${setting}`)) {
+    const detail = /running=(true|false);\s*pending_prompt=(true|false);\s*background_jobs=(\d+)/i.exec(msg);
+    if (detail?.[2] === "true") return t(keys.busyPrompt);
+    if (detail?.[1] === "true") return t(keys.busyRunning);
+    const jobs = Number(detail?.[3] ?? 0);
+    if (jobs > 0) return t(keys.busyJobs, { n: jobs });
+    return t(keys.busy);
+  }
+  if (lower.includes("already open in another reasonix window") || lower.includes("session lease held")) return t(keys.leaseHeld);
+  if (lower.includes("workspace is still starting")) return t(keys.starting);
+  if (lower.startsWith("workspace failed to start")) return t(keys.startupFailed, { err: msg });
+  if (lower.includes(`changed while switching ${setting}`) || (lower.includes("tab ") && lower.includes("not found"))) return t(keys.retry);
+  return t(keys.failed, { err: msg });
+}
+
+export function effortSwitchNoticeText(err: unknown): string {
+  return settingSwitchNoticeText(err, "effort", {
+    busy: "status.effortSwitchBusy",
+    busyRunning: "status.effortSwitchBusyRunning",
+    busyPrompt: "status.effortSwitchBusyPrompt",
+    busyJobs: "status.effortSwitchBusyJobs",
+    leaseHeld: "status.effortSwitchLeaseHeld",
+    starting: "status.effortSwitchStarting",
+    startupFailed: "status.effortSwitchStartupFailed",
+    retry: "status.effortSwitchRetry",
+    failed: "status.effortSwitchFailed",
+  });
+}
+
+export function modelSwitchNoticeText(err: unknown): string {
+  const msg = errorMessage(err).trim() || "unknown error";
+  const unknownModel = /^unknown model (.+)$/i.exec(msg);
+  if (unknownModel) return t("status.modelSwitchUnknown", { model: unknownModel[1] });
+  const unavailable = /^model (.+) is not available because provider (.+) is not added$/i.exec(msg);
+  if (unavailable) return t("status.modelSwitchProviderUnavailable", { model: unavailable[1], provider: unavailable[2] });
+  return settingSwitchNoticeText(msg, "model", {
+    busy: "status.modelSwitchBusy",
+    busyRunning: "status.modelSwitchBusyRunning",
+    busyPrompt: "status.modelSwitchBusyPrompt",
+    busyJobs: "status.modelSwitchBusyJobs",
+    leaseHeld: "status.modelSwitchLeaseHeld",
+    starting: "status.modelSwitchStarting",
+    startupFailed: "status.modelSwitchStartupFailed",
+    retry: "status.modelSwitchRetry",
+    failed: "status.modelSwitchFailed",
+  });
+}

--- a/desktop/frontend/src/lib/frontendDiagnostics.ts
+++ b/desktop/frontend/src/lib/frontendDiagnostics.ts
@@ -212,7 +212,8 @@ export function analyzeFrontendDiagnosticAnomalies(events: readonly FrontendDiag
       navigation.set(event.intent, { counts: new Set(), rows: [] });
     }
     if (event.type === "navigation.paint-ready" && event.intent !== undefined) painted.add(event.intent);
-    if (event.type === "navigation.settle" && event.intent !== undefined && !painted.has(event.intent)) {
+    if (event.type === "navigation.settle" && event.intent !== undefined && event.outcome !== "failed" &&
+      event.outcome !== "cancelled" && event.outcome !== "superseded" && !painted.has(event.intent)) {
       anomalies.push({ code: "settle-before-paint-ready", intent: event.intent });
     }
     if (event.type === "history.older-request" && event.trigger === "viewport-user") {

--- a/desktop/frontend/src/lib/frontendDiagnostics.ts
+++ b/desktop/frontend/src/lib/frontendDiagnostics.ts
@@ -124,11 +124,20 @@ export type FrontendDiagnosticEvent = {
   catalogRebuilding?: boolean;
   directoryState?: string;
   changeReason?: string;
+  outcome?: string;
+  trigger?: string;
   scope?: string;
   variant?: string;
   timeFilter?: string;
   button?: number;
   modifiers?: number;
+  intent?: number;
+};
+
+export type FrontendDiagnosticAnomaly = {
+  code: "settle-before-paint-ready" | "viewport-older-without-user-input" | "navigation-session-count-changed" | "unknown-scroll-writer" | "target-empty-sequence";
+  intent?: number;
+  count?: number;
 };
 
 export type FrontendDiagnosticEnvironment = {
@@ -151,6 +160,7 @@ export type FrontendDiagnosticPayload = {
     eventCount: number;
     droppedEventCount: number;
     markerCount: number;
+    anomalies: FrontendDiagnosticAnomaly[];
   };
   events: FrontendDiagnosticEvent[];
 };
@@ -172,7 +182,7 @@ type EventTargetListener = { target: EventTarget; type: string; listener: EventL
 const NUMBER_FIELDS = [
   "width", "height", "x", "y", "deltaX", "deltaY", "targetTop", "listHeight", "durationMs", "scrollTop", "scrollHeight",
   "clientHeight", "bottomDistance", "mountedRows", "totalRows", "firstVisibleIndex", "firstVisibleTop",
-  "rowIndex", "estimatedSize", "previousSize", "measuredSize", "sizeDelta", "relativeError", "disclosureCount", "contentRevision", "tabCount", "patchCount", "button", "modifiers",
+  "rowIndex", "estimatedSize", "previousSize", "measuredSize", "sizeDelta", "relativeError", "disclosureCount", "contentRevision", "tabCount", "patchCount", "button", "modifiers", "intent",
   "workspaceSessions", "visibleSessions", "hiddenSessions", "hiddenByFilter", "hiddenByCollapsed", "hiddenByTruncation", "runtimeSessions", "runtimeOnlySessions", "recoveryOnlySessions", "recoveryCopySessions", "recoveryCopies", "runningSessions", "unreadSessions", "pinnedSessions", "activeSessions", "activeVisibleSessions", "folderCount", "expandedFolders", "showAllFolders", "catalogRevision", "catalogIndexed", "catalogTotal", "repairPending", "treeRevision", "organizationRevision", "unloadedSessions", "deltaWorkspaceSessions", "deltaVisibleSessions", "deltaHiddenSessions", "deltaRecoveryCopies", "deltaRuntimeOnlySessions",
 ] as const;
 const BOOLEAN_FIELDS = [
@@ -182,8 +192,60 @@ const BOOLEAN_FIELDS = [
 const STRING_FIELDS = [
   "source", "eventSource", "action", "target", "targetRole", "targetTag", "keyClass", "pointerType", "inputType", "visibility", "phase",
   "reason", "status", "mode", "previousMode", "owner", "writeKind", "rowKind", "layoutVersion", "layoutVariant", "estimateSource", "foldState", "state", "errorName", "errorCode",
-  "directoryState", "changeReason", "scope", "variant", "timeFilter",
+  "directoryState", "changeReason", "outcome", "trigger", "scope", "variant", "timeFilter",
 ] as const;
+
+export function analyzeFrontendDiagnosticAnomalies(events: readonly FrontendDiagnosticEvent[]): FrontendDiagnosticAnomaly[] {
+  const anomalies: FrontendDiagnosticAnomaly[] = [];
+  const painted = new Set<number>();
+  const navigation = new Map<number, { sessionCount?: number; counts: Set<number>; rows: number[] }>();
+  const knownScrollWriters = new Set([
+    "tail-follow", "recovery", "reader-stability", "jump", "rewind", "jump-bottom", "custom-scrollbar",
+    "selection-edge-scroll", "anchor-compensation", "block-window-prepend",
+  ]);
+  let viewportPermit = 0;
+  let unknownWriters = 0;
+  let unpermittedOlder = 0;
+  for (const event of events) {
+    if (event.type === "history.viewport-permit") viewportPermit = 1;
+    if (event.type === "navigation.begin" && event.intent !== undefined) {
+      navigation.set(event.intent, { counts: new Set(), rows: [] });
+    }
+    if (event.type === "navigation.paint-ready" && event.intent !== undefined) painted.add(event.intent);
+    if (event.type === "navigation.settle" && event.intent !== undefined && !painted.has(event.intent)) {
+      anomalies.push({ code: "settle-before-paint-ready", intent: event.intent });
+    }
+    if (event.type === "history.older-request" && event.trigger === "viewport-user") {
+      if (viewportPermit > 0) viewportPermit -= 1;
+      else unpermittedOlder += 1;
+    }
+    if (event.type === "transcript.scroll-write" && event.owner && !knownScrollWriters.has(event.owner)) unknownWriters += 1;
+    for (const [intent, state] of navigation) {
+      if (painted.has(intent)) continue;
+      if (event.workspaceSessions !== undefined) state.counts.add(event.workspaceSessions);
+      if (event.type === "transcript.surface" && event.totalRows !== undefined) state.rows.push(event.totalRows);
+    }
+  }
+  for (const [intent, state] of navigation) {
+    if (state.counts.size > 1) anomalies.push({ code: "navigation-session-count-changed", intent, count: state.counts.size });
+    const sequence = state.rows;
+    let sawEmpty = false;
+    let sawNonEmptyAfterEmpty = false;
+    let exposed = false;
+    for (const rows of sequence) {
+      if (rows === 0) {
+        if (sawNonEmptyAfterEmpty) exposed = true;
+        sawEmpty = true;
+      } else if (sawEmpty) {
+        sawNonEmptyAfterEmpty = true;
+      }
+    }
+    if (exposed) anomalies.push({ code: "target-empty-sequence", intent });
+  }
+  if (unpermittedOlder > 0) anomalies.push({ code: "viewport-older-without-user-input", count: unpermittedOlder });
+  if (unknownWriters > 0) anomalies.push({ code: "unknown-scroll-writer", count: unknownWriters });
+  return anomalies;
+}
 
 function finiteNumber(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
@@ -440,7 +502,13 @@ export function createFrontendDiagnostics(options: {
     return {
       schemaVersion: FRONTEND_DIAGNOSTIC_SCHEMA_VERSION,
       manifest: { ...manifest, reportId, createdAt },
-      summary: { durationMs: Math.max(0, Math.round(stoppedAt - startedAt)), eventCount: events.length, droppedEventCount, markerCount },
+      summary: {
+        durationMs: Math.max(0, Math.round(stoppedAt - startedAt)),
+        eventCount: events.length,
+        droppedEventCount,
+        markerCount,
+        anomalies: analyzeFrontendDiagnosticAnomalies(events),
+      },
       events: events.map((event) => ({ ...event })),
     };
   };

--- a/desktop/frontend/src/lib/navigationSurfaceTransition.ts
+++ b/desktop/frontend/src/lib/navigationSurfaceTransition.ts
@@ -1,4 +1,77 @@
+export type SurfaceDataOutcome = "ready" | "failed" | "cancelled" | "superseded";
+
+export type SurfaceDataCommit = {
+  intent: number;
+  outcome: SurfaceDataOutcome;
+  tabId?: string;
+  surfaceKey?: string;
+  error?: string;
+};
+
+export type NavigationResult<T> = {
+  value: T;
+  surfaceReady: Promise<SurfaceDataCommit>;
+};
+
+export type NavigationSurfaceState = null | {
+  intent: number;
+  phase: "source-retained" | "target-masked";
+  targetTabId?: string;
+  targetSurfaceKey?: string;
+};
+
+export type SurfacePaintProgress = { attempts: number; stableFrames: number };
+export type SurfacePaintDecision = {
+  progress: SurfacePaintProgress;
+  outcome?: "ready" | "degraded";
+  requestRecovery: boolean;
+};
+
+/** Deterministic paint gate shared by Transcript and its fake-clock tests. */
+export function advanceSurfacePaintCommit(
+  current: SurfacePaintProgress,
+  sample: { rendered: boolean; placementReady: boolean; geometryReady: boolean },
+): SurfacePaintDecision {
+  const attempts = current.attempts + 1;
+  const stableFrames = sample.rendered && sample.placementReady && sample.geometryReady
+    ? current.stableFrames + 1
+    : 0;
+  if (stableFrames >= 2) {
+    return { progress: { attempts, stableFrames }, outcome: "ready", requestRecovery: false };
+  }
+  if (attempts >= 180) {
+    return { progress: { attempts, stableFrames }, outcome: "degraded", requestRecovery: false };
+  }
+  return {
+    progress: { attempts, stableFrames },
+    requestRecovery: attempts === 60 || attempts === 120,
+  };
+}
+
 export type NavigationSurfaceIntent = number | null;
+
+export function beginNavigationSurfaceState(intent: number): NavigationSurfaceState {
+  return { intent, phase: "source-retained" };
+}
+
+/** The Wails/navigation call returned; target data may still be hydrating. */
+export function markNavigationTargetMasked(
+  current: NavigationSurfaceState,
+  intent: number,
+  targetTabId?: string,
+  targetSurfaceKey?: string,
+): NavigationSurfaceState {
+  if (current?.intent !== intent) return current;
+  return { ...current, phase: "target-masked", targetTabId, targetSurfaceKey };
+}
+
+/** Only a target paint terminal may release the opaque surface mask. */
+export function settleNavigationSurfaceState(
+  current: NavigationSurfaceState,
+  completedIntent: number,
+): NavigationSurfaceState {
+  return current?.intent === completedIntent ? null : current;
+}
 
 /** Older completions must never release the latest navigation surface mask. */
 export function settleNavigationSurfaceIntent(

--- a/desktop/frontend/src/lib/navigationSurfaceTransition.ts
+++ b/desktop/frontend/src/lib/navigationSurfaceTransition.ts
@@ -20,7 +20,7 @@ export type NavigationSurfaceState = null | {
   targetSurfaceKey?: string;
 };
 
-export type SurfacePaintProgress = { attempts: number; stableFrames: number };
+export type SurfacePaintProgress = { attempts: number; stableFrames: number; geometryKey?: string };
 export type SurfacePaintDecision = {
   progress: SurfacePaintProgress;
   outcome?: "ready" | "degraded";
@@ -30,20 +30,22 @@ export type SurfacePaintDecision = {
 /** Deterministic paint gate shared by Transcript and its fake-clock tests. */
 export function advanceSurfacePaintCommit(
   current: SurfacePaintProgress,
-  sample: { rendered: boolean; placementReady: boolean; geometryReady: boolean },
+  sample: { rendered: boolean; placementReady: boolean; geometryReady: boolean; geometryKey?: string },
 ): SurfacePaintDecision {
   const attempts = current.attempts + 1;
-  const stableFrames = sample.rendered && sample.placementReady && sample.geometryReady
-    ? current.stableFrames + 1
+  const ready = sample.rendered && sample.placementReady && sample.geometryReady && Boolean(sample.geometryKey);
+  const stableFrames = ready
+    ? (current.geometryKey === sample.geometryKey ? current.stableFrames + 1 : 1)
     : 0;
+  const geometryKey = ready ? sample.geometryKey : undefined;
   if (stableFrames >= 2) {
-    return { progress: { attempts, stableFrames }, outcome: "ready", requestRecovery: false };
+    return { progress: { attempts, stableFrames, geometryKey }, outcome: "ready", requestRecovery: false };
   }
   if (attempts >= 180) {
-    return { progress: { attempts, stableFrames }, outcome: "degraded", requestRecovery: false };
+    return { progress: { attempts, stableFrames, geometryKey }, outcome: "degraded", requestRecovery: false };
   }
   return {
-    progress: { attempts, stableFrames },
+    progress: { attempts, stableFrames, geometryKey },
     requestRecovery: attempts === 60 || attempts === 120,
   };
 }

--- a/desktop/frontend/src/lib/transcriptNativeScrollbar.ts
+++ b/desktop/frontend/src/lib/transcriptNativeScrollbar.ts
@@ -32,10 +32,10 @@ export function measureTranscriptVirtuosoItem(
   freeze: boolean,
 ): number {
   if (freeze) {
-    const transcriptEstimate = Number.parseFloat(element.dataset.transcriptEstimate ?? "");
-    if (Number.isFinite(transcriptEstimate) && transcriptEstimate > 0) return transcriptEstimate;
     const knownSize = Number.parseFloat(element.dataset.knownSize ?? "");
     if (Number.isFinite(knownSize) && knownSize > 0) return knownSize;
+    const transcriptEstimate = Number.parseFloat(element.dataset.transcriptEstimate ?? "");
+    if (Number.isFinite(transcriptEstimate) && transcriptEstimate > 0) return transcriptEstimate;
     const staticEstimate = Number.parseFloat(element.dataset.staticEstimate ?? "");
     if (Number.isFinite(staticEstimate) && staticEstimate > 0) return staticEstimate;
   }

--- a/desktop/frontend/src/lib/transcriptStore.ts
+++ b/desktop/frontend/src/lib/transcriptStore.ts
@@ -39,10 +39,9 @@ import { fileDiffFromWire, summarizeFileDiff } from "./tools";
 import {
   historyToolError,
   isReadOnlyTool,
-  localizedNoticeText,
-  quietTranscriptNoticeKey,
   type Item,
 } from "./useController";
+import { localizedNoticeText, quietTranscriptNoticeKey } from "./controllerNotices";
 import type {
   HistoryContentChunk,
   HistoryContentRef,

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -21,12 +21,20 @@ import { applyLiveSegments, coalesceStreamDeltas, completeLiveReasoning, type St
 import { getTranscriptStore } from "./transcriptStore";
 import { recordFrontendDiagnostic } from "./frontendDiagnosticBridge";
 import { uiPerfTracker } from "./uiPerf";
-import { getLocale, t, type DictKey } from "./i18n";
+import { getLocale, t } from "./i18n";
+import {
+  deliveryReadinessDetail,
+  errorMessage,
+  localizedNoticeText,
+  quietTranscriptNoticeKey,
+  readinessMissingIds,
+} from "./controllerNotices";
 import { applyHydrateErrorState, hydratePlaceholderItems as resolveHydratePlaceholders } from "./hydrateErrorState";
 import { isHostRecoveryGuidance } from "./hostRecoverySteer";
 import { activeTabHydrationPlan, canAdoptUnboundLiveSurface, duplicateLiveItemIds, hasCachedLiveTurn, hasReusableCachedTranscript, hydratedHistoryApplyMode, sameSessionHydrateIdentity, sameSessionPlaceholderItems, shouldPreferResidentHistory, type HydrateSurfacePolicy } from "./hydrateHistoryApply";
 import { hydrateIdentityCurrent } from "./sessionIdentity";
 import { historyPageRequestBudget } from "./historyPaging";
+import type { NavigationResult, SurfaceDataCommit, SurfaceDataOutcome } from "./navigationSurfaceTransition";
 import { sameStringList, sameTodoList } from "./todoVisibility";
 import { resolveSnapshotTurnStartedAt, resolveTurnStartedAt, snapshotPredatesTurnLifecycle } from "./turnTiming";
 import { useStaleTurnWatchdog } from "./useStaleTurnWatchdog";
@@ -63,12 +71,18 @@ import type {
   WireExtensionForm,
   WireExtensionStatus,
   WireExtensionSurface,
-  WireFinalReadiness,
   WireTool,
   WireUsage,
   WireShellExecution,
 } from "./types";
 export { foregroundRunningFromRuntimeMeta } from "./runtimeMeta";
+export {
+  deliveryReadinessDetail,
+  localizedBackendNoticeText,
+  localizedNoticeText,
+  quietTranscriptNoticeKey,
+  readinessMissingIds,
+} from "./controllerNotices";
 export type ToolStatus = "running" | "done" | "error" | "stopped";
 // Reserved ToolProgress channel names for sub-agent progress previews (the Go
 // tracker emits these; ordinary tool progress must never use them).
@@ -213,15 +227,12 @@ export type HistoryMutationKind = "replace" | "prepend" | "append" | "patch";
 export type HistoryMutation = { seq: number; kind: HistoryMutationKind };
 export type HistoryLoadTrigger = "viewport-user" | "question-jump" | "retry" | "auto-fill";
 export type HydrateReason = "switch-tab" | "new-session" | "resume-session" | "open-topic" | "startup" | "rewind";
-type SyncActiveTabOptions = { preserveCachedHistory?: boolean; navigationIntentSeq?: number; surfacePolicy?: HydrateSurfacePolicy };
+type SyncActiveTabOptions = { preserveCachedHistory?: boolean; navigationIntentSeq?: number; surfacePolicy?: HydrateSurfacePolicy; deferHydration?: boolean };
 // A ticketed StartTopicActivation in flight. Only the latest one is tracked:
 // superseded requests get "cancelled" from the backend and are ignored.
 type PendingTopicActivation = {
   requestId: string;
   navigationSeq: number;
-  sourceTabId?: string;
-  sourceTab?: TabMeta;
-  sourceTabPromise?: Promise<TabMeta | undefined>;
   tabId?: string;
   placeholderItems?: Item[];
   surfacePolicy: HydrateSurfacePolicy;
@@ -479,6 +490,13 @@ interface State {
   // Host-local only; never hydrated from history.
   streamAttemptJournal?: StreamAttemptJournal;
 }
+
+type NavigationSourceSnapshot = {
+  tabId?: string;
+  state?: State;
+  tab?: TabMeta;
+  tabPromise?: Promise<TabMeta | undefined>;
+};
 export const initialState: State = {
   items: [],
   running: false,
@@ -2226,118 +2244,6 @@ function getOrCreateState(states: TabStates, tabId: string): State {
   return states.get(tabId)!;
 }
 
-function messageActionBusyText(scope: MessageActionScope): string {
-  switch (scope) {
-    case "fork":
-      return t("rewind.busyFork");
-    case "summ-from":
-      return t("rewind.busySummFrom");
-    case "summ-upto":
-      return t("rewind.busySummUpto");
-    case "conversation":
-      return t("rewind.busyConversation");
-    case "code":
-      return t("rewind.busyCode");
-    default:
-      return t("rewind.busyBoth");
-  }
-}
-
-function errorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  if (typeof err === "string") return err;
-  return String(err || "");
-}
-
-export function effortSwitchNoticeText(err: unknown): string {
-  return settingSwitchNoticeText(err, "effort", {
-    busy: "status.effortSwitchBusy",
-    busyRunning: "status.effortSwitchBusyRunning",
-    busyPrompt: "status.effortSwitchBusyPrompt",
-    busyJobs: "status.effortSwitchBusyJobs",
-    leaseHeld: "status.effortSwitchLeaseHeld",
-    starting: "status.effortSwitchStarting",
-    startupFailed: "status.effortSwitchStartupFailed",
-    retry: "status.effortSwitchRetry",
-    failed: "status.effortSwitchFailed",
-  });
-}
-
-export function modelSwitchNoticeText(err: unknown): string {
-  const msg = errorMessage(err).trim() || "unknown error";
-  const unknownModel = /^unknown model (.+)$/i.exec(msg);
-  if (unknownModel) {
-    return t("status.modelSwitchUnknown", { model: unknownModel[1] });
-  }
-  const unavailable = /^model (.+) is not available because provider (.+) is not added$/i.exec(msg);
-  if (unavailable) {
-    return t("status.modelSwitchProviderUnavailable", { model: unavailable[1], provider: unavailable[2] });
-  }
-  return settingSwitchNoticeText(msg, "model", {
-    busy: "status.modelSwitchBusy",
-    busyRunning: "status.modelSwitchBusyRunning",
-    busyPrompt: "status.modelSwitchBusyPrompt",
-    busyJobs: "status.modelSwitchBusyJobs",
-    leaseHeld: "status.modelSwitchLeaseHeld",
-    starting: "status.modelSwitchStarting",
-    startupFailed: "status.modelSwitchStartupFailed",
-    retry: "status.modelSwitchRetry",
-    failed: "status.modelSwitchFailed",
-  });
-}
-
-// noticeCodeKeys maps the backend's stable notice codes (event.NoticeCode*) to
-// dictionary keys. Codes survive backend copy edits, unlike the exact-text
-// matching in backendNoticeKey, which stays only as the fallback for events
-// and replayed histories that carry no code.
-const noticeCodeKeys: Record<string, DictKey> = {
-  final_readiness: "notice.finalReadiness",
-  empty_final: "notice.emptyFinal",
-  executor_handoff: "notice.executorHandoff",
-  tool_budget: "notice.toolBudget",
-  prompt_queued: "notice.promptQueued",
-  loop_guard: "notice.loopGuard",
-  workspace_lease: "notice.workspaceLease",
-  cancelled_turn_display: "notice.cancelledTurnDisplay",
-  session_recovery_forked: "recovery.noticeSavedCopy",
-  session_recovery_adopted: "recovery.noticeAdopted",
-  session_recovery_adopted_covered: "recovery.noticeAdoptedCovered",
-  session_recovery_depth_cap: "recovery.noticeKeptCurrent",
-  session_shutdown_recovery_forked: "recovery.noticeSavedCopy",
-  decision_receipt: "notice.decisionReceiptTitle",
-  context_editing_fallback: "notice.contextEditingFallback",
-};
-
-// localizedNoticeText localizes a notice's main copy by its stable code first,
-// then falls back to English-text matching for codeless payloads.
-export function localizedNoticeText(text: string, code?: string): string {
-  if (code === "unapplied_steer") {
-    const separator = text.indexOf("\n");
-    const guidance = separator >= 0 ? text.slice(separator + 1) : text;
-    return t("notice.unappliedSteer", { guidance });
-  }
-  const key = code ? noticeCodeKeys[code] : undefined;
-  if (key) return t(key);
-  return localizedBackendNoticeText(text);
-}
-
-const deliveryRequirementKeys: Record<string, DictKey> = {
-  project_check: "notice.deliveryRequirementProjectCheck",
-  todo: "notice.deliveryRequirementTodo",
-  criteria: "notice.deliveryRequirementCriteria",
-  verification: "notice.deliveryRequirementVerification",
-  review: "notice.deliveryRequirementReview",
-  signoff: "notice.deliveryRequirementSignoff",
-  action: "notice.deliveryRequirementAction",
-  mutation: "notice.deliveryRequirementMutation",
-  task: "notice.deliveryRequirementTask",
-  capability: "notice.deliveryRequirementCapability",
-};
-
-export function readinessMissingIds(readiness: WireFinalReadiness | undefined): string[] {
-  return asArray(readiness?.missing).map((id) => String(id));
-}
-
 // A delivery notice whose only gap was unfinished todos becomes stale the
 // moment the list shows every item completed.
 function todoOnlyMissing(missing: string[] | undefined): boolean {
@@ -2353,178 +2259,6 @@ function latestTodosAllComplete(items: Item[]): boolean {
     }
   }
   return false;
-}
-
-export function deliveryReadinessDetail(readiness: WireFinalReadiness | undefined, fallback = ""): string {
-  const labels = asArray(readiness?.missing)
-    .map((id) => deliveryRequirementKeys[id])
-    .filter((key): key is DictKey => Boolean(key))
-    .map((key) => t(key));
-  if (labels.length === 0) return fallback;
-  return t("notice.deliveryIncompleteMissing", { items: labels.join(t("notice.deliveryRequirementSeparator")) });
-}
-
-export function localizedBackendNoticeText(text: string): string {
-  const msg = text.trim();
-  const autosave = /^Session autosave failed: (.+)$/s.exec(msg);
-  if (autosave) {
-    return t("status.sessionAutosaveFailed", { err: autosave[1] });
-  }
-  const saveBefore = /^Session save failed before (.+?): (.+)$/s.exec(msg);
-  if (saveBefore) {
-    return t("status.sessionSaveFailedBefore", { action: localizedSessionAction(saveBefore[1]), err: saveBefore[2] });
-  }
-  const modelFallback = /^model (.+) is no longer available; switched to (.+)$/s.exec(msg);
-  if (modelFallback) {
-    return t("status.modelFallbackSwitched", { model: modelFallback[1], fallback: modelFallback[2] });
-  }
-  const backgroundJob = /^background (.+) failed: needs attention$/s.exec(msg);
-  if (backgroundJob) {
-    return t("notice.backgroundJobFailed", { kind: backgroundJob[1] });
-  }
-  const canonicalNoticeKey = backendNoticeKey(msg);
-  if (canonicalNoticeKey) {
-    return t(canonicalNoticeKey);
-  }
-  if (
-    /^session changed on disk; unsaved local transcript was saved as a conflict copy$/i.test(msg) ||
-    /^session changed on disk; unsaved local transcript was saved as recovery branch\b/i.test(msg)
-  ) {
-    return t("recovery.noticeSavedCopy");
-  }
-  if (
-    /^repeated save conflicts were detected; saved the current conflict copy in place$/i.test(msg) ||
-    /^repeated save conflicts were detected; saved the current conflict copy in an isolated recovery branch$/i.test(msg) ||
-    /^session conflicts kept recurring; kept the transcript on the current recovery branch$/i.test(msg)
-  ) {
-    return t("recovery.noticeKeptCurrent");
-  }
-  if (/^session changed on disk; adopted the newer transcript \(local changes already covered\)$/i.test(msg)) {
-    return t("recovery.noticeAdoptedCovered");
-  }
-  if (/^session changed on disk; adopted the newer transcript$/i.test(msg)) {
-    return t("recovery.noticeAdopted");
-  }
-  return msg;
-}
-
-function backendNoticeKey(msg: string): DictKey | "" {
-  switch (msg) {
-    case "Task status needs one more check; asking the assistant to finish or explain what is blocking it.":
-      return "notice.finalReadiness";
-    case "No visible answer was produced; asking the assistant to respond again.":
-      return "notice.emptyFinal";
-    case "The assistant answered before taking action; asking it to use the required tools.":
-      return "notice.executorHandoff";
-    case "Tool round limit reached; asking the assistant to summarize progress.":
-      return "notice.toolBudget";
-    case "The assistant is stuck retrying a blocked action; asking it to change approach.":
-      return "notice.loopGuard";
-    case "Context is getting large; preserving cache until cleanup is needed.":
-      return "notice.contextLarge";
-    case "Context cleanup skipped for now.":
-      return "notice.contextCleanupSkipped";
-    case "Automatic context cleanup paused because the context window is too small.":
-      return "notice.contextCleanupPaused";
-    case "Context was compacted without a generated summary.":
-      return "notice.compactionNoSummary";
-    case "Goal is not ready to complete yet; continuing the remaining work.":
-      return "notice.goalNotReady";
-    case "Goal still has unfinished task state; continuing the remaining work.":
-      return "notice.goalUnfinished";
-    case "Job artifact migration failed.":
-      return "notice.jobArtifactMigrationFailed";
-    case "Background job teardown timed out.":
-      return "notice.jobTeardownTimeout";
-    case "Some plan-mode tool settings were ignored.":
-      return "notice.planModeToolSettingsIgnored";
-    case "Some plan-mode command settings were ignored.":
-      return "notice.planModeCommandSettingsIgnored";
-    case "Config migration did not complete.":
-      return "notice.configMigrationIncomplete";
-    case "Selected model is missing its API key.":
-      return "notice.modelMissingApiKey";
-    case "An MCP server failed to start.":
-      return "notice.mcpServerFailed";
-    case "Some MCP servers failed to start; run /mcp for details.":
-      return "notice.mcpServersFailed";
-    case "Guardian was disabled because its model was not found.":
-      return "notice.guardianModelMissing";
-    case "Guardian was disabled because it could not start.":
-      return "notice.guardianStartFailed";
-    default:
-      return "";
-  }
-}
-
-function recoveryNoticeDedupeKey(text: string, code?: string): string {
-  switch (code) {
-    case "session_recovery_forked":
-    case "session_shutdown_recovery_forked":
-      return "recovery:saved-copy";
-    case "session_recovery_depth_cap":
-      return "recovery:kept-current";
-    case "session_recovery_adopted_covered":
-      return "recovery:adopted-covered";
-    case "session_recovery_adopted":
-      return "recovery:adopted";
-  }
-  const msg = text.trim();
-  if (
-    /^session changed on disk; unsaved local transcript was saved as a conflict copy$/i.test(msg) ||
-    /^session changed on disk; unsaved local transcript was saved as recovery branch\b/i.test(msg) ||
-    msg === t("recovery.noticeSavedCopy")
-  ) {
-    return "recovery:saved-copy";
-  }
-  if (
-    /^repeated save conflicts were detected; saved the current conflict copy in place$/i.test(msg) ||
-    /^repeated save conflicts were detected; saved the current conflict copy in an isolated recovery branch$/i.test(msg) ||
-    /^session conflicts kept recurring; kept the transcript on the current recovery branch$/i.test(msg) ||
-    msg === t("recovery.noticeKeptCurrent")
-  ) {
-    return "recovery:kept-current";
-  }
-  if (
-    /^session changed on disk; adopted the newer transcript \(local changes already covered\)$/i.test(msg) ||
-    msg === t("recovery.noticeAdoptedCovered")
-  ) {
-    return "recovery:adopted-covered";
-  }
-  if (
-    /^session changed on disk; adopted the newer transcript$/i.test(msg) ||
-    msg === t("recovery.noticeAdopted")
-  ) {
-    return "recovery:adopted";
-  }
-  return "";
-}
-
-export function quietTranscriptNoticeKey(text: string, code?: string): string {
-  const recovery = recoveryNoticeDedupeKey(text, code);
-  if (recovery) return recovery;
-
-  const msg = text.trim();
-  if (/^guardian enabled · model=.+$/i.test(msg)) {
-    return "startup:guardian-enabled";
-  }
-  if (/^\d+ MCP server\(s\) failed to start: .+ \u2014 run \/mcp for details$/i.test(msg)) {
-    return "startup:mcp-failures";
-  }
-  const directMCPFailure = /^mcp\s+([A-Za-z0-9._-]+):\s+.+$/i.exec(msg);
-  if (directMCPFailure) {
-    const name = directMCPFailure[1].toLowerCase();
-    if (!["add", "auth", "config", "connect", "import", "mode", "remove"].includes(name)) {
-      return "startup:mcp-failure";
-    }
-  }
-  if (/^plugin ".+" has been slow \d+ startups in a row \(last \d+ms, budget \d+ms\); demoting to background startup this session$/i.test(msg)) {
-    return "startup:plugin-demote";
-  }
-  if (/^.+ applied: session refreshed after the lease was released$/i.test(msg)) {
-    return "settings:deferred-refresh-applied";
-  }
-  return "";
 }
 
 function appendNoticeItem(items: Item[], seq: number, id: string, level: "info" | "warn", rawText: string, detail?: string, code?: string, decisionReceipt?: WireDecisionReceipt): { items: Item[]; seq: number } {
@@ -2544,65 +2278,6 @@ function appendNoticeToState(s: State, level: "info" | "warn", text: string, det
   return { ...s, running: s.turnActive ? s.running : false, seq: next.seq, items: next.items };
 }
 
-function localizedSessionAction(action: string): string {
-  switch (action.trim()) {
-    case "changing model":
-      return t("status.actionChangingModel");
-    case "changing effort":
-      return t("status.actionChangingEffort");
-    case "rebuilding settings":
-      return t("status.actionRebuildingSettings");
-    case "switching sessions":
-      return t("status.actionSwitchingSessions");
-    case "switching tabs":
-      return t("status.actionSwitchingTabs");
-    case "autosave":
-      return t("status.actionAutosave");
-    default:
-      return action.trim() || t("status.actionCurrentSession");
-  }
-}
-
-function settingSwitchNoticeText(
-  err: unknown,
-  setting: "effort" | "model" | "token mode",
-  keys: {
-    busy: DictKey;
-    busyRunning: DictKey;
-    busyPrompt: DictKey;
-    busyJobs: DictKey;
-    leaseHeld: DictKey;
-    starting: DictKey;
-    startupFailed: DictKey;
-    retry: DictKey;
-    failed: DictKey;
-  },
-): string {
-  const msg = errorMessage(err).trim() || "unknown error";
-  const lower = msg.toLowerCase();
-  if (lower.includes("finish or cancel") && lower.includes(`before changing ${setting}`)) {
-    const detail = /running=(true|false);\s*pending_prompt=(true|false);\s*background_jobs=(\d+)/i.exec(msg);
-    if (detail?.[2] === "true") return t(keys.busyPrompt);
-    if (detail?.[1] === "true") return t(keys.busyRunning);
-    const jobs = Number(detail?.[3] ?? 0);
-    if (jobs > 0) return t(keys.busyJobs, { n: jobs });
-    return t(keys.busy);
-  }
-  if (lower.includes("already open in another reasonix window") || lower.includes("session lease held")) {
-    return t(keys.leaseHeld);
-  }
-  if (lower.includes("workspace is still starting")) {
-    return t(keys.starting);
-  }
-  if (lower.startsWith("workspace failed to start")) {
-    return t(keys.startupFailed, { err: msg });
-  }
-  if (lower.includes(`changed while switching ${setting}`) || (lower.includes("tab ") && lower.includes("not found"))) {
-    return t(keys.retry);
-  }
-  return t(keys.failed, { err: msg });
-}
-
 export { replayPendingPromptsForActiveTab } from "./promptReplay";
 
 export function useController() {
@@ -2614,7 +2289,7 @@ export function useController() {
   const modelSwitchQueueByTab = useRef(new Map<string, ModelSwitchQueueState>());
   const lastTurnActivityAtByTab = useRef(new Map<string, number>());
   const runtimeEpochByTabRef = useRef(new Map<string, string>());
-  const listedSessionIdentityByTabRef = useRef(new Map<string, { sessionPath?: string; sessionGeneration?: number }>());
+  const listedSessionIdentityByTabRef = useRef(new Map<string, TabMeta>());
   const appliedComposerProfileByTabRef = useRef(new Map<string, string>());
   const composerProfileInFlightByTabRef = useRef(new Map<string, { key: string; promise: Promise<boolean> }>());
   const composerProfileQueueByTabRef = useRef(new Map<string, Promise<void>>());
@@ -2629,6 +2304,7 @@ export function useController() {
   // Invalidates async navigation completions even for ABA switches where the
   // visible tab ID eventually returns to the original value.
   const activeNavigationSeqRef = useRef(0);
+  const navigationSourcesRef = useRef(new Map<number, NavigationSourceSnapshot>());
   // A render-triggering counter so that mutations to a non-active tab's state still
   // cause a re-render when that tab becomes active.
   const [, setVersion] = useState(0);
@@ -2668,7 +2344,24 @@ export function useController() {
   }), []);
   const beginActiveNavigation = useCallback(() => {
     activeNavigationSeqRef.current += 1;
-    return activeNavigationSeqRef.current;
+    const seq = activeNavigationSeqRef.current;
+    const sourceTabId = activeTabIdRef.current;
+    const source: NavigationSourceSnapshot = {
+      tabId: sourceTabId,
+      state: sourceTabId ? statesRef.current.get(sourceTabId) : undefined,
+      tab: sourceTabId ? listedSessionIdentityByTabRef.current.get(sourceTabId) : undefined,
+    };
+    navigationSourcesRef.current.clear();
+    navigationSourcesRef.current.set(seq, source);
+    return seq;
+  }, []);
+  const snapshotNavigationSourceTab = useCallback((navigationSeq: number) => {
+    const source = navigationSourcesRef.current.get(navigationSeq);
+    if (!source?.tabId || source.tab || source.tabPromise) return;
+    source.tabPromise = app.ListTabs()
+      .then((tabs) => asArray(tabs).find((tab) => tab.id === source.tabId))
+      .catch(() => undefined);
+    void source.tabPromise.then((tab) => { source.tab = tab; });
   }, []);
   const isNavigationIntentCurrent = useCallback((seq: number): boolean => {
     return activeNavigationSeqRef.current === seq;
@@ -3170,6 +2863,9 @@ export function useController() {
     const pageBudget = historyPageRequestBudget(state.historyStartTurn, state.historyTotalTurns, targetTurn);
     const requestSeq = (historyOlderSeq.current.get(targetTabId) ?? 0) + 1;
     historyOlderSeq.current.set(targetTabId, requestSeq);
+    recordFrontendDiagnostic("history", "history.older-request", {
+      trigger, intent: activeNavigationSeqRef.current, targeted: targetTurn !== undefined,
+    });
     ensureTranscriptSubscription(targetTabId);
     dispatchTo(targetTabId, { type: "history_older_start" });
     const startedAt = Date.now();
@@ -3312,7 +3008,8 @@ export function useController() {
     if (!reset && hydration.surfacePolicy === "preserve-current") dispatchRuntimeStatusForTab(active.id, active, snapshotAt);
     const load = loadSessionDataForTab(active.id, reset, "startup", hydration.loadOptions);
     if (reset || hydration.surfacePolicy === "replace-surface") dispatchRuntimeStatusForTab(active.id, active, snapshotAt);
-    await load;
+    if (options.deferHydration) void load;
+    else await load;
     return active.id;
   }, [activeTabFromBackend, beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, isNavigationIntentCurrent, loadSessionDataForTab]);
 
@@ -3408,31 +3105,28 @@ export function useController() {
   // Events for superseded requestIds (including their "cancelled") are
   // dropped; agent:ready/agent:event handling is untouched and still covers
   // every non-ticketed flow (rebind, recovery, restore, SetActiveTab).
-  const restoreTopicActivationSource = useCallback(async (pending: PendingTopicActivation, targetTabId: string, error?: string) => {
-    const sourceTabId = pending.sourceTabId;
-    if (!sourceTabId || sourceTabId === targetTabId || !statesRef.current.has(sourceTabId)) return;
-    const sourceState = statesRef.current.get(sourceTabId);
-    if (!sourceState) return;
-    let restoredTabId = sourceTabId;
-    let restoredMeta: TabMeta | undefined;
-    const reboundExisting = await app.SetActiveTab(sourceTabId).then(() => true).catch(() => false);
-    if (!reboundExisting) {
-      const sourceTab = pending.sourceTab ?? await pending.sourceTabPromise;
-      if (!sourceTab?.topicId) return;
-      try {
-        restoredMeta = sourceTab.sessionPath
-          ? await app.OpenTopicSession(sourceTab.scope, sourceTab.workspaceRoot, sourceTab.topicId, sourceTab.sessionPath)
-          : await app.ActivateTopic(sourceTab.scope, sourceTab.workspaceRoot, sourceTab.topicId, "");
-        restoredTabId = restoredMeta.id;
-      } catch {
-        return;
-      }
+  const restoreNavigationSource = useCallback(async (navigationSeq: number, targetTabId: string, error?: string): Promise<boolean> => {
+    const source = navigationSourcesRef.current.get(navigationSeq);
+    const sourceTabId = source?.tabId;
+    const sourceState = source?.state;
+    if (!sourceTabId || !sourceState || !isNavigationIntentCurrent(navigationSeq) || activeTabIdRef.current !== targetTabId) return false;
+    // Keep the failed target masked while the backend source is rebound. If
+    // restoration also fails, backend_activation_done lets App expose the
+    // target's retry surface instead of leaving an infinite navigation mask.
+    dispatchTo(targetTabId, { type: "backend_activation_start" });
+    const sourceTab = source.tab ?? await source.tabPromise;
+    const { restoreNavigationBackend } = await import("./controllerSwitchNotices");
+    const restored = await restoreNavigationBackend(sourceTabId, targetTabId, sourceTab);
+    if (!restored) {
+      if (isNavigationIntentCurrent(navigationSeq) && activeTabIdRef.current === targetTabId) dispatchTo(targetTabId, { type: "backend_activation_done" });
+      return false;
     }
-    if (!isNavigationIntentCurrent(pending.navigationSeq) || activeTabIdRef.current !== targetTabId) {
-      await reassertVisibleTabAfterStaleNavigation("topic.restore-source", restoredTabId);
-      return;
+    const { restoredTabId, restoredMeta } = restored;
+    if (!isNavigationIntentCurrent(navigationSeq) || activeTabIdRef.current !== targetTabId) {
+      await reassertVisibleTabAfterStaleNavigation("navigation.restore-source", restoredTabId);
+      return false;
     }
-    if (restoredMeta && restoredTabId !== sourceTabId) {
+    if (restoredMeta) {
       ensureTranscriptSubscription(restoredTabId);
       statesRef.current.set(restoredTabId, {
         ...sourceState,
@@ -3461,7 +3155,30 @@ export function useController() {
         surfacePolicy: "preserve-current",
       }).then(() => reconcileTabRuntime(restoredTabId, { hydrateSessionData: false })).catch(() => {});
     }
+    navigationSourcesRef.current.delete(navigationSeq);
+    return true;
   }, [confirmBackendActiveTab, dispatchTo, ensureTranscriptSubscription, isNavigationIntentCurrent, loadSessionDataForTab, notifyLiveListeners, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime]);
+
+  const monitorNavigationHydration = useCallback((
+    navigationSeq: number,
+    targetTabId: string,
+    hydration: Promise<void>,
+    onReady?: () => unknown | Promise<unknown>,
+  ) => {
+    void hydration.then(async () => {
+      if (!isNavigationIntentCurrent(navigationSeq) || activeTabIdRef.current !== targetTabId) return;
+      if (statesRef.current.get(targetTabId)?.hydrateError) {
+        await restoreNavigationSource(navigationSeq, targetTabId, t("history.failedOpenSession"));
+        return;
+      }
+      await onReady?.();
+    }).catch(async () => {
+      if (!isNavigationIntentCurrent(navigationSeq) || activeTabIdRef.current !== targetTabId) return;
+      const safeError = t("history.failedOpenSession");
+      dispatchTo(targetTabId, { type: "hydrate_error", reason: "open-topic", error: safeError });
+      await restoreNavigationSource(navigationSeq, targetTabId, safeError);
+    });
+  }, [dispatchTo, isNavigationIntentCurrent, restoreNavigationSource]);
 
   const handleTopicActivationEvent = useCallback((event: TopicActivationEvent) => {
     const pending = pendingTopicActivationRef.current;
@@ -3479,7 +3196,7 @@ export function useController() {
       noteActivationSettled(event.requestId, "cancelled");
       if (pendingTopicActivationRef.current === pending) pendingTopicActivationRef.current = undefined;
       if (pending.tabId && isNavigationIntentCurrent(pending.navigationSeq) && activeTabIdRef.current === pending.tabId) {
-        void restoreTopicActivationSource(pending, pending.tabId);
+        void restoreNavigationSource(pending.navigationSeq, pending.tabId);
       }
       return;
     }
@@ -3495,7 +3212,7 @@ export function useController() {
         reason: "open-topic",
         error: safeError,
       });
-      void restoreTopicActivationSource(pending, tabId, safeError);
+      void restoreNavigationSource(pending.navigationSeq, tabId, safeError);
       return;
     }
     noteActivationSettled(event.requestId, "ready");
@@ -3505,17 +3222,17 @@ export function useController() {
         if (!isNavigationIntentCurrent(pending.navigationSeq) || activeTabIdRef.current !== tabId) return;
         const hydrated = statesRef.current.get(tabId);
         if (hydrated?.hydrateError) {
-          void restoreTopicActivationSource(pending, tabId, t("history.failedOpenSession"));
+          void restoreNavigationSource(pending.navigationSeq, tabId, t("history.failedOpenSession"));
           return;
         }
         return reconcileTabRuntime(tabId, { hydrateSessionData: false });
       })
       .catch(() => {
         if (isNavigationIntentCurrent(pending.navigationSeq) && activeTabIdRef.current === tabId) {
-          void restoreTopicActivationSource(pending, tabId, t("history.failedOpenSession"));
+          void restoreNavigationSource(pending.navigationSeq, tabId, t("history.failedOpenSession"));
         }
       });
-  }, [dispatchTo, ensureTranscriptSubscription, isNavigationIntentCurrent, loadSessionDataForTab, reconcileTabRuntime, restoreTopicActivationSource]);
+  }, [dispatchTo, ensureTranscriptSubscription, isNavigationIntentCurrent, loadSessionDataForTab, reconcileTabRuntime, restoreNavigationSource]);
 
   useEffect(() => {
     const textBatch = createRafBatch<StreamDeltaEntry>((batch) => {
@@ -4229,69 +3946,84 @@ export function useController() {
     replayPendingPromptsForActiveTab(tabId);
     return true;
   }, [isNavigationIntentCurrent, reconcileTabRuntime, refreshMetaOnlyForTab, sessionLoadCurrent]);
-  const resumeSession = useCallback(async (path: string, tabId?: string, navigationIntentSeq?: number) => {
+  const failSessionNavigation = useCallback(async (navigationSeq: number, tabId: string): Promise<SurfaceDataCommit> => {
+    if (!isNavigationIntentCurrent(navigationSeq)) return { intent: navigationSeq, outcome: "superseded", tabId };
+    const error = t("history.failedOpenSession");
+    dispatchTo(tabId, { type: "hydrate_error", reason: "resume-session", error });
+    await restoreNavigationSource(navigationSeq, tabId, error);
+    return { intent: navigationSeq, outcome: "failed", tabId, error };
+  }, [dispatchTo, isNavigationIntentCurrent, restoreNavigationSource]);
+  const resumeSession = useCallback((path: string, tabId?: string, navigationIntentSeq?: number): NavigationResult<void> | undefined => {
     const targetTabId = tabId || activeTabId;
     if (!targetTabId) return;
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
+    snapshotNavigationSourceTab(navigationSeq);
+    const terminal = (outcome: SurfaceDataOutcome, error?: string): SurfaceDataCommit => ({ intent: navigationSeq, outcome, tabId: targetTabId, error });
     const existingState = statesRef.current.get(targetTabId);
     const sameSession = sameSessionHydrateIdentity({ sessionPath: path }, existingState?.meta); const placeholderItems = sameSessionPlaceholderItems({ sessionPath: path }, existingState);
     if (existingState?.meta) dispatchTo(targetTabId, { type: "optimistic_meta", meta: { ...existingState.meta, sessionPath: path } });
     dispatchTo(targetTabId, { type: "hydrate_start", reason: "resume-session", placeholderItems });
     if (!sameSession) dispatchTo(targetTabId, { type: "reset" });
-    if (tabId) await waitForTabReady(tabId);
-    else if (!(await waitForBackendActiveTab(targetTabId))) return;
-    if (!navigationCompletionCurrent(navigationSeq, "session.resume", targetTabId)) return;
-    const seq = bumpSessionLoadSeq(targetTabId);
-    dispatchTo(targetTabId, { type: "hydrate_start", reason: "resume-session", placeholderItems });
-    let page: HistoryPage;
-    try {
-      page = tabId
-        ? await app.ResumeSessionPageForTab(tabId, path, HISTORY_PAGE_TURNS)
-        : await app.ResumeSessionPage(path, HISTORY_PAGE_TURNS);
-    } catch (err) {
-      if (isNavigationIntentCurrent(navigationSeq) && sessionLoadCurrent(targetTabId, seq)) {
-        dispatchTo(targetTabId, { type: "hydrate_error", reason: "resume-session", error: errorMessage(err) });
-        dispatchTo(targetTabId, { type: "local_notice", level: "warn", text: `${t("history.failedOpenSession")}: ${errorMessage(err)}` });
+    const surfaceReady = (async (): Promise<SurfaceDataCommit> => {
+      if (tabId) await waitForTabReady(tabId);
+      else if (!(await waitForBackendActiveTab(targetTabId))) {
+        return failSessionNavigation(navigationSeq, targetTabId);
       }
-      return;
-    }
-    if (!navigationCompletionCurrent(navigationSeq, "session.resume", targetTabId) || !sessionLoadCurrent(targetTabId, seq)) return;
-    dispatchTo(targetTabId, { type: "reset" });
-    dispatchTo(targetTabId, { type: "history_page", page, mode: "replace" });
-    dispatchTo(targetTabId, { type: "hydrate_done" });
-    if (!(await reconcileSessionNavigationForTab(targetTabId, navigationSeq, seq))) return;
-    app.ContextUsageForTab(targetTabId).then((context) => dispatchTo(targetTabId, { type: "context", context })).catch(() => {});
-    void refreshCheckpoints(targetTabId);
-  }, [activeTabId, beginActiveNavigation, bumpSessionLoadSeq, dispatchTo, navigationCompletionCurrent, reconcileSessionNavigationForTab, refreshCheckpoints, sessionLoadCurrent, waitForBackendActiveTab, waitForTabReady]);
+      if (!navigationCompletionCurrent(navigationSeq, "session.resume", targetTabId)) return terminal("superseded");
+      const seq = bumpSessionLoadSeq(targetTabId);
+      dispatchTo(targetTabId, { type: "hydrate_start", reason: "resume-session", placeholderItems });
+      let page: HistoryPage;
+      try {
+        page = tabId
+          ? await app.ResumeSessionPageForTab(tabId, path, HISTORY_PAGE_TURNS)
+          : await app.ResumeSessionPage(path, HISTORY_PAGE_TURNS);
+      } catch {
+        if (!isNavigationIntentCurrent(navigationSeq) || !sessionLoadCurrent(targetTabId, seq)) return terminal("superseded");
+        return failSessionNavigation(navigationSeq, targetTabId);
+      }
+      if (!navigationCompletionCurrent(navigationSeq, "session.resume", targetTabId) || !sessionLoadCurrent(targetTabId, seq)) return terminal("superseded");
+      dispatchTo(targetTabId, { type: "reset" });
+      dispatchTo(targetTabId, { type: "history_page", page, mode: "replace" });
+      dispatchTo(targetTabId, { type: "hydrate_done" });
+      if (!(await reconcileSessionNavigationForTab(targetTabId, navigationSeq, seq))) return terminal("superseded");
+      app.ContextUsageForTab(targetTabId).then((context) => dispatchTo(targetTabId, { type: "context", context })).catch(() => {});
+      void refreshCheckpoints(targetTabId);
+      return terminal("ready");
+    })().catch(() => failSessionNavigation(navigationSeq, targetTabId));
+    return { value: undefined, surfaceReady };
+  }, [activeTabId, beginActiveNavigation, bumpSessionLoadSeq, dispatchTo, failSessionNavigation, navigationCompletionCurrent, reconcileSessionNavigationForTab, refreshCheckpoints, sessionLoadCurrent, snapshotNavigationSourceTab, waitForBackendActiveTab, waitForTabReady]);
 
-  const openChannelSession = useCallback(async (path: string, tabId: string, navigationIntentSeq?: number) => {
+  const openChannelSession = useCallback((path: string, tabId: string, navigationIntentSeq?: number): NavigationResult<void> | undefined => {
     if (!tabId) return;
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
-    await waitForTabReady(tabId);
-    if (!navigationCompletionCurrent(navigationSeq, "session.channel", tabId)) return;
+    snapshotNavigationSourceTab(navigationSeq);
     const existingState = statesRef.current.get(tabId); const sameSession = sameSessionHydrateIdentity({ sessionPath: path }, existingState?.meta);
     if (existingState?.meta) dispatchTo(tabId, { type: "optimistic_meta", meta: { ...existingState.meta, sessionPath: path } });
-    const seq = bumpSessionLoadSeq(tabId);
     dispatchTo(tabId, { type: "hydrate_start", reason: "resume-session", placeholderItems: sameSessionPlaceholderItems({ sessionPath: path }, existingState) });
     if (!sameSession) dispatchTo(tabId, { type: "reset" });
-    let page: HistoryPage;
-    try {
-      page = await app.OpenChannelSessionPageForTab(tabId, path, HISTORY_PAGE_TURNS);
-    } catch (err) {
-      if (isNavigationIntentCurrent(navigationSeq) && sessionLoadCurrent(tabId, seq)) {
-        dispatchTo(tabId, { type: "hydrate_error", reason: "resume-session", error: errorMessage(err) });
-        dispatchTo(tabId, { type: "local_notice", level: "warn", text: `${t("history.failedOpenSession")}: ${errorMessage(err)}` });
+    const terminal = (outcome: SurfaceDataOutcome, error?: string): SurfaceDataCommit => ({ intent: navigationSeq, outcome, tabId, error });
+    const surfaceReady = (async (): Promise<SurfaceDataCommit> => {
+      await waitForTabReady(tabId);
+      if (!navigationCompletionCurrent(navigationSeq, "session.channel", tabId)) return terminal("superseded");
+      const seq = bumpSessionLoadSeq(tabId);
+      let page: HistoryPage;
+      try {
+        page = await app.OpenChannelSessionPageForTab(tabId, path, HISTORY_PAGE_TURNS);
+      } catch {
+        if (!isNavigationIntentCurrent(navigationSeq) || !sessionLoadCurrent(tabId, seq)) return terminal("superseded");
+        return failSessionNavigation(navigationSeq, tabId);
       }
-      return;
-    }
-    if (!navigationCompletionCurrent(navigationSeq, "session.channel", tabId) || !sessionLoadCurrent(tabId, seq)) return;
-    dispatchTo(tabId, { type: "reset" });
-    dispatchTo(tabId, { type: "history_page", page, mode: "replace" });
-    dispatchTo(tabId, { type: "hydrate_done" });
-    if (!(await reconcileSessionNavigationForTab(tabId, navigationSeq, seq))) return;
-    app.ContextUsageForTab(tabId).then((context) => dispatchTo(tabId, { type: "context", context })).catch(() => {});
-    void refreshCheckpoints(tabId);
-  }, [beginActiveNavigation, bumpSessionLoadSeq, dispatchTo, isNavigationIntentCurrent, navigationCompletionCurrent, reconcileSessionNavigationForTab, refreshCheckpoints, sessionLoadCurrent, waitForTabReady]);
+      if (!navigationCompletionCurrent(navigationSeq, "session.channel", tabId) || !sessionLoadCurrent(tabId, seq)) return terminal("superseded");
+      dispatchTo(tabId, { type: "reset" });
+      dispatchTo(tabId, { type: "history_page", page, mode: "replace" });
+      dispatchTo(tabId, { type: "hydrate_done" });
+      if (!(await reconcileSessionNavigationForTab(tabId, navigationSeq, seq))) return terminal("superseded");
+      app.ContextUsageForTab(tabId).then((context) => dispatchTo(tabId, { type: "context", context })).catch(() => {});
+      void refreshCheckpoints(tabId);
+      return terminal("ready");
+    })().catch(() => failSessionNavigation(navigationSeq, tabId));
+    return { value: undefined, surfaceReady };
+  }, [beginActiveNavigation, bumpSessionLoadSeq, dispatchTo, failSessionNavigation, isNavigationIntentCurrent, navigationCompletionCurrent, reconcileSessionNavigationForTab, refreshCheckpoints, sessionLoadCurrent, snapshotNavigationSourceTab, waitForTabReady]);
 
   const previewSession = useCallback(async (path: string): Promise<HistoryMessage[]> => asArray<HistoryMessage>(await app.PreviewSession(path).catch(() => [])), []);
   const deleteSession = useCallback((path: string) => app.DeleteSession(path).finally(() => invalidateCache()), []);
@@ -4308,7 +4040,7 @@ export function useController() {
     if (!path) return path;
     if (!isNavigationIntentCurrent(navigationSeq)) await reassertVisibleTabAfterStaleNavigation("workspace.switch", "");
     else {
-      const activatedTabId = await syncActiveTabFromBackend(true, false, { navigationIntentSeq: navigationSeq, surfacePolicy: "replace-surface" });
+      const activatedTabId = await syncActiveTabFromBackend(true, false, { navigationIntentSeq: navigationSeq, surfacePolicy: "replace-surface", deferHydration: true });
       if (!isNavigationIntentCurrent(navigationSeq)) await reassertVisibleTabAfterStaleNavigation("workspace.switch", activatedTabId ?? "");
     }
     return path;
@@ -4397,6 +4129,8 @@ export function useController() {
       );
     } catch (err) {
       if (modelSwitchSeqByTab.current.get(tabId) !== switchSeq) return false;
+      const { modelSwitchNoticeText } = await import("./controllerSwitchNotices");
+      if (modelSwitchSeqByTab.current.get(tabId) !== switchSeq) return false;
       dispatchTo(tabId, { type: "local_notice", level: "warn", text: modelSwitchNoticeText(err) });
       const olderSwitchSucceeded =
         (modelSwitchSuccessVersionByTab.current.get(tabId) ?? 0) !== successVersion;
@@ -4424,6 +4158,7 @@ export function useController() {
     try {
       await app.SetEffortForTab(activeTabId, level);
     } catch (err) {
+      const { effortSwitchNoticeText } = await import("./controllerSwitchNotices");
       dispatchTo(activeTabId, { type: "local_notice", level: "warn", text: effortSwitchNoticeText(err) });
       return;
     }
@@ -4487,6 +4222,7 @@ export function useController() {
     const forkNavigationSeq = activeNavigationSeqRef.current;
     await waitForTabReady(sourceTabId);
     const actionScope = (["fork", "summ-from", "summ-upto", "conversation", "code", "both"].includes(scope) ? scope : "both") as MessageActionScope;
+    const { messageActionBusyText } = await import("./controllerSwitchNotices");
     dispatchTo(sourceTabId, { type: "message_action_start", action: { turn, scope: actionScope } });
     dispatchTo(sourceTabId, { type: "local_notice", level: "info", text: messageActionBusyText(actionScope) });
     try {
@@ -4562,6 +4298,7 @@ export function useController() {
   const switchTab = useCallback(async (tabId: string, optimisticTab?: TabMeta, navigationIntentSeq?: number): Promise<TabMeta[] | undefined> => {
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
     if (!navigationCompletionCurrent(navigationSeq, "tab.switch", tabId)) return undefined;
+    snapshotNavigationSourceTab(navigationSeq);
     const startedAt = Date.now();
     topicActivationSeqRef.current += 1;
     const switchRequestId = `fe-switch-${Date.now()}-${topicActivationSeqRef.current}`;
@@ -4629,7 +4366,7 @@ export function useController() {
           if (!activated) noteActivationSettled(switchRequestId, "failed", "backend activation did not complete");
           return undefined;
         }
-        const tabs = await reconcileTabRuntime(tabId, { hydrateSessionData: false });
+        const tabs = await reconcileTabRuntime(tabId, { hydrateSessionData: false, refreshAncillary: false });
         if (!isNavigationIntentCurrent(navigationSeq)) return tabs;
         const hydration = loadSessionDataForTab(tabId, false, "switch-tab", {
           skipHistory: sameSession && hasCachedLiveTurn(statesRef.current.get(tabId)),
@@ -4649,20 +4386,15 @@ export function useController() {
           const hydratedTargetState = statesRef.current.get(tabId);
           if (hydratedTargetState?.hydrateError) {
             noteActivationSettled(switchRequestId, "failed", hydratedTargetState.hydrateError);
-            if (previousTabId && activeTabIdRef.current === tabId) {
-              await app.SetActiveTab(previousTabId).catch(() => undefined);
-              if (!isNavigationIntentCurrent(navigationSeq) || activeTabIdRef.current !== tabId) return;
-              setActiveTabId(previousTabId);
-              activeTabIdRef.current = previousTabId;
-              confirmBackendActiveTab(previousTabId);
-            }
+            await restoreNavigationSource(navigationSeq, tabId, t("history.failedOpenSession"));
             return;
           }
           noteActivationSettled(switchRequestId, "ready");
         }).catch((err) => {
           noteActivationSettled(switchRequestId, "failed", errorMessage(err));
           if (isNavigationIntentCurrent(navigationSeq)) {
-            dispatchTo(tabId, { type: "hydrate_error", reason: "switch-tab", error: errorMessage(err) });
+            dispatchTo(tabId, { type: "hydrate_error", reason: "switch-tab", error: t("history.failedOpenSession") });
+            void restoreNavigationSource(navigationSeq, tabId, t("history.failedOpenSession"));
           }
         });
         return tabs;
@@ -4670,15 +4402,17 @@ export function useController() {
       .catch((err) => {
         noteActivationSettled(switchRequestId, "failed", errorMessage(err));
         if (isNavigationIntentCurrent(navigationSeq)) {
-          dispatchTo(tabId, { type: "hydrate_error", reason: "switch-tab", error: errorMessage(err) });
+          dispatchTo(tabId, { type: "hydrate_error", reason: "switch-tab", error: t("history.failedOpenSession") });
+          void restoreNavigationSource(navigationSeq, tabId, t("history.failedOpenSession"));
         }
         return undefined;
       });
     return backendSwitch;
-  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchTo, isNavigationIntentCurrent, loadSessionDataForTab, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime, trackBackendActivation]);
+  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchTo, isNavigationIntentCurrent, loadSessionDataForTab, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime, restoreNavigationSource, snapshotNavigationSourceTab, trackBackendActivation]);
 
   const openProjectTab = useCallback(async (workspaceRoot: string, topicId: string, navigationIntentSeq?: number): Promise<TabMeta> => {
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
+    snapshotNavigationSourceTab(navigationSeq);
     const snapshotAt = promptEventClock();
     const meta = await app.OpenProjectTab(workspaceRoot, topicId);
     if (!navigationCompletionCurrent(navigationSeq, "tab.open-project", meta.id)) {
@@ -4698,13 +4432,13 @@ export function useController() {
       placeholderItems: sameSessionPlaceholderItems(meta, prevState), surfacePolicy: sameSession ? "preserve-current" : "replace-surface", preserveCachedHistory,
       sessionPath: meta.sessionPath, sessionRevision: meta.sessionRevision, sessionDigest: meta.sessionDigest, sessionGeneration: meta.sessionGeneration,
     });
-    if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});
-    else void load;
+    monitorNavigationHydration(navigationSeq, meta.id, load, isNewTab ? () => reconcileTabRuntime(meta.id, { hydrateSessionData: false }) : undefined);
     return meta;
-  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime]);
+  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, monitorNavigationHydration, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime, snapshotNavigationSourceTab]);
 
   const openGlobalTab = useCallback(async (topicId: string, navigationIntentSeq?: number): Promise<TabMeta> => {
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
+    snapshotNavigationSourceTab(navigationSeq);
     const snapshotAt = promptEventClock();
     const meta = await app.OpenGlobalTab(topicId);
     if (!navigationCompletionCurrent(navigationSeq, "tab.open-global", meta.id)) {
@@ -4724,13 +4458,13 @@ export function useController() {
       placeholderItems: sameSessionPlaceholderItems(meta, prevState), surfacePolicy: sameSession ? "preserve-current" : "replace-surface", preserveCachedHistory,
       sessionPath: meta.sessionPath, sessionRevision: meta.sessionRevision, sessionDigest: meta.sessionDigest, sessionGeneration: meta.sessionGeneration,
     });
-    if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});
-    else void load;
+    monitorNavigationHydration(navigationSeq, meta.id, load, isNewTab ? () => reconcileTabRuntime(meta.id, { hydrateSessionData: false }) : undefined);
     return meta;
-  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime]);
+  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, monitorNavigationHydration, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime, snapshotNavigationSourceTab]);
 
   const openTopicSession = useCallback(async (scope: string, workspaceRoot: string, topicId: string, sessionPath: string, navigationIntentSeq?: number): Promise<TabMeta> => {
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
+    snapshotNavigationSourceTab(navigationSeq);
     const snapshotAt = promptEventClock();
     const meta = await app.OpenTopicSession(scope, workspaceRoot, topicId, sessionPath);
     if (!navigationCompletionCurrent(navigationSeq, "tab.open-session", meta.id)) {
@@ -4750,13 +4484,13 @@ export function useController() {
       placeholderItems: sameSessionPlaceholderItems(meta, prevState), surfacePolicy: sameSession ? "preserve-current" : "replace-surface", preserveCachedHistory,
       sessionPath: meta.sessionPath, sessionRevision: meta.sessionRevision, sessionDigest: meta.sessionDigest, sessionGeneration: meta.sessionGeneration,
     });
-    if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});
-    else void load;
+    monitorNavigationHydration(navigationSeq, meta.id, load, isNewTab ? () => reconcileTabRuntime(meta.id, { hydrateSessionData: false }) : undefined);
     return meta;
-  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime]);
+  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, monitorNavigationHydration, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime, snapshotNavigationSourceTab]);
 
   const activateTopic = useCallback(async (scope: string, workspaceRoot: string, topicId: string, sessionPath = "", navigationIntentSeq?: number): Promise<TabMeta> => {
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
+    snapshotNavigationSourceTab(navigationSeq);
     const snapshotAt = promptEventClock();
     // Ticketed two-phase activation: the backend switches the visible surface
     // before returning the ticket; the controller build and tab prune finish
@@ -4766,15 +4500,8 @@ export function useController() {
     const pending: PendingTopicActivation = {
       requestId: `fe-act-${Date.now()}-${topicActivationSeqRef.current}`,
       navigationSeq,
-      sourceTabId: activeTabIdRef.current,
       surfacePolicy: "replace-surface",
     };
-    if (pending.sourceTabId) {
-      pending.sourceTabPromise = app.ListTabs()
-        .then((tabs) => asArray(tabs).find((tab) => tab.id === pending.sourceTabId))
-        .catch(() => undefined);
-      void pending.sourceTabPromise.then((tab) => { pending.sourceTab = tab; });
-    }
     pendingTopicActivationRef.current = pending;
     noteActivationRequested(pending.requestId);
     const ticket = await app.StartTopicActivation({
@@ -4823,12 +4550,13 @@ export function useController() {
       handleTopicActivationEvent(pending.terminal);
     }
     return meta;
-  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, handleTopicActivationEvent, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation]);
+  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, handleTopicActivationEvent, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, snapshotNavigationSourceTab]);
 
   // Ensure a blank tab exists for the given scope — reuses an existing one
   // or creates a new tab, then loads its session data.
   const ensureBlankTab = useCallback(async (scope: string, workspaceRoot: string, navigationIntentSeq?: number): Promise<TabMeta> => {
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
+    snapshotNavigationSourceTab(navigationSeq);
     const snapshotAt = promptEventClock();
     const meta = await app.EnsureBlankTab(scope, workspaceRoot);
     if (!navigationCompletionCurrent(navigationSeq, "tab.ensure-blank", meta.id)) {
@@ -4846,13 +4574,13 @@ export function useController() {
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
     const load = loadSessionDataForTab(meta.id, true, "new-session", { surfacePolicy: "replace-surface", sessionPath: meta.sessionPath, sessionGeneration: meta.sessionGeneration });
-    if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});
-    else void load;
+    monitorNavigationHydration(navigationSeq, meta.id, load, isNewTab ? () => reconcileTabRuntime(meta.id, { hydrateSessionData: false }) : undefined);
     return meta;
-  }, [beginActiveNavigation, bumpCheckpointRefreshSeq, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime]);
+  }, [beginActiveNavigation, bumpCheckpointRefreshSeq, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, monitorNavigationHydration, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime, snapshotNavigationSourceTab]);
 
   const ensureBlankSurface = useCallback(async (scope: string, workspaceRoot: string, navigationIntentSeq?: number): Promise<TabMeta> => {
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
+    snapshotNavigationSourceTab(navigationSeq);
     const snapshotAt = promptEventClock();
     const meta = await app.EnsureBlankSurface(scope, workspaceRoot);
     if (!navigationCompletionCurrent(navigationSeq, "surface.ensure-blank", meta.id)) {
@@ -4864,14 +4592,14 @@ export function useController() {
     confirmBackendActiveTab(meta.id);
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
-    void loadSessionDataForTab(meta.id, true, "new-session", { surfacePolicy: "replace-surface", sessionPath: meta.sessionPath, sessionGeneration: meta.sessionGeneration })
-      .then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false }))
-      .catch(() => {});
+    const load = loadSessionDataForTab(meta.id, true, "new-session", { surfacePolicy: "replace-surface", sessionPath: meta.sessionPath, sessionGeneration: meta.sessionGeneration });
+    monitorNavigationHydration(navigationSeq, meta.id, load, () => reconcileTabRuntime(meta.id, { hydrateSessionData: false }));
     return meta;
-  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime]);
+  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, monitorNavigationHydration, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime, snapshotNavigationSourceTab]);
 
   const createIsolatedWorktree = useCallback(async (workspaceRoot: string, navigationIntentSeq?: number): Promise<DeliveryWorktreeOpenResult> => {
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
+    snapshotNavigationSourceTab(navigationSeq);
     const snapshotAt = promptEventClock();
     const result = await app.CreateIsolatedWorktree(workspaceRoot);
     const meta = result.tab;
@@ -4891,10 +4619,9 @@ export function useController() {
       placeholderItems: sameSessionPlaceholderItems(meta, prevState), surfacePolicy: sameSession ? "preserve-current" : "replace-surface",
       sessionPath: meta.sessionPath, sessionRevision: meta.sessionRevision, sessionDigest: meta.sessionDigest, sessionGeneration: meta.sessionGeneration,
     });
-    if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});
-    else void load;
+    monitorNavigationHydration(navigationSeq, meta.id, load, isNewTab ? () => reconcileTabRuntime(meta.id, { hydrateSessionData: false }) : undefined);
     return result;
-  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime]);
+  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, monitorNavigationHydration, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime, snapshotNavigationSourceTab]);
 
   const commitSingleSurfaceNavigation = useCallback((tabId: string) => {
     if (!tabId || activeTabIdRef.current !== tabId) return false;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -209,6 +209,9 @@ export type ControllerLiveStore = {
 };
 export type MessageActionScope = "fork" | "summ-from" | "summ-upto" | "conversation" | "code" | "both";
 export type MessageActionState = { turn: number; scope: MessageActionScope };
+export type HistoryMutationKind = "replace" | "prepend" | "append" | "patch";
+export type HistoryMutation = { seq: number; kind: HistoryMutationKind };
+export type HistoryLoadTrigger = "viewport-user" | "question-jump" | "retry" | "auto-fill";
 export type HydrateReason = "switch-tab" | "new-session" | "resume-session" | "open-topic" | "startup" | "rewind";
 type SyncActiveTabOptions = { preserveCachedHistory?: boolean; navigationIntentSeq?: number; surfacePolicy?: HydrateSurfacePolicy };
 // A ticketed StartTopicActivation in flight. Only the latest one is tracked:
@@ -216,6 +219,9 @@ type SyncActiveTabOptions = { preserveCachedHistory?: boolean; navigationIntentS
 type PendingTopicActivation = {
   requestId: string;
   navigationSeq: number;
+  sourceTabId?: string;
+  sourceTab?: TabMeta;
+  sourceTabPromise?: Promise<TabMeta | undefined>;
   tabId?: string;
   placeholderItems?: Item[];
   surfacePolicy: HydrateSurfacePolicy;
@@ -370,6 +376,7 @@ interface State {
   historyDigest?: string;
   /** Bumped when lazy history content can change already-estimated row sizes. */
   historyLayoutRevision: number;
+  historyMutation: HistoryMutation;
   backendActivationPending: boolean;
   messageAction?: MessageActionState;
   currentAssistant?: string;
@@ -489,6 +496,7 @@ export const initialState: State = {
   historyHasOlder: false,
   historyOlderLoading: false,
   historyLayoutRevision: 0,
+  historyMutation: { seq: 0, kind: "replace" },
   backendActivationPending: false,
   deliveryRecoveryActive: false,
   promptEpoch: 0,
@@ -2064,7 +2072,7 @@ export function reducer(s: State, a: Action): State {
     case "message_action_done": return { ...s, messageAction: undefined };
     case "history": {
       const { items, seq } = historyMessagesToItems(a.messages, "h", s.seq);
-      return { ...s, items: compactArchivedToolItems(items), pendingSubmissionId: undefined, seq, hydrateHistoryLoaded: true, hydratePlaceholderItems: undefined, historyStartTurn: 0, historyTotalTurns: 0, historyHasOlder: false, historyOlderLoading: false, historyOlderError: undefined, historyRevision: undefined, historyDigest: undefined };
+      return { ...s, items: compactArchivedToolItems(items), pendingSubmissionId: undefined, seq, hydrateHistoryLoaded: true, hydratePlaceholderItems: undefined, historyStartTurn: 0, historyTotalTurns: 0, historyHasOlder: false, historyOlderLoading: false, historyOlderError: undefined, historyRevision: undefined, historyDigest: undefined, historyMutation: { seq: s.historyMutation.seq + 1, kind: "replace" } };
     }
     case "history_page": {
       const { items, seq, firstTurn } = historyPageItems(a.page);
@@ -2083,6 +2091,7 @@ export function reducer(s: State, a: Action): State {
         historyOlderError: undefined,
         historyRevision: a.page.revision,
         historyDigest: a.page.digest,
+        historyMutation: { seq: s.historyMutation.seq + 1, kind: a.mode },
       };
     }
     case "history_older_start": return s.historyOlderLoading && !s.historyOlderError ? s : { ...s, historyOlderLoading: true, historyOlderError: undefined };
@@ -2101,6 +2110,7 @@ export function reducer(s: State, a: Action): State {
         historyOlderError: undefined,
         historyRevision: a.revision,
         historyDigest: a.digest,
+        historyMutation: { seq: s.historyMutation.seq + 1, kind: "replace" },
       };
     case "history_prepend": {
       const remove = a.removeIds.length > 0 ? new Set(a.removeIds) : undefined;
@@ -2117,6 +2127,7 @@ export function reducer(s: State, a: Action): State {
         historyOlderError: undefined,
         historyRevision: a.revision,
         historyDigest: a.digest,
+        historyMutation: { seq: s.historyMutation.seq + 1, kind: "prepend" },
       };
     }
     // Ref-resolved full content landed for history items already on screen:
@@ -2130,7 +2141,7 @@ export function reducer(s: State, a: Action): State {
         changed = true;
         return patch;
       });
-      return changed ? { ...s, items: next, historyLayoutRevision: s.historyLayoutRevision + 1 } : s;
+      return changed ? { ...s, items: next, historyLayoutRevision: s.historyLayoutRevision + 1, historyMutation: { seq: s.historyMutation.seq + 1, kind: "patch" } } : s;
     }
     case "local_notice": return { ...s, running: a.preserveRuntime ? s.running : false, turnActive: a.preserveRuntime ? s.turnActive : false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
     case "clearApproval": {
@@ -2190,8 +2201,18 @@ export function reducer(s: State, a: Action): State {
       };
     case "reset": return { ...initialState, meta: metaWithoutCanonicalTodos(s.meta), context: { used: 0, window: s.context.window, sessionTokens: 0, compactRatio: s.context.compactRatio }, balance: s.balance, effort: s.effort, jobs: s.jobs, hydrating: s.hydrating, hydrateReason: s.hydrateReason, hydrateError: s.hydrateError, hydrateHistoryLoaded: s.hydrateHistoryLoaded, hydratePlaceholderItems: s.hydratePlaceholderItems, backendActivationPending: s.backendActivationPending, sessionGen: s.sessionGen + 1, promptEpoch: s.promptEpoch + 1 };
     case "context_panel_refresh": return { ...s, contextPanelSeq: s.contextPanelSeq + 1 };
-    case "event": return applyEvent(s, a.e);
-    case "stream_batch": return applyStreamBatch(s, a.segments);
+    case "event": {
+      const next = applyEvent(s, a.e);
+      return next.items.length > s.items.length
+        ? { ...next, historyMutation: { seq: s.historyMutation.seq + 1, kind: "append" } }
+        : next;
+    }
+    case "stream_batch": {
+      const next = applyStreamBatch(s, a.segments);
+      return next.items.length > s.items.length
+        ? { ...next, historyMutation: { seq: s.historyMutation.seq + 1, kind: "append" } }
+        : next;
+    }
     default: return s;
   }
 }
@@ -3138,7 +3159,7 @@ export function useController() {
     return getTranscriptStore().requestFullContent(tabId, entryId, field);
   }, [ensureTranscriptSubscription]);
 
-  const loadOlderHistory = useCallback(async (tabId?: string, targetTurn?: number): Promise<boolean> => {
+  const loadOlderHistory = useCallback(async (tabId?: string, targetTurn?: number, trigger: HistoryLoadTrigger = "retry"): Promise<boolean> => {
     const targetTabId = tabId || activeTabIdRef.current;
     if (!targetTabId) return false;
     const state = statesRef.current.get(targetTabId);
@@ -3204,7 +3225,7 @@ export function useController() {
       }
       addBreadcrumb(
         "tab.hydrate",
-        `history older ${targetTabId} kind=${result.kind} items=${result.kind === "prepend" ? result.prependItems.length : result.items.length} turns=${result.startTurn}-${result.endTurn}/${result.totalTurns} ms=${Date.now() - startedAt}`,
+        `history older ${targetTabId} trigger=${trigger} kind=${result.kind} items=${result.kind === "prepend" ? result.prependItems.length : result.items.length} turns=${result.startTurn}-${result.endTurn}/${result.totalTurns} ms=${Date.now() - startedAt}`,
       );
       return true;
     } catch (err) {
@@ -3387,6 +3408,61 @@ export function useController() {
   // Events for superseded requestIds (including their "cancelled") are
   // dropped; agent:ready/agent:event handling is untouched and still covers
   // every non-ticketed flow (rebind, recovery, restore, SetActiveTab).
+  const restoreTopicActivationSource = useCallback(async (pending: PendingTopicActivation, targetTabId: string, error?: string) => {
+    const sourceTabId = pending.sourceTabId;
+    if (!sourceTabId || sourceTabId === targetTabId || !statesRef.current.has(sourceTabId)) return;
+    const sourceState = statesRef.current.get(sourceTabId);
+    if (!sourceState) return;
+    let restoredTabId = sourceTabId;
+    let restoredMeta: TabMeta | undefined;
+    const reboundExisting = await app.SetActiveTab(sourceTabId).then(() => true).catch(() => false);
+    if (!reboundExisting) {
+      const sourceTab = pending.sourceTab ?? await pending.sourceTabPromise;
+      if (!sourceTab?.topicId) return;
+      try {
+        restoredMeta = sourceTab.sessionPath
+          ? await app.OpenTopicSession(sourceTab.scope, sourceTab.workspaceRoot, sourceTab.topicId, sourceTab.sessionPath)
+          : await app.ActivateTopic(sourceTab.scope, sourceTab.workspaceRoot, sourceTab.topicId, "");
+        restoredTabId = restoredMeta.id;
+      } catch {
+        return;
+      }
+    }
+    if (!isNavigationIntentCurrent(pending.navigationSeq) || activeTabIdRef.current !== targetTabId) {
+      await reassertVisibleTabAfterStaleNavigation("topic.restore-source", restoredTabId);
+      return;
+    }
+    if (restoredMeta && restoredTabId !== sourceTabId) {
+      ensureTranscriptSubscription(restoredTabId);
+      statesRef.current.set(restoredTabId, {
+        ...sourceState,
+        meta: metaFromTab(restoredMeta, sourceState.meta),
+        hydrating: false,
+        hydrateReason: undefined,
+        hydrateError: undefined,
+        hydrateHistoryLoaded: true,
+        hydratePlaceholderItems: undefined,
+        backendActivationPending: false,
+      });
+      notifyLiveListeners(restoredTabId);
+    }
+    setActiveTabId(restoredTabId);
+    activeTabIdRef.current = restoredTabId;
+    confirmBackendActiveTab(restoredTabId);
+    if (error) dispatchTo(restoredTabId, { type: "local_notice", level: "warn", text: error, preserveRuntime: true });
+    if (restoredMeta && restoredTabId !== sourceTabId) {
+      void loadSessionDataForTab(restoredTabId, false, "open-topic", {
+        placeholderItems: sourceState.items,
+        preserveCachedHistory: false,
+        sessionPath: restoredMeta.sessionPath,
+        sessionRevision: restoredMeta.sessionRevision,
+        sessionDigest: restoredMeta.sessionDigest,
+        sessionGeneration: restoredMeta.sessionGeneration,
+        surfacePolicy: "preserve-current",
+      }).then(() => reconcileTabRuntime(restoredTabId, { hydrateSessionData: false })).catch(() => {});
+    }
+  }, [confirmBackendActiveTab, dispatchTo, ensureTranscriptSubscription, isNavigationIntentCurrent, loadSessionDataForTab, notifyLiveListeners, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime]);
+
   const handleTopicActivationEvent = useCallback((event: TopicActivationEvent) => {
     const pending = pendingTopicActivationRef.current;
     if (!pending || event.requestId !== pending.requestId) return;
@@ -3402,6 +3478,9 @@ export function useController() {
     if (event.phase === "cancelled") {
       noteActivationSettled(event.requestId, "cancelled");
       if (pendingTopicActivationRef.current === pending) pendingTopicActivationRef.current = undefined;
+      if (pending.tabId && isNavigationIntentCurrent(pending.navigationSeq) && activeTabIdRef.current === pending.tabId) {
+        void restoreTopicActivationSource(pending, pending.tabId);
+      }
       return;
     }
     pendingTopicActivationRef.current = undefined;
@@ -3410,19 +3489,33 @@ export function useController() {
     if (activeTabIdRef.current !== tabId) return;
     if (event.phase === "failed") {
       noteActivationSettled(event.requestId, "failed", event.error);
+      const safeError = t("history.failedOpenSession");
       dispatchTo(tabId, {
         type: "hydrate_error",
         reason: "open-topic",
-        error: event.error?.trim() || "session is not ready",
+        error: safeError,
       });
+      void restoreTopicActivationSource(pending, tabId, safeError);
       return;
     }
     noteActivationSettled(event.requestId, "ready");
     ensureTranscriptSubscription(tabId);
     void loadSessionDataForTab(tabId, true, "open-topic", { placeholderItems: pending.placeholderItems, surfacePolicy: pending.surfacePolicy })
-      .then(() => reconcileTabRuntime(tabId, { hydrateSessionData: false }))
-      .catch(() => {});
-  }, [dispatchTo, ensureTranscriptSubscription, isNavigationIntentCurrent, loadSessionDataForTab, reconcileTabRuntime]);
+      .then(() => {
+        if (!isNavigationIntentCurrent(pending.navigationSeq) || activeTabIdRef.current !== tabId) return;
+        const hydrated = statesRef.current.get(tabId);
+        if (hydrated?.hydrateError) {
+          void restoreTopicActivationSource(pending, tabId, t("history.failedOpenSession"));
+          return;
+        }
+        return reconcileTabRuntime(tabId, { hydrateSessionData: false });
+      })
+      .catch(() => {
+        if (isNavigationIntentCurrent(pending.navigationSeq) && activeTabIdRef.current === tabId) {
+          void restoreTopicActivationSource(pending, tabId, t("history.failedOpenSession"));
+        }
+      });
+  }, [dispatchTo, ensureTranscriptSubscription, isNavigationIntentCurrent, loadSessionDataForTab, reconcileTabRuntime, restoreTopicActivationSource]);
 
   useEffect(() => {
     const textBatch = createRafBatch<StreamDeltaEntry>((batch) => {
@@ -4538,7 +4631,7 @@ export function useController() {
         }
         const tabs = await reconcileTabRuntime(tabId, { hydrateSessionData: false });
         if (!isNavigationIntentCurrent(navigationSeq)) return tabs;
-        await loadSessionDataForTab(tabId, false, "switch-tab", {
+        const hydration = loadSessionDataForTab(tabId, false, "switch-tab", {
           skipHistory: sameSession && hasCachedLiveTurn(statesRef.current.get(tabId)),
           placeholderItems,
           surfacePolicy: preserveTargetSurface ? "preserve-current" : "replace-surface",
@@ -4548,30 +4641,30 @@ export function useController() {
           sessionDigest: targetSessionDigest,
           sessionGeneration: targetSessionGeneration,
         });
-        // The navigation surface is committed by the caller only after the
-        // target history has been applied. This prevents the old surface from
-        // being replaced by an empty target state between SetActiveTab and
-        // the first history page.
-        if (!isNavigationIntentCurrent(navigationSeq)) return tabs;
-        const hydratedTargetState = statesRef.current.get(tabId);
-        if (hydratedTargetState?.hydrateError) {
-          noteActivationSettled(switchRequestId, "failed", hydratedTargetState.hydrateError);
-          // History loading errors are reported by loadSessionDataForTab as a
-          // state error rather than a rejected promise. Rebind the backend and
-          // visible tab to the previous session so the retained transcript can
-          // remain on screen while the user retries.
-          if (previousTabId && activeTabIdRef.current === tabId && isNavigationIntentCurrent(navigationSeq)) {
-            await app.SetActiveTab(previousTabId).catch(() => undefined);
-            // A newer click may arrive while the backend rebind is in flight.
-            // Do not let this stale failure restore the old frontend selection
-            // after that intent has already won.
-            if (!isNavigationIntentCurrent(navigationSeq) || activeTabIdRef.current !== tabId) return tabs;
-            setActiveTabId(previousTabId);
-            activeTabIdRef.current = previousTabId;
+        // Release the click queue as soon as activation has yielded its target.
+        // Hydration continues independently; the App-level surface transaction
+        // retains the source until this target commits data and paint.
+        void hydration.then(async () => {
+          if (!isNavigationIntentCurrent(navigationSeq)) return;
+          const hydratedTargetState = statesRef.current.get(tabId);
+          if (hydratedTargetState?.hydrateError) {
+            noteActivationSettled(switchRequestId, "failed", hydratedTargetState.hydrateError);
+            if (previousTabId && activeTabIdRef.current === tabId) {
+              await app.SetActiveTab(previousTabId).catch(() => undefined);
+              if (!isNavigationIntentCurrent(navigationSeq) || activeTabIdRef.current !== tabId) return;
+              setActiveTabId(previousTabId);
+              activeTabIdRef.current = previousTabId;
+              confirmBackendActiveTab(previousTabId);
+            }
+            return;
           }
-          return tabs;
-        }
-        noteActivationSettled(switchRequestId, "ready");
+          noteActivationSettled(switchRequestId, "ready");
+        }).catch((err) => {
+          noteActivationSettled(switchRequestId, "failed", errorMessage(err));
+          if (isNavigationIntentCurrent(navigationSeq)) {
+            dispatchTo(tabId, { type: "hydrate_error", reason: "switch-tab", error: errorMessage(err) });
+          }
+        });
         return tabs;
       })
       .catch((err) => {
@@ -4671,8 +4764,17 @@ export function useController() {
     // pending ticket before the call so synchronously-emitted events match.
     topicActivationSeqRef.current += 1;
     const pending: PendingTopicActivation = {
-      requestId: `fe-act-${Date.now()}-${topicActivationSeqRef.current}`, navigationSeq, surfacePolicy: "replace-surface",
+      requestId: `fe-act-${Date.now()}-${topicActivationSeqRef.current}`,
+      navigationSeq,
+      sourceTabId: activeTabIdRef.current,
+      surfacePolicy: "replace-surface",
     };
+    if (pending.sourceTabId) {
+      pending.sourceTabPromise = app.ListTabs()
+        .then((tabs) => asArray(tabs).find((tab) => tab.id === pending.sourceTabId))
+        .catch(() => undefined);
+      void pending.sourceTabPromise.then((tab) => { pending.sourceTab = tab; });
+    }
     pendingTopicActivationRef.current = pending;
     noteActivationRequested(pending.requestId);
     const ticket = await app.StartTopicActivation({
@@ -4704,21 +4806,16 @@ export function useController() {
     const sameSession = sameSessionHydrateIdentity(meta, previousSurface?.meta);
     const prevItems = sameSessionPlaceholderItems(meta, previousSurface);
     pending.placeholderItems = prevItems; pending.surfacePolicy = sameSession ? "preserve-current" : "replace-surface";
-    for (const id of Array.from(statesRef.current.keys())) {
-      if (id !== meta.id) {
-        invalidateProviderStateForTab(id);
-        disposeComposerProfileState(id);
-        statesRef.current.delete(id);
-        releaseTranscriptState(id);
-      }
-    }
     setActiveTabId(meta.id);
     activeTabIdRef.current = meta.id;
     confirmBackendActiveTab(meta.id);
     noteActivationStarted(pending.requestId, meta.id);
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
-    dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
     if (!sameSession) dispatchTo(meta.id, { type: "reset" });
+    // A new-surface reset clears volatile runtime flags. Publish the ticket's
+    // authoritative running state afterwards so a reattached live session
+    // cannot briefly become idle depending on React's reducer scheduling.
+    dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
     // Ready hydrates; only same-session items are a safe placeholder.
     dispatchTo(meta.id, { type: "hydrate_start", reason: "open-topic", placeholderItems: prevItems });
     if (pending.terminal && pendingTopicActivationRef.current === pending) {
@@ -4726,7 +4823,7 @@ export function useController() {
       handleTopicActivationEvent(pending.terminal);
     }
     return meta;
-  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, disposeComposerProfileState, handleTopicActivationEvent, invalidateProviderStateForTab, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, releaseTranscriptState]);
+  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, handleTopicActivationEvent, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation]);
 
   // Ensure a blank tab exists for the given scope — reuses an existing one
   // or creates a new tab, then loads its session data.
@@ -4762,14 +4859,6 @@ export function useController() {
       await reassertVisibleTabAfterStaleNavigation("surface.ensure-blank", meta.id);
       return meta;
     }
-    for (const id of Array.from(statesRef.current.keys())) {
-      if (id !== meta.id) {
-        invalidateProviderStateForTab(id);
-        disposeComposerProfileState(id);
-        statesRef.current.delete(id);
-        releaseTranscriptState(id);
-      }
-    }
     setActiveTabId(meta.id);
     activeTabIdRef.current = meta.id;
     confirmBackendActiveTab(meta.id);
@@ -4779,7 +4868,7 @@ export function useController() {
       .then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false }))
       .catch(() => {});
     return meta;
-  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, disposeComposerProfileState, invalidateProviderStateForTab, loadSessionDataForTab, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime, releaseTranscriptState]);
+  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime]);
 
   const createIsolatedWorktree = useCallback(async (workspaceRoot: string, navigationIntentSeq?: number): Promise<DeliveryWorktreeOpenResult> => {
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
@@ -4806,6 +4895,19 @@ export function useController() {
     else void load;
     return result;
   }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, navigationCompletionCurrent, reassertVisibleTabAfterStaleNavigation, reconcileTabRuntime]);
+
+  const commitSingleSurfaceNavigation = useCallback((tabId: string) => {
+    if (!tabId || activeTabIdRef.current !== tabId) return false;
+    for (const id of Array.from(statesRef.current.keys())) {
+      if (id === tabId) continue;
+      invalidateProviderStateForTab(id);
+      disposeComposerProfileState(id);
+      statesRef.current.delete(id);
+      releaseTranscriptState(id);
+      notifyLiveListeners(id);
+    }
+    return true;
+  }, [disposeComposerProfileState, invalidateProviderStateForTab, notifyLiveListeners, releaseTranscriptState]);
 
   const closeTab = useCallback(async (
     tabId: string,
@@ -4845,7 +4947,7 @@ export function useController() {
     requestHistoryFullContent,
     refreshMeta, pickWorkspace, switchWorkspace, compact, rewind, rewindForTab, rewindForTabDetailed, undoRewindForTab, setModel, setEffort, cancelJob,
     fetchMemory, remember, forget, saveDoc,
-    switchTab, openProjectTab, openGlobalTab, openTopicSession, ensureBlankTab, activateTopic, ensureBlankSurface, createIsolatedWorktree, closeTab, reorderTabs,
+    switchTab, openProjectTab, openGlobalTab, openTopicSession, ensureBlankTab, activateTopic, ensureBlankSurface, createIsolatedWorktree, commitSingleSurfaceNavigation, closeTab, reorderTabs,
     // Invalidate in-flight navigation completions (activateTopic's stale
     // guard) from outside the hook. The App-level navigation queue must call
     // this at ENQUEUE time: a queued click does not run — and so does not

--- a/desktop/frontend/src/lib/useNavigationSurface.ts
+++ b/desktop/frontend/src/lib/useNavigationSurface.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
+import type { Item } from "./useController";
+import { recordFrontendDiagnostic } from "./frontendDiagnosticBridge";
+import {
+  beginNavigationSurfaceState,
+  markNavigationTargetMasked,
+  settleNavigationSurfaceState,
+  type NavigationSurfaceState,
+} from "./navigationSurfaceTransition";
+
+export type PreservedTranscriptSurface = {
+  tabId?: string;
+  items: Item[];
+  geometrySessionKey?: string;
+};
+
+export function useNavigationSurface(target: {
+  activeTabId?: string;
+  ready: boolean;
+  backendActivationPending: boolean;
+  hydrating: boolean;
+  hydrateError?: string;
+}) {
+  const [surface, setSurface] = useState<NavigationSurfaceState>(null);
+  const [preserved, setPreserved] = useState<PreservedTranscriptSurface | null>(null);
+  const renderedRef = useRef<PreservedTranscriptSurface | null>(null);
+  const intent = surface?.intent ?? null;
+  const transitioning = intent !== null;
+  const dataReady = Boolean(
+    surface?.phase === "target-masked" && target.activeTabId && target.ready &&
+    !target.backendActivationPending && !target.hydrating && !target.hydrateError,
+  );
+  const failed = Boolean(
+    surface?.phase === "target-masked" && target.activeTabId &&
+    !target.backendActivationPending && !target.hydrating && target.hydrateError,
+  );
+
+  const begin = useCallback((nextIntent: number) => {
+    recordFrontendDiagnostic("navigation", "navigation.begin", { intent: nextIntent, phase: "begin" });
+    const rendered = renderedRef.current;
+    flushSync(() => {
+      setPreserved(rendered?.items.length ? rendered : null);
+      setSurface(beginNavigationSurfaceState(nextIntent));
+    });
+  }, []);
+  const maskTarget = useCallback((completedIntent: number) => {
+    setSurface((current) => markNavigationTargetMasked(current, completedIntent));
+  }, []);
+  const settle = useCallback((completedIntent: number, outcome: "ready" | "degraded" | "failed") => {
+    if (outcome !== "failed") recordFrontendDiagnostic("navigation", "navigation.paint-ready", { intent: completedIntent, outcome });
+    recordFrontendDiagnostic("navigation", "navigation.terminal", { intent: completedIntent, outcome });
+    recordFrontendDiagnostic("navigation", "navigation.settle", {
+      intent: completedIntent,
+      phase: outcome === "failed" ? "data-failed" : "paint-ready",
+      outcome,
+    });
+    setSurface((current) => settleNavigationSurfaceState(current, completedIntent));
+  }, []);
+  const commitPaint = useCallback((completedIntent: number, outcome: "ready" | "degraded") => {
+    settle(completedIntent, outcome);
+  }, [settle]);
+
+  const dataReadyIntentRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!dataReady || intent === null || dataReadyIntentRef.current === intent) return;
+    dataReadyIntentRef.current = intent;
+    recordFrontendDiagnostic("navigation", "navigation.target-mounted", { intent });
+    recordFrontendDiagnostic("navigation", "navigation.data-ready", { intent, outcome: "ready" });
+  }, [dataReady, intent]);
+  useEffect(() => {
+    if (!failed || intent === null) return;
+    recordFrontendDiagnostic("navigation", "navigation.data-ready", { intent, outcome: "failed" });
+    settle(intent, "failed");
+  }, [failed, intent, settle]);
+  useEffect(() => {
+    if (surface === null) setPreserved(null);
+  }, [surface]);
+
+  return {
+    surface,
+    intent,
+    transitioning,
+    dataReady,
+    preserved,
+    renderedRef,
+    begin,
+    maskTarget,
+    commitPaint,
+  };
+}

--- a/desktop/frontend/src/lib/useTranscriptNavigationSurface.ts
+++ b/desktop/frontend/src/lib/useTranscriptNavigationSurface.ts
@@ -1,0 +1,251 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type TouchEvent as ReactTouchEvent,
+  type WheelEvent as ReactWheelEvent,
+} from "react";
+import { recordFrontendDiagnostic } from "./frontendDiagnosticBridge";
+import { advanceSurfacePaintCommit, type SurfacePaintProgress } from "./navigationSurfaceTransition";
+import { hasTranscriptScrollableRange, TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX } from "./useTranscriptScrollArbiter";
+import type { HistoryLoadTrigger } from "./useController";
+
+type ScrollRef = { current: HTMLDivElement | null };
+
+export function grantsNativeScrollbarPagePermit(previous: number | null, current: number, tracking: boolean, alreadyGranted: boolean): boolean {
+  return tracking && !alreadyGranted && previous !== null && current < previous;
+}
+
+// State: 0=idle, 1=permitted, 2=request active. Action: 0=grant,
+// 1=consume, 2=complete.
+export function advanceViewportPagePermit(state: number, action: 0 | 1 | 2): number {
+  if (action === 2) return 0;
+  if (action === 0) return state === 0 ? 1 : state;
+  return state === 1 ? 2 : state;
+}
+
+export function useTranscriptPagingAuthorization(input: {
+  layoutSurfaceKey: string;
+  nativeScrollbarDragging: boolean;
+  scrollRef: ScrollRef;
+  noteUserScrollIntent: () => void;
+  onWheelIntent: (event: ReactWheelEvent<HTMLElement>) => boolean;
+  onWheelAccepted?: (deltaY: number) => void;
+  onTouchStartIntent: (event: ReactTouchEvent<HTMLElement>) => void;
+  onTouchMoveIntent: (event: ReactTouchEvent<HTMLElement>) => boolean;
+  onKeyScrollIntent: (event: ReactKeyboardEvent<HTMLElement>) => boolean;
+  onPointerDownIntent: (event: ReactPointerEvent<HTMLElement>) => boolean;
+}) {
+  const { layoutSurfaceKey, nativeScrollbarDragging, scrollRef, noteUserScrollIntent } = input;
+  const permitRef = useRef(0);
+  const touchStartYRef = useRef<number | null>(null);
+  const previousScrollTopRef = useRef<number | null>(null);
+  const nativeTrackingRef = useRef(false);
+  const nativePermitGrantedRef = useRef(false);
+  useEffect(() => {
+    permitRef.current = 0;
+    touchStartYRef.current = null;
+    previousScrollTopRef.current = null;
+    nativeTrackingRef.current = false;
+    nativePermitGrantedRef.current = false;
+  }, [layoutSurfaceKey]);
+  useEffect(() => {
+    if (nativeScrollbarDragging) return;
+    nativeTrackingRef.current = false;
+    nativePermitGrantedRef.current = false;
+  }, [nativeScrollbarDragging]);
+  const grant = useCallback(() => {
+    // Wheel/touch bursts that continue while a page is loading belong to the
+    // same viewport request. Do not let them leave a permit behind for the
+    // prepend-triggered startReached callback.
+    const next = advanceViewportPagePermit(permitRef.current, 0);
+    if (next !== permitRef.current) recordFrontendDiagnostic("history", "history.viewport-permit");
+    permitRef.current = next;
+  }, []);
+  const onWheelIntent = useCallback((event: ReactWheelEvent<HTMLElement>) => {
+    const accepted = input.onWheelIntent(event);
+    if (accepted) {
+      input.onWheelAccepted?.(event.deltaY);
+      noteUserScrollIntent();
+      if (event.deltaY < 0) grant();
+    }
+    return accepted;
+  }, [grant, input.onWheelAccepted, input.onWheelIntent, noteUserScrollIntent]);
+  const onTouchStartIntent = useCallback((event: ReactTouchEvent<HTMLElement>) => {
+    touchStartYRef.current = event.touches[0]?.clientY ?? null;
+    input.onTouchStartIntent(event);
+  }, [input.onTouchStartIntent]);
+  const onTouchMoveIntent = useCallback((event: ReactTouchEvent<HTMLElement>) => {
+    const accepted = input.onTouchMoveIntent(event);
+    if (accepted) {
+      noteUserScrollIntent();
+      const currentY = event.touches[0]?.clientY;
+      if (currentY !== undefined && touchStartYRef.current !== null && currentY > touchStartYRef.current) grant();
+      if (currentY !== undefined) touchStartYRef.current = currentY;
+    }
+    return accepted;
+  }, [grant, input.onTouchMoveIntent, noteUserScrollIntent]);
+  const onKeyScrollIntent = useCallback((event: ReactKeyboardEvent<HTMLElement>) => {
+    const accepted = input.onKeyScrollIntent(event);
+    if (accepted) {
+      noteUserScrollIntent();
+      if (event.key === "ArrowUp" || event.key === "PageUp" || event.key === "Home") grant();
+    }
+    return accepted;
+  }, [grant, input.onKeyScrollIntent, noteUserScrollIntent]);
+  const onPointerDownIntent = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    const accepted = input.onPointerDownIntent(event);
+    if (accepted) {
+      noteUserScrollIntent();
+      if (event.button === 0) {
+        nativeTrackingRef.current = true;
+        nativePermitGrantedRef.current = false;
+        previousScrollTopRef.current = scrollRef.current?.scrollTop ?? null;
+      }
+    }
+    return accepted;
+  }, [input.onPointerDownIntent, noteUserScrollIntent, scrollRef]);
+  const noteScrollPosition = useCallback(() => {
+    const scrollTop = scrollRef.current?.scrollTop;
+    if (scrollTop === undefined) return;
+    const previous = previousScrollTopRef.current;
+    if (grantsNativeScrollbarPagePermit(previous, scrollTop, nativeTrackingRef.current, nativePermitGrantedRef.current)) {
+      nativePermitGrantedRef.current = true;
+      grant();
+    }
+    previousScrollTopRef.current = scrollTop;
+  }, [grant, scrollRef]);
+  const consume = useCallback(() => {
+    const next = advanceViewportPagePermit(permitRef.current, 1);
+    const consumed = next !== permitRef.current;
+    permitRef.current = next;
+    return consumed;
+  }, []);
+  const complete = useCallback(() => {
+    permitRef.current = advanceViewportPagePermit(permitRef.current, 2);
+  }, []);
+  return { onWheelIntent, onTouchStartIntent, onTouchMoveIntent, onKeyScrollIntent, onPointerDownIntent, noteScrollPosition, consume, complete };
+}
+
+export function transcriptSurfaceGeometryKey(element: HTMLElement): string {
+  return `${Math.round(element.clientHeight)}:${Math.round(element.scrollHeight)}:${Math.round(element.scrollTop)}`;
+}
+
+export function useTranscriptSurfaceCommit(input: {
+  token?: string;
+  hydrating: boolean;
+  layoutSurfaceKey: string;
+  virtualRowCount: number;
+  scrollRef: ScrollRef;
+  virtuosoReadyRef: { current: boolean };
+  layoutTransientRef: { current: boolean };
+  scheduleRecovery: () => void;
+  onReady?: (token: string, outcome: "ready" | "degraded") => void;
+}) {
+  const { token, hydrating, layoutSurfaceKey, virtualRowCount, scrollRef, virtuosoReadyRef, layoutTransientRef, scheduleRecovery, onReady } = input;
+  const renderedTokenRef = useRef<string | null>(null);
+  const terminalTokenRef = useRef<string | null>(null);
+  const [renderSeq, setRenderSeq] = useState(0);
+  const [readySurfaceKey, setReadySurfaceKey] = useState<string | null>(null);
+  useEffect(() => setReadySurfaceKey(null), [layoutSurfaceKey]);
+  const markItemsRendered = useCallback((count: number) => {
+    if (count <= 0 || !token || renderedTokenRef.current === token) return;
+    renderedTokenRef.current = token;
+    setRenderSeq((value) => value + 1);
+  }, [token]);
+  useEffect(() => {
+    if (!token || hydrating || !onReady || terminalTokenRef.current === token) return;
+    let frame: number | null = null;
+    let cancelled = false;
+    let progress: SurfacePaintProgress = { attempts: 0, stableFrames: 0 };
+    const empty = virtualRowCount === 0;
+    const finish = (outcome: "ready" | "degraded") => {
+      if (cancelled || terminalTokenRef.current === token) return;
+      terminalTokenRef.current = token;
+      recordFrontendDiagnostic("transcript", "transcript.initial-placement-terminal", {
+        intent: Number(/^navigation-(\d+)-/.exec(token)?.[1] ?? 0), outcome,
+      });
+      setReadySurfaceKey(layoutSurfaceKey);
+      onReady(token, outcome);
+    };
+    const tick = () => {
+      frame = null;
+      if (cancelled) return;
+      const element = scrollRef.current;
+      const rendered = empty || renderedTokenRef.current === token;
+      const placementReady = empty ? Boolean(element) : Boolean(element && virtuosoReadyRef.current && !layoutTransientRef.current);
+      const bottomReady = Boolean(element && element.scrollHeight - element.scrollTop - element.clientHeight <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX);
+      const decision = advanceSurfacePaintCommit(progress, {
+        rendered, placementReady, geometryReady: bottomReady,
+        geometryKey: element ? transcriptSurfaceGeometryKey(element) : undefined,
+      });
+      progress = decision.progress;
+      if (decision.outcome) return finish(decision.outcome);
+      if (decision.requestRecovery) scheduleRecovery();
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => {
+      cancelled = true;
+      if (frame !== null) cancelAnimationFrame(frame);
+    };
+  }, [hydrating, layoutSurfaceKey, layoutTransientRef, onReady, renderSeq, scheduleRecovery, scrollRef, token, virtualRowCount, virtuosoReadyRef]);
+  return { readySurfaceKey, markItemsRendered };
+}
+
+export function useTranscriptHistoryAutoFill(input: {
+  readySurfaceKey: string | null;
+  layoutSurfaceKey: string;
+  hydrating: boolean;
+  hasOlderHistory: boolean;
+  loadingOlderHistory: boolean;
+  olderHistoryError?: string;
+  running: boolean;
+  historyStartTurn: number;
+  virtualRowCount: number;
+  scrollRef: ScrollRef;
+  virtuosoReadyRef: { current: boolean };
+  layoutTransientRef: { current: boolean };
+  onLoadOlderHistory?: (targetTurn?: number, trigger?: HistoryLoadTrigger) => boolean | Promise<boolean>;
+}) {
+  const {
+    readySurfaceKey, layoutSurfaceKey, hydrating, hasOlderHistory, loadingOlderHistory,
+    olderHistoryError, running, historyStartTurn, virtualRowCount, scrollRef,
+    virtuosoReadyRef, layoutTransientRef, onLoadOlderHistory,
+  } = input;
+  const pageCountRef = useRef(0);
+  const inFlightRef = useRef(false);
+  useEffect(() => {
+    pageCountRef.current = 0;
+    inFlightRef.current = false;
+  }, [layoutSurfaceKey]);
+  useEffect(() => {
+    if (readySurfaceKey !== layoutSurfaceKey || hydrating || !hasOlderHistory ||
+      loadingOlderHistory || olderHistoryError || running || !onLoadOlderHistory) return;
+    let frame: number | null = null;
+    let cancelled = false;
+    let attempts = 0;
+    const probe = () => {
+      frame = null;
+      if (cancelled) return;
+      attempts += 1;
+      const element = scrollRef.current;
+      if (!element || !virtuosoReadyRef.current || layoutTransientRef.current) {
+        if (attempts < 180) frame = requestAnimationFrame(probe);
+        return;
+      }
+      if (hasTranscriptScrollableRange(element) || inFlightRef.current || pageCountRef.current >= 3) return;
+      inFlightRef.current = true;
+      pageCountRef.current += 1;
+      void Promise.resolve(onLoadOlderHistory(undefined, "auto-fill")).finally(() => { inFlightRef.current = false; });
+    };
+    frame = requestAnimationFrame(probe);
+    return () => {
+      cancelled = true;
+      if (frame !== null) cancelAnimationFrame(frame);
+    };
+  }, [hasOlderHistory, historyStartTurn, hydrating, layoutSurfaceKey, layoutTransientRef, loadingOlderHistory, olderHistoryError, onLoadOlderHistory, readySurfaceKey, running, scrollRef, virtualRowCount, virtuosoReadyRef]);
+}

--- a/desktop/frontend/src/lib/useTranscriptQuestionNavigation.ts
+++ b/desktop/frontend/src/lib/useTranscriptQuestionNavigation.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { Item } from "./useController";
+import type { HistoryLoadTrigger, Item } from "./useController";
 import {
   activeQuestionTurn,
   compactQuestionText,
@@ -10,8 +10,6 @@ import {
   type QuestionAnchorPosition,
 } from "./transcriptGrouping";
 import { userRowKey } from "./transcriptRows";
-
-const HISTORY_AUTO_COMPLETE_TURNS = 60;
 
 export function useTranscriptQuestions(
   items: Item[],
@@ -109,7 +107,6 @@ export function useTranscriptQuestionJump({
   loadingOlderHistory,
   olderHistoryError,
   running,
-  suppressAutoComplete = false,
   onLoadOlderHistory,
   clearTranscriptSelection,
   invalidateAnchors,
@@ -125,9 +122,7 @@ export function useTranscriptQuestionJump({
   loadingOlderHistory: boolean;
   olderHistoryError?: string;
   running: boolean;
-  /** Avoid background history paging while a navigation surface is hidden. */
-  suppressAutoComplete?: boolean;
-  onLoadOlderHistory?: (targetTurn?: number) => boolean | Promise<boolean>;
+  onLoadOlderHistory?: (targetTurn?: number, trigger?: HistoryLoadTrigger) => boolean | Promise<boolean>;
   clearTranscriptSelection: (reason?: string) => void;
   invalidateAnchors: () => void;
   scrollToDataIndex: (index: number, behavior?: "auto" | "smooth") => void;
@@ -136,12 +131,12 @@ export function useTranscriptQuestionJump({
 }) {
   const [pendingQuestion, setPendingQuestion] = useState<{ surfaceKey: string; turn: number } | null>(null);
   const olderRequestInFlightRef = useRef<string | null>(null);
-  const requestOlderHistory = useCallback(async (targetTurn?: number, retry = false): Promise<boolean> => {
+  const requestOlderHistory = useCallback(async (targetTurn?: number, retry = false, trigger: HistoryLoadTrigger = "retry"): Promise<boolean> => {
     if (!hasOlderHistory || loadingOlderHistory || running || !onLoadOlderHistory || (!retry && olderHistoryError)) return false;
     if (olderRequestInFlightRef.current === layoutSurfaceKey) return false;
     olderRequestInFlightRef.current = layoutSurfaceKey;
     try {
-      return onLoadOlderHistory(targetTurn);
+      return onLoadOlderHistory(targetTurn, trigger);
     } finally {
       if (olderRequestInFlightRef.current === layoutSurfaceKey) olderRequestInFlightRef.current = null;
     }
@@ -165,7 +160,7 @@ export function useTranscriptQuestionJump({
     document.getSelection()?.removeAllRanges();
     clearTranscriptSelection("question-navigation");
     setPendingQuestion({ surfaceKey: layoutSurfaceKey, turn: question.turn });
-    void requestOlderHistory(question.turn + 1, true);
+    void requestOlderHistory(question.turn + 1, true, "question-jump");
   }, [clearTranscriptSelection, jumpToLoadedQuestion, layoutSurfaceKey, requestOlderHistory, setActiveQuestion]);
 
   useEffect(() => {
@@ -175,7 +170,7 @@ export function useTranscriptQuestionJump({
       setPendingQuestion(null);
       jumpToLoadedQuestion(question);
     } else if (!loadingOlderHistory && !olderHistoryError) {
-      void requestOlderHistory(pendingQuestion.turn + 1);
+      void requestOlderHistory(pendingQuestion.turn + 1, false, "question-jump");
     }
   }, [jumpToLoadedQuestion, layoutSurfaceKey, loadedByTurn, loadingOlderHistory, olderHistoryError, pendingQuestion, requestOlderHistory]);
 
@@ -184,15 +179,10 @@ export function useTranscriptQuestionJump({
     if (olderRequestInFlightRef.current !== layoutSurfaceKey) olderRequestInFlightRef.current = null;
   }, [layoutSurfaceKey]);
 
-  const earlierTurnsRemaining = questions[0]?.turn ?? 0;
-  useEffect(() => {
-    if (suppressAutoComplete) return;
-    if (earlierTurnsRemaining > 0 && earlierTurnsRemaining < HISTORY_AUTO_COMPLETE_TURNS) void requestOlderHistory();
-  }, [earlierTurnsRemaining, requestOlderHistory, suppressAutoComplete]);
-  const handleEarlierHistoryReached = useCallback(() => void requestOlderHistory(), [requestOlderHistory]);
+  const handleEarlierHistoryReached = useCallback(() => void requestOlderHistory(undefined, false, "viewport-user"), [requestOlderHistory]);
   const retryOlderHistory = useCallback(() => {
     const targetTurn = pendingQuestion?.surfaceKey === layoutSurfaceKey ? pendingQuestion.turn + 1 : undefined;
-    void requestOlderHistory(targetTurn, true);
+    void requestOlderHistory(targetTurn, true, "retry");
   }, [layoutSurfaceKey, pendingQuestion, requestOlderHistory]);
 
   useEffect(() => {

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -487,7 +487,7 @@ export function useTranscriptScrollArbiter({
     const measured = measureTranscriptVirtuosoItem(element, field, frozen);
     const pendingGeometry = field === "offsetHeight" && hasPendingTranscriptGeometry(element);
     if (field === "offsetHeight" && frozen) {
-      const estimate = Number.parseFloat(element.dataset.transcriptEstimate ?? element.dataset.knownSize ?? element.dataset.staticEstimate ?? "");
+      const estimate = Number.parseFloat(element.dataset.knownSize ?? element.dataset.transcriptEstimate ?? element.dataset.staticEstimate ?? "");
       if (Number.isFinite(estimate) && estimate > 0) {
         // Native thumb dragging owns the physical track. Keep the currently
         // measured row box stable for that drag only; wheel/touch reading does

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3486,7 +3486,7 @@ a[href] {
   justify-content: center;
   gap: 10px;
   color: var(--fg);
-  background: color-mix(in srgb, var(--chat-bg, var(--bg)) 88%, transparent);
+  background: var(--chat-bg, var(--bg));
   pointer-events: auto;
   user-select: none;
   cursor: progress;
@@ -9069,6 +9069,10 @@ body > .mermaid-diagram--fullscreen {
 .composer-decision-host--hidden,
 .composer-decision-host[hidden] {
   display: none !important;
+}
+.composer-decision-host--footprint-hidden {
+  visibility: hidden;
+  pointer-events: none;
 }
 .prompt-shelf__card {
   display: grid;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -9074,6 +9074,10 @@ body > .mermaid-diagram--fullscreen {
   visibility: hidden;
   pointer-events: none;
 }
+.footer--navigation-hidden {
+  visibility: hidden;
+  pointer-events: none;
+}
 .prompt-shelf__card {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
## Summary

Commit session navigation as a data-and-paint transaction so the source transcript stays intact until the latest target has authoritative history and stable native scroll geometry.

## User-visible problem

Switching sessions could expose an empty/intermediate target, change transcript height while the footer disappeared, jump through multiple scroll positions, or cascade older-history requests. Rapid `A → B → C` completion could also let an older request clear or prune the newest surface.

## Root cause

Navigation settled on activation/RPC completion instead of target history plus layout completion. Single-surface state was pruned before the target committed, `startReached` was treated as user intent, and height changes did not distinguish replace/prepend/append/patch ownership.

## Fix

- Add an internal navigation-surface state machine with source-retained, target-masked, data-ready, paint-ready, degraded, cancelled, and superseded terminals.
- Retain source controller/transcript/provider state until the latest target reaches data-ready and native-geometry paint-ready.
- Restore the source surface on activation/history failure; stale requests cannot prune, revert, expose an error, or clear a newer mask.
- Release the click queue after the activation ticket while hydration continues independently, so rapid navigation is not serialized behind the prior history load.
- Keep the composer/decision/Todo/rewind footprint mounted and inert during navigation. The source height is retained before data commit; the masked target footprint owns final paint geometry.
- Make Virtuoso initial placement the paint commit owner, with two stable geometry frames, bounded recovery, and a degraded terminal instead of permanent loading.
- Require one real upward wheel/touch/key/native-scrollbar permit per viewport history page; question jumps, retry, and bounded post-paint auto-fill have explicit trigger types.
- Classify history mutations as replace/prepend/append/patch so prepend cannot invoke tail follow and patches do not remount the transcript.
- Add privacy-safe ordering, pagination, placement, and scroll-writer diagnostics plus anomaly detection.

## Verification

- `pnpm test` — all 225 discovered frontend suites pass.
- `pnpm test:typecheck`
- `pnpm build` — hooks lint, WAAPI, single-scroll-writer, CSS/theme checks, TypeScript, Vite, and bounded bundle budgets pass.
- `pnpm test:transcript-browser` — selection, `A → B → A`, DPR, layout, question navigation, dock, dynamic measurement, rapid-scroll, tail-follow, and ref-resolution-storm coverage pass.
- Headless macOS Chromium deliberately skips native thumb drag because it has no deterministic pointer-draggable native track. Linux CI exercises the full drag/freeze path; Windows WebView2 has its native smoke path.
- `node scripts/check-single-scroll-writer.mjs`
- `cd desktop && go test ./...`
- `go run ./tools/repolint`
- `git diff --check`

Real Windows WebView2 100-switch qualification remains a release gate and is not claimed as a local manual result.

## Bundle budget

The final production build measures 434.8 KiB initial JavaScript gzip and 2369.1 KiB initial raw JavaScript/CSS. The corresponding caps are 435.0 KiB and 2369.6 KiB; unrelated chunk, locale, CSS, and largest-chunk gates remain enforced.

## Compatibility

- Wails API/public payloads: unchanged.
- JSONL/meta/session leases/user configuration: unchanged.
- SQLite schema: unchanged.
- Provider serialization, tool schema, system prompt, and prompt-cache shape: unchanged.

## Related work and merge order

- #9416 owns steady-state transcript scroll writer/geometry hardening. This PR owns cross-session surface commit, source retention, and pagination authorization. The files overlap; the recommended order is this focused navigation transaction first, then rebase #9416 while preserving these surface and trigger contracts.
- This supersedes the mask-bypass approach in #9385: a resident transcript may be fast, but it still must pass current identity and paint commit before becoming interactive. No code was copied from that PR.

Cache-impact: none - no provider-visible prompt, tool, or serialization bytes change.
Cache-guard: frontend navigation and diagnostics only; prompt cache contract is unaffected.
System-prompt-review: N/A - no system prompt or instruction text changes.
Documentation-impact: none - no public API or documented workflow changes.
