### PR TITLE
fix(provider): ignore request_url that merely repeats base_url

### DIFF
--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -90,6 +90,12 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	}
 	requestURL, _ := cfg.Extra["request_url"].(string)
 	requestURL = strings.TrimSpace(requestURL)
+	// A request_url that merely repeats the base root (e.g. the settings UI
+	// mirroring base_url into the exact-URL field) is a no-op: treat it as
+	// unset and derive the canonical endpoint instead of POSTing to the root.
+	if requestURL != "" && strings.TrimSuffix(strings.TrimRight(requestURL, "/"), "/v1") == root {
+		requestURL = ""
+	}
 	if requestURL == "" {
 		requestURL = root + "/v1/messages"
 	}

--- a/internal/provider/anthropic/request_url_test.go
+++ b/internal/provider/anthropic/request_url_test.go
@@ -63,3 +63,31 @@ func TestLegacyChatURLRemainsIgnored(t *testing.T) {
 		t.Fatalf("requestURL = %q, want legacy base-derived endpoint", got)
 	}
 }
+
+func TestRequestURLEqualToBaseRootIsIgnored(t *testing.T) {
+	p, err := New(provider.Config{
+		BaseURL: "https://base.example.com/api",
+		Model:   "model",
+		Extra:   map[string]any{"request_url": "https://base.example.com/api"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := p.(*client).requestURL; got != "https://base.example.com/api/v1/messages" {
+		t.Fatalf("requestURL = %q, want base-derived /v1/messages endpoint", got)
+	}
+}
+
+func TestRequestURLEqualToV1BaseIsIgnored(t *testing.T) {
+	p, err := New(provider.Config{
+		BaseURL: "https://base.example.com/v1",
+		Model:   "model",
+		Extra:   map[string]any{"request_url": "https://base.example.com/v1"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := p.(*client).requestURL; got != "https://base.example.com/v1/messages" {
+		t.Fatalf("requestURL = %q, want base-derived /v1/messages endpoint", got)
+	}
+}

--- a/internal/provider/openai/chaturl.go
+++ b/internal/provider/openai/chaturl.go
@@ -17,7 +17,9 @@ func resolveOpenAIChatURL(baseURL string, extra map[string]any) string {
 	if canonical, ok := canonicalKnownVendorChatURL(requestURL); ok {
 		return canonical
 	}
-	if requestURL != "" {
+	// A request_url that merely repeats the base URL is a no-op: fall through
+	// to the derived endpoint instead of POSTing to the base itself.
+	if requestURL != "" && strings.TrimRight(requestURL, "/") != strings.TrimRight(strings.TrimSpace(baseURL), "/") {
 		return requestURL
 	}
 	legacyChatURL, _ := extra["chat_url"].(string)

--- a/internal/provider/openai/request_url_test.go
+++ b/internal/provider/openai/request_url_test.go
@@ -22,3 +22,17 @@ func TestNewPrefersExactRequestURLOverLegacyChatURL(t *testing.T) {
 		t.Fatalf("chatURL = %q, want exact request_url", got)
 	}
 }
+
+func TestRequestURLEqualToBaseURLIsIgnored(t *testing.T) {
+	p, err := New(provider.Config{
+		BaseURL: "https://base.example.com/v1",
+		Model:   "model-a",
+		Extra:   map[string]any{"request_url": "https://base.example.com/v1"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := p.(*client).chatURL; got != "https://base.example.com/v1/chat/completions" {
+		t.Fatalf("chatURL = %q, want base-derived chat/completions endpoint", got)
+	}
+}

--- a/internal/provider/responses/request_url_test.go
+++ b/internal/provider/responses/request_url_test.go
@@ -50,3 +50,17 @@ func TestFactoryUsesRequestURLAndIgnoresLegacyChatURL(t *testing.T) {
 		t.Fatalf("legacy requestURL = %q, want base-derived endpoint", got)
 	}
 }
+
+func TestRequestURLEqualToBaseURLIsIgnored(t *testing.T) {
+	p, err := newFromConfig(provider.Config{
+		BaseURL: "https://base.example.com/v1",
+		Model:   "m",
+		Extra:   map[string]any{"request_url": "https://base.example.com/v1"},
+	})
+	if err != nil {
+		t.Fatalf("newFromConfig: %v", err)
+	}
+	if got := p.(*client).requestURL; got != "https://base.example.com/v1/responses" {
+		t.Fatalf("requestURL = %q, want base-derived /responses endpoint", got)
+	}
+}

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -155,6 +155,11 @@ func New(cfg Config) provider.Provider {
 	}
 	baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
 	requestURL := strings.TrimSpace(cfg.RequestURL)
+	// A request_url that merely repeats the base URL is a no-op: fall through
+	// to the derived endpoint instead of POSTing to the base itself.
+	if requestURL != "" && strings.TrimRight(requestURL, "/") == baseURL {
+		requestURL = ""
+	}
 	if requestURL == "" {
 		requestURL = baseURL + "/responses"
 	}


### PR DESCRIPTION
## Summary

- Treat a `request_url` that merely duplicates `base_url` as unset: the
  three providers that honor an exact request URL (anthropic, openai,
  responses) now derive the canonical endpoint (`/v1/messages`,
  `/chat/completions`, `/responses`) from `base_url` instead of POSTing
  to the base route itself, which returns 404.
- Exact custom `request_url`s (e.g. with a token query string) are still
  used verbatim, unchanged.

## Issues

Refs #8781

## Verification

- `go test ./internal/provider/anthropic/ ./internal/provider/openai/ ./internal/provider/responses/`
- `go build ./internal/provider/...`
- `go vet ./internal/provider/anthropic/ ./internal/provider/openai/ ./internal/provider/responses/`
- New tests: `TestRequestURLEqualToBaseRootIsIgnored`, `TestRequestURLEqualToV1BaseIsIgnored` (anthropic), `TestRequestURLEqualToBaseURLIsIgnored` (openai, responses)

## Documentation impact

Documentation-impact: none - `request_url` semantics are unchanged; only a redundant value identical to `base_url` is normalized away.

## Cache impact

Cache-impact: none - no system prompt, tool schema, or request construction changes.
Cache-guard: existing + new request_url resolution tests cover both the redundant and exact cases.
System-prompt-review: N/A