### PR TITLE
fix(todo): include canonical snapshot in continuity errors

### DIFF
--- a/internal/tool/builtin/todo.go
+++ b/internal/tool/builtin/todo.go
@@ -187,13 +187,21 @@ func verifyCompletedTodoPositions(ctx context.Context, todos []todoItem) error {
 		}
 		match, found := evidence.MatchTodoIdentity(toEvidenceTodo(todo), previous)
 		if !found || match.Index != i+1 {
-			return fmt.Errorf("completed todo %d %q cannot be inserted, duplicated, or reordered; preserve the completed prefix", i+1, todo.Content)
+			return fmt.Errorf("completed todo %d %q cannot be inserted, duplicated, or reordered; preserve the completed prefix; canonical todo snapshot: %s", i+1, todo.Content, canonicalTodoSnapshot(previous))
 		}
 	}
 	if len(evidence.IncompleteTodos(previous)) > 0 && !evidence.PreservesCompletedTodoPositions(previous, toEvidenceTodos(todos)) {
-		return fmt.Errorf("completed task history cannot be removed, changed, or reordered while the plan is active; preserve every completed item at its original position")
+		return fmt.Errorf("completed task history cannot be removed, changed, or reordered while the plan is active; preserve every completed item at its original position; canonical todo snapshot: %s", canonicalTodoSnapshot(previous))
 	}
 	return nil
+}
+
+func canonicalTodoSnapshot(todos []evidence.TodoItem) string {
+	snapshot, err := json.Marshal(todos)
+	if err != nil {
+		return "<unavailable>"
+	}
+	return string(snapshot)
 }
 
 func todoBaseline(ctx context.Context) []evidence.TodoItem {

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -264,6 +264,34 @@ func TestTodoWriteRejectsDuplicatedOrReorderedCompletedPrefix(t *testing.T) {
 	}
 }
 
+func TestTodoWriteCompletedPrefixErrorIncludesCanonicalSnapshot(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos: []evidence.TodoItem{
+			{Content: "Inspect environment", Status: "completed", StepID: "inspect"},
+			{Content: "Design solution", Status: "completed", StepID: "design"},
+			{Content: "Write code", Status: "in_progress", StepID: "write"},
+		},
+	})
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	args := json.RawMessage(`{"todos":[
+		{"content":"Design solution","status":"completed","step_id":"design"},
+		{"content":"Inspect environment","status":"completed","step_id":"inspect"},
+		{"content":"Write code","status":"in_progress","step_id":"write"}
+	]}`)
+
+	_, err := (todoWrite{}).Execute(ctx, args)
+	if err == nil {
+		t.Fatal("reordered completed prefix should be rejected")
+	}
+	want := `canonical todo snapshot: [{"content":"Inspect environment","status":"completed","step_id":"inspect"},{"content":"Design solution","status":"completed","step_id":"design"},{"content":"Write code","status":"in_progress","step_id":"write"}]`
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("todo_write error = %q, want recovery snapshot %q", err, want)
+	}
+}
+
 func TestTodoWriteAcceptsCompletedAfterFailedCompleteStep(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
@@ -545,7 +573,12 @@ func TestTodoWriteRejectsUnauthorizedCompletedHistoryRewrite(t *testing.T) {
 	ctx := evidence.WithLedger(context.Background(), ledger)
 	args := json.RawMessage(`{"todos":[{"content":"Write code","status":"in_progress"}]}`)
 
-	if _, err := (todoWrite{}).Execute(ctx, args); err == nil || !strings.Contains(err.Error(), "completed task history") {
+	_, err := (todoWrite{}).Execute(ctx, args)
+	if err == nil || !strings.Contains(err.Error(), "completed task history") {
 		t.Fatalf("unauthorized drop of completed history should be rejected: %v", err)
+	}
+	want := `canonical todo snapshot: [{"content":"Inspect environment","status":"completed"},{"content":"Write code","status":"in_progress"}]`
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("todo_write error = %q, want recovery snapshot %q", err, want)
 	}
 }


### PR DESCRIPTION
## Summary

- include the canonical todo snapshot in completed-history continuity errors
- preserve the existing continuity, plan-replacement, and write-precondition gates

## Issues

Refs #9449

## Verification

- `GOTOOLCHAIN=local go test ./internal/tool/builtin -run TestTodoWrite -count=1`
- `GOTOOLCHAIN=local go test ./internal/tool/builtin -count=1`
- `GOTOOLCHAIN=local go vet ./internal/tool/builtin`

## Documentation impact

Documentation-impact: none - the change only makes an existing recovery error actionable.

## Cache impact

Cache-impact: none - no system prompt, tool schema, or provider request construction changes.
Cache-guard: focused todo continuity tests cover both rejection paths.
System-prompt-review: N/A
