### PR TITLE
feat(serve): POST /attachments image upload endpoint / serve 图片上传端点（#8855）

### DIFF
--- a/internal/serve/attachments.go
+++ b/internal/serve/attachments.go
@@ -3,6 +3,7 @@ package serve
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -40,7 +41,16 @@ func (s *Server) uploadAttachment(w http.ResponseWriter, r *http.Request) {
 		Data string `json:"data"` // base64-encoded image bytes
 		Mime string `json:"mime"` // optional, e.g. "image/png"
 	}
+	// Cap the request body before decoding so oversized uploads can't exhaust
+	// memory. maxUploadBytes is the decoded image size; base64 inflates by ~4/3
+	// in transit, so cap the raw body at maxUploadBytes*2 (64 MiB + headroom).
+	r.Body = http.MaxBytesReader(w, r.Body, maxUploadBytes*2)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, fmt.Sprintf("bad request: %v", err), http.StatusBadRequest)
 		return
 	}
@@ -49,14 +59,10 @@ func (s *Server) uploadAttachment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	raw, err := base64.StdEncoding.DecodeString(req.Data)
+	raw, err := decodeBase64Flexible(req.Data)
 	if err != nil {
-		// Try URL-safe base64 as fallback.
-		raw, err = base64.URLEncoding.DecodeString(req.Data)
-		if err != nil {
-			http.Error(w, "invalid base64 data", http.StatusBadRequest)
-			return
-		}
+		http.Error(w, "invalid base64 data", http.StatusBadRequest)
+		return
 	}
 	if len(raw) > maxUploadBytes {
 		http.Error(w, "file too large (max 64 MiB)", http.StatusRequestEntityTooLarge)
@@ -76,4 +82,26 @@ func (s *Server) uploadAttachment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, map[string]string{"ref": path})
+}
+
+// decodeBase64Flexible decodes standard or URL-safe base64, tolerating missing
+// padding (unpadded encoding) which many clients produce. It trims surrounding
+// whitespace first. The strconv-based length check mirrors Go's raw unpadded
+// decode: padding is appended only when the remainder calls for it.
+func decodeBase64Flexible(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	encs := []*base64.Encoding{base64.StdEncoding, base64.URLEncoding}
+	for i := 0; i < len(encs); i++ {
+		raw, err := encs[i].DecodeString(s)
+		if err == nil {
+			return raw, nil
+		}
+		// Missing-padding error: append the needed '='s and retry.
+		if rem := len(s) % 4; rem > 0 {
+			if padded, e := encs[i].DecodeString(s + strings.Repeat("=", 4-rem)); e == nil {
+				return padded, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("invalid base64 data")
 }

--- a/internal/serve/attachments.go
+++ b/internal/serve/attachments.go
@@ -1,0 +1,79 @@
+package serve
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"reasonix/internal/control"
+)
+
+const maxUploadBytes = 64 << 20 // 64 MiB, matching maxImageAttachmentBytes
+
+// POST /attachments — upload an image and get back a reference path.
+//
+// Request body (JSON):
+//
+//	{"data": "<base64-encoded image>", "mime": "image/png"}
+//
+// Returns:
+//
+//	{"ref": ".reasonix/attachments/clipboard-<ts>-<seq>.png"}
+//
+// The caller then sends `POST /submit {"input": "@<ref> ..."}` to include
+// the image in a message.  The agent's existing @ref parsing and multimodal
+// pipeline handles the rest — no protocol changes needed.
+func (s *Server) uploadAttachment(w http.ResponseWriter, r *http.Request) {
+	if s.ctl() == nil {
+		http.Error(w, "no active session", http.StatusBadRequest)
+		return
+	}
+	root := s.ctl().WorkspaceRoot()
+	if root == "" {
+		http.Error(w, "workspace root unknown", http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		Data string `json:"data"` // base64-encoded image bytes
+		Mime string `json:"mime"` // optional, e.g. "image/png"
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("bad request: %v", err), http.StatusBadRequest)
+		return
+	}
+	if req.Data == "" {
+		http.Error(w, "data field required (base64-encoded image)", http.StatusBadRequest)
+		return
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(req.Data)
+	if err != nil {
+		// Try URL-safe base64 as fallback.
+		raw, err = base64.URLEncoding.DecodeString(req.Data)
+		if err != nil {
+			http.Error(w, "invalid base64 data", http.StatusBadRequest)
+			return
+		}
+	}
+	if len(raw) > maxUploadBytes {
+		http.Error(w, "file too large (max 64 MiB)", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	// Normalize MIME: strip parameters like "; charset=..."
+	mime := strings.TrimSpace(req.Mime)
+	if i := strings.IndexByte(mime, ';'); i >= 0 {
+		mime = strings.TrimSpace(mime[:i])
+	}
+
+	path, err := control.SaveImageBytesInRoot(root, mime, raw)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	writeJSON(w, map[string]string{"ref": path})
+}

--- a/internal/serve/attachments_test.go
+++ b/internal/serve/attachments_test.go
@@ -1,0 +1,103 @@
+package serve
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+)
+
+// minimalPNG returns a valid 1x1 white PNG.
+func minimalPNG() []byte {
+	var buf bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.White)
+	_ = png.Encode(&buf, img)
+	return buf.Bytes()
+}
+
+func TestUploadAttachmentJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+
+	projRoot := filepath.Join(home, "project")
+	if err := os.MkdirAll(projRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, WorkspaceRoot: projRoot})
+	srv := httptest.NewServer(New(ctrl, bc, config.ServeConfig{}).Handler())
+	defer srv.Close()
+
+	pngData := minimalPNG()
+	b64 := base64.StdEncoding.EncodeToString(pngData)
+	body, _ := json.Marshal(map[string]string{
+		"data": b64,
+		"mime": "image/png",
+	})
+
+	resp, err := http.Post(srv.URL+"/attachments", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	ref := result["ref"]
+	if ref == "" {
+		t.Fatal("ref is empty")
+	}
+	if !strings.Contains(ref, ".reasonix/attachments/") {
+		t.Fatalf("ref %q does not contain .reasonix/attachments/", ref)
+	}
+	if !strings.HasSuffix(ref, ".png") {
+		t.Fatalf("ref %q does not end with .png", ref)
+	}
+	// Verify the file was actually written (relative to project root).
+	if _, err := os.Stat(filepath.Join(projRoot, ref)); err != nil {
+		t.Fatalf("file not written: %v", err)
+	}
+}
+
+func TestUploadAttachmentNoData(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+
+	projRoot := filepath.Join(home, "project")
+	os.MkdirAll(projRoot, 0o755)
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, WorkspaceRoot: projRoot})
+	srv := httptest.NewServer(New(ctrl, bc, config.ServeConfig{}).Handler())
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]string{"mime": "image/png"})
+	resp, err := http.Post(srv.URL+"/attachments", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 400 {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/internal/serve/attachments_test.go
+++ b/internal/serve/attachments_test.go
@@ -101,3 +101,61 @@ func TestUploadAttachmentNoData(t *testing.T) {
 		t.Fatalf("status = %d, want 400", resp.StatusCode)
 	}
 }
+
+func TestUploadAttachmentUnpaddedBase64(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+
+	projRoot := filepath.Join(home, "project")
+	if err := os.MkdirAll(projRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, WorkspaceRoot: projRoot})
+	srv := httptest.NewServer(New(ctrl, bc, config.ServeConfig{}).Handler())
+	defer srv.Close()
+
+	pngData := minimalPNG()
+	b64 := base64.StdEncoding.EncodeToString(pngData)
+	b64 = strings.TrimRight(b64, "=") // strip padding, as many clients do
+
+	body, _ := json.Marshal(map[string]string{
+		"data": b64,
+		"mime": "image/png",
+	})
+	resp, err := http.Post(srv.URL+"/attachments", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := readAll(resp)
+		t.Fatalf("status = %d, want 200 (unpadded base64 accepted); body=%s", resp.StatusCode, b)
+	}
+}
+
+func TestUploadAttachmentOversize(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+
+	projRoot := filepath.Join(home, "project")
+	os.MkdirAll(projRoot, 0o755)
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, WorkspaceRoot: projRoot})
+	srv := httptest.NewServer(New(ctrl, bc, config.ServeConfig{}).Handler())
+	defer srv.Close()
+
+	// Raw body over the MaxBytesReader cap (well beyond maxUploadBytes*2).
+	huge := strings.Repeat("A", maxUploadBytes*2+1)
+	body, _ := json.Marshal(map[string]string{"data": huge, "mime": "image/png"})
+	resp, err := http.Post(srv.URL+"/attachments", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -549,6 +549,8 @@ func (s *Server) handler() http.Handler {
 	mux.HandleFunc("POST /plan-decision", s.foregroundMutation(s.planDecision))
 	mux.HandleFunc("POST /plan", s.foregroundMutation(s.plan))
 	mux.HandleFunc("POST /composer-profile", s.composerProfile)
+	mux.HandleFunc("GET /projects", s.listProjects)
+	mux.HandleFunc("POST /attachments", s.uploadAttachment)
 	mux.HandleFunc("POST /compact", s.foregroundMutation(s.compact))
 	mux.HandleFunc("POST /new", s.newSession)
 	mux.HandleFunc("POST /clear", s.clearSession)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -549,7 +549,6 @@ func (s *Server) handler() http.Handler {
 	mux.HandleFunc("POST /plan-decision", s.foregroundMutation(s.planDecision))
 	mux.HandleFunc("POST /plan", s.foregroundMutation(s.plan))
 	mux.HandleFunc("POST /composer-profile", s.composerProfile)
-	mux.HandleFunc("GET /projects", s.listProjects)
 	mux.HandleFunc("POST /attachments", s.uploadAttachment)
 	mux.HandleFunc("POST /compact", s.foregroundMutation(s.compact))
 	mux.HandleFunc("POST /new", s.newSession)


### PR DESCRIPTION
TL;DR: 新增 POST /attachments 端点，接受 JSON body（base64 编码图片），调用 control.SaveImageBytesInRoot 落盘到 .reasonix/attachments/，返回 @ref 路径。客户端拿到 ref 后通过 POST /submit {"input": "@ref ..."} 发送图片消息，复用 agent 全套多模态管线。移动端（GrandCouncil）可复刻桌面端发图体验。Fixes #8855

Documentation-impact: none - serve POST /attachments endpoint; no docs/*.md changed
Cache-impact: none - new serve HTTP endpoint; no prompt or tool schema changes
Cache-guard: none - not required; changed paths are outside provider-visible cache construction

System-prompt-review: none- serve HTTP POST /attachments endpoint only; no system-prompt bytes change.
