### PR TITLE
feat(serve): GET /projects multi-project session browser / serve 多项目会话浏览端点（#8789）

### DIFF
--- a/internal/serve/projects.go
+++ b/internal/serve/projects.go
@@ -1,0 +1,121 @@
+package serve
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/store"
+)
+
+// GET /projects — read-only multi-project session browser.
+//
+// Reads the same desktop-projects.json the desktop sidebar uses, resolves each
+// project's session directory, and returns the per-session metadata in the same
+// shape as GET /sessions.  This endpoint does NOT bind to a different workspace;
+// submit/resume/approve remain bound to the serve instance's startup directory.
+func (s *Server) listProjects(w http.ResponseWriter, r *http.Request) {
+	type sessionEntry struct {
+		Name    string `json:"name"`
+		Path    string `json:"path"`
+		Title   string `json:"title,omitempty"`
+		Turns   int    `json:"turns,omitempty"`
+		Current bool   `json:"current,omitempty"`
+	}
+	type projectEntry struct {
+		Root     string         `json:"root"`
+		Name     string         `json:"name,omitempty"`
+		Sessions []sessionEntry `json:"sessions"`
+	}
+
+	home := config.ReasonixHomeDir()
+	if home == "" {
+		writeJSON(w, []projectEntry{})
+		return
+	}
+
+	// Parse desktop-projects.json.
+	type pf struct {
+		Projects []struct {
+			Root string `json:"root"`
+		} `json:"projects"`
+	}
+	var saved pf
+	if data, err := os.ReadFile(filepath.Join(home, "desktop-projects.json")); err == nil {
+		_ = json.Unmarshal(data, &saved)
+	}
+
+	// Always include the global workspace.
+	seen := map[string]bool{}
+	var roots []string
+	addRoot := func(root string) {
+		root = filepath.Clean(strings.TrimSpace(root))
+		if root == "" || root == "." || seen[root] {
+			return
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+	addRoot(filepath.Join(home, "global-workspace"))
+	for _, p := range saved.Projects {
+		addRoot(p.Root)
+	}
+
+	currentSession := ""
+	if s.ctl() != nil {
+		currentSession = filepath.Clean(s.ctl().SessionPath())
+	}
+
+	var out []projectEntry
+	for _, root := range roots {
+		sessDir := config.ProjectSessionDir(root)
+		if sessDir == "" {
+			continue
+		}
+		entries, err := os.ReadDir(sessDir)
+		if err != nil {
+			continue
+		}
+		var sessions []sessionEntry
+		for _, e := range entries {
+			if e.IsDir() || !store.IsSessionTranscriptName(e.Name()) {
+				continue
+			}
+			path := filepath.Join(sessDir, e.Name())
+			if agent.IsCleanupPending(path) {
+				continue
+			}
+			name := strings.TrimSuffix(e.Name(), ".jsonl")
+			se := sessionEntry{
+				Name:    name,
+				Path:    path,
+				Current: filepath.Clean(path) == currentSession,
+			}
+			if first, turns := agent.SessionPreview(path); turns > 0 {
+				se.Turns = turns
+				se.Title = s.sessionTitle(r.Context(), e.Name(), first, agent.SessionContentModTime(path).UnixNano())
+			}
+			sessions = append(sessions, se)
+		}
+		// Reverse for newest-first.
+		for i, j := 0, len(sessions)-1; i < j; i, j = i+1, j-1 {
+			sessions[i], sessions[j] = sessions[j], sessions[i]
+		}
+		if sessions == nil {
+			sessions = []sessionEntry{}
+		}
+		out = append(out, projectEntry{
+			Root:     root,
+			Name:     filepath.Base(root),
+			Sessions: sessions,
+		})
+	}
+	if out == nil {
+		out = []projectEntry{}
+	}
+	writeJSON(w, out)
+}

--- a/internal/serve/projects_test.go
+++ b/internal/serve/projects_test.go
@@ -1,0 +1,114 @@
+package serve
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+	"reasonix/internal/provider"
+)
+
+func TestListProjectsEndpoint(t *testing.T) {
+	// Set up a temp REASONIX_HOME with desktop-projects.json and session files.
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+
+	// Create a fake project workspace.
+	projRoot := filepath.Join(home, "test-project")
+	if err := os.MkdirAll(projRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sessDir := config.ProjectSessionDir(projRoot)
+	if err := os.MkdirAll(sessDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a session file.
+	s := agent.NewSession("system prompt")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	if err := s.Save(filepath.Join(sessDir, "test-session.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write desktop-projects.json pointing to our test project.
+	type pf struct {
+		Projects []struct {
+			Root string `json:"root"`
+		} `json:"projects"`
+	}
+	pfData, _ := json.Marshal(pf{
+		Projects: []struct {
+			Root string `json:"root"`
+		}{{Root: projRoot}},
+	})
+	if err := os.WriteFile(filepath.Join(home, "desktop-projects.json"), pfData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Also create the global-workspace sessions dir so it's included.
+	gwRoot := filepath.Join(home, "global-workspace")
+	gwSessDir := config.ProjectSessionDir(gwRoot)
+	t.Logf("global-workspace sessions dir: %s", gwSessDir)
+	if err := os.MkdirAll(gwSessDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc})
+	srv := httptest.NewServer(New(ctrl, bc, config.ServeConfig{}).Handler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/projects")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var projects []struct {
+		Root     string `json:"root"`
+		Name     string `json:"name"`
+		Sessions []struct {
+			Name  string `json:"name"`
+			Title string `json:"title,omitempty"`
+			Turns int    `json:"turns,omitempty"`
+		} `json:"sessions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&projects); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have at least global-workspace + test-project.
+	if len(projects) < 2 {
+		t.Fatalf("got %d projects, want >= 2", len(projects))
+	}
+
+	// Find our test project.
+	var found bool
+	for _, p := range projects {
+		if filepath.Clean(p.Root) == filepath.Clean(projRoot) {
+			found = true
+			if len(p.Sessions) != 1 {
+				t.Fatalf("test-project sessions = %d, want 1", len(p.Sessions))
+			}
+			if p.Sessions[0].Name != "test-session" {
+				t.Fatalf("session name = %q, want test-session", p.Sessions[0].Name)
+			}
+			if p.Sessions[0].Turns != 1 {
+				t.Fatalf("session turns = %d, want 1", p.Sessions[0].Turns)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("test-project not found in /projects response")
+	}
+}


### PR DESCRIPTION
TL;DR: 新增 GET /projects 端点，读取 desktop-projects.json 列出所有项目的会话（复用 config.ProjectSessionDir + agent.SessionPreview），返回与 GET /sessions 相同的 session 元数据结构。移动端/网页端单个 serve 实例即可浏览全部项目，无需每项目一个 serve。Fixes #8789

Documentation-impact: none - serve GET /projects endpoint; no docs/*.md changed
Cache-impact: none - new serve HTTP endpoint; no prompt or tool schema changes
Cache-guard: none - not required; changed paths are outside provider-visible cache construction

System-prompt-review: none- serve HTTP GET /projects endpoint only; no system-prompt bytes change.
