### PR TITLE
fix(crash): Bound Firebase migration output capture / 限制 Firebase 迁移输出缓冲

### DIFF
--- a/workers/crash-report/scripts/migrate-firebase-data.d.mts
+++ b/workers/crash-report/scripts/migrate-firebase-data.d.mts
@@ -1,4 +1,16 @@
 export const firebaseOAuthGrantType: string;
+export const wranglerD1MaxBufferBytes: number;
+
+export function runWrangler(
+  projectDir: string,
+  database: string,
+  query: string,
+  spawn?: (
+    command: string,
+    args: string[],
+    options: { maxBuffer: number; [key: string]: unknown },
+  ) => { error?: Error; status: number | null; stdout?: string },
+): Array<Record<string, unknown>>;
 
 export function classifyMigrationGroup(
   row: Record<string, unknown>,

--- a/workers/crash-report/scripts/migrate-firebase-data.mjs
+++ b/workers/crash-report/scripts/migrate-firebase-data.mjs
@@ -13,6 +13,10 @@ const PAGE_SIZE = 200;
 const MAX_PASSES = 3;
 const STORAGE_BUDGET = 700 * 1024 * 1024;
 const RESERVATIONS = { active: 640 * 1024, compacted: 128 * 1024, archived: 0 };
+// One page can contain six retained 96 KiB reports for each of 200 groups.
+// Keep the capture bounded while leaving room for Wrangler's JSON envelope
+// and escaping; Node's default child-process buffer is too small for this path.
+export const wranglerD1MaxBufferBytes = 192 * 1024 * 1024;
 export const firebaseOAuthGrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer";
 
 function base64url(value) {
@@ -148,13 +152,14 @@ export function buildFirebaseGroups(groupRows, reportRows, now = new Date()) {
   return output;
 }
 
-function runWrangler(projectDir, database, query) {
+export function runWrangler(projectDir, database, query, spawn = spawnSync) {
   const executable = process.platform === "win32" ? "wrangler.cmd" : "wrangler";
   const wrangler = path.join(projectDir, "node_modules", ".bin", executable);
-  const result = spawnSync(wrangler, ["d1", "execute", database, "--remote", "--json", "--command", query], {
+  const result = spawn(wrangler, ["d1", "execute", database, "--remote", "--json", "--command", query], {
     cwd: projectDir,
     encoding: "utf8",
     env: process.env,
+    maxBuffer: wranglerD1MaxBufferBytes,
     stdio: ["ignore", "pipe", "inherit"],
   });
   if (result.error) throw result.error;

--- a/workers/crash-report/src/firebase_migration.test.ts
+++ b/workers/crash-report/src/firebase_migration.test.ts
@@ -5,11 +5,29 @@ import {
   classifyMigrationGroup,
   contentDigest,
   firebaseOAuthGrantType,
+  runWrangler,
+  wranglerD1MaxBufferBytes,
 } from "../scripts/migrate-firebase-data.mjs";
 
 describe("Firebase retained-sample migration", () => {
   it("uses the OAuth JWT bearer grant expected by Google's token endpoint", () => {
     expect(firebaseOAuthGrantType).toBe("urn:ietf:params:oauth:grant-type:jwt-bearer");
+  });
+
+  it("captures a full retained-report page without using Node's default child-process buffer", () => {
+    let configuredMaxBuffer = 0;
+    const rows = runWrangler("/tmp/crash-worker", "reasonix-crash", "SELECT 1", (
+      _command: string,
+      _args: string[],
+      options: { maxBuffer?: number },
+    ) => {
+      configuredMaxBuffer = options.maxBuffer ?? 0;
+      return { status: 0, stdout: '[{"results":[{"value":1}]}]' };
+    });
+
+    expect(rows).toEqual([{ value: 1 }]);
+    expect(configuredMaxBuffer).toBe(wranglerD1MaxBufferBytes);
+    expect(configuredMaxBuffer).toBeGreaterThan(200 * 6 * 96 * 1024);
   });
 
   it("keeps the first sample and maps the newest five into absolute ring slots", () => {


### PR DESCRIPTION
## Summary

- bound the Firebase history migration's captured Wrangler stdout at 192 MiB
- cover a full page of 200 groups with six retained 96 KiB reports per group, plus JSON envelope and escaping headroom
- add a regression contract proving the bound is passed to `spawnSync`

The first protected canary dry-run reached the migration operation with all required secrets, then failed before capacity analysis with `spawnSync ... ENOBUFS`. The failed run did not deploy the Worker, apply the migration, or change `CRASH_STORAGE_MODE`.

## Issues

Follow-up to #9418 and failed dry-run [Actions run 32883869327](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/32883869327).

## Verification

- `cd workers/crash-report && npm run typecheck`
- `cd workers/crash-report && npm test` — 13 files, 111 tests passed
- `go run ./tools/repolint` — clean, 1266 baselined findings
- `git diff --check`

After merge, the same protected `firebase_data_action=dry-run` workflow will be rerun before any `apply` action.

## Documentation impact

Documentation-impact: none - this only repairs the operator migration process; documented commands, product behavior, and storage mode are unchanged.

## Cache impact

Cache-impact: none - no prompt, provider serialization, tool schema, ordering, or cache key changes.
Cache-guard: existing cache guards are unaffected; Worker typecheck and all 111 Worker tests pass.
System-prompt-review: N/A
