### PR TITLE
fix(desktop): commit completed GFM table rows immediately while streaming / 流式输出中 GFM 表格行立即提交（#8972）

### DIFF
--- a/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
+++ b/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
@@ -269,6 +269,12 @@ console.log("\nmermaid rendering");
   eq(streamingCommitTarget("para\n## Next sec"), "para\n", "a partial heading line completes the paragraph before it");
   eq(streamingCommitTarget("para\n## Done\ntail"), "para\n## Done\n", "a terminated heading promotes itself as a complete block");
 
+  // GFM table rows commit per terminated line.
+  eq(streamingCommitTarget("| a | b |\n|---|---|\n| 1 | 2 |\n"), "| a | b |\n|---|---|\n| 1 | 2 |\n", "completed table rows commit immediately");
+  eq(streamingCommitTarget("| a | b |\n|---|---|\n| 1 | 2 |"), "| a | b |\n|---|---|\n", "incomplete last row stays in tail");
+  eq(streamingCommitTarget("| a | b |\n|---|---|\n| 1 | 2 |\n\nnext"), "| a | b |\n|---|---|\n| 1 | 2 |\n\n", "blank line closes table");
+  eq(streamingCommitTarget("text\n\n| h1 | h2 |\n|---|---|\n| r1 | r1 |\n| r2 | r2 |\nmore"), "text\n\n| h1 | h2 |\n|---|---|\n| r1 | r1 |\n| r2 | r2 |\n", "table rows commit, non-pipe tail stays");
+
   const searchItem = (title: string, url: string) => `- **${title}**\n  <${url}>`;
   const searchDump = [
     searchItem("新闻本文", "https://example.com/a"),

--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -180,6 +180,11 @@ export function streamingCommitTarget(text: string): string {
       // completes everything before it; a terminated one is itself complete.
       else if (/^ {0,3}#{1,6}[ \t]+/.test(line)) boundary = terminated ? lineEnd : lineStart;
       else if (isStreamingListItemLine(line)) boundary = lineStart;
+      // GFM table rows commit per terminated line. A row is any terminated
+      // line that contains '|'. Non-pipe lines stay in the tail because a
+      // plain line after table rows is swallowed as a single-cell row by the
+      // final remark-gfm parse.
+      else if (terminated && line.includes("|")) boundary = lineEnd;
     }
     lineStart = lineEnd;
   }


### PR DESCRIPTION
## TL;DR（中文摘要）

流式输出中 GFM 表格的已完成行延迟渲染——需等空行或流结束才显示。在 `streamingCommitTarget` 中加了 `|` 检测规则：已终止的含管道符行（表格行）立即提交，非管道行留在 tail（remark-gfm 会将其吞为单格行）。

## What

GFM table rows in streaming output ride the plain-text tail until a blank line or another block boundary arrives, so completed rows stay unrendered until the stream ends.

## Why

`streamingCommitTarget` (`Markdown.tsx:151`) has no table-specific commit rule. Table rows are only committed when a blank line or block-start arrives.

## How

Add a pipe-detection rule to the boundary check in `streamingCommitTarget`: any terminated line containing `|` is a complete table row and promotes immediately. Non-pipe lines stay in the tail because remark-gfm swallows them as single-cell rows.

```ts
else if (terminated && line.includes("|")) boundary = lineEnd;
```

## Verification

- Completed table rows render immediately during streaming ✅
- Incomplete last row stays in tail ✅
- Blank line closes table ✅
- Non-pipe lines after table stay in tail (matching remark-gfm parse) ✅
- Existing streamingCommitTarget tests unchanged ✅

Fixes #8972

Documentation-impact: none - GFM table streaming fix; no docs/*.md changed
Cache-impact: none - frontend streaming display fix; no prompt or tool schema changes
Cache-guard: none - not required; changed paths are outside provider-visible cache construction

System-prompt-review: none- frontend streaming/GFM display fix; no system-prompt bytes change.
