### PR TITLE
fix(desktop): refresh context panel after compaction completes / 压缩完成后刷新上下文面板

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1215,7 +1215,7 @@ export default function App() {
         action: e.kind,
         status: e.err ? "error" : "ok",
       });
-      if (e.kind === "turn_done") {
+      if (e.kind === "turn_done" || e.kind === "compaction_done") {
         setDockRefreshKey((v) => v + 1);
       }
       if (shouldPlayAttentionChimeForEvent(e, attentionChimeEvents.current)) {


### PR DESCRIPTION
## Summary

After running /compact, the context panel (right sidebar) did not refresh its content - the user had to manually switch tabs to see updated token counts and memory state.

## Changes

1 file, +1/-1:
- desktop/frontend/src/App.tsx - call refreshMeta() after compaction completes so the context panel re-renders with fresh data.

## Verification

- Run /compact in a session
- Observe the right context panel updates immediately with new token counts
- No manual tab switch required

Fixes #9458

Documentation-impact: none - internal UX refresh behavior; no docs/*.md changed.
Cache-impact: none - frontend-only; no provider-visible prompt or tool schema changes.
Cache-guard: none - not required; changed paths are outside provider-visible cache construction.
System-prompt-review: none - frontend-only change; no system prompt or provider-visible prompt modifications.