### PR TITLE
fix(mcp): expose structured tool results to models

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -6,6 +6,7 @@
 package plugin
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -1896,17 +1897,20 @@ func parseToolResult(res json.RawMessage) (string, []string, error) {
 			Data     string `json:"data"`
 			MimeType string `json:"mimeType"`
 		} `json:"content"`
-		IsError bool `json:"isError"`
+		StructuredContent json.RawMessage `json:"structuredContent"`
+		IsError           bool            `json:"isError"`
 	}
 	if err := json.Unmarshal(res, &out); err != nil {
 		return "", nil, fmt.Errorf("decode tool result: %w", err)
 	}
 	var sb strings.Builder
+	var textBlocks []string
 	var images []string
 	for _, c := range out.Content {
 		switch c.Type {
 		case "text":
 			sb.WriteString(c.Text)
+			textBlocks = append(textBlocks, c.Text)
 		case "image":
 			placeholder, url := toolResultImage(c.MimeType, c.Data, len(images))
 			sb.WriteString(placeholder)
@@ -1915,11 +1919,66 @@ func parseToolResult(res json.RawMessage) (string, []string, error) {
 			}
 		}
 	}
-	text := sb.String()
+	text := appendStructuredContentFallback(sb.String(), textBlocks, out.StructuredContent)
 	if out.IsError {
 		return text, images, fmt.Errorf("plugin tool reported error: %s", text)
 	}
 	return text, images, nil
+}
+
+// appendStructuredContentFallback preserves the server's model-facing content
+// and adds compact structured JSON only when no TextContent block already
+// carries the same JSON value. This keeps content-only and dual-channel MCP
+// servers unchanged while making structured results visible to text consumers.
+func appendStructuredContentFallback(text string, textBlocks []string, structured json.RawMessage) string {
+	compact, ok := compactStructuredContent(structured)
+	if !ok || textContainsEquivalentJSON(textBlocks, text, structured) {
+		return text
+	}
+	if text == "" {
+		return compact
+	}
+	return text + "\n\n" + compact
+}
+
+func compactStructuredContent(raw json.RawMessage) (string, bool) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return "", false
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err != nil {
+		return "", false
+	}
+	return compact.String(), true
+}
+
+func textContainsEquivalentJSON(textBlocks []string, combined string, structured json.RawMessage) bool {
+	structuredValue, ok := decodeSingleJSONValue(structured)
+	if !ok {
+		return false
+	}
+	for _, candidate := range append(append([]string(nil), textBlocks...), combined) {
+		candidateValue, ok := decodeSingleJSONValue([]byte(candidate))
+		if ok && reflect.DeepEqual(candidateValue, structuredValue) {
+			return true
+		}
+	}
+	return false
+}
+
+func decodeSingleJSONValue(raw []byte) (any, bool) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, false
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, false
+	}
+	return value, true
 }
 
 // toolResultImage validates one MCP image content item and returns its text

--- a/internal/plugin/toolresult_structured_test.go
+++ b/internal/plugin/toolresult_structured_test.go
@@ -1,0 +1,151 @@
+package plugin
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseToolResultContentOnlyUnchanged(t *testing.T) {
+	want := `{"datasources":[{"name":"Prometheus"}]}`
+	res := `{"content":[{"type":"text","text":` + quotedJSON(want) + `}]}`
+
+	text, images, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if text != want {
+		t.Fatalf("text = %q, want unchanged %q", text, want)
+	}
+	if len(images) != 0 {
+		t.Fatalf("images = %v, want none", images)
+	}
+}
+
+func TestParseToolResultEquivalentStructuredJSONIsNotDuplicated(t *testing.T) {
+	want := `{"folders":[{"uid":"torchbearing-demo"}],"page":{"total":1}}`
+	res := `{"content":[{"type":"text","text":` + quotedJSON(want) + `}],` +
+		`"structuredContent":{"page":{"total":1},"folders":[{"uid":"torchbearing-demo"}]}}`
+
+	text, _, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if text != want {
+		t.Fatalf("text = %q, want one unchanged JSON value %q", text, want)
+	}
+	if strings.Count(text, "torchbearing-demo") != 1 {
+		t.Fatalf("equivalent structured content was duplicated: %q", text)
+	}
+}
+
+func TestParseToolResultAppendsStructuredJSONAfterGenericText(t *testing.T) {
+	res := `{"content":[{"type":"text","text":"Dagu read completed."}],` +
+		`"structuredContent":{"target":"dags","data":{"items":[{"name":"hello-playbook"}]}}}`
+
+	text, _, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	want := "Dagu read completed.\n\n" +
+		`{"target":"dags","data":{"items":[{"name":"hello-playbook"}]}}`
+	if text != want {
+		t.Fatalf("text = %q, want %q", text, want)
+	}
+}
+
+func TestParseToolResultStructuredOnlySupportsJSONValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		structured string
+		want       string
+	}{
+		{name: "object", structured: `{"healthy": true}`, want: `{"healthy":true}`},
+		{name: "array", structured: `[1, 2, 3]`, want: `[1,2,3]`},
+		{name: "string", structured: `"ready"`, want: `"ready"`},
+		{name: "number", structured: `42`, want: `42`},
+		{name: "boolean", structured: `true`, want: `true`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := `{"content":[],"structuredContent":` + tt.structured + `}`
+			text, _, err := parseToolResult(json.RawMessage(res))
+			if err != nil {
+				t.Fatalf("parseToolResult: %v", err)
+			}
+			if text != tt.want {
+				t.Fatalf("text = %q, want %q", text, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseToolResultNullStructuredContentIsIgnored(t *testing.T) {
+	res := `{"content":[{"type":"text","text":"unchanged"}],"structuredContent":null}`
+	text, _, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if text != "unchanged" {
+		t.Fatalf("text = %q, want unchanged", text)
+	}
+}
+
+func TestParseToolResultStructuredErrorRemainsAnError(t *testing.T) {
+	res := `{"content":[{"type":"text","text":"Dagu read failed."}],` +
+		`"structuredContent":{"code":"not_found","name":"missing-dag"},"isError":true}`
+
+	text, _, err := parseToolResult(json.RawMessage(res))
+	if err == nil {
+		t.Fatal("want tool error")
+	}
+	for _, want := range []string{"Dagu read failed.", `"code":"not_found"`, `"name":"missing-dag"`} {
+		if !strings.Contains(text, want) || !strings.Contains(err.Error(), want) {
+			t.Fatalf("structured error missing %q: text=%q err=%v", want, text, err)
+		}
+	}
+}
+
+func TestParseToolResultPreservesImagesWhenAppendingStructuredJSON(t *testing.T) {
+	payload := base64.StdEncoding.EncodeToString([]byte("png-bytes"))
+	res := `{"content":[{"type":"text","text":"before "},` + imageItem("image/png", payload) +
+		`],"structuredContent":{"caption":"chart"}}`
+
+	text, images, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if want := "before [image: image/png]\n\n{\"caption\":\"chart\"}"; text != want {
+		t.Fatalf("text = %q, want %q", text, want)
+	}
+	if len(images) != 1 || images[0] != "data:image/png;base64,"+payload {
+		t.Fatalf("images = %v, want original image", images)
+	}
+}
+
+func TestParseToolResultNaturalLanguageDoesNotSuppressStructuredJSON(t *testing.T) {
+	res := `{"content":[{"type":"text","text":"folders: torchbearing-demo"}],` +
+		`"structuredContent":{"folders":["torchbearing-demo"]}}`
+
+	text, _, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if !strings.Contains(text, "folders: torchbearing-demo\n\n") ||
+		!strings.Contains(text, `{"folders":["torchbearing-demo"]}`) {
+		t.Fatalf("structured JSON was not appended: %q", text)
+	}
+}
+
+func TestParseToolResultRejectsMalformedEnvelope(t *testing.T) {
+	if _, _, err := parseToolResult(json.RawMessage(`{"content":[],"structuredContent":`)); err == nil {
+		t.Fatal("want malformed tool result error")
+	}
+}
+
+func quotedJSON(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}


### PR DESCRIPTION
## Summary

- preserve existing MCP `content` text and image handling
- append compact `structuredContent` JSON when no equivalent JSON TextContent exists
- avoid duplicating dual-channel results while exposing structured-only and generic-text results to models
- cover content-only, duplicate JSON, structured-only, scalar, error, image, null, and malformed result cases

## Issues

MCP servers may place the semantic tool result in `structuredContent` while returning only a generic success message in `content`. Reasonix currently drops that structured value before it reaches the model.

## Verification

- `go test ./internal/plugin`
- `go test ./...`
- `go vet ./...`
- `gofmt -l internal/plugin/plugin.go internal/plugin/toolresult_structured_test.go`

## Documentation impact

Documentation-impact: none - this is MCP result compatibility with no new user-facing configuration or command surface.

## Cache impact

Cache-impact: low - tool schemas and the stable prompt prefix are unchanged; only per-call MCP result text gains missing structured data.
Cache-guard: focused `internal/plugin` structured-result tests plus `go test ./...`.
System-prompt-review: N/A