### PR TITLE
fix(desktop): move topic metadata to SQLite / 将 Topic 元数据迁移到 SQLite

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -128,6 +128,10 @@ type App struct {
 	ctx          context.Context
 	workspaceHub *workspaceChangeHub
 	topicState   *topicStateManager
+	// topicTitleMutationMu keeps the authoritative title commit and its Tab /
+	// session-sidecar publication in the same order for manual and automatic
+	// renames. It is never held by generic topic-state reads or other metadata.
+	topicTitleMutationMu sync.Mutex
 
 	// sessionCatalog is a disposable, asynchronously opened projection of
 	// authoritative session sidecars. Project-shell APIs must tolerate nil here:

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -127,6 +127,7 @@ type PromptHistoryResult struct {
 type App struct {
 	ctx          context.Context
 	workspaceHub *workspaceChangeHub
+	topicState   *topicStateManager
 
 	// sessionCatalog is a disposable, asynchronously opened projection of
 	// authoritative session sidecars. Project-shell APIs must tolerate nil here:
@@ -440,6 +441,7 @@ func NewApp() *App {
 		botRuntime:           newDesktopBotRuntime(),
 		remoteWindows:        newRemoteWindowRegistry(),
 		remoteWindowOwnerID:  newRemoteWindowOwnerID(),
+		topicState:           desktopTopicState,
 	}
 	a.desktopShell.trayState = "probing"
 	a.webView2Recovery = newWebView2RecoveryCoordinator(a)

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2071,8 +2071,7 @@ func (a *App) assignFreshSessionTopic(tab *WorkspaceTab) {
 	// topic index repair fails here, keep the session usable and let persisted
 	// session metadata repair the topic index later instead of surfacing a false
 	// "new session failed" error to the frontend.
-	_ = ensureTopicIndexed(scope, workspaceRoot, topicID, defaultTopicTitle, topicTitleSourceAuto)
-	_ = setTopicCreatedAt(topicTitleRoot(scope, workspaceRoot), topicID, time.Now().UnixMilli())
+	_ = ensureTopicIndexedWithCreatedAt(scope, workspaceRoot, topicID, defaultTopicTitle, topicTitleSourceAuto, time.Now().UnixMilli())
 }
 
 func (a *App) ensureTabTopicIndexedForUserTurn(tab *WorkspaceTab) {
@@ -2102,8 +2101,7 @@ func (a *App) ensureTabTopicIndexedForUserTurn(tab *WorkspaceTab) {
 		workspaceRoot = normalizeProjectRoot(workspaceRoot)
 	}
 
-	_ = ensureTopicIndexed(scope, workspaceRoot, topicID, defaultTopicTitle, topicTitleSourceAuto)
-	_ = setTopicCreatedAt(topicTitleRoot(scope, workspaceRoot), topicID, time.Now().UnixMilli())
+	_ = ensureTopicIndexedWithCreatedAt(scope, workspaceRoot, topicID, defaultTopicTitle, topicTitleSourceAuto, time.Now().UnixMilli())
 	path := a.currentSessionPathFor(tab)
 	a.persistTabSessionPath(tab, path)
 	a.emitProjectTreeChangedForSessionDirs(sessionDirectoryForPath(path))

--- a/desktop/app_session_dedup_test.go
+++ b/desktop/app_session_dedup_test.go
@@ -525,6 +525,7 @@ func TestEnsureBlankTabKeepsActiveTabWhenTitleResetFails(t *testing.T) {
 	isolateDesktopUserDirs(t)
 
 	projectRoot := t.TempDir()
+	seedLegacyTopicBridge(t, projectRoot)
 	app := NewApp()
 	topic, err := app.CreateTopic("project", projectRoot, "")
 	if err != nil {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -237,11 +237,11 @@ func isolateDesktopUserDirs(t *testing.T) string {
 	t.Setenv("REASONIX_STATE_HOME", filepath.Join(home, "state"))
 	t.Setenv("REASONIX_CACHE_HOME", filepath.Join(home, "cache"))
 	t.Setenv("AppData", appData)
-	// Process-local catalog projections pin SQLite files under cache. Close them
-	// before TempDir cleanup so Windows does not fail unlinkat on open handles.
+	// Close process-local SQLite handles before TempDir cleanup for Windows.
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
+		desktopTopicState.close()
 		_ = history.CloseSharedCatalog(ctx)
 		_ = stats.CloseUsageCatalogs(ctx)
 		_ = taskcatalog.ShutdownShared(ctx)

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -288,6 +288,7 @@ export function ProjectTree({
     setWorkbenchHeaderMenu(null);
   }, []);
   const topicLoadSeqRef = useRef<Record<string, number>>({});
+  const topicLoadErrorRef = useRef<Record<string, string>>({});
   const refreshRef = useRef<ProjectTreeRefresh>(async () => {});
   const { trashingTopics, trashingSessions, currentArchiveTombstones, trashTopic, trashSession } = useProjectTreeArchiveController({
     treeRef, topicLoadSeqRef, topicPageStateRef, updateTopicPageState, refreshRef,
@@ -355,6 +356,7 @@ export function ProjectTree({
         sortMode,
       });
       if (topicLoadSeqRef.current[key] !== seq) return;
+      delete topicLoadErrorRef.current[key];
       if (!projectTreeTopicPageIsFresh(topicRevisionRef.current, key, page.revision)) {
         updateTopicPageState(key, { ...topicPageStateRef.current[key], loading: false });
         return;
@@ -376,11 +378,16 @@ export function ProjectTree({
       updateTopicPageState(key, preserveCompletePage
         ? { ...topicPageStateRef.current[key], loading: false }
         : { nextCursor: page.nextCursor, loading: false });
-    } catch {
+    } catch (error) {
       if (topicLoadSeqRef.current[key] !== seq) return;
       updateTopicPageState(key, { ...topicPageStateRef.current[key], loading: false });
+      const message = error instanceof Error ? error.message : String(error);
+      if (topicLoadErrorRef.current[key] !== message) {
+        topicLoadErrorRef.current[key] = message;
+        showToast(message, "error", { durationMs: 6000 });
+      }
     }
-  }, [applyRuntimeProjection, creationTopics, currentArchiveTombstones, query, timeFilter, updateTopicPageState]);
+  }, [applyRuntimeProjection, creationTopics, currentArchiveTombstones, query, showToast, timeFilter, updateTopicPageState]);
   loadProjectTopicsRef.current = loadProjectTopics;
 
   const selectWorkbenchSortMode = useCallback((sortMode: WorkbenchSortMode) => {

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -480,7 +480,7 @@ func topicSummaryFromCatalogTopic(topic sessioncatalog.TopicRecord, visible []se
 	return summary
 }
 
-func (a *App) ListProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, error) {
+func (a *App) listProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, error) {
 	catalog := a.sessionCatalog.Load()
 	if catalog == nil {
 		return a.metadataTopicPage(req), nil

--- a/desktop/shutdown.go
+++ b/desktop/shutdown.go
@@ -22,6 +22,9 @@ func completeDesktopShutdown(tracker *desktopLifecycleTracker, body func()) {
 }
 
 func (a *App) shutdownBody() {
+	if a.topicState != nil {
+		defer a.topicState.close()
+	}
 	if a.desktopShell.linuxRecovery != nil {
 		a.desktopShell.linuxRecovery.stop()
 	}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -4695,6 +4695,8 @@ func (a *App) maybeAutoTitleTopic(tab *WorkspaceTab) bool {
 	if tab == nil {
 		return false
 	}
+	a.topicTitleMutationMu.Lock()
+	defer a.topicTitleMutationMu.Unlock()
 	// Runs on the autosave goroutine; TopicID/Scope/WorkspaceRoot/Ctrl are
 	// written under a.mu by session switches and recovery.
 	a.mu.RLock()
@@ -4721,6 +4723,9 @@ func (a *App) maybeAutoTitleTopic(tab *WorkspaceTab) bool {
 	nextTitle, updated := autoTitleTopicFromSession(titleRoot, topicID, sessionPath)
 	if !updated {
 		return false
+	}
+	if topicAutoTitleCommittedHookForTest != nil {
+		topicAutoTitleCommittedHookForTest()
 	}
 	a.updateOpenTopicTitle(topicID, nextTitle, topicTitleSourceAuto)
 	changedDirs := a.updateTopicSessionTitles(topicID, nextTitle)
@@ -6269,6 +6274,10 @@ func deleteTopicState(workspaceRoot, topicID string) error {
 // repair its missing index.
 var topicIndexMu sync.Mutex
 
+// topicAutoTitleCommittedHookForTest pauses between the authoritative auto
+// title commit and its in-memory/session publication. Production leaves it nil.
+var topicAutoTitleCommittedHookForTest func()
+
 func ensureTopicIndexed(scope, workspaceRoot, topicID, title, source string) error {
 	return ensureTopicIndexedState(scope, workspaceRoot, topicID, title, source, 0)
 }
@@ -6773,6 +6782,8 @@ func (a *App) ReorderProjects(workspaceRoots []string) error {
 
 // RenameTopic updates a topic's display title.
 func (a *App) RenameTopic(topicID, title string) error {
+	a.topicTitleMutationMu.Lock()
+	defer a.topicTitleMutationMu.Unlock()
 	trimmed := strings.TrimSpace(title)
 	if trimmed == "" {
 		trimmed = defaultTopicTitle

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5884,34 +5884,6 @@ func (a *App) localizedTopicTitle(title, source string) string {
 	return title
 }
 
-func topicTitlesPath(workspaceRoot string) string {
-	if workspaceRoot == "" {
-		return filepath.Join(desktopConfigDir(), "global", topicTitlesFile)
-	}
-	return filepath.Join(workspaceRoot, ".reasonix", topicTitlesFile)
-}
-
-func topicTitleSourcesPath(workspaceRoot string) string {
-	if workspaceRoot == "" {
-		return filepath.Join(desktopConfigDir(), "global", topicTitleSourcesFile)
-	}
-	return filepath.Join(workspaceRoot, ".reasonix", topicTitleSourcesFile)
-}
-
-func topicCreatedAtsPath(workspaceRoot string) string {
-	if workspaceRoot == "" {
-		return filepath.Join(desktopConfigDir(), "global", topicCreatedAtsFile)
-	}
-	return filepath.Join(workspaceRoot, ".reasonix", topicCreatedAtsFile)
-}
-
-func topicAutoTitleMetaPath(workspaceRoot string) string {
-	if workspaceRoot == "" {
-		return filepath.Join(desktopConfigDir(), "global", topicAutoTitlesFile)
-	}
-	return filepath.Join(workspaceRoot, ".reasonix", topicAutoTitlesFile)
-}
-
 const topicFileReadTimeout = 200 * time.Millisecond
 
 var readFileWithTimeoutSlots = make(chan struct{}, 16)
@@ -5945,56 +5917,11 @@ func readFileWithTimeout(path string, timeout time.Duration) ([]byte, error) {
 	}
 }
 
-func loadTopicTitles(workspaceRoot string) map[string]string {
-	m := map[string]string{}
-	b, err := readFileWithTimeout(topicTitlesPath(workspaceRoot), topicFileReadTimeout)
-	if err != nil {
-		return m
-	}
-	_ = json.Unmarshal(b, &m)
-	// Same read-boundary cleaning as loadSessionTitles: older builds could
-	// persist titles carrying internal wrappers (#5666).
-	for key, title := range m {
-		m[key] = agent.UserPreviewText(title)
-	}
-	return m
-}
-
-func loadTopicTitleSources(workspaceRoot string) map[string]string {
-	m := map[string]string{}
-	b, err := readFileWithTimeout(topicTitleSourcesPath(workspaceRoot), topicFileReadTimeout)
-	if err != nil {
-		return m
-	}
-	_ = json.Unmarshal(b, &m)
-	return m
-}
-
-func loadTopicCreatedAts(workspaceRoot string) map[string]int64 {
-	m := map[string]int64{}
-	b, err := readFileWithTimeout(topicCreatedAtsPath(workspaceRoot), topicFileReadTimeout)
-	if err != nil {
-		return m
-	}
-	_ = json.Unmarshal(b, &m)
-	return m
-}
-
 type topicAutoTitleMeta struct {
 	Stage     int    `json:"stage,omitempty"`
 	UserTurns int    `json:"userTurns,omitempty"`
 	BasisHash string `json:"basisHash,omitempty"`
 	UpdatedAt int64  `json:"updatedAt,omitempty"`
-}
-
-func loadTopicAutoTitleMeta(workspaceRoot string) map[string]topicAutoTitleMeta {
-	m := map[string]topicAutoTitleMeta{}
-	b, err := readFileWithTimeout(topicAutoTitleMetaPath(workspaceRoot), topicFileReadTimeout)
-	if err != nil {
-		return m
-	}
-	_ = json.Unmarshal(b, &m)
-	return m
 }
 
 func loadStringMapForUpdate(path string) (map[string]string, error) {
@@ -6012,122 +5939,44 @@ func loadStringMapForUpdate(path string) (map[string]string, error) {
 	return m, nil
 }
 
-func loadTopicAutoTitleMetaForUpdate(workspaceRoot string) (map[string]topicAutoTitleMeta, error) {
-	m := map[string]topicAutoTitleMeta{}
-	path := topicAutoTitleMetaPath(workspaceRoot)
-	b, err := readFileUTF8(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return m, nil
-		}
-		return nil, err
-	}
-	if err := json.Unmarshal(b, &m); err != nil || m == nil {
-		return map[string]topicAutoTitleMeta{}, nil
-	}
-	return m, nil
-}
-
-func loadInt64MapForUpdate(path string) (map[string]int64, error) {
-	m := map[string]int64{}
-	b, err := readFileUTF8(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return m, nil
-		}
-		return nil, err
-	}
-	if err := json.Unmarshal(b, &m); err != nil || m == nil {
-		return map[string]int64{}, nil
-	}
-	return m, nil
-}
-
 func loadTopicTitlesForUpdate(workspaceRoot string) (map[string]string, error) {
-	return loadStringMapForUpdate(topicTitlesPath(workspaceRoot))
+	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
+	if err != nil {
+		return loadLegacyStringMap(topicTitlesPath(workspaceRoot))
+	}
+	values := make(map[string]string, len(snapshot.Records))
+	for id, record := range snapshot.Records {
+		if record.Title != "" {
+			values[id] = agent.UserPreviewText(record.Title)
+		}
+	}
+	return values, nil
 }
 
 func loadTopicTitleSourcesForUpdate(workspaceRoot string) (map[string]string, error) {
-	return loadStringMapForUpdate(topicTitleSourcesPath(workspaceRoot))
-}
-
-func loadTopicCreatedAtsForUpdate(workspaceRoot string) (map[string]int64, error) {
-	return loadInt64MapForUpdate(topicCreatedAtsPath(workspaceRoot))
-}
-
-// ensureTopicStateDir prepares the directory holding a topic-state file. A
-// project file lives under the workspace root, so the directory is only created
-// while that root still exists — otherwise deleting the folder outside Reasonix
-// resurrects it on the next launch (#4566).
-func ensureTopicStateDir(workspaceRoot, path string) error {
-	if root := strings.TrimSpace(workspaceRoot); root != "" && !existingDirectory(root) {
-		return fmt.Errorf("workspace root %q no longer exists", root)
+	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
+	if err != nil {
+		return loadLegacyStringMap(topicTitleSourcesPath(workspaceRoot))
 	}
-	return os.MkdirAll(filepath.Dir(path), 0o755)
+	values := make(map[string]string, len(snapshot.Records))
+	for id, record := range snapshot.Records {
+		if record.TitleSource != "" {
+			values[id] = record.TitleSource
+		}
+	}
+	return values, nil
 }
 
 func saveTopicTitles(workspaceRoot string, m map[string]string) error {
-	b, err := json.MarshalIndent(m, "", "  ")
-	if err != nil {
-		return err
-	}
-	path := topicTitlesPath(workspaceRoot)
-	if err := ensureTopicStateDir(workspaceRoot, path); err != nil {
-		return err
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
-		return err
-	}
-	return fileutil.ReplaceFile(tmp, path)
+	return desktopTopicState.replaceTitles(workspaceRoot, m)
 }
 
 func saveTopicTitleSources(workspaceRoot string, m map[string]string) error {
-	b, err := json.MarshalIndent(m, "", "  ")
-	if err != nil {
-		return err
-	}
-	path := topicTitleSourcesPath(workspaceRoot)
-	if err := ensureTopicStateDir(workspaceRoot, path); err != nil {
-		return err
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
-		return err
-	}
-	return fileutil.ReplaceFile(tmp, path)
+	return desktopTopicState.replaceSources(workspaceRoot, m)
 }
 
 func saveTopicCreatedAts(workspaceRoot string, m map[string]int64) error {
-	b, err := json.MarshalIndent(m, "", "  ")
-	if err != nil {
-		return err
-	}
-	path := topicCreatedAtsPath(workspaceRoot)
-	if err := ensureTopicStateDir(workspaceRoot, path); err != nil {
-		return err
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
-		return err
-	}
-	return fileutil.ReplaceFile(tmp, path)
-}
-
-func saveTopicAutoTitleMeta(workspaceRoot string, m map[string]topicAutoTitleMeta) error {
-	b, err := json.MarshalIndent(m, "", "  ")
-	if err != nil {
-		return err
-	}
-	path := topicAutoTitleMetaPath(workspaceRoot)
-	if err := ensureTopicStateDir(workspaceRoot, path); err != nil {
-		return err
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
-		return err
-	}
-	return fileutil.ReplaceFile(tmp, path)
+	return desktopTopicState.replaceCreatedAts(workspaceRoot, m)
 }
 
 func loadTopicTitle(workspaceRoot, topicID string) string {
@@ -6357,36 +6206,7 @@ func setTopicTitle(workspaceRoot, topicID, title string) error {
 }
 
 func setTopicTitleWithSource(workspaceRoot, topicID, title, source string) error {
-	m, err := loadTopicTitlesForUpdate(workspaceRoot)
-	if err != nil {
-		return err
-	}
-	if strings.TrimSpace(title) == "" {
-		delete(m, topicID)
-	} else {
-		m[topicID] = strings.TrimSpace(title)
-	}
-	if err := saveTopicTitles(workspaceRoot, m); err != nil {
-		return err
-	}
-
-	sources, err := loadTopicTitleSourcesForUpdate(workspaceRoot)
-	if err != nil {
-		return err
-	}
-	if strings.TrimSpace(title) == "" || strings.TrimSpace(source) == "" {
-		delete(sources, topicID)
-	} else {
-		sources[topicID] = strings.TrimSpace(source)
-	}
-	if err := saveTopicTitleSources(workspaceRoot, sources); err != nil {
-		return err
-	}
-	if strings.TrimSpace(source) == topicTitleSourceManual ||
-		(strings.TrimSpace(source) == topicTitleSourceAuto && isDefaultTopicTitle(title)) {
-		_ = deleteTopicAutoTitleMeta(workspaceRoot, topicID)
-	}
-	return nil
+	return desktopTopicState.setTitle(workspaceRoot, topicID, title, source)
 }
 
 func recordTopicAutoTitleMeta(workspaceRoot, topicID string, proposal autoTopicTitleProposal) error {
@@ -6394,17 +6214,13 @@ func recordTopicAutoTitleMeta(workspaceRoot, topicID string, proposal autoTopicT
 	if topicID == "" || proposal.Stage <= 0 || proposal.BasisHash == "" {
 		return nil
 	}
-	m, err := loadTopicAutoTitleMetaForUpdate(workspaceRoot)
-	if err != nil {
-		return err
-	}
-	m[topicID] = topicAutoTitleMeta{
+	value := topicAutoTitleMeta{
 		Stage:     proposal.Stage,
 		UserTurns: proposal.UserTurns,
 		BasisHash: proposal.BasisHash,
 		UpdatedAt: time.Now().UnixMilli(),
 	}
-	return saveTopicAutoTitleMeta(workspaceRoot, m)
+	return desktopTopicState.setAutoMeta(workspaceRoot, topicID, &value)
 }
 
 func deleteTopicAutoTitleMeta(workspaceRoot, topicID string) error {
@@ -6412,41 +6228,15 @@ func deleteTopicAutoTitleMeta(workspaceRoot, topicID string) error {
 	if topicID == "" {
 		return nil
 	}
-	m, err := loadTopicAutoTitleMetaForUpdate(workspaceRoot)
-	if err != nil {
-		return err
-	}
-	if _, ok := m[topicID]; !ok {
-		return nil
-	}
-	delete(m, topicID)
-	return saveTopicAutoTitleMeta(workspaceRoot, m)
+	return desktopTopicState.setAutoMeta(workspaceRoot, topicID, nil)
 }
 
 func setTopicCreatedAt(workspaceRoot, topicID string, createdAt int64) error {
-	created, err := loadTopicCreatedAtsForUpdate(workspaceRoot)
-	if err != nil {
-		return err
-	}
-	topicID = strings.TrimSpace(topicID)
-	if topicID == "" || createdAt <= 0 {
-		delete(created, topicID)
-	} else {
-		created[topicID] = createdAt
-	}
-	return saveTopicCreatedAts(workspaceRoot, created)
+	return desktopTopicState.setCreatedAt(workspaceRoot, topicID, createdAt)
 }
 
-func deleteTopicCreatedAt(workspaceRoot, topicID string) error {
-	created, err := loadTopicCreatedAtsForUpdate(workspaceRoot)
-	if err != nil {
-		return err
-	}
-	if _, ok := created[topicID]; !ok {
-		return nil
-	}
-	delete(created, topicID)
-	return saveTopicCreatedAts(workspaceRoot, created)
+func deleteTopicState(workspaceRoot, topicID string) error {
+	return desktopTopicState.delete(workspaceRoot, topicID)
 }
 
 // topicIndexMu serializes recovery writes to desktop-projects.json and topic
@@ -7150,31 +6940,8 @@ func (a *App) deleteTopic(topicID string) error {
 		if !hasTitle && !indexed[root] {
 			continue
 		}
-		// Fallible cleanup runs before the title entry is removed: for a
-		// title-map-only topic the title is the only locator that makes this
-		// root a candidate again, so it must survive a failed attempt and be
-		// deleted last.
-		sources, err := loadTopicTitleSourcesForUpdate(root)
-		if err != nil {
+		if err := deleteTopicState(root, topicID); err != nil {
 			return err
-		}
-		if _, ok := sources[topicID]; ok {
-			delete(sources, topicID)
-			if err := saveTopicTitleSources(root, sources); err != nil {
-				return err
-			}
-		}
-		if err := deleteTopicCreatedAt(root, topicID); err != nil {
-			return err
-		}
-		if err := deleteTopicAutoTitleMeta(root, topicID); err != nil {
-			return err
-		}
-		if hasTitle {
-			delete(titles, topicID)
-			if err := saveTopicTitles(root, titles); err != nil {
-				return err
-			}
 		}
 	}
 	if err := removeTopicFromProjectsFile(topicID); err != nil {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2862,11 +2862,7 @@ func (a *App) ensureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 	topicID := newTopicID()
 	topicTitle := defaultTopicTitle
 	createdAt := time.Now().UnixMilli()
-	if err := setTopicTitleWithSource(workspaceRoot, topicID, topicTitle, topicTitleSourceAuto); err != nil {
-		a.mu.Unlock()
-		return TabMeta{}, err
-	}
-	if err := setTopicCreatedAt(workspaceRoot, topicID, createdAt); err != nil {
+	if err := createTopicState(workspaceRoot, topicID, topicTitle, topicTitleSourceAuto, createdAt); err != nil {
 		a.mu.Unlock()
 		return TabMeta{}, err
 	}
@@ -4751,14 +4747,14 @@ func autoTitleTopicFromSession(workspaceRoot, topicID, sessionPath string) (stri
 		return "", false
 	}
 	nextTitle := proposal.Title
-	if nextTitle == strings.TrimSpace(loadTopicTitle(workspaceRoot, topicID)) {
-		_ = recordTopicAutoTitleMeta(workspaceRoot, topicID, proposal)
+	sameTitle := nextTitle == strings.TrimSpace(loadTopicTitle(workspaceRoot, topicID))
+	applied, err := applyAutoTopicTitle(workspaceRoot, topicID, nextTitle, proposal)
+	if err != nil || !applied {
 		return "", false
 	}
-	if err := setTopicTitleWithSource(workspaceRoot, topicID, nextTitle, topicTitleSourceAuto); err != nil {
+	if sameTitle {
 		return "", false
 	}
-	_ = recordTopicAutoTitleMeta(workspaceRoot, topicID, proposal)
 	return nextTitle, true
 }
 
@@ -5942,7 +5938,14 @@ func loadStringMapForUpdate(path string) (map[string]string, error) {
 func loadTopicTitlesForUpdate(workspaceRoot string) (map[string]string, error) {
 	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
 	if err != nil {
-		return loadLegacyStringMap(topicTitlesPath(workspaceRoot))
+		if !legacyTopicFilesExist(workspaceRoot) {
+			return nil, err
+		}
+		legacy, legacyErr := loadLegacyStringMap(topicTitlesPath(workspaceRoot))
+		if legacyErr != nil {
+			return nil, errors.Join(err, legacyErr)
+		}
+		return legacy, nil
 	}
 	values := make(map[string]string, len(snapshot.Records))
 	for id, record := range snapshot.Records {
@@ -5956,7 +5959,14 @@ func loadTopicTitlesForUpdate(workspaceRoot string) (map[string]string, error) {
 func loadTopicTitleSourcesForUpdate(workspaceRoot string) (map[string]string, error) {
 	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
 	if err != nil {
-		return loadLegacyStringMap(topicTitleSourcesPath(workspaceRoot))
+		if !legacyTopicFilesExist(workspaceRoot) {
+			return nil, err
+		}
+		legacy, legacyErr := loadLegacyStringMap(topicTitleSourcesPath(workspaceRoot))
+		if legacyErr != nil {
+			return nil, errors.Join(err, legacyErr)
+		}
+		return legacy, nil
 	}
 	values := make(map[string]string, len(snapshot.Records))
 	for id, record := range snapshot.Records {
@@ -6209,6 +6219,10 @@ func setTopicTitleWithSource(workspaceRoot, topicID, title, source string) error
 	return desktopTopicState.setTitle(workspaceRoot, topicID, title, source)
 }
 
+func createTopicState(workspaceRoot, topicID, title, source string, createdAt int64) error {
+	return desktopTopicState.createTopic(workspaceRoot, topicID, title, source, createdAt)
+}
+
 func recordTopicAutoTitleMeta(workspaceRoot, topicID string, proposal autoTopicTitleProposal) error {
 	topicID = strings.TrimSpace(topicID)
 	if topicID == "" || proposal.Stage <= 0 || proposal.BasisHash == "" {
@@ -6221,6 +6235,17 @@ func recordTopicAutoTitleMeta(workspaceRoot, topicID string, proposal autoTopicT
 		UpdatedAt: time.Now().UnixMilli(),
 	}
 	return desktopTopicState.setAutoMeta(workspaceRoot, topicID, &value)
+}
+
+func applyAutoTopicTitle(workspaceRoot, topicID, title string, proposal autoTopicTitleProposal) (bool, error) {
+	topicID = strings.TrimSpace(topicID)
+	if topicID == "" || proposal.Stage <= 0 || proposal.BasisHash == "" {
+		return false, nil
+	}
+	return desktopTopicState.applyAutoTitle(workspaceRoot, topicID, title, topicAutoTitleMeta{
+		Stage: proposal.Stage, UserTurns: proposal.UserTurns,
+		BasisHash: proposal.BasisHash, UpdatedAt: time.Now().UnixMilli(),
+	})
 }
 
 func deleteTopicAutoTitleMeta(workspaceRoot, topicID string) error {
@@ -6245,6 +6270,14 @@ func deleteTopicState(workspaceRoot, topicID string) error {
 var topicIndexMu sync.Mutex
 
 func ensureTopicIndexed(scope, workspaceRoot, topicID, title, source string) error {
+	return ensureTopicIndexedState(scope, workspaceRoot, topicID, title, source, 0)
+}
+
+func ensureTopicIndexedWithCreatedAt(scope, workspaceRoot, topicID, title, source string, createdAt int64) error {
+	return ensureTopicIndexedState(scope, workspaceRoot, topicID, title, source, createdAt)
+}
+
+func ensureTopicIndexedState(scope, workspaceRoot, topicID, title, source string, createdAt int64) error {
 	topicID = strings.TrimSpace(topicID)
 	if topicID == "" {
 		return fmt.Errorf("topicID is required")
@@ -6264,8 +6297,31 @@ func ensureTopicIndexed(scope, workspaceRoot, topicID, title, source string) err
 	if source == "" {
 		source = topicTitleSourceManual
 	}
-	if err := setTopicTitleWithSource(workspaceRoot, topicID, title, source); err != nil {
+	wasDeleted := containsDesktopString(loadProjectsFile().DeletedTopics, topicID)
+	if wasDeleted {
+		// A migrated scope prunes tombstoned SQLite rows before mirroring. Clear
+		// the tombstone first for an explicit restore; if the authoritative state
+		// write then fails, restore the tombstone so the topic cannot be half shown.
+		if err := prependTopicInProjectsFile(workspaceRoot, topicID, true); err != nil {
+			return err
+		}
+	}
+	var err error
+	if createdAt > 0 {
+		err = createTopicState(workspaceRoot, topicID, title, source, createdAt)
+	} else {
+		err = setTopicTitleWithSource(workspaceRoot, topicID, title, source)
+	}
+	if err != nil {
+		if wasDeleted {
+			if rollbackErr := removeTopicFromProjectsFile(topicID); rollbackErr != nil {
+				return errors.Join(err, fmt.Errorf("restore topic tombstone: %w", rollbackErr))
+			}
+		}
 		return err
+	}
+	if wasDeleted {
+		return nil
 	}
 	return prependTopicInProjectsFile(workspaceRoot, topicID, true)
 }
@@ -6500,7 +6556,7 @@ func restoreSessionTopicIndex(dir, sessionPath string) error {
 	if title == "" {
 		title = defaultTopicTitle
 	}
-	if err := setTopicTitleWithSource(workspaceRoot, topicID, title, topicTitleSourceManual); err != nil {
+	if err := ensureTopicIndexed(scope, workspaceRoot, topicID, title, topicTitleSourceManual); err != nil {
 		return err
 	}
 
@@ -6513,9 +6569,6 @@ func restoreSessionTopicIndex(dir, sessionPath string) error {
 	}
 	meta.TopicID = topicID
 	meta.TopicTitle = title
-	if err := prependTopicInProjectsFile(workspaceRoot, topicID, scope == "project"); err != nil {
-		return err
-	}
 	if err := agent.SaveBranchMetaPreserveUpdatedLocked(sessionPath, meta); err != nil {
 		return err
 	}
@@ -6597,10 +6650,7 @@ func (a *App) CreateTopic(scope, workspaceRoot, title string) (TopicMeta, error)
 			workspaceRoot = abs
 		}
 	}
-	if err := setTopicTitleWithSource(workspaceRoot, topicID, trimmedTitle, titleSource); err != nil {
-		return TopicMeta{}, err
-	}
-	if err := setTopicCreatedAt(workspaceRoot, topicID, createdAt); err != nil {
+	if err := createTopicState(workspaceRoot, topicID, trimmedTitle, titleSource, createdAt); err != nil {
 		return TopicMeta{}, err
 	}
 	// New topics should appear first in their project/global group so the item
@@ -6927,6 +6977,12 @@ func (a *App) deleteTopic(topicID string) error {
 		indexed[p.Root] = containsDesktopString(p.Topics, topicID) ||
 			containsDesktopString(p.PinnedTopics, topicID)
 	}
+	// Publish the tombstone before clearing any per-scope state. A concurrent
+	// session repair may already hold a stale title snapshot, but its commit-time
+	// merge will now see the tombstone and cannot resurrect this topic.
+	if err := removeTopicFromProjectsFile(topicID); err != nil {
+		return err
+	}
 	roots = append(roots, "")
 	for _, root := range roots {
 		titles, err := loadTopicTitlesForUpdate(root)
@@ -6943,9 +6999,6 @@ func (a *App) deleteTopic(topicID string) error {
 		if err := deleteTopicState(root, topicID); err != nil {
 			return err
 		}
-	}
-	if err := removeTopicFromProjectsFile(topicID); err != nil {
-		return err
 	}
 	a.emitProjectTreeMetadataChanged()
 	return nil

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -398,6 +398,7 @@ func TestDeleteTopicRetryAfterPartialFailureCompletesCleanup(t *testing.T) {
 	isolateDesktopUserDirs(t)
 
 	projectRoot := t.TempDir()
+	seedLegacyTopicBridge(t, projectRoot)
 	topicID := "topic_partial_delete"
 	if err := addProject(projectRoot, ""); err != nil {
 		t.Fatalf("add project: %v", err)
@@ -412,8 +413,7 @@ func TestDeleteTopicRetryAfterPartialFailureCompletesCleanup(t *testing.T) {
 		t.Fatalf("index topic: %v", err)
 	}
 
-	// Inject a failure before title removal: swapping the title-sources file
-	// for a directory makes its load fail while the title locator is intact.
+	// Block the legacy source mirror while the title locator is still intact.
 	sourcesPath := topicTitleSourcesPath(projectRoot)
 	backupPath := sourcesPath + ".bak"
 	if err := os.Rename(sourcesPath, backupPath); err != nil {
@@ -484,13 +484,12 @@ func TestDeleteTopicTitleOnlyRetryAfterSourceFailureCompletesCleanup(t *testing.
 	isolateDesktopUserDirs(t)
 
 	projectRoot := t.TempDir()
+	seedLegacyTopicBridge(t, projectRoot)
 	topicID := "topic_title_only_delete"
 	if err := addProject(projectRoot, ""); err != nil {
 		t.Fatalf("add project: %v", err)
 	}
-	// No prependTopicInProjectsFile: the topic renders purely through the
-	// orderedTopicIDs title-map fallback, so the title entry is the only
-	// locator a retry can use.
+	// Without a sidebar index, the title is the retry's only locator.
 	if err := setTopicTitle(projectRoot, topicID, "Doomed"); err != nil {
 		t.Fatalf("set topic title: %v", err)
 	}
@@ -541,6 +540,7 @@ func TestDeleteTopicTitleOnlyRetryAfterSecondaryMetadataFailureCompletesCleanup(
 			isolateDesktopUserDirs(t)
 
 			projectRoot := t.TempDir()
+			seedLegacyTopicBridge(t, projectRoot)
 			topicID := "topic_title_only_" + strings.ReplaceAll(tt.name, "-", "_")
 			if err := addProject(projectRoot, ""); err != nil {
 				t.Fatalf("add project: %v", err)
@@ -595,6 +595,7 @@ func TestDeleteTopicIgnoresUnrelatedProjectMetadataDamage(t *testing.T) {
 	// reaching the target root.
 	brokenRoot := t.TempDir()
 	targetRoot := t.TempDir()
+	seedLegacyTopicBridge(t, brokenRoot)
 	topicID := "topic_target_delete"
 	if err := addProject(brokenRoot, ""); err != nil {
 		t.Fatalf("add broken project: %v", err)
@@ -615,8 +616,7 @@ func TestDeleteTopicIgnoresUnrelatedProjectMetadataDamage(t *testing.T) {
 		t.Fatalf("index topic: %v", err)
 	}
 
-	// Make the unrelated project's title metadata unreadable: deleting the
-	// target topic must skip over it instead of aborting half-way.
+	// Unrelated unreadable legacy metadata must not abort target deletion.
 	for _, path := range []string{topicTitlesPath(brokenRoot), topicTitleSourcesPath(brokenRoot)} {
 		if err := os.Remove(path); err != nil {
 			t.Fatalf("remove %s: %v", path, err)
@@ -631,7 +631,6 @@ func TestDeleteTopicIgnoresUnrelatedProjectMetadataDamage(t *testing.T) {
 	}
 	assertTopicFullyDeleted(t, targetRoot, topicID)
 
-	// The broken project's own sidebar index must be untouched.
 	f := loadProjectsFile()
 	if i := projectIndexByRoot(f.Projects, brokenRoot); i < 0 {
 		t.Fatalf("projects = %#v, want entry for broken root", f.Projects)
@@ -2303,11 +2302,11 @@ func TestRenameTopicRecreatesDeletedProjectTitleIndexFromOpenTab(t *testing.T) {
 		t.Fatalf("open project tab: %v", err)
 	}
 	waitForTabReady(t, app, tab.ID)
-	if err := os.Remove(topicTitlesPath(projectRoot)); err != nil {
-		t.Fatalf("remove topic titles: %v", err)
+	if err := saveTopicTitles(projectRoot, map[string]string{}); err != nil {
+		t.Fatalf("clear topic titles: %v", err)
 	}
-	if err := os.Remove(topicTitleSourcesPath(projectRoot)); err != nil {
-		t.Fatalf("remove topic title sources: %v", err)
+	if err := saveTopicTitleSources(projectRoot, map[string]string{}); err != nil {
+		t.Fatalf("clear topic title sources: %v", err)
 	}
 
 	if err := app.RenameTopic(topic.ID, "恢复标题"); err != nil {
@@ -2338,11 +2337,11 @@ func TestRenameTopicRecreatesDeletedProjectTitleIndexFromSessionMeta(t *testing.
 		t.Fatalf("mkdir sessions: %v", err)
 	}
 	writeTopicSession(t, dir, "missing-index.jsonl", topicID, "旧标题", projectRoot)
-	if err := os.Remove(topicTitlesPath(projectRoot)); err != nil {
-		t.Fatalf("remove topic titles: %v", err)
+	if err := saveTopicTitles(projectRoot, map[string]string{}); err != nil {
+		t.Fatalf("clear topic titles: %v", err)
 	}
-	if err := os.Remove(topicTitleSourcesPath(projectRoot)); err != nil {
-		t.Fatalf("remove topic title sources: %v", err)
+	if err := saveTopicTitleSources(projectRoot, map[string]string{}); err != nil {
+		t.Fatalf("clear topic title sources: %v", err)
 	}
 
 	if err := NewApp().RenameTopic(topicID, "恢复标题"); err != nil {
@@ -2371,8 +2370,8 @@ func TestOpenProjectTabRecoversMissingTopicTitleFromSessionMeta(t *testing.T) {
 		t.Fatalf("mkdir sessions: %v", err)
 	}
 	sessionPath := writeTopicSessionWithPrompt(t, dir, "stored-meta.jsonl", topic.ID, "用户保存标题", projectRoot, "first prompt should not win", time.Now())
-	if err := os.Remove(topicTitlesPath(projectRoot)); err != nil {
-		t.Fatalf("remove topic titles: %v", err)
+	if err := saveTopicTitles(projectRoot, map[string]string{}); err != nil {
+		t.Fatalf("clear topic titles: %v", err)
 	}
 	if got := loadTopicTitleSource(projectRoot, topic.ID); got != topicTitleSourceManual {
 		t.Fatalf("precondition title source = %q, want manual", got)
@@ -2414,8 +2413,8 @@ func TestOpenProjectTabRecoversMissingTopicTitleFromSessionTitle(t *testing.T) {
 	if err := setSessionTitle(dir, sessionPath, "历史手动标题"); err != nil {
 		t.Fatalf("set session title: %v", err)
 	}
-	if err := os.Remove(topicTitlesPath(projectRoot)); err != nil {
-		t.Fatalf("remove topic titles: %v", err)
+	if err := saveTopicTitles(projectRoot, map[string]string{}); err != nil {
+		t.Fatalf("clear topic titles: %v", err)
 	}
 	if got := loadTopicTitleSource(projectRoot, topic.ID); got != topicTitleSourceManual {
 		t.Fatalf("precondition title source = %q, want manual", got)

--- a/desktop/topic_archive.go
+++ b/desktop/topic_archive.go
@@ -467,14 +467,5 @@ func cleanupTransientBlankTopicRegistration(meta agent.BranchMeta) {
 		return changed, nil
 	})
 	titleRoot := topicTitleRoot(scope, root)
-	if titles, err := loadTopicTitlesForUpdate(titleRoot); err == nil {
-		delete(titles, topicID)
-		_ = saveTopicTitles(titleRoot, titles)
-	}
-	if sources, err := loadTopicTitleSourcesForUpdate(titleRoot); err == nil {
-		delete(sources, topicID)
-		_ = saveTopicTitleSources(titleRoot, sources)
-	}
-	_ = deleteTopicCreatedAt(titleRoot, topicID)
-	_ = deleteTopicAutoTitleMeta(titleRoot, topicID)
+	_ = deleteTopicState(titleRoot, topicID)
 }

--- a/desktop/topic_archive_test.go
+++ b/desktop/topic_archive_test.go
@@ -296,9 +296,10 @@ func TestTrashTopicCommittedCleanupFailureReconcilesWithoutFailureResponse(t *te
 	}
 }
 
-func TestTrashTopicMetadataFailureReconcilesFromDurableIntent(t *testing.T) {
+func TestTrashTopicLegacyMirrorFailureStaysCommittedAndRepairs(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	projectRoot := t.TempDir()
+	seedLegacyTopicBridge(t, projectRoot)
 	topicID := "topic_metadata_retry"
 	if err := addProject(projectRoot, ""); err != nil {
 		t.Fatalf("add project: %v", err)
@@ -311,27 +312,35 @@ func TestTrashTopicMetadataFailureReconcilesFromDurableIntent(t *testing.T) {
 		t.Fatalf("mkdir sessions: %v", err)
 	}
 	writeTopicSessionWithPrompt(t, dir, "metadata-retry.jsonl", topicID, "Metadata retry", projectRoot, "preserve me", time.Now())
-	blockedTempPath := topicTitleSourcesPath(projectRoot) + ".tmp"
-	if err := os.MkdirAll(blockedTempPath, 0o755); err != nil {
-		t.Fatalf("block metadata temp write: %v", err)
+	topicLegacyWriteHookForTest = func(path string) error {
+		if path == topicTitleSourcesPath(projectRoot) {
+			return errors.New("injected legacy mirror failure")
+		}
+		return nil
 	}
+	t.Cleanup(func() { topicLegacyWriteHookForTest = nil })
 
 	app := NewApp()
 	if err := app.TrashTopic(topicID); err != nil {
 		t.Fatalf("committed TrashTopic returned a failure: %v", err)
 	}
-	if got := loadTopicTitle(projectRoot, topicID); got != "Metadata retry" {
-		t.Fatalf("failed metadata cleanup title = %q, want retained retry locator", got)
+	if got := loadTopicTitle(projectRoot, topicID); got != "" {
+		t.Fatalf("authoritative deleted title = %q, want empty", got)
 	}
-	if _, err := os.Stat(topicArchiveMetadataPendingPath(topicID)); err != nil {
-		t.Fatalf("metadata cleanup intent was not retained: %v", err)
+	if _, err := os.Stat(topicArchiveMetadataPendingPath(topicID)); !os.IsNotExist(err) {
+		t.Fatalf("SQLite-committed delete should not create archive retry intent: %v", err)
 	}
 
-	if err := os.RemoveAll(blockedTempPath); err != nil {
-		t.Fatalf("unblock metadata temp write: %v", err)
+	topicLegacyWriteHookForTest = nil
+	if err := setTopicCreatedAt(projectRoot, "topic-live", 1234); err != nil {
+		t.Fatalf("trigger pending mirror repair: %v", err)
 	}
-	if err := reconcileTopicArchiveMetadataPending(app.deleteTopic); err != nil {
-		t.Fatalf("reconcile topic metadata: %v", err)
+	legacyTitles, err := loadLegacyStringMap(topicTitlesPath(projectRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := legacyTitles[topicID]; ok {
+		t.Fatalf("repaired legacy mirror resurrected deleted topic: %#v", legacyTitles)
 	}
 	if got := loadTopicTitle(projectRoot, topicID); got != "" {
 		t.Fatalf("reconciled archive retained topic title %q", got)

--- a/desktop/topic_legacy_migration.go
+++ b/desktop/topic_legacy_migration.go
@@ -169,11 +169,8 @@ func migrateLegacySessionsIntoGlobalTopicsWithGates(dir string, migrationDone, r
 	// saves, so a concurrent DeleteTopic of an unrelated topic must not have
 	// its title written back by this migration batch.
 	pruneDeletedTopicEntries(topicTitles, topicSources)
-	if topicTitles != nil {
-		_ = saveTopicTitles(topicTitleRoot, topicTitles)
-	}
-	if topicSources != nil {
-		_ = saveTopicTitleSources(topicTitleRoot, topicSources)
+	if topicTitles != nil || topicSources != nil {
+		_ = saveTopicTitleIndex(topicTitleRoot, topicTitles, topicSources)
 	}
 	invalidateTopicSessionIndex(dir)
 	if !deferred {
@@ -311,13 +308,8 @@ func repairIndexedSessionTopicsWithGate(dir string, repairDone func(string) bool
 		if err := prependTopicsInProjectsFile(workspaceRoot, repairedTopicIDs, false); err != nil {
 			deferred = true
 		}
-		if titlesChanged {
-			if err := saveTopicTitles(topicTitleRoot, topicTitles); err != nil {
-				deferred = true
-			}
-		}
-		if sourcesChanged {
-			if err := saveTopicTitleSources(topicTitleRoot, topicSources); err != nil {
+		if titlesChanged || sourcesChanged {
+			if err := saveTopicTitleIndex(topicTitleRoot, topicTitles, topicSources); err != nil {
 				deferred = true
 			}
 		}

--- a/desktop/topic_state_catalog.go
+++ b/desktop/topic_state_catalog.go
@@ -1,0 +1,11 @@
+package main
+
+// ListProjectTopics keeps authoritative topic-state failures visible to the
+// Wails caller instead of converting a future-schema or unreadable database
+// into an apparently empty sidebar page.
+func (a *App) ListProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, error) {
+	if err := topicStateReadable(topicTitleRoot(req.Scope, req.WorkspaceRoot)); err != nil {
+		return ProjectTopicPage{Items: []ProjectNode{}}, err
+	}
+	return a.listProjectTopics(req)
+}

--- a/desktop/topic_state_hardening_test.go
+++ b/desktop/topic_state_hardening_test.go
@@ -168,6 +168,11 @@ func TestRestartRepairsPendingMirrorBeforeLegacyReconciliation(t *testing.T) {
 	if applied, err := applyAutoTopicTitle(workspaceRoot, "topic-1", updated.Title, updated); err != nil || !applied {
 		t.Fatalf("apply updated title: applied=%v err=%v", applied, err)
 	}
+	// A second write while the mirror is still failing must advance SQLite,
+	// not silently succeed through the legacy-only fallback.
+	if err := setTopicCreatedAt(workspaceRoot, "topic-1", 999); err != nil {
+		t.Fatal(err)
+	}
 	desktopTopicState.close()
 	topicLegacyWriteHookForTest = nil
 
@@ -180,7 +185,7 @@ func TestRestartRepairsPendingMirrorBeforeLegacyReconciliation(t *testing.T) {
 	if err := json.Unmarshal(record.AutoMeta, &meta); err != nil {
 		t.Fatal(err)
 	}
-	if record.Title != updated.Title || meta.Stage != updated.Stage || meta.BasisHash != updated.BasisHash {
+	if record.Title != updated.Title || record.CreatedAtMS != 999 || meta.Stage != updated.Stage || meta.BasisHash != updated.BasisHash {
 		t.Fatalf("pending mirror rolled SQLite back: record=%+v meta=%+v", record, meta)
 	}
 	legacy, err := loadLegacyAutoMetaMap(topicAutoTitleMetaPath(workspaceRoot))

--- a/desktop/topic_state_hardening_test.go
+++ b/desktop/topic_state_hardening_test.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/topicstate"
+)
+
+func TestTopicIndexRepairDoesNotOverwriteConcurrentManualRename(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	seedLegacyTopicBridge(t, workspaceRoot)
+	if err := setTopicTitleWithSource(workspaceRoot, "topic-1", "Before repair", topicTitleSourceAuto); err != nil {
+		t.Fatal(err)
+	}
+	staleTitles := loadTopicTitles(workspaceRoot)
+	staleSources := loadTopicTitleSources(workspaceRoot)
+	staleTitles["topic-2"] = "Recovered topic"
+	staleSources["topic-2"] = topicTitleSourceManual
+
+	startSave := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		<-startSave
+		done <- saveTopicTitleIndex(workspaceRoot, staleTitles, staleSources)
+	}()
+	if err := setTopicTitle(workspaceRoot, "topic-1", "Manual rename wins"); err != nil {
+		t.Fatal(err)
+	}
+	close(startSave)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if got := loadTopicTitle(workspaceRoot, "topic-1"); got != "Manual rename wins" {
+		t.Fatalf("manual rename was overwritten: %q", got)
+	}
+	if got := loadTopicTitle(workspaceRoot, "topic-2"); got != "Recovered topic" {
+		t.Fatalf("missing title was not repaired: %q", got)
+	}
+	legacy, err := loadLegacyStringMap(topicTitlesPath(workspaceRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy["topic-1"] != "Manual rename wins" {
+		t.Fatalf("legacy mirror reverted manual rename: %#v", legacy)
+	}
+}
+
+func TestRestoreTombstonedTopicInLegacyBridgeScope(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	if err := addProject(workspaceRoot, ""); err != nil {
+		t.Fatal(err)
+	}
+	seedLegacyTopicBridge(t, workspaceRoot)
+	topicID := "topic-restored"
+	if err := setTopicTitle(workspaceRoot, topicID, "Before delete"); err != nil {
+		t.Fatal(err)
+	}
+	if err := deleteTopicState(workspaceRoot, topicID); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeTopicFromProjectsFile(topicID); err != nil {
+		t.Fatal(err)
+	}
+	dir := desktopSessionDir(workspaceRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "restored.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"restore"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{
+		CreatedAt: time.Now().Add(-time.Minute), Scope: "project", WorkspaceRoot: workspaceRoot,
+		TopicID: topicID, TopicTitle: "Restored title",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := restoreSessionTopicIndex(dir, path); err != nil {
+		t.Fatal(err)
+	}
+	projects := loadProjectsFile()
+	if containsDesktopString(projects.DeletedTopics, topicID) {
+		t.Fatalf("restore left tombstone behind: %#v", projects.DeletedTopics)
+	}
+	projectIndex := projectIndexByRoot(projects.Projects, workspaceRoot)
+	if projectIndex < 0 || !containsDesktopString(projects.Projects[projectIndex].Topics, topicID) {
+		t.Fatalf("restored topic is not indexed: %#v", projects.Projects)
+	}
+	if got := loadTopicTitle(workspaceRoot, topicID); got != "Restored title" {
+		t.Fatalf("authoritative restored title = %q", got)
+	}
+	legacy, err := loadLegacyStringMap(topicTitlesPath(workspaceRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy[topicID] != "Restored title" {
+		t.Fatalf("legacy restored title = %q", legacy[topicID])
+	}
+}
+
+func TestLegacyAutoMetaMergePreservesDatabaseOnlyUnknownFields(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	seedLegacyTopicBridge(t, workspaceRoot)
+	path := topicAutoTitleMetaPath(workspaceRoot)
+	if err := os.WriteFile(path, []byte(`{"topic-1":{"stage":1,"future":{"kept":true}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := loadTopicAutoTitleMeta(workspaceRoot)["topic-1"].Stage; got != 1 {
+		t.Fatalf("initial stage = %d", got)
+	}
+	if err := os.WriteFile(path, []byte(`{"topic-1":{"stage":3,"basisHash":"old-writer"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := setTopicCreatedAt(workspaceRoot, "topic-1", 1234); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := snapshot.Records["topic-1"].AutoMeta
+	if !containsJSONKey(raw, "future") {
+		t.Fatalf("database-only unknown field was lost: %s", raw)
+	}
+	var meta topicAutoTitleMeta
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta.Stage != 3 || meta.BasisHash != "old-writer" {
+		t.Fatalf("legacy known fields were not merged: %+v", meta)
+	}
+}
+
+func TestCompoundTopicMutationsCommitOneRevision(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	if err := createTopicState(workspaceRoot, "topic-1", defaultTopicTitle, topicTitleSourceAuto, 123); err != nil {
+		t.Fatal(err)
+	}
+	created, err := desktopTopicState.snapshot(workspaceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.State.Revision != 1 {
+		t.Fatalf("create revision = %d, want 1", created.State.Revision)
+	}
+	record := created.Records["topic-1"]
+	if record.Title != defaultTopicTitle || record.TitleSource != topicTitleSourceAuto || record.CreatedAtMS != 123 {
+		t.Fatalf("created record is partial: %+v", record)
+	}
+	proposal := autoTopicTitleProposal{Title: "Generated title", Stage: 2, UserTurns: 3, BasisHash: "basis"}
+	if applied, err := applyAutoTopicTitle(workspaceRoot, "topic-1", proposal.Title, proposal); err != nil {
+		t.Fatal(err)
+	} else if !applied {
+		t.Fatal("automatic title was not applied")
+	}
+	updated, err := desktopTopicState.snapshot(workspaceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.State.Revision != 2 {
+		t.Fatalf("auto-title revision = %d, want 2", updated.State.Revision)
+	}
+	record = updated.Records["topic-1"]
+	var meta topicAutoTitleMeta
+	if err := json.Unmarshal(record.AutoMeta, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if record.Title != proposal.Title || record.TitleSource != topicTitleSourceAuto || meta.Stage != proposal.Stage || meta.BasisHash != proposal.BasisHash {
+		t.Fatalf("auto-title record is partial: record=%+v meta=%+v", record, meta)
+	}
+}
+
+func TestAutomaticTitleDoesNotOverwriteConcurrentManualRename(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	if err := createTopicState(workspaceRoot, "topic-1", defaultTopicTitle, topicTitleSourceAuto, 123); err != nil {
+		t.Fatal(err)
+	}
+	proposal := autoTopicTitleProposal{Title: "Stale automatic title", Stage: 2, UserTurns: 3, BasisHash: "basis"}
+	if err := setTopicTitle(workspaceRoot, "topic-1", "Manual rename wins"); err != nil {
+		t.Fatal(err)
+	}
+	if applied, err := applyAutoTopicTitle(workspaceRoot, "topic-1", proposal.Title, proposal); err != nil {
+		t.Fatal(err)
+	} else if applied {
+		t.Fatal("stale automatic title overwrote a manual rename")
+	}
+	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := snapshot.Records["topic-1"]
+	if record.Title != "Manual rename wins" || record.TitleSource != topicTitleSourceManual || len(record.AutoMeta) != 0 {
+		t.Fatalf("manual record changed: %+v", record)
+	}
+}
+
+func TestFutureTopicSchemaWithoutLegacyReturnsVisibleReadError(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	path := config.DesktopTopicStatePath(workspaceRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO schema_migrations(version, applied_at) VALUES(2, 0)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadTopicTitlesForUpdate(workspaceRoot); err == nil {
+		t.Fatal("future schema without legacy unexpectedly became an empty title map")
+	} else {
+		var future *topicstate.FutureSchemaError
+		if !errors.As(err, &future) {
+			t.Fatalf("update read error = %v, want FutureSchemaError", err)
+		}
+	}
+	_, err = NewApp().ListProjectTopics(ProjectTopicPageRequest{Scope: "project", WorkspaceRoot: workspaceRoot})
+	if err == nil || !strings.Contains(err.Error(), "newer Reasonix version") {
+		t.Fatalf("Wails read error = %v", err)
+	}
+	if strings.Contains(err.Error(), workspaceRoot) {
+		t.Fatalf("Wails read error leaked workspace path: %v", err)
+	}
+}
+
+func TestCorruptTopicDatabaseRecoversFromSessionMetadataWithoutLegacy(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	dir := desktopSessionDir(workspaceRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	liveID := "topic-live"
+	deletedID := "topic-deleted"
+	for _, entry := range []struct{ id, name, title string }{
+		{liveID, "live.jsonl", "Recovered title"},
+		{deletedID, "deleted.jsonl", "Must stay deleted"},
+	} {
+		path := filepath.Join(dir, entry.name)
+		if err := os.WriteFile(path, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := agent.SaveBranchMeta(path, agent.BranchMeta{
+			CreatedAt: time.Now().Add(-time.Hour), Scope: "project", WorkspaceRoot: workspaceRoot,
+			TopicID: entry.id, TopicTitle: entry.title,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := updateProjectsFile(func(file *desktopProjectFile) (bool, error) {
+		file.DeletedTopics = append(file.DeletedTopics, deletedID)
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := config.DesktopTopicStatePath(workspaceRoot)
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dbPath, []byte("not a sqlite database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := setTopicCreatedAt(workspaceRoot, liveID, 5678); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshot.Records[liveID]; got.Title != "Recovered title" || got.CreatedAtMS != 5678 {
+		t.Fatalf("recovered record = %+v", got)
+	}
+	if _, ok := snapshot.Records[deletedID]; ok {
+		t.Fatalf("tombstoned topic was recovered: %+v", snapshot.Records[deletedID])
+	}
+	if matches, _ := filepath.Glob(dbPath + ".corrupt-*"); len(matches) != 1 {
+		t.Fatalf("corrupt backups = %#v", matches)
+	}
+	for _, legacyPath := range legacyTopicPaths(workspaceRoot) {
+		if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+			t.Fatalf("session recovery created legacy file %s: %v", filepath.Base(legacyPath), err)
+		}
+	}
+	state, err := topicstate.Open(context.Background(), dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = state.Close()
+}

--- a/desktop/topic_state_hardening_test.go
+++ b/desktop/topic_state_hardening_test.go
@@ -262,6 +262,70 @@ func TestAutomaticTitleDoesNotOverwriteConcurrentManualRename(t *testing.T) {
 	}
 }
 
+func TestManualRenamePublishesAfterInFlightAutomaticTitle(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	app := NewApp()
+	topic, err := app.CreateTopic("project", workspaceRoot, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := desktopSessionDir(workspaceRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := writeTopicSessionWithPrompt(t, dir, "rename-race.jsonl", topic.ID, defaultTopicTitle, workspaceRoot, "automatic candidate", time.Now())
+	ctrl := controllerWithContent(t, path)
+	defer ctrl.Close()
+	tab := &WorkspaceTab{
+		ID: "rename-race", Scope: "project", WorkspaceRoot: workspaceRoot,
+		TopicID: topic.ID, TopicTitle: defaultTopicTitle, topicTitleSource: topicTitleSourceAuto,
+		SessionPath: path, Ctrl: ctrl,
+	}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+
+	autoCommitted := make(chan struct{})
+	releaseAuto := make(chan struct{})
+	topicAutoTitleCommittedHookForTest = func() {
+		close(autoCommitted)
+		<-releaseAuto
+	}
+	t.Cleanup(func() { topicAutoTitleCommittedHookForTest = nil })
+	autoDone := make(chan bool, 1)
+	go func() { autoDone <- app.maybeAutoTitleTopic(tab) }()
+	<-autoCommitted
+
+	renameDone := make(chan error, 1)
+	go func() { renameDone <- app.RenameTopic(topic.ID, "Manual title wins") }()
+	select {
+	case err := <-renameDone:
+		t.Fatalf("manual rename bypassed in-flight auto publication: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(releaseAuto)
+	if updated := <-autoDone; !updated {
+		t.Fatal("automatic title was not applied before the manual rename")
+	}
+	if err := <-renameDone; err != nil {
+		t.Fatal(err)
+	}
+
+	if got := loadTopicTitle(workspaceRoot, topic.ID); got != "Manual title wins" {
+		t.Fatalf("authoritative title = %q", got)
+	}
+	if tab.TopicTitle != "Manual title wins" || tab.topicTitleSource != topicTitleSourceManual {
+		t.Fatalf("tab title publication = %q source=%q", tab.TopicTitle, tab.topicTitleSource)
+	}
+	meta, ok, err := agent.LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("load branch metadata: ok=%v err=%v", ok, err)
+	}
+	if meta.TopicTitle != "Manual title wins" {
+		t.Fatalf("session metadata title = %q", meta.TopicTitle)
+	}
+}
+
 func TestFutureTopicSchemaWithoutLegacyReturnsVisibleReadError(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	workspaceRoot := t.TempDir()

--- a/desktop/topic_state_hardening_test.go
+++ b/desktop/topic_state_hardening_test.go
@@ -145,6 +145,53 @@ func TestLegacyAutoMetaMergePreservesDatabaseOnlyUnknownFields(t *testing.T) {
 	}
 }
 
+func TestRestartRepairsPendingMirrorBeforeLegacyReconciliation(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	seedLegacyTopicBridge(t, workspaceRoot)
+	if err := createTopicState(workspaceRoot, "topic-1", defaultTopicTitle, topicTitleSourceAuto, 123); err != nil {
+		t.Fatal(err)
+	}
+	initial := autoTopicTitleProposal{Title: "Initial title", Stage: 1, UserTurns: 1, BasisHash: "initial"}
+	if applied, err := applyAutoTopicTitle(workspaceRoot, "topic-1", initial.Title, initial); err != nil || !applied {
+		t.Fatalf("apply initial title: applied=%v err=%v", applied, err)
+	}
+
+	topicLegacyWriteHookForTest = func(path string) error {
+		if path == topicAutoTitleMetaPath(workspaceRoot) {
+			return errors.New("injected partial legacy mirror")
+		}
+		return nil
+	}
+	t.Cleanup(func() { topicLegacyWriteHookForTest = nil })
+	updated := autoTopicTitleProposal{Title: "Updated title", Stage: 3, UserTurns: 4, BasisHash: "updated"}
+	if applied, err := applyAutoTopicTitle(workspaceRoot, "topic-1", updated.Title, updated); err != nil || !applied {
+		t.Fatalf("apply updated title: applied=%v err=%v", applied, err)
+	}
+	desktopTopicState.close()
+	topicLegacyWriteHookForTest = nil
+
+	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := snapshot.Records["topic-1"]
+	var meta topicAutoTitleMeta
+	if err := json.Unmarshal(record.AutoMeta, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if record.Title != updated.Title || meta.Stage != updated.Stage || meta.BasisHash != updated.BasisHash {
+		t.Fatalf("pending mirror rolled SQLite back: record=%+v meta=%+v", record, meta)
+	}
+	legacy, err := loadLegacyAutoMetaMap(topicAutoTitleMetaPath(workspaceRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := legacy["topic-1"]; got.Stage != updated.Stage || got.BasisHash != updated.BasisHash {
+		t.Fatalf("pending mirror was not repaired: %+v", got)
+	}
+}
+
 func TestCompoundTopicMutationsCommitOneRevision(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	workspaceRoot := t.TempDir()

--- a/desktop/topic_state_mutations.go
+++ b/desktop/topic_state_mutations.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"strings"
+
+	"reasonix/internal/topicstate"
+)
+
+func (m *topicStateManager) createTopic(workspaceRoot, topicID, title, source string, createdAt int64) error {
+	topicID, title, source = strings.TrimSpace(topicID), strings.TrimSpace(title), strings.TrimSpace(source)
+	return m.mutate(workspaceRoot, func(ctx context.Context, store *topicstate.Store) (topicstate.State, error) {
+		return store.Update(ctx, topicID, func(record *topicstate.Record) {
+			applyTopicTitle(record, title, source)
+			record.CreatedAtMS = createdAt
+		})
+	}, func() error {
+		if err := setLegacyTopicTitle(workspaceRoot, topicID, title, source); err != nil {
+			return err
+		}
+		return setLegacyTopicCreatedAt(workspaceRoot, topicID, createdAt)
+	})
+}
+
+func (m *topicStateManager) applyAutoTitle(workspaceRoot, topicID, title string, value topicAutoTitleMeta) (bool, error) {
+	topicID, title = strings.TrimSpace(topicID), strings.TrimSpace(title)
+	applied := false
+	err := m.mutate(workspaceRoot, func(ctx context.Context, store *topicstate.Store) (topicstate.State, error) {
+		return store.Update(ctx, topicID, func(record *topicstate.Record) {
+			if record.TitleSource != topicTitleSourceAuto {
+				return
+			}
+			applyTopicTitle(record, title, topicTitleSourceAuto)
+			record.AutoMeta = mergeKnownAutoMeta(record.AutoMeta, value)
+			applied = true
+		})
+	}, func() error {
+		sources, err := loadLegacyStringMap(topicTitleSourcesPath(workspaceRoot))
+		if err != nil {
+			return err
+		}
+		if sources[topicID] != topicTitleSourceAuto {
+			return nil
+		}
+		if err := setLegacyTopicTitle(workspaceRoot, topicID, title, topicTitleSourceAuto); err != nil {
+			return err
+		}
+		if err := setLegacyTopicAutoMeta(workspaceRoot, topicID, &value); err != nil {
+			return err
+		}
+		applied = true
+		return nil
+	})
+	return applied, err
+}
+
+func applyTopicTitle(record *topicstate.Record, title, source string) {
+	record.Title = title
+	if title == "" || source == "" {
+		record.TitleSource = ""
+	} else {
+		record.TitleSource = source
+	}
+	if source == topicTitleSourceManual || (source == topicTitleSourceAuto && isDefaultTopicTitle(title)) {
+		record.AutoMeta = nil
+	}
+}
+
+func logTopicStateReadFallback(workspaceRoot string, stateErr, legacyErr error, legacyExists bool) {
+	attrs := []any{"scope", topicScopeKind(workspaceRoot), "error_type", topicStateErrorType(stateErr), "legacy_available", legacyExists}
+	if legacyErr != nil {
+		attrs = append(attrs, "legacy_error_type", topicStateErrorType(legacyErr))
+	}
+	slog.Warn("desktop: topic state read fallback", attrs...)
+}
+
+func topicStateReadable(workspaceRoot string) error {
+	if _, err := desktopTopicState.snapshot(workspaceRoot); err != nil {
+		legacy, legacyErr := readLegacyTopicSnapshot(workspaceRoot)
+		if legacyErr == nil && legacy.exists {
+			return nil
+		}
+		logTopicStateReadFallback(workspaceRoot, err, legacyErr, legacy.exists)
+		var future *topicstate.FutureSchemaError
+		if errors.As(err, &future) {
+			return errors.New("topic metadata was written by a newer Reasonix version; upgrade Reasonix to open it safely")
+		}
+		return fmt.Errorf("topic metadata is unavailable (%s); retry or check the Reasonix state directory permissions", topicStateErrorType(err))
+	}
+	return nil
+}
+
+func mergeLegacyAutoMeta(existing, legacy json.RawMessage) json.RawMessage {
+	fields := map[string]json.RawMessage{}
+	_ = json.Unmarshal(existing, &fields)
+	legacyFields := map[string]json.RawMessage{}
+	if json.Unmarshal(legacy, &legacyFields) != nil {
+		return append(json.RawMessage(nil), existing...)
+	}
+	for _, key := range []string{"stage", "userTurns", "basisHash", "updatedAt"} {
+		delete(fields, key)
+	}
+	maps.Copy(fields, legacyFields)
+	data, _ := json.Marshal(fields)
+	return data
+}
+
+func mergeLegacyMissingTitleIndex(workspaceRoot string, titles, sources map[string]string) error {
+	currentTitles, err := loadLegacyStringMap(topicTitlesPath(workspaceRoot))
+	if err != nil {
+		return err
+	}
+	currentSources, err := loadLegacyStringMap(topicTitleSourcesPath(workspaceRoot))
+	if err != nil {
+		return err
+	}
+	deleted := deletedTopicSet()
+	for id := range deleted {
+		delete(currentTitles, id)
+		delete(currentSources, id)
+	}
+	for id, title := range titles {
+		if deleted[id] || strings.TrimSpace(currentTitles[id]) != "" {
+			continue
+		}
+		currentTitles[id] = title
+	}
+	for id, source := range sources {
+		if deleted[id] || strings.TrimSpace(currentSources[id]) != "" {
+			continue
+		}
+		currentSources[id] = source
+	}
+	if err := writeLegacyStringMap(workspaceRoot, topicTitlesPath(workspaceRoot), currentTitles); err != nil {
+		return err
+	}
+	return writeLegacyStringMap(workspaceRoot, topicTitleSourcesPath(workspaceRoot), currentSources)
+}

--- a/desktop/topic_state_paths.go
+++ b/desktop/topic_state_paths.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/topicstate"
+)
+
+func topicTitlesPath(workspaceRoot string) string {
+	if workspaceRoot == "" {
+		return filepath.Join(desktopConfigDir(), "global", topicTitlesFile)
+	}
+	return filepath.Join(workspaceRoot, ".reasonix", topicTitlesFile)
+}
+
+func topicTitleSourcesPath(workspaceRoot string) string {
+	if workspaceRoot == "" {
+		return filepath.Join(desktopConfigDir(), "global", topicTitleSourcesFile)
+	}
+	return filepath.Join(workspaceRoot, ".reasonix", topicTitleSourcesFile)
+}
+
+func topicCreatedAtsPath(workspaceRoot string) string {
+	if workspaceRoot == "" {
+		return filepath.Join(desktopConfigDir(), "global", topicCreatedAtsFile)
+	}
+	return filepath.Join(workspaceRoot, ".reasonix", topicCreatedAtsFile)
+}
+
+func topicAutoTitleMetaPath(workspaceRoot string) string {
+	if workspaceRoot == "" {
+		return filepath.Join(desktopConfigDir(), "global", topicAutoTitlesFile)
+	}
+	return filepath.Join(workspaceRoot, ".reasonix", topicAutoTitlesFile)
+}
+
+func legacyTopicPaths(workspaceRoot string) [4]string {
+	return [4]string{
+		topicTitlesPath(workspaceRoot), topicTitleSourcesPath(workspaceRoot),
+		topicCreatedAtsPath(workspaceRoot), topicAutoTitleMetaPath(workspaceRoot),
+	}
+}
+
+func legacyTopicFilesExist(workspaceRoot string) bool {
+	for _, path := range legacyTopicPaths(workspaceRoot) {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func topicScopeKind(workspaceRoot string) string {
+	if strings.TrimSpace(workspaceRoot) == "" {
+		return "global"
+	}
+	return "project"
+}
+
+func topicStateErrorType(err error) string {
+	if err == nil {
+		return "none"
+	}
+	var future *topicstate.FutureSchemaError
+	if errors.As(err, &future) {
+		return "future_schema"
+	}
+	if topicstate.IsCorruptionError(err) {
+		return "corruption"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, os.ErrPermission) {
+		return "permission"
+	}
+	return "io"
+}

--- a/desktop/topic_state_recovery.go
+++ b/desktop/topic_state_recovery.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/topicstate"
+)
+
+// recoverTopicRecordsFromSessions reconstructs only metadata already carried
+// by valid branch sidecars. It is used after a quick_check failure, before the
+// corrupt database is quarantined, and never turns transcript text into a new
+// authority source.
+func recoverTopicRecordsFromSessions(workspaceRoot string) (map[string]topicstate.Record, error) {
+	workspaceRoot = normalizeProjectRoot(workspaceRoot)
+	dirs := topicRecoverySessionDirs(workspaceRoot)
+	deleted := deletedTopicSet()
+	records := map[string]topicstate.Record{}
+	var recoveryErr error
+	for _, dir := range dirs {
+		infos, err := agent.ListSessionOrder(dir)
+		if err != nil {
+			recoveryErr = errors.Join(recoveryErr, err)
+			continue
+		}
+		sessionTitles := loadSessionTitles(dir)
+		for _, info := range infos {
+			topicID := strings.TrimSpace(info.TopicID)
+			if topicID == "" || deleted[topicID] || !topicRecoveryInfoMatchesScope(info, workspaceRoot) {
+				continue
+			}
+			title := topicTitleFromText(info.TopicTitle)
+			if title == "" {
+				title = topicTitleFromText(sessionTitles[filepath.Base(info.Path)])
+			}
+			if title == "" {
+				continue
+			}
+			record := records[topicID]
+			record.TopicID = topicID
+			if record.Title == "" || isDefaultTopicTitle(record.Title) {
+				record.Title = agent.UserPreviewText(title)
+				record.TitleSource = topicTitleSourceManual
+			}
+			createdAt := info.CreatedAt.UnixMilli()
+			if createdAt > 0 && (record.CreatedAtMS == 0 || createdAt < record.CreatedAtMS) {
+				record.CreatedAtMS = createdAt
+			}
+			records[topicID] = record
+		}
+	}
+	return records, recoveryErr
+}
+
+func topicRecoverySessionDirs(workspaceRoot string) []string {
+	if workspaceRoot != "" {
+		return []string{desktopSessionDir(workspaceRoot)}
+	}
+	dirs := []string{config.SessionDir(), desktopSessionDir(globalWorkspaceRoot())}
+	if sameDesktopPath(dirs[0], dirs[1]) {
+		return dirs[:1]
+	}
+	return dirs
+}
+
+func topicRecoveryInfoMatchesScope(info agent.SessionOrderInfo, workspaceRoot string) bool {
+	if workspaceRoot == "" {
+		return strings.TrimSpace(info.Scope) != "project" && strings.TrimSpace(info.WorkspaceRoot) == ""
+	}
+	return strings.TrimSpace(info.Scope) == "project" && sameProjectRoot(info.WorkspaceRoot, workspaceRoot)
+}

--- a/desktop/topic_state_recovery.go
+++ b/desktop/topic_state_recovery.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -9,6 +12,35 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/topicstate"
 )
+
+func (m *topicStateManager) openTopicStoreWithRecovery(ctx context.Context, scope *topicStateScope) (*topicstate.Store, error) {
+	store, err := topicstate.Open(ctx, scope.path)
+	if err == nil || !topicstate.IsCorruptionError(err) {
+		return store, err
+	}
+	recovered, recoveryErr := recoverTopicRecordsFromSessions(scope.root)
+	hasLegacy := legacyTopicFilesExist(scope.root)
+	if recoveryErr != nil {
+		slog.Warn("desktop: topic session recovery source incomplete", "scope", topicScopeKind(scope.root), "error_type", topicStateErrorType(recoveryErr))
+	}
+	if !hasLegacy && len(recovered) == 0 {
+		return nil, err
+	}
+	quarantined, quarantineErr := topicstate.Quarantine(scope.path, m.now())
+	if quarantineErr != nil {
+		return nil, fmt.Errorf("preserve corrupt topic database: %w", quarantineErr)
+	}
+	slog.Warn("desktop: rebuilt corrupt topic state", "scope", topicScopeKind(scope.root), "records", len(recovered), "legacy", hasLegacy, "quarantined", filepath.Base(quarantined))
+	store, err = topicstate.Open(ctx, scope.path)
+	if err != nil || len(recovered) == 0 {
+		return store, err
+	}
+	if _, err := store.ReplaceAll(ctx, recovered); err != nil {
+		_ = store.Close()
+		return nil, err
+	}
+	return store, nil
+}
 
 // recoverTopicRecordsFromSessions reconstructs only metadata already carried
 // by valid branch sidecars. It is used after a quick_check failure, before the

--- a/desktop/topic_state_store.go
+++ b/desktop/topic_state_store.go
@@ -182,7 +182,11 @@ func (m *topicStateManager) ensureOpenAndReconcileLocked(scope *topicStateScope)
 	// metadata back into SQLite.
 	if dbSnapshot.State.LegacyBridge && dbSnapshot.State.LegacyPendingRevision != 0 {
 		if err := m.mirrorIfPendingLocked(ctx, scope); err != nil {
-			return err
+			// SQLite remains readable and authoritative. Do not reconcile the
+			// known-partial JSON snapshot, and do not divert a following mutation
+			// into the legacy-only fallback path.
+			slog.Warn("desktop: topic legacy mirror still pending", "scope", topicScopeKind(scope.root), "error_type", topicStateErrorType(err))
+			return nil
 		}
 		dbSnapshot, err = scope.store.Snapshot(ctx)
 		if err != nil {
@@ -208,7 +212,12 @@ func (m *topicStateManager) ensureOpenAndReconcileLocked(scope *topicStateScope)
 			return err
 		}
 	}
-	return m.mirrorIfPendingLocked(ctx, scope)
+	if err := m.mirrorIfPendingLocked(ctx, scope); err != nil {
+		// Migration/reconciliation already committed to SQLite. Keep the outbox
+		// pending and let this access use the authoritative store.
+		slog.Warn("desktop: topic legacy mirror pending after reconcile", "scope", topicScopeKind(scope.root), "error_type", topicStateErrorType(err))
+	}
+	return nil
 }
 
 func (m *topicStateManager) mirrorIfPendingLocked(ctx context.Context, scope *topicStateScope) error {

--- a/desktop/topic_state_store.go
+++ b/desktop/topic_state_store.go
@@ -1,0 +1,786 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/filelock"
+	"reasonix/internal/fileutil"
+	"reasonix/internal/topicstate"
+)
+
+const (
+	topicStateLockTimeout      = 2 * time.Second
+	topicStateOperationTimeout = 5 * time.Second
+)
+
+type topicStateManager struct {
+	mu     sync.Mutex
+	scopes map[string]*topicStateScope
+	now    func() time.Time
+}
+
+type topicStateScope struct {
+	mu    sync.Mutex
+	root  string
+	path  string
+	store *topicstate.Store
+}
+
+type legacyTopicSnapshot struct {
+	titles     map[string]string
+	sources    map[string]string
+	createdAts map[string]int64
+	autoMeta   map[string]json.RawMessage
+	digests    [4]string
+	exists     bool
+}
+
+var desktopTopicState = newTopicStateManager()
+
+// topicLegacyWriteHookForTest injects deterministic mirror failures after the
+// authoritative SQLite transaction has committed. Production leaves it nil.
+var topicLegacyWriteHookForTest func(string) error
+
+func newTopicStateManager() *topicStateManager {
+	return &topicStateManager{scopes: map[string]*topicStateScope{}, now: time.Now}
+}
+
+func (m *topicStateManager) scope(workspaceRoot string) *topicStateScope {
+	workspaceRoot = normalizeProjectRoot(workspaceRoot)
+	path := config.DesktopTopicStatePath(workspaceRoot)
+	key := path
+	if key == "" {
+		key = "missing:" + workspaceRoot
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if scope := m.scopes[key]; scope != nil {
+		return scope
+	}
+	scope := &topicStateScope{root: workspaceRoot, path: path}
+	m.scopes[key] = scope
+	return scope
+}
+
+func (m *topicStateManager) close() {
+	m.mu.Lock()
+	scopes := make([]*topicStateScope, 0, len(m.scopes))
+	for _, scope := range m.scopes {
+		scopes = append(scopes, scope)
+	}
+	m.scopes = map[string]*topicStateScope{}
+	m.mu.Unlock()
+	for _, scope := range scopes {
+		scope.mu.Lock()
+		if scope.store != nil {
+			_ = scope.store.Close()
+			scope.store = nil
+		}
+		scope.mu.Unlock()
+	}
+}
+
+func (m *topicStateManager) snapshot(workspaceRoot string) (topicstate.Snapshot, error) {
+	scope := m.scope(workspaceRoot)
+	scope.mu.Lock()
+	defer scope.mu.Unlock()
+	if err := m.ensureOpenLocked(scope); err != nil {
+		return topicstate.Snapshot{}, err
+	}
+	return scope.store.Snapshot(context.Background())
+}
+
+func (m *topicStateManager) mutate(workspaceRoot string, mutation func(context.Context, *topicstate.Store) (topicstate.State, error), legacyFallback func() error) error {
+	scope := m.scope(workspaceRoot)
+	scope.mu.Lock()
+	defer scope.mu.Unlock()
+	if scope.root != "" && !existingDirectory(scope.root) {
+		return fmt.Errorf("workspace root %q no longer exists", scope.root)
+	}
+	if scope.path == "" {
+		return errors.New("topic state directory is unavailable")
+	}
+	if err := os.MkdirAll(filepath.Dir(scope.path), 0o700); err != nil {
+		return err
+	}
+	lockCtx, cancelLock := context.WithTimeout(context.Background(), topicStateLockTimeout)
+	release, err := filelock.Acquire(lockCtx, scope.path+".compat.lock")
+	cancelLock()
+	if err != nil {
+		return err
+	}
+	defer release()
+	ctx, cancelOperation := context.WithTimeout(context.Background(), topicStateOperationTimeout)
+	defer cancelOperation()
+	if err := m.ensureOpenAndReconcileLocked(scope); err != nil {
+		if legacyFallback != nil && legacyTopicFilesExist(scope.root) && legacyFallbackAllowed(err) {
+			slog.Warn("desktop: topic state using legacy write fallback", "scope", topicScopeKind(scope.root), "error_type", topicStateErrorType(err))
+			return legacyFallback()
+		}
+		return err
+	}
+	if _, err := mutation(ctx, scope.store); err != nil {
+		return err
+	}
+	if err := m.mirrorIfPendingLocked(ctx, scope); err != nil {
+		// The SQLite mutation is already authoritative. Keep the pending outbox
+		// for startup/next-write repair instead of reporting a false rollback.
+		slog.Warn("desktop: topic legacy mirror pending", "scope", topicScopeKind(scope.root), "error_type", topicStateErrorType(err))
+	}
+	return nil
+}
+
+func (m *topicStateManager) ensureOpenLocked(scope *topicStateScope) error {
+	if scope.store != nil {
+		return nil
+	}
+	if scope.path == "" {
+		return errors.New("topic state directory is unavailable")
+	}
+	if err := os.MkdirAll(filepath.Dir(scope.path), 0o700); err != nil {
+		return err
+	}
+	lockCtx, cancelLock := context.WithTimeout(context.Background(), topicStateLockTimeout)
+	release, err := filelock.Acquire(lockCtx, scope.path+".compat.lock")
+	cancelLock()
+	if err != nil {
+		return err
+	}
+	defer release()
+	return m.ensureOpenAndReconcileLocked(scope)
+}
+
+func (m *topicStateManager) ensureOpenAndReconcileLocked(scope *topicStateScope) error {
+	ctx := context.Background()
+	if scope.store == nil {
+		store, err := topicstate.Open(ctx, scope.path)
+		if err != nil && topicstate.IsCorruptionError(err) && legacyTopicFilesExist(scope.root) {
+			quarantined, quarantineErr := topicstate.Quarantine(scope.path, m.now())
+			if quarantineErr != nil {
+				return fmt.Errorf("preserve corrupt topic database: %w", quarantineErr)
+			}
+			slog.Warn("desktop: rebuilt corrupt topic state from legacy data", "scope", topicScopeKind(scope.root), "quarantined", filepath.Base(quarantined))
+			store, err = topicstate.Open(ctx, scope.path)
+		}
+		if err != nil {
+			return err
+		}
+		scope.store = store
+	}
+	legacy, err := readLegacyTopicSnapshot(scope.root)
+	if err != nil {
+		return err
+	}
+	dbSnapshot, err := scope.store.Snapshot(ctx)
+	if err != nil {
+		return err
+	}
+	if legacy.exists && !dbSnapshot.State.LegacyBridge {
+		if _, err := scope.store.SetLegacyBridge(ctx); err != nil {
+			return err
+		}
+		dbSnapshot, err = scope.store.Snapshot(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	if legacy.exists && !legacyDigestsMatch(dbSnapshot.State, legacy.digests) {
+		merged := mergeLegacyTopicSnapshot(dbSnapshot.Records, legacy, deletedTopicSet())
+		if _, err := scope.store.ReplaceAll(ctx, merged); err != nil {
+			return err
+		}
+	}
+	return m.mirrorIfPendingLocked(ctx, scope)
+}
+
+func (m *topicStateManager) mirrorIfPendingLocked(ctx context.Context, scope *topicStateScope) error {
+	snapshot, err := scope.store.Snapshot(ctx)
+	if err != nil {
+		return err
+	}
+	if !snapshot.State.LegacyBridge {
+		return nil
+	}
+	deleted := deletedTopicSet()
+	pruned := false
+	for topicID := range deleted {
+		if _, ok := snapshot.Records[topicID]; ok {
+			delete(snapshot.Records, topicID)
+			pruned = true
+		}
+	}
+	if pruned {
+		if _, err := scope.store.ReplaceAll(ctx, snapshot.Records); err != nil {
+			return err
+		}
+		snapshot, err = scope.store.Snapshot(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	legacy, err := readLegacyTopicSnapshot(scope.root)
+	if err != nil {
+		return err
+	}
+	if snapshot.State.LegacyPendingRevision == 0 && legacyDigestsMatch(snapshot.State, legacy.digests) {
+		return nil
+	}
+	digests, err := writeLegacyTopicSnapshot(scope.root, snapshot.Records)
+	if err != nil {
+		return err
+	}
+	_, err = scope.store.MarkLegacyExported(ctx, snapshot.State.Revision, digests)
+	return err
+}
+
+func (m *topicStateManager) setTitle(workspaceRoot, topicID, title, source string) error {
+	topicID, title, source = strings.TrimSpace(topicID), strings.TrimSpace(title), strings.TrimSpace(source)
+	return m.mutate(workspaceRoot, func(ctx context.Context, store *topicstate.Store) (topicstate.State, error) {
+		return store.Update(ctx, topicID, func(record *topicstate.Record) {
+			record.Title = title
+			if title == "" || source == "" {
+				record.TitleSource = ""
+			} else {
+				record.TitleSource = source
+			}
+			if source == topicTitleSourceManual || (source == topicTitleSourceAuto && isDefaultTopicTitle(title)) {
+				record.AutoMeta = nil
+			}
+		})
+	}, func() error { return setLegacyTopicTitle(workspaceRoot, topicID, title, source) })
+}
+
+func (m *topicStateManager) setCreatedAt(workspaceRoot, topicID string, createdAt int64) error {
+	topicID = strings.TrimSpace(topicID)
+	return m.mutate(workspaceRoot, func(ctx context.Context, store *topicstate.Store) (topicstate.State, error) {
+		return store.Update(ctx, topicID, func(record *topicstate.Record) { record.CreatedAtMS = createdAt })
+	}, func() error { return setLegacyTopicCreatedAt(workspaceRoot, topicID, createdAt) })
+}
+
+func (m *topicStateManager) setAutoMeta(workspaceRoot, topicID string, value *topicAutoTitleMeta) error {
+	topicID = strings.TrimSpace(topicID)
+	return m.mutate(workspaceRoot, func(ctx context.Context, store *topicstate.Store) (topicstate.State, error) {
+		return store.Update(ctx, topicID, func(record *topicstate.Record) {
+			if value == nil {
+				record.AutoMeta = nil
+				return
+			}
+			record.AutoMeta = mergeKnownAutoMeta(record.AutoMeta, *value)
+		})
+	}, func() error { return setLegacyTopicAutoMeta(workspaceRoot, topicID, value) })
+}
+
+func (m *topicStateManager) delete(workspaceRoot, topicID string) error {
+	topicID = strings.TrimSpace(topicID)
+	return m.mutate(workspaceRoot, func(ctx context.Context, store *topicstate.Store) (topicstate.State, error) {
+		return store.Delete(ctx, topicID)
+	}, func() error { return deleteLegacyTopicState(workspaceRoot, topicID) })
+}
+
+func (m *topicStateManager) replaceTitles(workspaceRoot string, values map[string]string) error {
+	return m.mutate(workspaceRoot, func(ctx context.Context, store *topicstate.Store) (topicstate.State, error) {
+		return store.ReplaceTitles(ctx, values)
+	}, func() error { return writeLegacyStringMap(workspaceRoot, topicTitlesPath(workspaceRoot), values) })
+}
+
+func (m *topicStateManager) replaceSources(workspaceRoot string, values map[string]string) error {
+	return m.mutate(workspaceRoot, func(ctx context.Context, store *topicstate.Store) (topicstate.State, error) {
+		return store.ReplaceSources(ctx, values)
+	}, func() error { return writeLegacyStringMap(workspaceRoot, topicTitleSourcesPath(workspaceRoot), values) })
+}
+
+func (m *topicStateManager) replaceTitleIndex(workspaceRoot string, titles, sources map[string]string) error {
+	return m.mutate(workspaceRoot, func(ctx context.Context, store *topicstate.Store) (topicstate.State, error) {
+		return store.ReplaceTitleIndex(ctx, titles, sources)
+	}, func() error {
+		if err := writeLegacyStringMap(workspaceRoot, topicTitlesPath(workspaceRoot), titles); err != nil {
+			return err
+		}
+		return writeLegacyStringMap(workspaceRoot, topicTitleSourcesPath(workspaceRoot), sources)
+	})
+}
+
+func (m *topicStateManager) replaceCreatedAts(workspaceRoot string, values map[string]int64) error {
+	return m.mutate(workspaceRoot, func(ctx context.Context, store *topicstate.Store) (topicstate.State, error) {
+		return store.ReplaceCreatedAts(ctx, values)
+	}, func() error { return writeLegacyInt64Map(workspaceRoot, topicCreatedAtsPath(workspaceRoot), values) })
+}
+
+func loadTopicTitles(workspaceRoot string) map[string]string {
+	values := map[string]string{}
+	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
+	if err != nil {
+		legacy, _ := loadLegacyStringMap(topicTitlesPath(workspaceRoot))
+		for id, title := range legacy {
+			values[id] = agent.UserPreviewText(title)
+		}
+		return values
+	}
+	for id, record := range snapshot.Records {
+		if record.Title != "" {
+			values[id] = agent.UserPreviewText(record.Title)
+		}
+	}
+	return values
+}
+
+func loadTopicTitleSources(workspaceRoot string) map[string]string {
+	values := map[string]string{}
+	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
+	if err != nil {
+		legacy, _ := loadLegacyStringMap(topicTitleSourcesPath(workspaceRoot))
+		return legacy
+	}
+	for id, record := range snapshot.Records {
+		if record.TitleSource != "" {
+			values[id] = record.TitleSource
+		}
+	}
+	return values
+}
+
+func loadTopicCreatedAts(workspaceRoot string) map[string]int64 {
+	values := map[string]int64{}
+	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
+	if err != nil {
+		legacy, _ := loadLegacyInt64Map(topicCreatedAtsPath(workspaceRoot))
+		return legacy
+	}
+	for id, record := range snapshot.Records {
+		if record.CreatedAtMS > 0 {
+			values[id] = record.CreatedAtMS
+		}
+	}
+	return values
+}
+
+func loadTopicAutoTitleMeta(workspaceRoot string) map[string]topicAutoTitleMeta {
+	values := map[string]topicAutoTitleMeta{}
+	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
+	if err != nil {
+		legacy, _ := loadLegacyAutoMetaMap(topicAutoTitleMetaPath(workspaceRoot))
+		return legacy
+	}
+	for id, record := range snapshot.Records {
+		var value topicAutoTitleMeta
+		if len(record.AutoMeta) > 0 && json.Unmarshal(record.AutoMeta, &value) == nil {
+			values[id] = value
+		}
+	}
+	return values
+}
+
+func saveTopicTitleIndex(workspaceRoot string, titles, sources map[string]string) error {
+	if titles == nil {
+		titles = loadTopicTitles(workspaceRoot)
+	}
+	if sources == nil {
+		sources = loadTopicTitleSources(workspaceRoot)
+	}
+	return desktopTopicState.replaceTitleIndex(workspaceRoot, titles, sources)
+}
+
+func readLegacyTopicSnapshot(workspaceRoot string) (legacyTopicSnapshot, error) {
+	snapshot := legacyTopicSnapshot{
+		titles: map[string]string{}, sources: map[string]string{},
+		createdAts: map[string]int64{}, autoMeta: map[string]json.RawMessage{},
+	}
+	paths := legacyTopicPaths(workspaceRoot)
+	for index, path := range paths {
+		data, err := readFileUTF8(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return snapshot, err
+		}
+		snapshot.exists = true
+		snapshot.digests[index] = digestBytes(data)
+		var entries map[string]json.RawMessage
+		if err := json.Unmarshal(data, &entries); err != nil || entries == nil {
+			if err == nil {
+				err = errors.New("legacy topic file is not an object")
+			}
+			return snapshot, fmt.Errorf("decode %s: %w", filepath.Base(path), err)
+		}
+		for topicID, raw := range entries {
+			topicID = strings.TrimSpace(topicID)
+			if topicID == "" {
+				continue
+			}
+			switch index {
+			case 0:
+				var value string
+				if json.Unmarshal(raw, &value) == nil {
+					snapshot.titles[topicID] = agent.UserPreviewText(value)
+				}
+			case 1:
+				var value string
+				if json.Unmarshal(raw, &value) == nil {
+					snapshot.sources[topicID] = strings.TrimSpace(value)
+				}
+			case 2:
+				var value int64
+				if json.Unmarshal(raw, &value) == nil && value > 0 {
+					snapshot.createdAts[topicID] = value
+				}
+			case 3:
+				var object map[string]json.RawMessage
+				if json.Unmarshal(raw, &object) == nil && object != nil {
+					snapshot.autoMeta[topicID] = append(json.RawMessage(nil), raw...)
+				}
+			}
+		}
+	}
+	return snapshot, nil
+}
+
+func mergeLegacyTopicSnapshot(current map[string]topicstate.Record, legacy legacyTopicSnapshot, deleted map[string]bool) map[string]topicstate.Record {
+	merged := make(map[string]topicstate.Record, len(current)+len(legacy.titles))
+	for id, record := range current {
+		if !deleted[id] {
+			merged[id] = record
+		}
+	}
+	ids := map[string]bool{}
+	for id := range legacy.titles {
+		ids[id] = true
+	}
+	for id := range legacy.sources {
+		ids[id] = true
+	}
+	for id := range legacy.createdAts {
+		ids[id] = true
+	}
+	for id := range legacy.autoMeta {
+		ids[id] = true
+	}
+	for id := range ids {
+		if deleted[id] {
+			delete(merged, id)
+			continue
+		}
+		record := merged[id]
+		record.TopicID = id
+		legacySource := strings.TrimSpace(legacy.sources[id])
+		legacyTitle := strings.TrimSpace(legacy.titles[id])
+		if legacyTitle != "" && (legacySource != topicTitleSourceAuto || record.TitleSource != topicTitleSourceManual) {
+			record.Title = legacyTitle
+		}
+		if legacySource != "" && !(legacySource == topicTitleSourceAuto && record.TitleSource == topicTitleSourceManual) {
+			record.TitleSource = legacySource
+		}
+		if createdAt := legacy.createdAts[id]; createdAt > 0 {
+			record.CreatedAtMS = createdAt
+		}
+		if raw := legacy.autoMeta[id]; len(raw) > 0 {
+			record.AutoMeta = append(json.RawMessage(nil), raw...)
+		}
+		merged[id] = record
+	}
+	return merged
+}
+
+func writeLegacyTopicSnapshot(workspaceRoot string, records map[string]topicstate.Record) ([4]string, error) {
+	var digests [4]string
+	titles := map[string]string{}
+	sources := map[string]string{}
+	created := map[string]int64{}
+	auto := map[string]json.RawMessage{}
+	for id, record := range records {
+		if strings.TrimSpace(record.Title) != "" {
+			titles[id] = record.Title
+		}
+		if strings.TrimSpace(record.TitleSource) != "" {
+			sources[id] = record.TitleSource
+		}
+		if record.CreatedAtMS > 0 {
+			created[id] = record.CreatedAtMS
+		}
+		if len(record.AutoMeta) > 0 {
+			auto[id] = append(json.RawMessage(nil), record.AutoMeta...)
+		}
+	}
+	values := []any{titles, sources, created, auto}
+	for index, path := range legacyTopicPaths(workspaceRoot) {
+		data, err := json.MarshalIndent(values[index], "", "  ")
+		if err != nil {
+			return digests, err
+		}
+		if err := ensureLegacyTopicStateDir(workspaceRoot, path); err != nil {
+			return digests, err
+		}
+		if topicLegacyWriteHookForTest != nil {
+			if err := topicLegacyWriteHookForTest(path); err != nil {
+				return digests, err
+			}
+		}
+		if err := fileutil.AtomicWriteFile(path, data, 0o600); err != nil {
+			return digests, err
+		}
+		digests[index] = digestBytes(data)
+	}
+	return digests, nil
+}
+
+func digestBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func legacyDigestsMatch(state topicstate.State, digests [4]string) bool {
+	return state.LegacyTitlesDigest == digests[0] &&
+		state.LegacySourcesDigest == digests[1] &&
+		state.LegacyCreatedAtsDigest == digests[2] &&
+		state.LegacyAutoMetaDigest == digests[3]
+}
+
+func deletedTopicSet() map[string]bool {
+	deleted := loadProjectsFile().DeletedTopics
+	set := make(map[string]bool, len(deleted))
+	for _, topicID := range deleted {
+		set[strings.TrimSpace(topicID)] = true
+	}
+	return set
+}
+
+func mergeKnownAutoMeta(existing json.RawMessage, value topicAutoTitleMeta) json.RawMessage {
+	fields := map[string]json.RawMessage{}
+	_ = json.Unmarshal(existing, &fields)
+	known, _ := json.Marshal(value)
+	var knownFields map[string]json.RawMessage
+	_ = json.Unmarshal(known, &knownFields)
+	for _, key := range []string{"stage", "userTurns", "basisHash", "updatedAt"} {
+		delete(fields, key)
+	}
+	maps.Copy(fields, knownFields)
+	data, _ := json.Marshal(fields)
+	return data
+}
+
+func ensureLegacyTopicStateDir(workspaceRoot, path string) error {
+	if root := strings.TrimSpace(workspaceRoot); root != "" && !existingDirectory(root) {
+		return fmt.Errorf("workspace root %q no longer exists", root)
+	}
+	return os.MkdirAll(filepath.Dir(path), 0o700)
+}
+
+func writeLegacyStringMap(workspaceRoot, path string, values map[string]string) error {
+	data, err := json.MarshalIndent(values, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := ensureLegacyTopicStateDir(workspaceRoot, path); err != nil {
+		return err
+	}
+	return fileutil.AtomicWriteFile(path, data, 0o600)
+}
+
+func writeLegacyInt64Map(workspaceRoot, path string, values map[string]int64) error {
+	data, err := json.MarshalIndent(values, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := ensureLegacyTopicStateDir(workspaceRoot, path); err != nil {
+		return err
+	}
+	return fileutil.AtomicWriteFile(path, data, 0o600)
+}
+
+func writeLegacyAutoMetaMap(workspaceRoot string, values map[string]topicAutoTitleMeta) error {
+	existing, err := loadLegacyRawAutoMetaMap(topicAutoTitleMetaPath(workspaceRoot))
+	if err != nil {
+		return err
+	}
+	rawValues := make(map[string]json.RawMessage, len(values))
+	for id, value := range values {
+		rawValues[id] = mergeKnownAutoMeta(existing[id], value)
+	}
+	data, err := json.MarshalIndent(rawValues, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := topicAutoTitleMetaPath(workspaceRoot)
+	if err := ensureLegacyTopicStateDir(workspaceRoot, path); err != nil {
+		return err
+	}
+	return fileutil.AtomicWriteFile(path, data, 0o600)
+}
+
+func setLegacyTopicTitle(workspaceRoot, topicID, title, source string) error {
+	titles, err := loadLegacyStringMap(topicTitlesPath(workspaceRoot))
+	if err != nil {
+		return err
+	}
+	sources, err := loadLegacyStringMap(topicTitleSourcesPath(workspaceRoot))
+	if err != nil {
+		return err
+	}
+	if title == "" {
+		delete(titles, topicID)
+		delete(sources, topicID)
+	} else {
+		titles[topicID] = title
+		if source == "" {
+			delete(sources, topicID)
+		} else {
+			sources[topicID] = source
+		}
+	}
+	if err := writeLegacyStringMap(workspaceRoot, topicTitlesPath(workspaceRoot), titles); err != nil {
+		return err
+	}
+	if err := writeLegacyStringMap(workspaceRoot, topicTitleSourcesPath(workspaceRoot), sources); err != nil {
+		return err
+	}
+	if source == topicTitleSourceManual || (source == topicTitleSourceAuto && isDefaultTopicTitle(title)) {
+		return setLegacyTopicAutoMeta(workspaceRoot, topicID, nil)
+	}
+	return nil
+}
+
+func setLegacyTopicCreatedAt(workspaceRoot, topicID string, createdAt int64) error {
+	values, err := loadLegacyInt64Map(topicCreatedAtsPath(workspaceRoot))
+	if err != nil {
+		return err
+	}
+	if topicID == "" || createdAt <= 0 {
+		delete(values, topicID)
+	} else {
+		values[topicID] = createdAt
+	}
+	return writeLegacyInt64Map(workspaceRoot, topicCreatedAtsPath(workspaceRoot), values)
+}
+
+func setLegacyTopicAutoMeta(workspaceRoot, topicID string, value *topicAutoTitleMeta) error {
+	values, err := loadLegacyRawAutoMetaMap(topicAutoTitleMetaPath(workspaceRoot))
+	if err != nil {
+		return err
+	}
+	if value == nil {
+		delete(values, topicID)
+	} else {
+		values[topicID] = mergeKnownAutoMeta(values[topicID], *value)
+	}
+	data, err := json.MarshalIndent(values, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := topicAutoTitleMetaPath(workspaceRoot)
+	if err := ensureLegacyTopicStateDir(workspaceRoot, path); err != nil {
+		return err
+	}
+	return fileutil.AtomicWriteFile(path, data, 0o600)
+}
+
+func deleteLegacyTopicState(workspaceRoot, topicID string) error {
+	titles, err := loadLegacyStringMap(topicTitlesPath(workspaceRoot))
+	if err != nil {
+		return err
+	}
+	sources, err := loadLegacyStringMap(topicTitleSourcesPath(workspaceRoot))
+	if err != nil {
+		return err
+	}
+	created, err := loadLegacyInt64Map(topicCreatedAtsPath(workspaceRoot))
+	if err != nil {
+		return err
+	}
+	auto, err := loadLegacyAutoMetaMap(topicAutoTitleMetaPath(workspaceRoot))
+	if err != nil {
+		return err
+	}
+	delete(titles, topicID)
+	delete(sources, topicID)
+	delete(created, topicID)
+	delete(auto, topicID)
+	if err := writeLegacyStringMap(workspaceRoot, topicTitlesPath(workspaceRoot), titles); err != nil {
+		return err
+	}
+	if err := writeLegacyStringMap(workspaceRoot, topicTitleSourcesPath(workspaceRoot), sources); err != nil {
+		return err
+	}
+	if err := writeLegacyInt64Map(workspaceRoot, topicCreatedAtsPath(workspaceRoot), created); err != nil {
+		return err
+	}
+	return writeLegacyAutoMetaMap(workspaceRoot, auto)
+}
+
+func loadLegacyStringMap(path string) (map[string]string, error) {
+	values := map[string]string{}
+	data, err := readFileUTF8(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return values, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &values); err != nil || values == nil {
+		return map[string]string{}, nil
+	}
+	return values, nil
+}
+
+func loadLegacyInt64Map(path string) (map[string]int64, error) {
+	values := map[string]int64{}
+	data, err := readFileUTF8(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return values, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &values); err != nil || values == nil {
+		return map[string]int64{}, nil
+	}
+	return values, nil
+}
+
+func loadLegacyAutoMetaMap(path string) (map[string]topicAutoTitleMeta, error) {
+	values := map[string]topicAutoTitleMeta{}
+	data, err := readFileUTF8(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return values, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &values); err != nil || values == nil {
+		return map[string]topicAutoTitleMeta{}, nil
+	}
+	return values, nil
+}
+
+func loadLegacyRawAutoMetaMap(path string) (map[string]json.RawMessage, error) {
+	values := map[string]json.RawMessage{}
+	data, err := readFileUTF8(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return values, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &values); err != nil || values == nil {
+		return map[string]json.RawMessage{}, nil
+	}
+	return values, nil
+}
+
+func legacyFallbackAllowed(err error) bool {
+	var future *topicstate.FutureSchemaError
+	return !errors.As(err, &future)
+}

--- a/desktop/topic_state_store.go
+++ b/desktop/topic_state_store.go
@@ -167,39 +167,29 @@ func (m *topicStateManager) ensureOpenLocked(scope *topicStateScope) error {
 func (m *topicStateManager) ensureOpenAndReconcileLocked(scope *topicStateScope) error {
 	ctx := context.Background()
 	if scope.store == nil {
-		store, err := topicstate.Open(ctx, scope.path)
-		if err != nil && topicstate.IsCorruptionError(err) {
-			recovered, recoveryErr := recoverTopicRecordsFromSessions(scope.root)
-			hasLegacy := legacyTopicFilesExist(scope.root)
-			if recoveryErr != nil {
-				slog.Warn("desktop: topic session recovery source incomplete", "scope", topicScopeKind(scope.root), "error_type", topicStateErrorType(recoveryErr))
-			}
-			if !hasLegacy && len(recovered) == 0 {
-				return err
-			}
-			quarantined, quarantineErr := topicstate.Quarantine(scope.path, m.now())
-			if quarantineErr != nil {
-				return fmt.Errorf("preserve corrupt topic database: %w", quarantineErr)
-			}
-			slog.Warn("desktop: rebuilt corrupt topic state", "scope", topicScopeKind(scope.root), "records", len(recovered), "legacy", hasLegacy, "quarantined", filepath.Base(quarantined))
-			store, err = topicstate.Open(ctx, scope.path)
-			if err == nil && len(recovered) > 0 {
-				if _, replaceErr := store.ReplaceAll(ctx, recovered); replaceErr != nil {
-					_ = store.Close()
-					return replaceErr
-				}
-			}
-		}
+		store, err := m.openTopicStoreWithRecovery(ctx, scope)
 		if err != nil {
 			return err
 		}
 		scope.store = store
 	}
-	legacy, err := readLegacyTopicSnapshot(scope.root)
+	dbSnapshot, err := scope.store.Snapshot(ctx)
 	if err != nil {
 		return err
 	}
-	dbSnapshot, err := scope.store.Snapshot(ctx)
+	// Publish a pending authoritative snapshot before inspecting legacy digests;
+	// otherwise a half-written mirror can look like an old-version edit and roll
+	// metadata back into SQLite.
+	if dbSnapshot.State.LegacyBridge && dbSnapshot.State.LegacyPendingRevision != 0 {
+		if err := m.mirrorIfPendingLocked(ctx, scope); err != nil {
+			return err
+		}
+		dbSnapshot, err = scope.store.Snapshot(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	legacy, err := readLegacyTopicSnapshot(scope.root)
 	if err != nil {
 		return err
 	}
@@ -246,12 +236,14 @@ func (m *topicStateManager) mirrorIfPendingLocked(ctx context.Context, scope *to
 			return err
 		}
 	}
-	legacy, err := readLegacyTopicSnapshot(scope.root)
-	if err != nil {
-		return err
-	}
-	if snapshot.State.LegacyPendingRevision == 0 && legacyDigestsMatch(snapshot.State, legacy.digests) {
-		return nil
+	if snapshot.State.LegacyPendingRevision == 0 {
+		legacy, err := readLegacyTopicSnapshot(scope.root)
+		if err != nil {
+			return err
+		}
+		if legacyDigestsMatch(snapshot.State, legacy.digests) {
+			return nil
+		}
 	}
 	digests, err := writeLegacyTopicSnapshot(scope.root, snapshot.Records)
 	if err != nil {

--- a/desktop/topic_state_store.go
+++ b/desktop/topic_state_store.go
@@ -168,13 +168,27 @@ func (m *topicStateManager) ensureOpenAndReconcileLocked(scope *topicStateScope)
 	ctx := context.Background()
 	if scope.store == nil {
 		store, err := topicstate.Open(ctx, scope.path)
-		if err != nil && topicstate.IsCorruptionError(err) && legacyTopicFilesExist(scope.root) {
+		if err != nil && topicstate.IsCorruptionError(err) {
+			recovered, recoveryErr := recoverTopicRecordsFromSessions(scope.root)
+			hasLegacy := legacyTopicFilesExist(scope.root)
+			if recoveryErr != nil {
+				slog.Warn("desktop: topic session recovery source incomplete", "scope", topicScopeKind(scope.root), "error_type", topicStateErrorType(recoveryErr))
+			}
+			if !hasLegacy && len(recovered) == 0 {
+				return err
+			}
 			quarantined, quarantineErr := topicstate.Quarantine(scope.path, m.now())
 			if quarantineErr != nil {
 				return fmt.Errorf("preserve corrupt topic database: %w", quarantineErr)
 			}
-			slog.Warn("desktop: rebuilt corrupt topic state from legacy data", "scope", topicScopeKind(scope.root), "quarantined", filepath.Base(quarantined))
+			slog.Warn("desktop: rebuilt corrupt topic state", "scope", topicScopeKind(scope.root), "records", len(recovered), "legacy", hasLegacy, "quarantined", filepath.Base(quarantined))
 			store, err = topicstate.Open(ctx, scope.path)
+			if err == nil && len(recovered) > 0 {
+				if _, replaceErr := store.ReplaceAll(ctx, recovered); replaceErr != nil {
+					_ = store.Close()
+					return replaceErr
+				}
+			}
 		}
 		if err != nil {
 			return err
@@ -251,15 +265,7 @@ func (m *topicStateManager) setTitle(workspaceRoot, topicID, title, source strin
 	topicID, title, source = strings.TrimSpace(topicID), strings.TrimSpace(title), strings.TrimSpace(source)
 	return m.mutate(workspaceRoot, func(ctx context.Context, store *topicstate.Store) (topicstate.State, error) {
 		return store.Update(ctx, topicID, func(record *topicstate.Record) {
-			record.Title = title
-			if title == "" || source == "" {
-				record.TitleSource = ""
-			} else {
-				record.TitleSource = source
-			}
-			if source == topicTitleSourceManual || (source == topicTitleSourceAuto && isDefaultTopicTitle(title)) {
-				record.AutoMeta = nil
-			}
+			applyTopicTitle(record, title, source)
 		})
 	}, func() error { return setLegacyTopicTitle(workspaceRoot, topicID, title, source) })
 }
@@ -303,14 +309,11 @@ func (m *topicStateManager) replaceSources(workspaceRoot string, values map[stri
 	}, func() error { return writeLegacyStringMap(workspaceRoot, topicTitleSourcesPath(workspaceRoot), values) })
 }
 
-func (m *topicStateManager) replaceTitleIndex(workspaceRoot string, titles, sources map[string]string) error {
+func (m *topicStateManager) mergeMissingTitleIndex(workspaceRoot string, titles, sources map[string]string) error {
 	return m.mutate(workspaceRoot, func(ctx context.Context, store *topicstate.Store) (topicstate.State, error) {
-		return store.ReplaceTitleIndex(ctx, titles, sources)
+		return store.MergeMissingTitleIndex(ctx, titles, sources, deletedTopicSet())
 	}, func() error {
-		if err := writeLegacyStringMap(workspaceRoot, topicTitlesPath(workspaceRoot), titles); err != nil {
-			return err
-		}
-		return writeLegacyStringMap(workspaceRoot, topicTitleSourcesPath(workspaceRoot), sources)
+		return mergeLegacyMissingTitleIndex(workspaceRoot, titles, sources)
 	})
 }
 
@@ -324,7 +327,8 @@ func loadTopicTitles(workspaceRoot string) map[string]string {
 	values := map[string]string{}
 	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
 	if err != nil {
-		legacy, _ := loadLegacyStringMap(topicTitlesPath(workspaceRoot))
+		legacy, legacyErr := loadLegacyStringMap(topicTitlesPath(workspaceRoot))
+		logTopicStateReadFallback(workspaceRoot, err, legacyErr, legacyTopicFilesExist(workspaceRoot))
 		for id, title := range legacy {
 			values[id] = agent.UserPreviewText(title)
 		}
@@ -342,7 +346,8 @@ func loadTopicTitleSources(workspaceRoot string) map[string]string {
 	values := map[string]string{}
 	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
 	if err != nil {
-		legacy, _ := loadLegacyStringMap(topicTitleSourcesPath(workspaceRoot))
+		legacy, legacyErr := loadLegacyStringMap(topicTitleSourcesPath(workspaceRoot))
+		logTopicStateReadFallback(workspaceRoot, err, legacyErr, legacyTopicFilesExist(workspaceRoot))
 		return legacy
 	}
 	for id, record := range snapshot.Records {
@@ -357,7 +362,8 @@ func loadTopicCreatedAts(workspaceRoot string) map[string]int64 {
 	values := map[string]int64{}
 	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
 	if err != nil {
-		legacy, _ := loadLegacyInt64Map(topicCreatedAtsPath(workspaceRoot))
+		legacy, legacyErr := loadLegacyInt64Map(topicCreatedAtsPath(workspaceRoot))
+		logTopicStateReadFallback(workspaceRoot, err, legacyErr, legacyTopicFilesExist(workspaceRoot))
 		return legacy
 	}
 	for id, record := range snapshot.Records {
@@ -372,7 +378,8 @@ func loadTopicAutoTitleMeta(workspaceRoot string) map[string]topicAutoTitleMeta 
 	values := map[string]topicAutoTitleMeta{}
 	snapshot, err := desktopTopicState.snapshot(workspaceRoot)
 	if err != nil {
-		legacy, _ := loadLegacyAutoMetaMap(topicAutoTitleMetaPath(workspaceRoot))
+		legacy, legacyErr := loadLegacyAutoMetaMap(topicAutoTitleMetaPath(workspaceRoot))
+		logTopicStateReadFallback(workspaceRoot, err, legacyErr, legacyTopicFilesExist(workspaceRoot))
 		return legacy
 	}
 	for id, record := range snapshot.Records {
@@ -391,7 +398,7 @@ func saveTopicTitleIndex(workspaceRoot string, titles, sources map[string]string
 	if sources == nil {
 		sources = loadTopicTitleSources(workspaceRoot)
 	}
-	return desktopTopicState.replaceTitleIndex(workspaceRoot, titles, sources)
+	return desktopTopicState.mergeMissingTitleIndex(workspaceRoot, titles, sources)
 }
 
 func readLegacyTopicSnapshot(workspaceRoot string) (legacyTopicSnapshot, error) {
@@ -488,7 +495,7 @@ func mergeLegacyTopicSnapshot(current map[string]topicstate.Record, legacy legac
 			record.CreatedAtMS = createdAt
 		}
 		if raw := legacy.autoMeta[id]; len(raw) > 0 {
-			record.AutoMeta = append(json.RawMessage(nil), raw...)
+			record.AutoMeta = mergeLegacyAutoMeta(record.AutoMeta, raw)
 		}
 		merged[id] = record
 	}

--- a/desktop/topic_state_store_test.go
+++ b/desktop/topic_state_store_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/topicstate"
+)
+
+func seedLegacyTopicBridge(t *testing.T, workspaceRoot string) {
+	t.Helper()
+	for _, path := range legacyTopicPaths(workspaceRoot) {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestFreshTopicStateUsesSQLiteWithoutLegacyFiles(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	if err := setTopicTitle(workspaceRoot, "topic-fresh", "Fresh"); err != nil {
+		t.Fatal(err)
+	}
+	if got := loadTopicTitle(workspaceRoot, "topic-fresh"); got != "Fresh" {
+		t.Fatalf("title = %q", got)
+	}
+	if _, err := os.Stat(config.DesktopTopicStatePath(workspaceRoot)); err != nil {
+		t.Fatalf("SQLite topic state missing: %v", err)
+	}
+	for _, path := range legacyTopicPaths(workspaceRoot) {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("fresh workspace created legacy file %s: %v", filepath.Base(path), err)
+		}
+	}
+}
+
+func TestLegacyTopicStateMigratesAndContinuesMirroring(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	paths := legacyTopicPaths(workspaceRoot)
+	for _, path := range paths {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(paths[0], []byte(`{"topic-old":"Old title"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths[1], []byte(`{"topic-old":"manual"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths[2], []byte(`{"topic-old":1234}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths[3], []byte(`{"topic-old":{"stage":1,"basisHash":"old","future":{"kept":true}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := loadTopicTitle(workspaceRoot, "topic-old"); got != "Old title" {
+		t.Fatalf("migrated title = %q", got)
+	}
+	if err := setTopicCreatedAt(workspaceRoot, "topic-old", 5678); err != nil {
+		t.Fatal(err)
+	}
+	if err := recordTopicAutoTitleMeta(workspaceRoot, "topic-old", autoTopicTitleProposal{Stage: 2, UserTurns: 3, BasisHash: "new"}); err != nil {
+		t.Fatal(err)
+	}
+	legacyTitles, err := loadLegacyStringMap(paths[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := legacyTitles["topic-old"]; got != "Old title" {
+		t.Fatalf("legacy mirror title = %q", got)
+	}
+	var raw map[string]json.RawMessage
+	data, err := os.ReadFile(paths[3])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(raw["topic-old"]) || !containsJSONKey(raw["topic-old"], "future") {
+		t.Fatalf("unknown auto-title metadata was lost: %s", raw["topic-old"])
+	}
+	var meta topicAutoTitleMeta
+	if err := json.Unmarshal(raw["topic-old"], &meta); err != nil || meta.Stage != 2 || meta.BasisHash != "new" {
+		t.Fatalf("known auto-title metadata was not updated: %+v, %v", meta, err)
+	}
+}
+
+func TestLegacyWriterChangeMergesOnNextNewWrite(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	seedLegacyTopicBridge(t, workspaceRoot)
+	if err := setTopicTitle(workspaceRoot, "topic-old", "Before downgrade"); err != nil {
+		t.Fatal(err)
+	}
+	if err := setLegacyTopicTitle(workspaceRoot, "topic-old", "Changed by old version", topicTitleSourceManual); err != nil {
+		t.Fatal(err)
+	}
+	if err := setTopicCreatedAt(workspaceRoot, "topic-old", 999); err != nil {
+		t.Fatal(err)
+	}
+	if got := loadTopicTitle(workspaceRoot, "topic-old"); got != "Changed by old version" {
+		t.Fatalf("reconciled title = %q", got)
+	}
+}
+
+func TestLegacyMigrationSkipsInvalidEntriesAndDeletedTopics(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	if err := addProject(workspaceRoot, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateProjectsFile(func(file *desktopProjectFile) (bool, error) {
+		file.DeletedTopics = append(file.DeletedTopics, "topic-deleted")
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	path := topicTitlesPath(workspaceRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"topic-good":"Good","topic-invalid":7,"topic-deleted":"Do not restore"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	titles := loadTopicTitles(workspaceRoot)
+	if titles["topic-good"] != "Good" || titles["topic-invalid"] != "" || titles["topic-deleted"] != "" {
+		t.Fatalf("migrated titles = %#v", titles)
+	}
+	legacy, err := loadLegacyStringMap(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := legacy["topic-deleted"]; ok {
+		t.Fatalf("legacy mirror resurrected tombstone: %#v", legacy)
+	}
+}
+
+func TestFutureTopicSchemaUsesLegacyReadOnlyFallback(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspaceRoot := t.TempDir()
+	seedLegacyTopicBridge(t, workspaceRoot)
+	if err := setLegacyTopicTitle(workspaceRoot, "topic-old", "Readable by old version", topicTitleSourceManual); err != nil {
+		t.Fatal(err)
+	}
+	path := config.DesktopTopicStatePath(workspaceRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO schema_migrations(version, applied_at) VALUES(2, 0)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := loadTopicTitle(workspaceRoot, "topic-old"); got != "Readable by old version" {
+		t.Fatalf("legacy read fallback = %q", got)
+	}
+	err = setTopicTitle(workspaceRoot, "topic-old", "must not overwrite")
+	var future *topicstate.FutureSchemaError
+	if !errors.As(err, &future) {
+		t.Fatalf("write error = %v, want FutureSchemaError", err)
+	}
+	legacy, err := loadLegacyStringMap(topicTitlesPath(workspaceRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy["topic-old"] != "Readable by old version" {
+		t.Fatalf("future-schema write changed legacy data: %#v", legacy)
+	}
+}
+
+func TestCorruptTopicDatabaseRebuildsOnlyWithLegacySource(t *testing.T) {
+	t.Run("legacy recovery", func(t *testing.T) {
+		isolateDesktopUserDirs(t)
+		workspaceRoot := t.TempDir()
+		seedLegacyTopicBridge(t, workspaceRoot)
+		if err := setLegacyTopicTitle(workspaceRoot, "topic-old", "Recovered", topicTitleSourceManual); err != nil {
+			t.Fatal(err)
+		}
+		path := config.DesktopTopicStatePath(workspaceRoot)
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("not a sqlite database"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if got := loadTopicTitle(workspaceRoot, "topic-old"); got != "Recovered" {
+			t.Fatalf("recovered title = %q", got)
+		}
+		if matches, _ := filepath.Glob(path + ".corrupt-*"); len(matches) != 1 {
+			t.Fatalf("corrupt backups = %#v", matches)
+		}
+	})
+
+	t.Run("no recovery source", func(t *testing.T) {
+		isolateDesktopUserDirs(t)
+		workspaceRoot := t.TempDir()
+		path := config.DesktopTopicStatePath(workspaceRoot)
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		original := []byte("not a sqlite database")
+		if err := os.WriteFile(path, original, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := setTopicTitle(workspaceRoot, "topic-new", "No silent reset"); err == nil {
+			t.Fatal("write unexpectedly replaced corrupt authoritative database")
+		}
+		if got, err := os.ReadFile(path); err != nil || string(got) != string(original) {
+			t.Fatalf("corrupt database changed: %q, %v", got, err)
+		}
+		if matches, _ := filepath.Glob(path + ".corrupt-*"); len(matches) != 0 {
+			t.Fatalf("database without recovery source was quarantined: %#v", matches)
+		}
+	})
+}
+
+func containsJSONKey(data []byte, key string) bool {
+	var fields map[string]json.RawMessage
+	return json.Unmarshal(data, &fields) == nil && fields[key] != nil
+}

--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -40,6 +40,8 @@ non-destructively when `<Reasonix home>/.env` is missing them.
 | Sessions | `<state root>/sessions/` |
 | Archives | `<state root>/archive/` |
 | Memory | `<state root>/memory/` and `<state root>/projects/` |
+| Global Desktop topic metadata | `<state root>/desktop/topic-state-v1.sqlite` |
+| Project Desktop topic metadata | `<state root>/projects/<workspace slug>/desktop/topic-state-v1.sqlite` |
 | Disposable session catalog | `<cache root>/session-catalog/v5.sqlite` |
 | Disposable history search catalog | `<cache root>/history-search/v1.sqlite` |
 | Disposable usage catalog | `<cache root>/usage-catalog/v1.sqlite` |
@@ -47,6 +49,14 @@ non-destructively when `<Reasonix home>/.env` is missing them.
 
 `<state root>` defaults to `<Reasonix home>`. It only differs when
 `REASONIX_STATE_HOME` is set.
+
+Desktop topic titles, title sources, creation times, and automatic-title state
+are authoritative in these SQLite files. On first access, Desktop imports the
+legacy `desktop-topic-*.json` files from a project's `.reasonix/` directory (or
+the global Reasonix directory). A scope with legacy files continues mirroring
+them for downgrade compatibility; a fresh scope does not create them. Legacy
+files are retained, and project-local settings, skills, commands, attachments,
+and `reasonix.toml` are unaffected.
 
 The session catalog is a rebuildable query projection, not user data. Session
 JSONL, event logs, metadata sidecars, and `desktop-projects.json` remain

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -33,11 +33,19 @@ Legacy 迁移、OS home 约定目录扫描以及其他 fallback 路径都会跳�
 | 会话 | `<state root>/sessions/` |
 | 归档 | `<state root>/archive/` |
 | 记忆 | `<state root>/memory/` 与 `<state root>/projects/` |
+| 全局 Desktop Topic 元数据 | `<state root>/desktop/topic-state-v1.sqlite` |
+| 项目 Desktop Topic 元数据 | `<state root>/projects/<workspace slug>/desktop/topic-state-v1.sqlite` |
 | 可丢弃的会话 Catalog | `<cache root>/session-catalog/v5.sqlite` |
 | 可丢弃的 Task Catalog | `<cache root>/task-catalog/v1.sqlite` |
 
 `<state root>` 默认等于 `<Reasonix home>`；只有设置 `REASONIX_STATE_HOME`
 时才会不同。
+
+Desktop Topic 的标题、标题来源、创建时间和自动标题状态以这些 SQLite 文件为权威存储。
+首次访问时，Desktop 会导入项目 `.reasonix/` 目录（或全局 Reasonix 目录）中的旧
+`desktop-topic-*.json`。检测到旧文件的 scope 会继续镜像旧格式以支持降级；全新 scope
+不会创建这些 JSON。旧文件不会被删除，项目本地 settings、skills、commands、attachments
+以及 `reasonix.toml` 均不受影响。
 
 会话 Catalog 是可重建的查询投影，不是用户数据；JSONL、event log、
 metadata sidecar 和 `desktop-projects.json` 仍是权威数据。详见

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -91,9 +91,11 @@ Desktop automatically migrates its four legacy `desktop-topic-*.json` indexes
 to an authoritative per-scope SQLite database under the Reasonix state root.
 Existing scopes keep the JSON files synchronized so a normal downgrade to the
 previous Desktop can still read titles and timestamps. Fresh scopes write only
-SQLite. The migration never deletes the legacy files or changes project-owned
-`.reasonix` assets. Running old and new Desktop versions concurrently against
-the same workspace is not supported.
+SQLite. An older Desktop cannot read that SQLite-only state directly: existing
+session metadata may recover titles, but creation times and automatic-title
+stages are not guaranteed. The migration never deletes the legacy files or
+changes project-owned `.reasonix` assets. Running old and new Desktop versions
+concurrently against the same workspace is not supported.
 
 ## Context Engine v2 upgrade
 

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -85,6 +85,16 @@ v0.x sessions are in a custom Windows install/data directory, use
 See
 [Configuration paths](./CONFIG_PATHS.md) for the full path list and limitations.
 
+### Desktop topic metadata
+
+Desktop automatically migrates its four legacy `desktop-topic-*.json` indexes
+to an authoritative per-scope SQLite database under the Reasonix state root.
+Existing scopes keep the JSON files synchronized so a normal downgrade to the
+previous Desktop can still read titles and timestamps. Fresh scopes write only
+SQLite. The migration never deletes the legacy files or changes project-owned
+`.reasonix` assets. Running old and new Desktop versions concurrently against
+the same workspace is not supported.
+
 ## Context Engine v2 upgrade
 
 Instruction and memory upgrades are automatic and do not require a setup mode,

--- a/docs/MIGRATING.zh-CN.md
+++ b/docs/MIGRATING.zh-CN.md
@@ -70,8 +70,10 @@ cd DeepSeek-Reasonix && make build                        # -> bin/reasonix(.exe
 
 Desktop 会自动把四个旧 `desktop-topic-*.json` 索引迁移到 Reasonix 状态根目录下按
 scope 隔离的权威 SQLite 数据库。已存在旧文件的 scope 会继续同步 JSON，因此正常降级到
-前一版本 Desktop 时仍能读取标题和时间；全新 scope 只写 SQLite。迁移不会删除旧文件，
-也不会修改项目拥有的 `.reasonix` 资产。不支持新旧 Desktop 同时写同一个工作区。
+前一版本 Desktop 时仍能读取标题和时间；全新 scope 只写 SQLite，旧版 Desktop 无法直接
+读取这部分状态：现有 session metadata 可能恢复标题，但不保证创建时间和自动标题阶段完整。
+迁移不会删除旧文件，也不会修改项目拥有的 `.reasonix` 资产。不支持新旧 Desktop 同时写
+同一个工作区。
 
 ## Context Engine v2 升级
 

--- a/docs/MIGRATING.zh-CN.md
+++ b/docs/MIGRATING.zh-CN.md
@@ -66,6 +66,13 @@ cd DeepSeek-Reasonix && make build                        # -> bin/reasonix(.exe
 
 完整路径和限制见[配置路径](./CONFIG_PATHS.zh-CN.md)。
 
+### Desktop Topic 元数据
+
+Desktop 会自动把四个旧 `desktop-topic-*.json` 索引迁移到 Reasonix 状态根目录下按
+scope 隔离的权威 SQLite 数据库。已存在旧文件的 scope 会继续同步 JSON，因此正常降级到
+前一版本 Desktop 时仍能读取标题和时间；全新 scope 只写 SQLite。迁移不会删除旧文件，
+也不会修改项目拥有的 `.reasonix` 资产。不支持新旧 Desktop 同时写同一个工作区。
+
 ## Context Engine v2 升级
 
 指令与记忆升级会自动完成，不需要 setup mode、re-index 命令或新配置：

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -462,6 +462,24 @@ func ProjectSessionDir(workspaceRoot string) string {
 	return filepath.Join(base, "projects", WorkspaceSlug(root), "sessions")
 }
 
+// DesktopTopicStatePath returns the authoritative SQLite path for Desktop
+// topic metadata. Global topics live directly under the user state root;
+// project topics share the same stable workspace slug as project sessions.
+func DesktopTopicStatePath(workspaceRoot string) string {
+	base := MemoryUserDir()
+	if base == "" {
+		return ""
+	}
+	root := strings.TrimSpace(workspaceRoot)
+	if root == "" {
+		return filepath.Join(base, "desktop", "topic-state-v1.sqlite")
+	}
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
+	return filepath.Join(base, "projects", WorkspaceSlug(root), "desktop", "topic-state-v1.sqlite")
+}
+
 // WorkspaceSlug flattens an absolute workspace path into the directory name
 // used under <config root>/projects. Windows spells the same folder with
 // varying case (drive-letter case, Explorer renames), so the slug folds case

--- a/internal/config/topic_state_path_test.go
+++ b/internal/config/topic_state_path_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDesktopTopicStatePathUsesStateHome(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("REASONIX_STATE_HOME", stateHome)
+
+	if got, want := DesktopTopicStatePath(""), filepath.Join(stateHome, "desktop", "topic-state-v1.sqlite"); got != want {
+		t.Fatalf("global path = %q, want %q", got, want)
+	}
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	abs, err := filepath.Abs(workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(stateHome, "projects", WorkspaceSlug(abs), "desktop", "topic-state-v1.sqlite")
+	if got := DesktopTopicStatePath(workspace); got != want {
+		t.Fatalf("project path = %q, want %q", got, want)
+	}
+}

--- a/internal/topicstate/store.go
+++ b/internal/topicstate/store.go
@@ -421,21 +421,34 @@ func (s *Store) ReplaceSources(ctx context.Context, values map[string]string) (S
 	})
 }
 
-// ReplaceTitleIndex replaces titles and their sources in one transaction.
-func (s *Store) ReplaceTitleIndex(ctx context.Context, titles, sources map[string]string) (State, error) {
+// MergeMissingTitleIndex fills title-index gaps from a scan-built snapshot
+// without replacing values written after that scan began. Background session
+// repair uses this compare-at-commit behavior so a concurrent manual rename
+// cannot be reverted by stale whole-map data.
+func (s *Store) MergeMissingTitleIndex(ctx context.Context, titles, sources map[string]string, deleted map[string]bool) (State, error) {
 	return s.replaceField(ctx, func(records map[string]Record) {
-		for id, record := range records {
-			record.Title = ""
-			record.TitleSource = ""
-			records[id] = record
+		for id := range deleted {
+			delete(records, id)
 		}
 		for id, value := range titles {
+			if deleted[id] {
+				continue
+			}
 			record := records[id]
+			if strings.TrimSpace(record.Title) != "" {
+				continue
+			}
 			record.TopicID, record.Title = id, value
 			records[id] = record
 		}
 		for id, value := range sources {
+			if deleted[id] {
+				continue
+			}
 			record := records[id]
+			if strings.TrimSpace(record.TitleSource) != "" {
+				continue
+			}
 			record.TopicID, record.TitleSource = id, value
 			records[id] = record
 		}

--- a/internal/topicstate/store.go
+++ b/internal/topicstate/store.go
@@ -1,0 +1,713 @@
+// Package topicstate persists authoritative Desktop topic metadata in SQLite.
+// Unlike projection databases, a Store owns user-visible state and must never
+// silently fall back to an empty in-memory database.
+package topicstate
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	moderncsqlite "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+const schemaVersion = 1
+
+// FutureSchemaError means a newer Reasonix version owns this database. Callers
+// must leave the file untouched and may only use an explicitly compatible
+// legacy read path.
+type FutureSchemaError struct {
+	Found     int
+	Supported int
+}
+
+func (e *FutureSchemaError) Error() string {
+	return fmt.Sprintf("topic state schema %d is newer than supported %d", e.Found, e.Supported)
+}
+
+// Record is the complete durable metadata for one Desktop topic. AutoMeta is
+// retained as raw JSON so a read/modify/write by this version preserves fields
+// introduced by a future compatible writer.
+type Record struct {
+	TopicID     string
+	Title       string
+	TitleSource string
+	CreatedAtMS int64
+	AutoMeta    json.RawMessage
+	RowRevision int64
+	UpdatedAtMS int64
+}
+
+// State tracks the authoritative revision and the legacy JSON mirror outbox.
+type State struct {
+	Revision               int64
+	LegacyBridge           bool
+	LegacyExportedRevision int64
+	LegacyPendingRevision  int64
+	LegacyTitlesDigest     string
+	LegacySourcesDigest    string
+	LegacyCreatedAtsDigest string
+	LegacyAutoMetaDigest   string
+}
+
+// Snapshot is one transactionally consistent view of all topic metadata.
+type Snapshot struct {
+	Records map[string]Record
+	State   State
+}
+
+// Store is a single-scope SQLite topic database.
+type Store struct {
+	path string
+	db   *sql.DB
+	now  func() time.Time
+}
+
+// Open opens or creates a durable topic database at path.
+func Open(ctx context.Context, path string) (*Store, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, errors.New("topic state path is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create topic state directory: %w", err)
+	}
+	_ = os.Chmod(filepath.Dir(path), 0o700)
+
+	db, err := sql.Open("sqlite", diskFileDSN(path))
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	fail := func(err error) (*Store, error) {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := db.PingContext(ctx); err != nil {
+		return fail(err)
+	}
+	for _, pragma := range []string{`PRAGMA foreign_keys=ON`, `PRAGMA busy_timeout=2000`} {
+		if _, err := db.ExecContext(ctx, pragma); err != nil {
+			return fail(err)
+		}
+	}
+	var integrity string
+	if err := db.QueryRowContext(ctx, `PRAGMA quick_check`).Scan(&integrity); err != nil {
+		return fail(err)
+	}
+	if integrity != "ok" {
+		return fail(fmt.Errorf("topic state quick check: %s", integrity))
+	}
+	if err := applyMigrations(ctx, db, time.Now); err != nil {
+		return fail(err)
+	}
+	if _, err := db.ExecContext(ctx, `PRAGMA journal_mode=WAL`); err != nil {
+		return fail(err)
+	}
+	for _, pragma := range []string{`PRAGMA synchronous=FULL`, `PRAGMA secure_delete=ON`} {
+		if _, err := db.ExecContext(ctx, pragma); err != nil {
+			return fail(err)
+		}
+	}
+	_ = os.Chmod(path, 0o600)
+	_ = os.Chmod(path+"-wal", 0o600)
+	_ = os.Chmod(path+"-shm", 0o600)
+	return &Store{path: path, db: db, now: time.Now}, nil
+}
+
+func diskFileDSN(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	slash := filepath.ToSlash(abs)
+	if runtime.GOOS == "windows" && len(slash) >= 2 && slash[1] == ':' {
+		slash = "/" + slash
+	}
+	u := &url.URL{Scheme: "file", Path: slash}
+	return u.String() + "?_pragma=busy_timeout%282000%29&_pragma=foreign_keys%281%29"
+}
+
+func applyMigrations(ctx context.Context, db *sql.DB, now func() time.Time) error {
+	if _, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
+        version INTEGER PRIMARY KEY,
+        applied_at INTEGER NOT NULL
+    )`); err != nil {
+		return err
+	}
+	var current int
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(MAX(version), 0) FROM schema_migrations`).Scan(&current); err != nil {
+		return err
+	}
+	if current > schemaVersion {
+		return &FutureSchemaError{Found: current, Supported: schemaVersion}
+	}
+	if current == schemaVersion {
+		return nil
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `CREATE TABLE topics (
+        topic_id TEXT PRIMARY KEY,
+        title TEXT NOT NULL DEFAULT '',
+        title_source TEXT NOT NULL DEFAULT '',
+        created_at_ms INTEGER NOT NULL DEFAULT 0,
+        auto_meta_json TEXT NOT NULL DEFAULT '',
+        row_revision INTEGER NOT NULL DEFAULT 0,
+        updated_at_ms INTEGER NOT NULL DEFAULT 0
+    )`); err != nil {
+		return fmt.Errorf("create topics table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE TABLE store_state (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        revision INTEGER NOT NULL DEFAULT 0,
+        legacy_bridge INTEGER NOT NULL DEFAULT 0,
+        legacy_exported_revision INTEGER NOT NULL DEFAULT 0,
+        legacy_pending_revision INTEGER NOT NULL DEFAULT 0,
+        legacy_titles_digest TEXT NOT NULL DEFAULT '',
+        legacy_sources_digest TEXT NOT NULL DEFAULT '',
+        legacy_created_ats_digest TEXT NOT NULL DEFAULT '',
+        legacy_auto_meta_digest TEXT NOT NULL DEFAULT ''
+    )`); err != nil {
+		return fmt.Errorf("create store state table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO store_state(id) VALUES(1)`); err != nil {
+		return fmt.Errorf("initialize store state: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO schema_migrations(version, applied_at) VALUES(?, ?)`, schemaVersion, now().UnixMilli()); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// Close releases the underlying SQLite handle.
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+// Path returns the database path for diagnostics and lock coordination.
+func (s *Store) Path() string {
+	if s == nil {
+		return ""
+	}
+	return s.path
+}
+
+// Snapshot returns all records and bridge state from one read transaction.
+func (s *Store) Snapshot(ctx context.Context) (Snapshot, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	state, err := readState(ctx, tx)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	records, err := readRecords(ctx, tx)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Snapshot{}, err
+	}
+	return Snapshot{Records: records, State: state}, nil
+}
+
+// SetLegacyBridge enables the compatibility outbox permanently. Enabling it
+// marks the current revision pending so the caller must publish a full mirror.
+func (s *Store) SetLegacyBridge(ctx context.Context) (State, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return State{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	state, err := readState(ctx, tx)
+	if err != nil {
+		return State{}, err
+	}
+	if !state.LegacyBridge {
+		state.LegacyBridge = true
+		state.LegacyPendingRevision = state.Revision
+		if _, err := tx.ExecContext(ctx, `UPDATE store_state SET legacy_bridge=1, legacy_pending_revision=? WHERE id=1`, state.LegacyPendingRevision); err != nil {
+			return State{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return State{}, err
+	}
+	return state, nil
+}
+
+// MarkLegacyExported acknowledges a complete legacy mirror. It only clears the
+// outbox when expectedRevision is still the current authoritative revision.
+func (s *Store) MarkLegacyExported(ctx context.Context, expectedRevision int64, digests [4]string) (State, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return State{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	state, err := readState(ctx, tx)
+	if err != nil {
+		return State{}, err
+	}
+	if state.Revision == expectedRevision {
+		state.LegacyExportedRevision = expectedRevision
+		state.LegacyPendingRevision = 0
+		state.LegacyTitlesDigest = digests[0]
+		state.LegacySourcesDigest = digests[1]
+		state.LegacyCreatedAtsDigest = digests[2]
+		state.LegacyAutoMetaDigest = digests[3]
+		if _, err := tx.ExecContext(ctx, `UPDATE store_state SET
+            legacy_exported_revision=?, legacy_pending_revision=0,
+            legacy_titles_digest=?, legacy_sources_digest=?,
+            legacy_created_ats_digest=?, legacy_auto_meta_digest=?
+            WHERE id=1`, expectedRevision, digests[0], digests[1], digests[2], digests[3]); err != nil {
+			return State{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return State{}, err
+	}
+	return state, nil
+}
+
+// Update atomically changes one topic. Empty records are removed.
+func (s *Store) Update(ctx context.Context, topicID string, mutate func(*Record)) (State, error) {
+	topicID = strings.TrimSpace(topicID)
+	if topicID == "" {
+		return State{}, errors.New("topic id is empty")
+	}
+	return s.mutateOne(ctx, topicID, mutate)
+}
+
+// Delete removes all metadata for one topic in a single transaction.
+func (s *Store) Delete(ctx context.Context, topicID string) (State, error) {
+	topicID = strings.TrimSpace(topicID)
+	if topicID == "" {
+		return s.currentState(ctx)
+	}
+	return s.mutateOne(ctx, topicID, func(record *Record) {
+		*record = Record{TopicID: topicID}
+	})
+}
+
+func (s *Store) mutateOne(ctx context.Context, topicID string, mutate func(*Record)) (State, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return State{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	state, err := readState(ctx, tx)
+	if err != nil {
+		return State{}, err
+	}
+	record := Record{TopicID: topicID}
+	var autoMeta string
+	err = tx.QueryRowContext(ctx, `SELECT title, title_source, created_at_ms,
+        auto_meta_json, row_revision, updated_at_ms FROM topics WHERE topic_id=?`, topicID).Scan(
+		&record.Title, &record.TitleSource, &record.CreatedAtMS, &autoMeta,
+		&record.RowRevision, &record.UpdatedAtMS,
+	)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return State{}, err
+	}
+	if autoMeta != "" {
+		record.AutoMeta = json.RawMessage(autoMeta)
+	}
+	before := cloneRecord(record)
+	mutate(&record)
+	record.TopicID = topicID
+	normalizeRecord(&record)
+	if recordEqual(before, record) {
+		if err := tx.Commit(); err != nil {
+			return State{}, err
+		}
+		return state, nil
+	}
+	state.Revision++
+	if recordEmpty(record) {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM topics WHERE topic_id=?`, topicID); err != nil {
+			return State{}, err
+		}
+	} else {
+		record.RowRevision = state.Revision
+		record.UpdatedAtMS = s.now().UnixMilli()
+		if _, err := tx.ExecContext(ctx, `INSERT INTO topics(
+            topic_id, title, title_source, created_at_ms, auto_meta_json,
+            row_revision, updated_at_ms) VALUES(?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(topic_id) DO UPDATE SET
+            title=excluded.title, title_source=excluded.title_source,
+            created_at_ms=excluded.created_at_ms, auto_meta_json=excluded.auto_meta_json,
+            row_revision=excluded.row_revision, updated_at_ms=excluded.updated_at_ms`,
+			record.TopicID, record.Title, record.TitleSource, record.CreatedAtMS,
+			string(record.AutoMeta), record.RowRevision, record.UpdatedAtMS); err != nil {
+			return State{}, err
+		}
+	}
+	if state.LegacyBridge {
+		state.LegacyPendingRevision = state.Revision
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE store_state SET revision=?, legacy_pending_revision=? WHERE id=1`, state.Revision, state.LegacyPendingRevision); err != nil {
+		return State{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return State{}, err
+	}
+	return state, nil
+}
+
+// ReplaceAll transactionally replaces the complete record set. It is intended
+// for first migration and deterministic legacy reconciliation.
+func (s *Store) ReplaceAll(ctx context.Context, records map[string]Record) (State, error) {
+	return s.mutate(ctx, func(current map[string]Record) {
+		clear(current)
+		for id, record := range records {
+			record.TopicID = strings.TrimSpace(id)
+			normalizeRecord(&record)
+			if record.TopicID != "" && !recordEmpty(record) {
+				current[record.TopicID] = cloneRecord(record)
+			}
+		}
+	})
+}
+
+// ReplaceTitles replaces only the title field while preserving every other
+// field, including unknown auto-title metadata.
+func (s *Store) ReplaceTitles(ctx context.Context, values map[string]string) (State, error) {
+	return s.replaceField(ctx, func(records map[string]Record) {
+		for id, record := range records {
+			record.Title = ""
+			records[id] = record
+		}
+		for id, value := range values {
+			record := records[id]
+			record.TopicID, record.Title = id, value
+			records[id] = record
+		}
+	})
+}
+
+// ReplaceSources replaces only the title source field.
+func (s *Store) ReplaceSources(ctx context.Context, values map[string]string) (State, error) {
+	return s.replaceField(ctx, func(records map[string]Record) {
+		for id, record := range records {
+			record.TitleSource = ""
+			records[id] = record
+		}
+		for id, value := range values {
+			record := records[id]
+			record.TopicID, record.TitleSource = id, value
+			records[id] = record
+		}
+	})
+}
+
+// ReplaceTitleIndex replaces titles and their sources in one transaction.
+func (s *Store) ReplaceTitleIndex(ctx context.Context, titles, sources map[string]string) (State, error) {
+	return s.replaceField(ctx, func(records map[string]Record) {
+		for id, record := range records {
+			record.Title = ""
+			record.TitleSource = ""
+			records[id] = record
+		}
+		for id, value := range titles {
+			record := records[id]
+			record.TopicID, record.Title = id, value
+			records[id] = record
+		}
+		for id, value := range sources {
+			record := records[id]
+			record.TopicID, record.TitleSource = id, value
+			records[id] = record
+		}
+	})
+}
+
+// ReplaceCreatedAts replaces only topic creation timestamps.
+func (s *Store) ReplaceCreatedAts(ctx context.Context, values map[string]int64) (State, error) {
+	return s.replaceField(ctx, func(records map[string]Record) {
+		for id, record := range records {
+			record.CreatedAtMS = 0
+			records[id] = record
+		}
+		for id, value := range values {
+			record := records[id]
+			record.TopicID, record.CreatedAtMS = id, value
+			records[id] = record
+		}
+	})
+}
+
+// ReplaceAutoMeta replaces only raw automatic-title metadata.
+func (s *Store) ReplaceAutoMeta(ctx context.Context, values map[string]json.RawMessage) (State, error) {
+	return s.replaceField(ctx, func(records map[string]Record) {
+		for id, record := range records {
+			record.AutoMeta = nil
+			records[id] = record
+		}
+		for id, value := range values {
+			record := records[id]
+			record.TopicID, record.AutoMeta = id, append(json.RawMessage(nil), value...)
+			records[id] = record
+		}
+	})
+}
+
+func (s *Store) replaceField(ctx context.Context, mutate func(map[string]Record)) (State, error) {
+	return s.mutate(ctx, func(records map[string]Record) {
+		mutate(records)
+		for id, record := range records {
+			normalizeRecord(&record)
+			if recordEmpty(record) {
+				delete(records, id)
+			} else {
+				records[id] = record
+			}
+		}
+	})
+}
+
+func (s *Store) mutate(ctx context.Context, mutate func(map[string]Record)) (State, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return State{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	state, err := readState(ctx, tx)
+	if err != nil {
+		return State{}, err
+	}
+	records, err := readRecords(ctx, tx)
+	if err != nil {
+		return State{}, err
+	}
+	before := cloneRecords(records)
+	mutate(records)
+	if recordsEqual(before, records) {
+		if err := tx.Commit(); err != nil {
+			return State{}, err
+		}
+		return state, nil
+	}
+	nowMS := s.now().UnixMilli()
+	state.Revision++
+	for id, record := range records {
+		if previous, ok := before[id]; !ok || !recordEqual(previous, record) {
+			record.RowRevision = state.Revision
+			record.UpdatedAtMS = nowMS
+			records[id] = record
+		}
+	}
+	if err := writeRecords(ctx, tx, records); err != nil {
+		return State{}, err
+	}
+	if state.LegacyBridge {
+		state.LegacyPendingRevision = state.Revision
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE store_state SET revision=?, legacy_pending_revision=? WHERE id=1`, state.Revision, state.LegacyPendingRevision); err != nil {
+		return State{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return State{}, err
+	}
+	return state, nil
+}
+
+func (s *Store) currentState(ctx context.Context) (State, error) {
+	return readState(ctx, s.db)
+}
+
+type rowQuerier interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func readState(ctx context.Context, q rowQuerier) (State, error) {
+	var state State
+	var bridge int
+	err := q.QueryRowContext(ctx, `SELECT revision, legacy_bridge,
+        legacy_exported_revision, legacy_pending_revision,
+        legacy_titles_digest, legacy_sources_digest,
+        legacy_created_ats_digest, legacy_auto_meta_digest
+        FROM store_state WHERE id=1`).Scan(
+		&state.Revision, &bridge, &state.LegacyExportedRevision,
+		&state.LegacyPendingRevision, &state.LegacyTitlesDigest,
+		&state.LegacySourcesDigest, &state.LegacyCreatedAtsDigest,
+		&state.LegacyAutoMetaDigest,
+	)
+	state.LegacyBridge = bridge != 0
+	return state, err
+}
+
+type rowsQuerier interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func readRecords(ctx context.Context, q rowsQuerier) (map[string]Record, error) {
+	rows, err := q.QueryContext(ctx, `SELECT topic_id, title, title_source,
+        created_at_ms, auto_meta_json, row_revision, updated_at_ms FROM topics`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	records := map[string]Record{}
+	for rows.Next() {
+		var record Record
+		var autoMeta string
+		if err := rows.Scan(&record.TopicID, &record.Title, &record.TitleSource,
+			&record.CreatedAtMS, &autoMeta, &record.RowRevision, &record.UpdatedAtMS); err != nil {
+			return nil, err
+		}
+		if autoMeta != "" {
+			record.AutoMeta = json.RawMessage(autoMeta)
+		}
+		records[record.TopicID] = record
+	}
+	return records, rows.Err()
+}
+
+func writeRecords(ctx context.Context, tx *sql.Tx, records map[string]Record) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM topics`); err != nil {
+		return err
+	}
+	stmt, err := tx.PrepareContext(ctx, `INSERT INTO topics(
+        topic_id, title, title_source, created_at_ms, auto_meta_json,
+        row_revision, updated_at_ms) VALUES(?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	ids := make([]string, 0, len(records))
+	for id := range records {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		record := records[id]
+		normalizeRecord(&record)
+		if recordEmpty(record) {
+			continue
+		}
+		if _, err := stmt.ExecContext(ctx, record.TopicID, record.Title,
+			record.TitleSource, record.CreatedAtMS, string(record.AutoMeta),
+			record.RowRevision, record.UpdatedAtMS); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizeRecord(record *Record) {
+	record.TopicID = strings.TrimSpace(record.TopicID)
+	record.Title = strings.TrimSpace(record.Title)
+	record.TitleSource = strings.TrimSpace(record.TitleSource)
+	if record.CreatedAtMS < 0 {
+		record.CreatedAtMS = 0
+	}
+	if len(bytes.TrimSpace(record.AutoMeta)) == 0 || bytes.Equal(bytes.TrimSpace(record.AutoMeta), []byte("null")) || bytes.Equal(bytes.TrimSpace(record.AutoMeta), []byte("{}")) {
+		record.AutoMeta = nil
+	} else {
+		record.AutoMeta = append(json.RawMessage(nil), bytes.TrimSpace(record.AutoMeta)...)
+	}
+}
+
+func recordEmpty(record Record) bool {
+	return record.Title == "" && record.TitleSource == "" && record.CreatedAtMS <= 0 && len(record.AutoMeta) == 0
+}
+
+func cloneRecord(record Record) Record {
+	record.AutoMeta = append(json.RawMessage(nil), record.AutoMeta...)
+	return record
+}
+
+func cloneRecords(records map[string]Record) map[string]Record {
+	clone := make(map[string]Record, len(records))
+	for id, record := range records {
+		clone[id] = cloneRecord(record)
+	}
+	return clone
+}
+
+func recordsEqual(a, b map[string]Record) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for id, record := range a {
+		if other, ok := b[id]; !ok || !recordEqual(record, other) {
+			return false
+		}
+	}
+	return true
+}
+
+func recordEqual(a, b Record) bool {
+	return a.TopicID == b.TopicID && a.Title == b.Title &&
+		a.TitleSource == b.TitleSource && a.CreatedAtMS == b.CreatedAtMS &&
+		bytes.Equal(a.AutoMeta, b.AutoMeta)
+}
+
+// IsCorruptionError reports only integrity-level failures. Busy, permissions,
+// IO errors, and future schemas must never cause an authoritative DB rename.
+func IsCorruptionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var future *FutureSchemaError
+	if errors.As(err, &future) {
+		return false
+	}
+	var sqliteErr *moderncsqlite.Error
+	if errors.As(err, &sqliteErr) {
+		switch sqliteErr.Code() & 0xff {
+		case sqlite3.SQLITE_CORRUPT, sqlite3.SQLITE_NOTADB:
+			return true
+		}
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "quick check") ||
+		strings.Contains(message, "malformed") ||
+		strings.Contains(message, "file is not a database") ||
+		strings.Contains(message, "not a database")
+}
+
+// Quarantine preserves a corrupt database and its WAL sidecars for diagnosis.
+func Quarantine(path string, now time.Time) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("topic state path is empty")
+	}
+	quarantined := fmt.Sprintf("%s.corrupt-%d", path, now.UnixMilli())
+	if err := os.Rename(path, quarantined); err != nil {
+		return "", err
+	}
+	moved := []string{}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if err := os.Rename(path+suffix, quarantined+suffix); err == nil {
+			moved = append(moved, suffix)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			for _, movedSuffix := range moved {
+				_ = os.Rename(quarantined+movedSuffix, path+movedSuffix)
+			}
+			_ = os.Rename(quarantined, path)
+			return "", err
+		}
+	}
+	return quarantined, nil
+}

--- a/internal/topicstate/store_test.go
+++ b/internal/topicstate/store_test.go
@@ -1,0 +1,196 @@
+package topicstate
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestStorePersistsAtomicTopicRecord(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "topic-state-v1.sqlite")
+	store, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Update(ctx, "topic-1", func(record *Record) {
+		record.Title = "First title"
+		record.TitleSource = "manual"
+		record.CreatedAtMS = 123
+		record.AutoMeta = json.RawMessage(`{"stage":2,"future":"kept"}`)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Revision != 1 || state.LegacyPendingRevision != 0 {
+		t.Fatalf("state = %+v", state)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	snapshot, err := store.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := snapshot.Records["topic-1"]
+	if record.Title != "First title" || record.TitleSource != "manual" || record.CreatedAtMS != 123 {
+		t.Fatalf("record = %+v", record)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(record.AutoMeta, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta["future"] != "kept" {
+		t.Fatalf("auto meta = %s", record.AutoMeta)
+	}
+	if info, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	} else if info.Mode().Perm() != 0o600 {
+		t.Fatalf("database mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestStoreLegacyOutboxTracksCommittedRevision(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "topic-state-v1.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	state, err := store.SetLegacyBridge(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.LegacyBridge {
+		t.Fatal("legacy bridge was not enabled")
+	}
+	state, err = store.Update(ctx, "topic-1", func(record *Record) { record.Title = "renamed" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.LegacyPendingRevision != state.Revision || state.Revision == 0 {
+		t.Fatalf("state = %+v", state)
+	}
+	digests := [4]string{"titles", "sources", "created", "auto"}
+	state, err = store.MarkLegacyExported(ctx, state.Revision, digests)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.LegacyPendingRevision != 0 || state.LegacyExportedRevision != state.Revision {
+		t.Fatalf("state = %+v", state)
+	}
+	if state.LegacyTitlesDigest != "titles" || state.LegacyAutoMetaDigest != "auto" {
+		t.Fatalf("digests not retained: %+v", state)
+	}
+}
+
+func TestReplaceFieldPreservesUnknownAutoMetadata(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "topic-state-v1.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	_, err = store.Update(ctx, "topic-1", func(record *Record) {
+		record.Title = "old"
+		record.AutoMeta = json.RawMessage(`{"stage":1,"future":{"value":7}}`)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ReplaceTitles(ctx, map[string]string{"topic-1": "new"}); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(snapshot.Records["topic-1"].AutoMeta); got != `{"stage":1,"future":{"value":7}}` {
+		t.Fatalf("auto metadata changed: %s", got)
+	}
+}
+
+func TestStoreRejectsFutureSchemaWithoutChangingFile(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "topic-state-v1.sqlite")
+	db, err := sql.Open("sqlite", diskFileDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO schema_migrations(version, applied_at) VALUES(2, 0)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ctx, path)
+	var future *FutureSchemaError
+	if !errors.As(err, &future) {
+		t.Fatalf("Open error = %v, want FutureSchemaError", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Fatal("future-schema database was modified")
+	}
+}
+
+func TestStoreConcurrentUpdatesAreSerialized(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "topic-state-v1.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	const writers = 12
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	for i := range writers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := store.Update(ctx, "topic-"+time.Unix(int64(i), 0).UTC().Format("150405"), func(record *Record) {
+				record.Title = "title"
+			})
+			errs <- err
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := store.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Records) != writers || snapshot.State.Revision != writers {
+		t.Fatalf("records=%d revision=%d", len(snapshot.Records), snapshot.State.Revision)
+	}
+}

--- a/internal/topicstate/store_test.go
+++ b/internal/topicstate/store_test.go
@@ -125,6 +125,44 @@ func TestReplaceFieldPreservesUnknownAutoMetadata(t *testing.T) {
 	}
 }
 
+func TestMergeMissingTitleIndexDoesNotOverwriteNewerRename(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "topic-state-v1.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if _, err := store.Update(ctx, "topic-1", func(record *Record) {
+		record.Title = "New manual title"
+		record.TitleSource = "manual"
+	}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := store.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.MergeMissingTitleIndex(ctx,
+		map[string]string{"topic-1": "Stale repaired title", "topic-2": "Recovered title"},
+		map[string]string{"topic-1": "auto", "topic-2": "manual"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	after, err := store.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := after.Records["topic-1"]; got.Title != "New manual title" || got.TitleSource != "manual" {
+		t.Fatalf("newer rename was overwritten: %+v", got)
+	}
+	if got := after.Records["topic-2"]; got.Title != "Recovered title" || got.TitleSource != "manual" {
+		t.Fatalf("missing topic was not repaired: %+v", got)
+	}
+	if after.State.Revision != before.State.Revision+1 {
+		t.Fatalf("revision = %d, want %d", after.State.Revision, before.State.Revision+1)
+	}
+}
+
 func TestStoreRejectsFutureSchemaWithoutChangingFile(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "topic-state-v1.sqlite")


### PR DESCRIPTION
## Summary

- Move Desktop-generated Topic titles, title sources, creation timestamps, and auto-title metadata into an authoritative per-scope SQLite store under the Reasonix state directory.
- Lazily migrate existing legacy JSON scopes and keep mirroring all four JSON snapshots so sequential downgrade and re-upgrade workflows remain readable.
- Keep fresh workspaces SQLite-only, so Desktop Topic state no longer creates `.reasonix/desktop-topic-*` files.
- Add tombstone-aware reconciliation, pending-mirror recovery, corruption quarantine/rebuild, future-schema protection, transactional updates, focused tests, and English/Chinese migration documentation.

## Compatibility and recovery

- Existing scopes migrate on first access and retain the legacy bridge permanently for this release; legacy files are not deleted and `.gitignore` is unchanged.
- Legacy JSON edits made after a downgrade are merged back on the next upgrade. Explicit deletion tombstones win, missing JSON entries are not treated as deletion, and unknown auto-title fields survive round trips.
- Fresh scopes do not create legacy JSON. A direct downgrade from a fresh SQLite-only scope can recover titles only through existing session metadata and does not guarantee creation-time or auto-title-stage recovery.
- Concurrent writes from old and new Reasonix versions to the same workspace are unsupported; sequential upgrade/downgrade compatibility is supported.
- A future schema is never overwritten or rebuilt. Legacy data may be served read-only when available; otherwise the user receives an explicit version error.
- Corrupt databases are quarantined and rebuilt only when legacy/session recovery evidence exists. Diagnostics omit Topic titles, session contents, and full workspace paths.

## Concurrency and security

- Per-scope writes are serialized in-process, while a cross-process compatibility lock protects migration, legacy reconciliation, and snapshot mirroring.
- SQLite transactions provide authoritative atomicity; a persisted pending revision repairs a failed legacy mirror on the next startup or write.
- Tombstones are checked before import and export so deleted Topics cannot be revived by stale JSON or session metadata.
- SQLite files use private directory/file permissions, WAL mode, `synchronous=FULL`, bounded busy waits, and `quick_check` on open.

## Issues

No linked issue.

## Verification

- `go test ./... -count=1`
- `cd desktop && go test ./... -count=1`
- `go test -race ./internal/topicstate ./internal/config`
- `cd desktop && go test -race . -count=1`
- `golangci-lint run --timeout=5m ./...` (root module)
- `cd desktop && golangci-lint run --timeout=5m ./...`
- `go run ./tools/repolint`
- `git diff --check origin/main-v2...HEAD`

## Documentation impact

Documentation-impact: updated - documented the new state paths, lazy migration, legacy bridge, downgrade boundary, and recovery behavior in English and Chinese.

## Cache impact

Cache-impact: none - this changes only Desktop Topic persistence and does not modify prompts, provider serialization, tools, compaction, memory, MCP, or agent context.
Cache-guard: N/A - no cache-sensitive surface changed.
System-prompt-review: N/A
