### PR TITLE
fix(crash): Explain Firebase capacity reservations / 解释 Firebase 容量预留

### DIFF
--- a/workers/crash-report/scripts/firebase-migration-assessment.mjs
+++ b/workers/crash-report/scripts/firebase-migration-assessment.mjs
@@ -1,0 +1,61 @@
+const STATUS_KEYS = ["open", "resolved", "ignored", "other"];
+const AGE_KEYS = ["under30d", "days30to59d", "days60plus", "invalid"];
+
+function emptyCounts(keys) {
+  return Object.fromEntries(keys.map((key) => [key, 0]));
+}
+
+function statusKey(value) {
+  return value === "open" || value === "resolved" || value === "ignored" ? value : "other";
+}
+
+function ageKey(value, now) {
+  const age = now.getTime() - new Date(value == null ? "" : String(value)).getTime();
+  if (!Number.isFinite(age)) return "invalid";
+  if (age < 30 * 86400_000) return "under30d";
+  return age < 60 * 86400_000 ? "days30to59d" : "days60plus";
+}
+
+export function createMigrationCapacityAssessment() {
+  return {
+    statusTotals: emptyCounts(STATUS_KEYS),
+    ageByStatus: Object.fromEntries(STATUS_KEYS.map((status) => [status, emptyCounts(AGE_KEYS)])),
+  };
+}
+
+export function accumulateMigrationCapacityAssessment(summary, rows, now = new Date()) {
+  for (const row of rows) {
+    const status = statusKey(row.status);
+    const age = ageKey(row.last_seen, now);
+    summary.statusTotals[status]++;
+    summary.ageByStatus[status][age]++;
+  }
+  return summary;
+}
+
+export function finalizeMigrationCapacityAssessment(summary) {
+  const { open, resolved, ignored, other } = summary.ageByStatus;
+  return {
+    ...summary,
+    activeReasons: {
+      open: summary.statusTotals.open,
+      otherStatus: summary.statusTotals.other,
+      recentResolvedOrIgnored: resolved.under30d + ignored.under30d,
+      invalidResolvedOrIgnored: resolved.invalid + ignored.invalid,
+    },
+    automaticRetention: {
+      compacted: resolved.days30to59d + ignored.days30to59d,
+      archived: resolved.days60plus + ignored.days60plus,
+    },
+    manualReview: {
+      open30to59d: open.days30to59d,
+      open60dPlus: open.days60plus,
+      otherStatus30dPlus: other.days30to59d + other.days60plus,
+    },
+  };
+}
+
+export function assessMigrationCapacity(rows, now = new Date()) {
+  const summary = accumulateMigrationCapacityAssessment(createMigrationCapacityAssessment(), rows, now);
+  return finalizeMigrationCapacityAssessment(summary);
+}

--- a/workers/crash-report/scripts/migrate-firebase-data.d.mts
+++ b/workers/crash-report/scripts/migrate-firebase-data.d.mts
@@ -1,6 +1,25 @@
 export const firebaseOAuthGrantType: string;
 export const wranglerD1MaxBufferBytes: number;
 
+export function assessMigrationCapacity(
+  rows: Array<Record<string, unknown>>,
+  now?: Date,
+): {
+  statusTotals: Record<"open" | "resolved" | "ignored" | "other", number>;
+  ageByStatus: Record<
+    "open" | "resolved" | "ignored" | "other",
+    Record<"under30d" | "days30to59d" | "days60plus" | "invalid", number>
+  >;
+  activeReasons: {
+    open: number;
+    otherStatus: number;
+    recentResolvedOrIgnored: number;
+    invalidResolvedOrIgnored: number;
+  };
+  automaticRetention: { compacted: number; archived: number };
+  manualReview: { open30to59d: number; open60dPlus: number; otherStatus30dPlus: number };
+};
+
 export function runWrangler(
   projectDir: string,
   database: string,

--- a/workers/crash-report/scripts/migrate-firebase-data.mjs
+++ b/workers/crash-report/scripts/migrate-firebase-data.mjs
@@ -6,6 +6,14 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { parseWranglerRows } from "./apply-diagnostics-v2.mjs";
+import {
+  assessMigrationCapacity,
+  accumulateMigrationCapacityAssessment,
+  createMigrationCapacityAssessment,
+  finalizeMigrationCapacityAssessment,
+} from "./firebase-migration-assessment.mjs";
+
+export { assessMigrationCapacity };
 
 const tokenURL = "https://oauth2.googleapis.com/token";
 const scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/firebase.database";
@@ -332,11 +340,13 @@ function parseArgs(argv, projectDir) {
 async function dryRun(projectDir, database, now) {
   let cursor = "";
   const counts = { active: 0, compacted: 0, archived: 0 };
+  const assessmentCounts = createMigrationCapacityAssessment();
   let estimatedBytes = 0;
   let contentBytes = 0;
   while (true) {
     const page = readPage(projectDir, database, cursor);
     if (!page.groups.length) break;
+    accumulateMigrationCapacityAssessment(assessmentCounts, page.groups, now);
     const entries = buildFirebaseGroups(page.groups, page.reports, now);
     for (const entry of entries.values()) {
       counts[entry.state]++;
@@ -345,9 +355,36 @@ async function dryRun(projectDir, database, now) {
     }
     cursor = text(page.groups.at(-1).fingerprint);
   }
+  const assessment = finalizeMigrationCapacityAssessment(assessmentCounts);
+  const explainedActive = Object.values(assessment.activeReasons).reduce((sum, value) => sum + value, 0);
+  if (explainedActive !== counts.active || assessment.automaticRetention.compacted !== counts.compacted ||
+      assessment.automaticRetention.archived !== counts.archived) {
+    throw new Error("Firebase capacity assessment disagrees with lifecycle classification");
+  }
+  const ageLine = (status) => {
+    const value = assessment.ageByStatus[status];
+    return `${status}=${value.under30d}/${value.days30to59d}/${value.days60plus}/${value.invalid}`;
+  };
+  const manualSavings = assessment.manualReview.open30to59d * (RESERVATIONS.active - RESERVATIONS.compacted) +
+    assessment.manualReview.open60dPlus * RESERVATIONS.active;
+  const statusTotals = `open=${assessment.statusTotals.open}, resolved=${assessment.statusTotals.resolved}, ` +
+    `ignored=${assessment.statusTotals.ignored}, other=${assessment.statusTotals.other}`;
+  const activeReasons = `open=${assessment.activeReasons.open}, other_status=${assessment.activeReasons.otherStatus}, ` +
+    `recent_resolved_or_ignored=${assessment.activeReasons.recentResolvedOrIgnored}, ` +
+    `invalid_resolved_or_ignored=${assessment.activeReasons.invalidResolvedOrIgnored}`;
+  const manualReview = `open_30_to_59d=${assessment.manualReview.open30to59d}, ` +
+    `open_60d_plus=${assessment.manualReview.open60dPlus}, ` +
+    `other_status_30d_plus=${assessment.manualReview.otherStatus30dPlus}, ` +
+    `potential_reduction=${(manualSavings / 1048576).toFixed(1)} MiB`;
   console.log(`Groups: active=${counts.active}, compacted=${counts.compacted}, archived=${counts.archived}.`);
+  console.log(`Status totals: ${statusTotals}.`);
+  console.log(`Last-seen buckets (<30d/30-59d/>=60d/invalid): ${ageLine("open")}; ${ageLine("resolved")}; ${ageLine("ignored")}; ${ageLine("other")}.`);
+  console.log(`Active reasons: ${activeReasons}.`);
+  console.log(`Manual review only: ${manualReview}.`);
   console.log(`Canonical Firebase content estimate: ${(contentBytes / 1048576).toFixed(1)} MiB.`);
-  console.log(`Conservative reservation: ${(estimatedBytes / 1048576).toFixed(1)} MiB / 700 MiB.`);
+  const reservationPercent = estimatedBytes / STORAGE_BUDGET * 100;
+  console.log(`Conservative reservation: ${(estimatedBytes / 1048576).toFixed(1)} MiB / 700 MiB (${reservationPercent.toFixed(1)}%).`);
+  if (reservationPercent >= 80) console.log("Capacity warning: reservation is at or above the 80% review threshold; do not apply without operator review.");
   if (estimatedBytes > STORAGE_BUDGET) throw new Error("Estimated Firebase reservation exceeds the 700 MiB safety budget");
 }
 

--- a/workers/crash-report/src/firebase_migration.test.ts
+++ b/workers/crash-report/src/firebase_migration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  assessMigrationCapacity,
   buildFirebaseGroups,
   canonicalJSONString,
   classifyMigrationGroup,
@@ -12,6 +13,31 @@ import {
 describe("Firebase retained-sample migration", () => {
   it("uses the OAuth JWT bearer grant expected by Google's token endpoint", () => {
     expect(firebaseOAuthGrantType).toBe("urn:ietf:params:oauth:grant-type:jwt-bearer");
+  });
+
+  it("explains active reservations without treating stale open groups as automatically eligible", () => {
+    const now = new Date("2026-08-25T00:00:00Z");
+    const assessment = assessMigrationCapacity([
+      { status: "open", last_seen: "2026-08-20T00:00:00Z", fingerprint: "private", message: "private" },
+      { status: "open", last_seen: "2026-07-10T00:00:00Z" },
+      { status: "open", last_seen: "2026-06-01T00:00:00Z" },
+      { status: "resolved", last_seen: "2026-08-20T00:00:00Z" },
+      { status: "resolved", last_seen: "2026-07-10T00:00:00Z" },
+      { status: "ignored", last_seen: "2026-06-01T00:00:00Z" },
+      { status: "resolved", last_seen: "invalid" },
+      { status: "future-status", last_seen: "2026-06-01T00:00:00Z" },
+    ], now);
+
+    expect(assessment.statusTotals).toEqual({ open: 3, resolved: 3, ignored: 1, other: 1 });
+    expect(assessment.activeReasons).toEqual({
+      open: 3,
+      otherStatus: 1,
+      recentResolvedOrIgnored: 1,
+      invalidResolvedOrIgnored: 1,
+    });
+    expect(assessment.automaticRetention).toEqual({ compacted: 1, archived: 1 });
+    expect(assessment.manualReview).toEqual({ open30to59d: 1, open60dPlus: 1, otherStatus30dPlus: 1 });
+    expect(JSON.stringify(assessment)).not.toContain("private");
   });
 
   it("captures a full retained-report page without using Node's default child-process buffer", () => {


### PR DESCRIPTION
## Summary

- explain every Firebase migration lifecycle classification using count-only status and last-seen buckets
- distinguish automatically eligible resolved/ignored groups from stale open groups that require manual operator review
- report the theoretical reservation reduction from reviewing stale open groups and emit the existing 80% capacity warning
- fail closed if the assessment totals disagree with the migration's active/compacted/archived classification

The current protected dry-run reports 948 active groups and 592.5 MiB reserved, but the previous output cannot show why those groups remain active. This change adds only aggregate counts; it deliberately excludes fingerprints, samples, messages, credentials, and database URLs.

## Issues

Follow-up to #9418 and #9424. The assessment will be rerun through the protected canary `dry-run` path before any `apply` decision.

## Verification

- `cd workers/crash-report && npm run typecheck`
- `cd workers/crash-report && npm test` — 13 files, 112 tests passed
- `go run ./tools/repolint` — clean, 1266 baselined findings
- `git diff --check`

The regression test proves stale open groups remain manual-review candidates and that fingerprint/message inputs cannot appear in the assessment result.

## Documentation impact

Documentation-impact: none - this enriches protected operator dry-run output without changing commands, retention policy, storage mode, or user-facing behavior.

## Cache impact

Cache-impact: none - no prompt, provider serialization, tool schema, ordering, or cache key changes.
Cache-guard: existing cache guards are unaffected; Worker typecheck and all 112 Worker tests pass.
System-prompt-review: N/A
