### PR TITLE
fix(desktop): allow archiving sessions with stale write authority / 修复恢复失败会话无法归档的死循环（#9393）

### DIFF
--- a/desktop/topic_archive_ownership.go
+++ b/desktop/topic_archive_ownership.go
@@ -77,17 +77,36 @@ func acquireTopicArchiveOwnership(targets []topicTrashTarget, removed []removedS
 		}
 		lease := takeTopicArchiveSessionLease(tab, target.sessionPath)
 		if lease == nil {
-			batch.rollback()
-			return nil, errTopicArchiveBusy
+			// No lease available (e.g. tab in sessionRuntimeFailed after
+			// a failed restore). Fall back to non-runtime guard acquisition
+			// so the archive can proceed without a live lease.
+			guard, err := acquireSessionRemovalGuard(target.sessionPath)
+			if err != nil {
+				batch.rollback()
+				return nil, err
+			}
+			batch.add(target, guard, nil)
+			continue
 		}
 		guard, err := lease.TryConvertToRemovalGuard()
 		if err != nil {
+			// Lease conversion failed (stale authority, mismatched generation,
+			// etc.). Release the lease and fall back to a non-runtime guard
+			// instead of aborting the entire archive.
 			tab.adoptSessionLease(lease)
-			batch.rollback()
 			if errors.Is(err, agent.ErrSessionLeaseHeld) {
+				batch.rollback()
 				return nil, errSessionBusyElsewhere
 			}
-			return nil, err
+			slog.Warn("desktop: topic archive lease conversion failed, falling back to non-runtime guard",
+				"session", target.sessionPath, "err", err)
+			guard2, err2 := acquireSessionRemovalGuard(target.sessionPath)
+			if err2 != nil {
+				batch.rollback()
+				return nil, err2
+			}
+			batch.add(target, guard2, nil)
+			continue
 		}
 		batch.add(target, guard, tab)
 	}


### PR DESCRIPTION
TL;DR: 恢复失败的会话（write authority 未绑定）无法归档，重启后自动恢复再次失败形成死循环。修复：lease 转换失败时 fallback 到非运行时 guard，让归档继续。Fixes #9393

Documentation-impact: none - fix stale write authority preventing archive; no docs/*.md changed
Cache-impact: none - desktop session management fix; no prompt or tool schema changes
Cache-guard: none - not required; changed paths are outside provider-visible cache construction

System-prompt-review: none- desktop session-management/archive fix; no system-prompt bytes change.
