### PR TITLE
feat: refresh system-prompt memory region after compaction / 压缩后刷新系统提示中的持久记忆段

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -522,3 +522,28 @@ func (s *Session) HasSystemMessage() bool {
 	defer s.mu.RUnlock()
 	return len(s.Messages) > 0 && s.Messages[0].Role == provider.RoleSystem
 }
+
+// ReplaceSystemMessage swaps the leading system message's content in place,
+// preserving the rest of the conversation so history stays continuous (as on a
+// post-compaction memory refresh). It bumps the session version (dirty/save
+// tracking) but not the rewrite version — it must not be persisted as a content
+// rewrite since it does not touch provider-visible user/tool bytes beyond the
+// system message itself (which is never compacted away). Returns true when a
+// change was applied. It is a no-op when the session does not start with a
+// system message or the content is already up to date.
+func (s *Session) ReplaceSystemMessage(content string) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.Messages) == 0 || s.Messages[0].Role != provider.RoleSystem {
+		return false
+	}
+	if s.Messages[0].Content == content {
+		return false
+	}
+	s.Messages[0].Content = content
+	s.version++
+	return true
+}

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -695,3 +695,43 @@ func TestPersistedStateTracksBaseline(t *testing.T) {
 		t.Fatal("after rewrite: AppendOnlyTail should be false")
 	}
 }
+
+func TestReplaceSystemMessageUpdatesLeadingSystemInPlace(t *testing.T) {
+	s := NewSession("old system")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first user"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "first answer"})
+	before := len(s.Messages)
+
+	if !s.ReplaceSystemMessage("new system with latest memory") {
+		t.Fatal("ReplaceSystemMessage should report a change")
+	}
+	if len(s.Messages) != before {
+		t.Fatalf("ReplaceSystemMessage should not change message count: got %d want %d", len(s.Messages), before)
+	}
+	if s.Messages[0].Role != provider.RoleSystem || s.Messages[0].Content != "new system with latest memory" {
+		t.Fatalf("system message not replaced: %+v", s.Messages[0])
+	}
+	// History beyond the system message must be untouched.
+	if s.Messages[1].Content != "first user" || s.Messages[2].Content != "first answer" {
+		t.Fatalf("history was disturbed by system replacement: %+v", s.Messages)
+	}
+}
+
+func TestReplaceSystemMessageNoopSameContentAndNoSystem(t *testing.T) {
+	s := NewSession("stable")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "u"})
+	if s.ReplaceSystemMessage("stable") {
+		t.Error("ReplaceSystemMessage should be a no-op when content is identical")
+	}
+
+	noSys := &Session{}
+	if noSys.ReplaceSystemMessage("x") {
+		t.Error("ReplaceSystemMessage should be a no-op on a session without a leading system message")
+	}
+
+	userOnly := NewSession("")
+	userOnly.Add(provider.Message{Role: provider.RoleUser, Content: "u"})
+	if userOnly.ReplaceSystemMessage("x") {
+		t.Error("ReplaceSystemMessage should be a no-op when the first message is not system")
+	}
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -636,6 +636,11 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 	}
 	mem := memory.Load(memory.Options{CWD: root, UserDir: config.MemoryUserDir()})
 	projectChecks := instruction.ExtractHostChecks(mem.Docs)
+	// sysPromptBase is the assembled prefix up to (but not including) the memory
+	// region: base prompt + core policies + workspace + environment. A
+	// post-compaction memory reload reuses it so only the # Memory region is
+	// regenerated from the latest on-disk memory.
+	sysPromptBase := sysPrompt
 	sysPrompt = memory.Compose(sysPrompt, mem)
 
 	implicitSkillInvocation := cfg.ImplicitSkillInvocationEnabled()
@@ -670,6 +675,22 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		}
 	}
 	sysPrompt = config.ApplyOfficialDeepSeekV4ProPersona(sysPrompt, entry)
+
+	// memoryReload regenerates only the memory (# Memory) region of the system
+	// prompt from the latest on-disk memory, keeping the assembled prefix
+	// (base + policies + workspace + environment), the skills index, and the
+	// model persona identical to boot time. The controller invokes it after a
+	// compaction — a low-frequency cache-reset point — so a long-running
+	// session does not keep serving stale memory in its system prefix.
+	var memoryReload = func() string {
+		rebuilt := memory.Compose(sysPromptBase, memory.Load(memory.Options{CWD: root, UserDir: config.MemoryUserDir()}))
+		// Re-apply the skills index and persona onto the freshly composed
+		// memory region, mirroring the boot-time assembly exactly.
+		if implicitSkillInvocation {
+			rebuilt = skill.ApplyIndex(rebuilt, skills)
+		}
+		return config.ApplyOfficialDeepSeekV4ProPersona(rebuilt, entry)
+	}
 
 	reg := tool.NewRegistry()
 	writeRoots := cfg.WriteRootsForRoot(root)
@@ -1777,6 +1798,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		VisionProviderResolver:         visionProviderResolver,
 		VisionModelSelector:            visionModelSelector,
 		SystemPrompt:                   sysPrompt,
+		MemorySystemReload:             memoryReload,
 		SessionDir:                     sessionDir,
 		Host:                           pluginHost,
 		Commands:                       cmds,

--- a/internal/boot/runtime_test.go
+++ b/internal/boot/runtime_test.go
@@ -395,3 +395,36 @@ func TestSpliceFreshSystemPrompt(t *testing.T) {
 		}
 	})
 }
+
+
+func TestBuildWiresMemorySystemReload(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeRuntimeFixture(t, dir)
+
+	res := buildRuntimeFixture(t)
+	reload := res.Controller.MemorySystemReload()
+	if reload == nil {
+		t.Fatal("build should wire a post-compaction memory system-prompt reloader")
+	}
+	if got := reload(); strings.TrimSpace(got) == "" {
+		t.Fatal("memory reloader produced an empty system prompt")
+	}
+	// With memory unchanged, the reloader must reproduce the same system
+	// message the controller is already carrying — proving the reloader
+	// regenerates the identical stable prefix from the same inputs.
+	if got, want := reload(), systemMessage(res.Controller.History()); strings.TrimSpace(got) != strings.TrimSpace(want) {
+		t.Fatalf("memory reloader diverged from the controller system message\n got: %.200q...\nwant: %.200q...", got, strings.TrimSpace(want))
+	}
+	// Simulate another session writing a memory document into the workspace:
+	// the reloader must pick it up on the next call even though the controller
+	// session was built before the document existed.
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("## Test memory note\n\nThis project prefers TAB indentation for tests.\n"), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+	refreshed := reload()
+	if !strings.Contains(refreshed, "prefers TAB indentation") {
+		t.Fatalf("memory reloader did not pick up the newly written memory document\n got: %.200q...", refreshed)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -125,7 +125,14 @@ type Controller struct {
 	visionProviderResolver func(string) (provider.Provider, error)
 	visionModelSelector    func(string, string) (string, bool)
 	systemPrompt           string
-	sessionDir             string
+	// memorySystemReload, when set, regenerates just the memory (# Memory)
+	// region of the system prompt from the latest on-disk memory. The
+	// controller invokes it after a compaction — a low-frequency cache-reset
+	// point where refreshing durable memory costs no extra prefix invalidation
+	// — and swaps the result into the executor session's leading system
+	// message without disturbing conversation history.
+	memorySystemReload func() string
+	sessionDir          string
 	commands               atomic.Pointer[[]command.Command]
 	// skills owns the session's discovered skills (enabled subset, full set, and
 	// the reloadable stores) — the skills slice of the Capabilities concern. See
@@ -464,7 +471,13 @@ type Options struct {
 	VisionProviderResolver func(string) (provider.Provider, error)
 	VisionModelSelector    func(string, string) (string, bool)
 	SystemPrompt           string
-	SessionDir             string
+	// MemorySystemReload regenerates only the memory (# Memory) region of the
+	// system prompt from the latest on-disk memory. When set, the controller
+	// calls it after each compaction and replaces the executor session's
+	// leading system message, so a low-frequency cache-reset point also
+	// refreshes durable memory. nil disables the behavior.
+	MemorySystemReload func() string
+	SessionDir         string
 	SessionPath            string
 	Host                   *plugin.Host
 	Commands               []command.Command
@@ -637,6 +650,7 @@ func New(opts Options) *Controller {
 		visionProviderResolver:            opts.VisionProviderResolver,
 		visionModelSelector:               opts.VisionModelSelector,
 		systemPrompt:                      opts.SystemPrompt,
+		memorySystemReload:                opts.MemorySystemReload,
 		sessionDir:                        opts.SessionDir,
 		sessionPath:                       opts.SessionPath,
 		commands:                          atomic.Pointer[[]command.Command]{},
@@ -2940,7 +2954,40 @@ func (c *Controller) Compact(ctx context.Context, instructions string) error {
 		return err
 	}
 	defer c.endRotation()
-	return c.executor.CompactNow(ctx, instructions)
+	if err := c.executor.CompactNow(ctx, instructions); err != nil {
+		return err
+	}
+	c.refreshMemorySystemPrompt()
+	return nil
+}
+
+// refreshMemorySystemPrompt regenerates the memory (# Memory) region of the
+// system prompt from the latest on-disk memory and swaps it into the executor
+// session's leading system message. It is intended to run right after a
+// compaction, which is a low-frequency cache-reset point: refreshing durable
+// memory there costs no prefix invalidation beyond what compaction already
+// paid, and keeps long-running sessions from serving stale memory. It is a
+// no-op when no reloader is installed or the session cannot carry it.
+func (c *Controller) refreshMemorySystemPrompt() {
+	if c == nil || c.executor == nil || c.memorySystemReload == nil {
+		return
+	}
+	prompt := strings.TrimSpace(c.memorySystemReload())
+	if prompt == "" {
+		return
+	}
+	c.executor.Session().ReplaceSystemMessage(prompt)
+}
+
+// MemorySystemReload returns the installed post-compaction memory system-prompt
+// reloader, or nil when none is wired. Hosts can invoke it to refresh the
+// system prompt's memory region (for example an explicit "refresh memory"
+// surface) and verify its effect.
+func (c *Controller) MemorySystemReload() func() string {
+	if c == nil {
+		return nil
+	}
+	return c.memorySystemReload
 }
 
 // maybeSessionStart fires the SessionStart hook exactly once per session, lazily

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -5417,3 +5417,56 @@ func TestCacheColdAfterFailureFallsBackTo24h(t *testing.T) {
 		t.Fatalf("ResolveModel failure must fall back to 24h, got %v", got)
 	}
 }
+
+func TestRefreshMemorySystemPromptReplacesLeadingSystem(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSession("base + policies + [oldMemory] + skills")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "history one"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "history two"})
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+
+	var called int
+	c := New(Options{
+		Executor:   exec,
+		SessionDir: dir,
+		Label:      "test",
+		MemorySystemReload: func() string {
+			called++
+			return "base + policies + [new memory loaded from disk] + skills"
+		},
+	})
+
+	c.refreshMemorySystemPrompt()
+
+	if called == 0 {
+		t.Fatal("memorySystemReload should be invoked")
+	}
+	msgs := exec.Session().Snapshot()
+	if len(msgs) != 3 {
+		t.Fatalf("message count changed: got %d want 3", len(msgs))
+	}
+	if msgs[0].Role != provider.RoleSystem || !strings.Contains(msgs[0].Content, "new memory loaded from disk") {
+		t.Fatalf("system message not refreshed: %+v", msgs[0])
+	}
+	if msgs[1].Content != "history one" || msgs[2].Content != "history two" {
+		t.Fatalf("history was disturbed: %+v", msgs)
+	}
+}
+
+func TestRefreshMemorySystemPromptNoopWithoutReloaderOrSession(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+
+	// No reloader installed → no-op, session untouched.
+	c := New(Options{Executor: exec, SessionDir: dir, Label: "test"})
+	c.refreshMemorySystemPrompt()
+	if got := exec.Session().Snapshot()[0].Content; got != "sys" {
+		t.Fatalf("system changed without reloader: %q", got)
+	}
+
+	// Reloader present but no executor → no panic.
+	c2 := New(Options{SessionDir: dir, Label: "test", MemorySystemReload: func() string { return "x" }})
+	c2.executor = nil
+	c2.refreshMemorySystemPrompt()
+}


### PR DESCRIPTION
## Summary

Refresh the system prompt's `# Memory` (durable memory) region from the latest on-disk memory **after a compaction**, so long-running sessions stop serving boot-time-stale memory and cross-session (multi-tab) memory additions are picked up at the next compact.

- `agent.Session.ReplaceSystemMessage(content)`: swap the leading system message in place, bump `version` but not `rewriteVersion` (not a provider-visible content rewrite; history continuous).
- `control.Controller`: new `MemorySystemReload` option; after `CompactNow` succeeds call `refreshMemorySystemPrompt()` and replace the system message; expose `MemorySystemReload()` accessor.
- `boot`: capture the assembled pre-memory prefix (`sysPromptBase`) plus skills/persona inputs, build a reload closure regenerating only the memory region from the latest disk memory.

A compaction is already a low-frequency cache-reset point (it rebuilds the history segment), so refreshing the memory prefix there costs no additional prompt-cache invalidation.

## Issues

Fixes #9447

## Verification

- `go test ./internal/agent/ -run 'TestReplaceSystemMessage' -count=1` — PASS
- `go test ./internal/control/ -run 'TestRefreshMemorySystemPrompt' -count=1` — PASS
- `go test ./internal/boot/ -run 'TestBuildWiresMemorySystemReload' -count=1` — PASS: (a) reloader reproduces the controller system message when memory is unchanged; (b) writing a new `AGENTS.md` into the workspace is picked up by the reloader on the next call — proving the injected system-message swap is the verified behavior.

## Documentation impact

Documentation-impact: none - no user-visible CLI/Desktop/config/provider/permission/tool behavior changes; this is an internal system-prompt refresh on an existing compaction path.

## Cache impact

Cache-impact: low - the memory prefix (`# Memory`) in the system prompt is refreshed only after compaction (an existing cache-reset point); it never changes per normal turn, so per-turn prefix caching is preserved.

Cache-guard: `go test ./internal/boot/ -run 'TestBuildWiresMemorySystemReload'` + `TestBuildRuntimeSnapshotMatchesController` (boot-wiring + snapshot parity); compaction-path tests in the same package cover the fold boundary.

System-prompt-review: @SivanCola - this changes the provider-visible memory (`# Memory`) prefix region of the system prompt, so the reviewer-approval note is required (not N/A).