### PR TITLE
feat(release): the studio line signs its Windows artifacts through SignPath

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,9 @@
 /.github/workflows/release-stable.yml @SivanCola @esengine
 /.github/workflows/release-stable-trigger.yml @SivanCola @esengine
 /.github/workflows/release-desktop.yml @SivanCola @esengine
+/.github/workflows/release-studio.yml @SivanCola @esengine
 /scripts/complete-signpath-request.ps1 @SivanCola @esengine
 /scripts/package-windows-desktop.sh @SivanCola @esengine
 /scripts/verify-windows-authenticode.ps1 @SivanCola @esengine
+/scripts/studio-build.sh @SivanCola @esengine
 /cmd/signpath-contract/ @SivanCola @esengine

--- a/.github/workflows/release-studio.yml
+++ b/.github/workflows/release-studio.yml
@@ -10,9 +10,11 @@ run-name: Release Studio ${{ inputs.tag || github.ref_name }}
 # the desktop line's catalog. Studio artifacts land under the tag prefix, which
 # cannot collide because the tag name itself differs.
 #
-# Windows artifacts are unsigned. The production SignPath policy allows exactly
-# one origin (protected main-v2), so a build from this branch cannot request it
-# and users will see a SmartScreen warning.
+# Windows artifacts are Authenticode-signed through SignPath in two stages: the
+# executable a user runs, then the installer built around it. Signing only the
+# container leaves reasonix-studio.exe unsigned on disk after installation,
+# which is what reputation heuristics quarantine. Signing engages only when
+# SIGNPATH_API_TOKEN is set, so forks and token-less runs still build unsigned.
 on:
   push:
     tags: ['studio-v*']
@@ -69,12 +71,42 @@ jobs:
           { echo "tag=$tag"; echo "version=$version"; echo "sha=$sha"; } >> "$GITHUB_OUTPUT"
           echo "resolved $tag -> $version at $sha"
 
+  # The contract is this repository's mirror of what SignPath's console trusts:
+  # which branch and which workflow may request the release certificate. It is
+  # checked before anything is built so a widened origin fails here rather than
+  # at the signing request, and fingerprinted so the protected files cannot move
+  # under an attestation that was recorded against different bytes.
+  signing-contract:
+    name: validate SignPath release contract
+    needs: resolve
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Validate and fingerprint the contract
+        run: |
+          go run ./cmd/signpath-contract validate
+          echo "fingerprint=$(go run ./cmd/signpath-contract fingerprint)" >> "$GITHUB_STEP_SUMMARY"
+
   build:
     name: build (${{ matrix.platform }})
-    needs: resolve
+    needs: [resolve, signing-contract]
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      actions: read # SignPath reads run details and downloads the unsigned artifact
+    env:
+      # Signing engages only when the token is set, mirroring the APPLE_* gate:
+      # a fork still builds, unsigned, instead of failing on a secret it cannot
+      # have.
+      HAS_SIGNPATH: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -179,7 +211,133 @@ jobs:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/notary.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
-        run: bash scripts/studio-build.sh "${{ matrix.platform }}" "${{ needs.resolve.outputs.version }}"
+        run: |
+          # Windows splits so a signature can be taken between the executable
+          # and the packages built around it; every other platform is one shot.
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            bash scripts/studio-build.sh --windows-payload amd64 "${{ needs.resolve.outputs.version }}"
+          else
+            bash scripts/studio-build.sh "${{ matrix.platform }}" "${{ needs.resolve.outputs.version }}"
+          fi
+
+      # Stage one: the executable a user actually runs, signed while it is still
+      # a loose file. MicrosoftEdgeWebview2Setup.exe is fetched by the packaging
+      # stage, after this — it is Microsoft's and already signed, and this
+      # request must not re-sign somebody else's binary.
+      - name: Upload unsigned Windows payload for SignPath
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        id: unsigned-payload
+        uses: actions/upload-artifact@v5
+        with:
+          name: unsigned-studio-payload-amd64
+          path: dist/windows-payload-amd64/reasonix-studio.exe
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Submit Windows payload for Authenticode signing
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        id: submit-payload
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: DeepSeek-Reasonix
+          signing-policy-slug: release-signing
+          artifact-configuration-slug: studio-windows-payload
+          github-artifact-id: ${{ steps.unsigned-payload.outputs.artifact-id }}
+          github-token: ${{ github.token }}
+          wait-for-completion: false
+
+      # The release certificate requires an approval per request. The publish
+      # job's environment gate is the human one; the SignPath CI identity records
+      # the request approval so this does not become a second prompt.
+      - name: Approve and download signed payload
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        shell: pwsh
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        run: |
+          ./scripts/complete-signpath-request.ps1 `
+            -OrganizationId "${{ secrets.SIGNPATH_ORGANIZATION_ID }}" `
+            -SigningRequestId "${{ steps.submit-payload.outputs.signing-request-id }}" `
+            -ExpectedSigningPolicySlug "release-signing" `
+            -OutputArtifactDirectory "signed-payload" `
+            -TimeoutSeconds 1800
+
+      - name: Put the signed executable back in the payload
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        shell: bash
+        run: cp signed-payload/reasonix-studio.exe dist/windows-payload-amd64/reasonix-studio.exe
+
+      - name: Package Windows from the payload
+        if: runner.os == 'Windows'
+        shell: bash
+        run: bash scripts/studio-build.sh --windows-package amd64 "${{ needs.resolve.outputs.version }}"
+
+      # Stage two: the finished NSIS container, signed only once the payload it
+      # was built from is present and already signed — the artifact
+      # configuration verifies that rather than trusting this job's ordering.
+      - name: Upload unsigned installer for SignPath
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        id: unsigned-installer
+        shell: bash
+        run: |
+          mkdir -p installer-bundle
+          cp dist/ReasonixStudio-windows-amd64-installer.exe installer-bundle/
+          cp dist/windows-payload-amd64/reasonix-studio.exe installer-bundle/
+
+      - name: Upload installer bundle
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        id: installer-artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: unsigned-studio-installer-amd64
+          path: installer-bundle/*.exe
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Submit installer for Authenticode signing
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        id: submit-installer
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: DeepSeek-Reasonix
+          signing-policy-slug: release-signing
+          artifact-configuration-slug: studio-windows-installer
+          github-artifact-id: ${{ steps.installer-artifact.outputs.artifact-id }}
+          github-token: ${{ github.token }}
+          wait-for-completion: false
+
+      - name: Approve and download signed installer
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        shell: pwsh
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        run: |
+          ./scripts/complete-signpath-request.ps1 `
+            -OrganizationId "${{ secrets.SIGNPATH_ORGANIZATION_ID }}" `
+            -SigningRequestId "${{ steps.submit-installer.outputs.signing-request-id }}" `
+            -ExpectedSigningPolicySlug "release-signing" `
+            -OutputArtifactDirectory "signed-installer" `
+            -TimeoutSeconds 1800
+
+      - name: Replace the installer with the signed build
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        shell: bash
+        run: cp signed-installer/*installer*.exe dist/
+
+      # Both stages are read back off the artifacts that will actually ship. A
+      # signature this job believes it applied but that is not on the bytes in
+      # dist/ is the one failure the two requests above cannot catch themselves.
+      - name: Verify the Windows Authenticode chain
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        shell: pwsh
+        run: |
+          ./scripts/verify-windows-authenticode.ps1 `
+            -PayloadDirectory signed-payload `
+            -InstallerPath "dist/ReasonixStudio-windows-amd64-installer.exe"
 
       - uses: actions/upload-artifact@v5
         with:

--- a/.signpath/artifact-configurations/studio-windows-installer.xml
+++ b/.signpath/artifact-configurations/studio-windows-installer.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Stage two: sign the finished NSIS container, and only when the exact payload
+     it was built from is present and already signed. The authenticode-verify
+     entry is what makes the two stages one contract rather than two independent
+     requests — an installer rebuilt from an unsigned binary is refused here
+     rather than discovered by a user after it is installed.
+
+     GitHub Actions wraps this flat bundle in a zip before SignPath receives it. -->
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <zip-file>
+    <pe-file path="*installer*.exe">
+      <authenticode-sign />
+    </pe-file>
+    <pe-file path="reasonix-studio.exe">
+      <authenticode-verify />
+    </pe-file>
+  </zip-file>
+</artifact-configuration>

--- a/.signpath/artifact-configurations/studio-windows-payload.xml
+++ b/.signpath/artifact-configurations/studio-windows-payload.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Stage one: sign the executable a user actually runs, before anything is
+     packaged around it. Signing only the finished NSIS container would leave
+     reasonix-studio.exe unsigned on disk after installation, which is what
+     reputation and ML heuristics quarantine.
+
+     Studio ships one executable of its own. MicrosoftEdgeWebview2Setup.exe is
+     Microsoft's and arrives already signed, so it is not listed here — this
+     configuration must not re-sign somebody else's binary. GitHub Actions wraps
+     the flat payload directory in a zip before SignPath receives it. -->
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <zip-file>
+    <pe-file path="reasonix-studio.exe">
+      <authenticode-sign />
+    </pe-file>
+  </zip-file>
+</artifact-configuration>

--- a/.signpath/contracts/release-signing.yml
+++ b/.signpath/contracts/release-signing.yml
@@ -1,0 +1,16 @@
+version: 1
+project_slug: DeepSeek-Reasonix
+signing_policy_slug: release-signing
+repository_url: https://github.com/esengine/DeepSeek-Reasonix.git
+allowed_branch_names:
+  - studio
+allowed_build_definitions:
+  - .github/workflows/release-studio.yml
+fingerprint_files:
+  - .github/workflows/release-studio.yml
+  - .signpath/artifact-configurations/studio-windows-payload.xml
+  - .signpath/artifact-configurations/studio-windows-installer.xml
+  - scripts/complete-signpath-request.ps1
+  - scripts/studio-build.sh
+  - scripts/verify-windows-authenticode.ps1
+  - cmd/signpath-contract/main.go

--- a/cmd/signpath-contract/main.go
+++ b/cmd/signpath-contract/main.go
@@ -1,0 +1,394 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	contractPath = ".signpath/contracts/release-signing.yml"
+	projectSlug  = "DeepSeek-Reasonix"
+	policySlug   = "release-signing"
+	repository   = "https://github.com/esengine/DeepSeek-Reasonix.git"
+)
+
+// The studio line has its own tag namespace and its own protected branch, so
+// the origin a signing request must carry is this one and not the desktop
+// line's. Pinned here rather than read from the contract: this guard exists to
+// catch the contract being widened, and a guard that reads its own answer out
+// of the file it is checking cannot.
+var expectedBranches = []string{"studio"}
+
+type releaseSigningContract struct {
+	Version                 int      `yaml:"version"`
+	ProjectSlug             string   `yaml:"project_slug"`
+	SigningPolicySlug       string   `yaml:"signing_policy_slug"`
+	RepositoryURL           string   `yaml:"repository_url"`
+	AllowedBranchNames      []string `yaml:"allowed_branch_names"`
+	AllowedBuildDefinitions []string `yaml:"allowed_build_definitions"`
+	FingerprintFiles        []string `yaml:"fingerprint_files"`
+}
+
+type workflowInfo struct {
+	externallyTriggered bool
+	directSigning       bool
+	calls               []string
+}
+
+func main() {
+	if len(os.Args) < 2 || len(os.Args) > 3 {
+		fatalf("usage: signpath-contract <validate|fingerprint> [repository-root]")
+	}
+	root := "."
+	if len(os.Args) == 3 {
+		root = os.Args[2]
+	}
+	contract, err := loadAndValidate(root)
+	if err != nil {
+		fatalf("%v", err)
+	}
+
+	switch os.Args[1] {
+	case "validate":
+		fmt.Println("SignPath release signing contract is valid")
+	case "fingerprint":
+		fingerprint, err := contractFingerprint(root, contract)
+		if err != nil {
+			fatalf("fingerprint contract: %v", err)
+		}
+		fmt.Printf("v1:%x\n", fingerprint)
+	default:
+		fatalf("unknown command %q", os.Args[1])
+	}
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "signpath-contract: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+func loadAndValidate(root string) (releaseSigningContract, error) {
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(contractPath)))
+	if err != nil {
+		return releaseSigningContract{}, fmt.Errorf("read %s: %w", contractPath, err)
+	}
+	var contract releaseSigningContract
+	if err := yaml.Unmarshal(data, &contract); err != nil {
+		return releaseSigningContract{}, fmt.Errorf("parse %s: %w", contractPath, err)
+	}
+	if err := validateContract(root, contract); err != nil {
+		return releaseSigningContract{}, err
+	}
+	return contract, nil
+}
+
+func validateContract(root string, contract releaseSigningContract) error {
+	if contract.Version != 1 {
+		return fmt.Errorf("%s version is %d, want 1", contractPath, contract.Version)
+	}
+	if contract.ProjectSlug != projectSlug {
+		return fmt.Errorf("project_slug is %q, want %q", contract.ProjectSlug, projectSlug)
+	}
+	if contract.SigningPolicySlug != policySlug {
+		return fmt.Errorf("signing_policy_slug is %q, want %q", contract.SigningPolicySlug, policySlug)
+	}
+	if contract.RepositoryURL != repository {
+		return fmt.Errorf("repository_url is %q, want %q", contract.RepositoryURL, repository)
+	}
+	if err := requireExactSet("allowed_branch_names", contract.AllowedBranchNames, expectedBranches); err != nil {
+		return err
+	}
+	if len(contract.AllowedBuildDefinitions) == 0 {
+		return errors.New("allowed_build_definitions must not be empty")
+	}
+	for _, value := range append(append([]string{}, contract.AllowedBranchNames...), contract.AllowedBuildDefinitions...) {
+		if strings.ContainsAny(value, "*?[") {
+			return fmt.Errorf("SignPath allowlists must not contain wildcard %q", value)
+		}
+	}
+	for _, name := range contract.AllowedBuildDefinitions {
+		if err := validateRepositoryPath(name); err != nil {
+			return fmt.Errorf("invalid allowed build definition %q: %w", name, err)
+		}
+		if !strings.HasPrefix(name, ".github/workflows/") {
+			return fmt.Errorf("allowed build definition %q is outside .github/workflows", name)
+		}
+	}
+	if err := requireUnique("allowed_build_definitions", contract.AllowedBuildDefinitions); err != nil {
+		return err
+	}
+	if len(contract.FingerprintFiles) == 0 {
+		return errors.New("fingerprint_files must not be empty")
+	}
+	seen := make(map[string]bool, len(contract.FingerprintFiles))
+	for _, name := range contract.FingerprintFiles {
+		if err := validateRepositoryPath(name); err != nil {
+			return fmt.Errorf("invalid fingerprint file %q: %w", name, err)
+		}
+		if seen[name] {
+			return fmt.Errorf("duplicate fingerprint file %q", name)
+		}
+		seen[name] = true
+		info, err := os.Stat(filepath.Join(root, filepath.FromSlash(name)))
+		if err != nil {
+			return fmt.Errorf("fingerprint file %q: %w", name, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("fingerprint file %q is not a regular file", name)
+		}
+	}
+
+	reachable, err := discoverTopLevelSigningWorkflows(root)
+	if err != nil {
+		return err
+	}
+	if err := requireExactSet("top-level workflows that reach SignPath", reachable, contract.AllowedBuildDefinitions); err != nil {
+		return fmt.Errorf("SignPath build-definition drift: %w", err)
+	}
+	return nil
+}
+
+func requireExactSet(name string, got, want []string) error {
+	gotCopy := append([]string(nil), got...)
+	wantCopy := append([]string(nil), want...)
+	sort.Strings(gotCopy)
+	sort.Strings(wantCopy)
+	if len(gotCopy) != len(wantCopy) {
+		return fmt.Errorf("%s is %v, want %v", name, got, want)
+	}
+	for i := range gotCopy {
+		if gotCopy[i] != wantCopy[i] {
+			return fmt.Errorf("%s is %v, want %v", name, got, want)
+		}
+		if i > 0 && gotCopy[i] == gotCopy[i-1] {
+			return fmt.Errorf("%s contains duplicate %q", name, gotCopy[i])
+		}
+	}
+	return nil
+}
+
+func requireUnique(name string, values []string) error {
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		if seen[value] {
+			return fmt.Errorf("%s contains duplicate %q", name, value)
+		}
+		seen[value] = true
+	}
+	return nil
+}
+
+func validateRepositoryPath(name string) error {
+	if name == "" || filepath.IsAbs(filepath.FromSlash(name)) {
+		return errors.New("path must be non-empty and repository-relative")
+	}
+	clean := filepath.Clean(filepath.FromSlash(name))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return errors.New("path escapes the repository")
+	}
+	if filepath.ToSlash(clean) != name {
+		return errors.New("path must be normalized with forward slashes")
+	}
+	return nil
+}
+
+func discoverTopLevelSigningWorkflows(root string) ([]string, error) {
+	paths, err := filepath.Glob(filepath.Join(root, ".github", "workflows", "*.y*ml"))
+	if err != nil {
+		return nil, fmt.Errorf("list workflows: %w", err)
+	}
+	workflows := make(map[string]workflowInfo, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read workflow %s: %w", path, err)
+		}
+		name, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil, err
+		}
+		name = filepath.ToSlash(name)
+		info, err := parseWorkflow(data)
+		if err != nil {
+			return nil, fmt.Errorf("parse workflow %s: %w", name, err)
+		}
+		workflows[name] = info
+	}
+
+	state := make(map[string]uint8, len(workflows))
+	memo := make(map[string]bool, len(workflows))
+	var reachesSigning func(string) (bool, error)
+	reachesSigning = func(name string) (bool, error) {
+		if state[name] == 2 {
+			return memo[name], nil
+		}
+		if state[name] == 1 {
+			return false, fmt.Errorf("reusable workflow cycle includes %s", name)
+		}
+		info, ok := workflows[name]
+		if !ok {
+			return false, fmt.Errorf("workflow calls missing local workflow %s", name)
+		}
+		state[name] = 1
+		reachable := info.directSigning
+		for _, called := range info.calls {
+			calledReachable, err := reachesSigning(called)
+			if err != nil {
+				return false, err
+			}
+			reachable = reachable || calledReachable
+		}
+		state[name] = 2
+		memo[name] = reachable
+		return reachable, nil
+	}
+
+	var result []string
+	for name, info := range workflows {
+		if !info.externallyTriggered {
+			continue
+		}
+		reachable, err := reachesSigning(name)
+		if err != nil {
+			return nil, err
+		}
+		if reachable {
+			result = append(result, name)
+		}
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func parseWorkflow(data []byte) (workflowInfo, error) {
+	var document yaml.Node
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return workflowInfo{}, err
+	}
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return workflowInfo{}, errors.New("workflow root must be a mapping")
+	}
+	root := document.Content[0]
+	on := mappingValue(root, "on")
+	jobs := mappingValue(root, "jobs")
+	if on == nil || jobs == nil || jobs.Kind != yaml.MappingNode {
+		return workflowInfo{}, errors.New("workflow must contain on and jobs mappings")
+	}
+
+	info := workflowInfo{externallyTriggered: hasExternalTrigger(on)}
+	for i := 1; i < len(jobs.Content); i += 2 {
+		job := jobs.Content[i]
+		if job.Kind != yaml.MappingNode {
+			continue
+		}
+		if uses := mappingScalar(job, "uses"); strings.HasPrefix(uses, "./.github/workflows/") {
+			info.calls = append(info.calls, strings.TrimPrefix(uses, "./"))
+		}
+		if nodeContains(job, "secrets.SIGNPATH_API_TOKEN") {
+			info.directSigning = true
+		}
+		steps := mappingValue(job, "steps")
+		if steps == nil || steps.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, step := range steps.Content {
+			if step.Kind != yaml.MappingNode {
+				continue
+			}
+			if strings.HasPrefix(mappingScalar(step, "uses"), "signpath/github-action-submit-signing-request@") {
+				info.directSigning = true
+			}
+		}
+	}
+	sort.Strings(info.calls)
+	return info, nil
+}
+
+func nodeContains(node *yaml.Node, text string) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == yaml.ScalarNode && strings.Contains(node.Value, text) {
+		return true
+	}
+	for _, child := range node.Content {
+		if nodeContains(child, text) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExternalTrigger(node *yaml.Node) bool {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return node.Value != "workflow_call"
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			if child.Value != "workflow_call" {
+				return true
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i < len(node.Content); i += 2 {
+			if node.Content[i].Value != "workflow_call" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func mappingScalar(node *yaml.Node, key string) string {
+	value := mappingValue(node, key)
+	if value == nil || value.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return value.Value
+}
+
+func contractFingerprint(root string, contract releaseSigningContract) ([sha256.Size]byte, error) {
+	names := append([]string{contractPath}, contract.FingerprintFiles...)
+	sort.Strings(names)
+	hash := sha256.New()
+	_, _ = io.WriteString(hash, "reasonix-signpath-release-contract-v1\x00")
+	for _, name := range names {
+		data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
+		if err != nil {
+			return [sha256.Size]byte{}, fmt.Errorf("read %s: %w", name, err)
+		}
+		writeLengthPrefixed(hash, []byte(name))
+		writeLengthPrefixed(hash, data)
+	}
+	var result [sha256.Size]byte
+	copy(result[:], hash.Sum(nil))
+	return result, nil
+}
+
+func writeLengthPrefixed(writer io.Writer, data []byte) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(data)))
+	_, _ = writer.Write(length[:])
+	_, _ = writer.Write(data)
+}

--- a/cmd/signpath-contract/main_test.go
+++ b/cmd/signpath-contract/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestRepositoryReleaseSigningContract(t *testing.T) {
+	root := "../.."
+	contract, err := loadAndValidate(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fingerprint, err := contractFingerprint(root, contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprintf("%x", fingerprint); len(got) != 64 {
+		t.Fatalf("fingerprint length = %d, want 64", len(got))
+	}
+}
+
+func TestTopLevelSignPathWorkflowCallGraph(t *testing.T) {
+	got, err := discoverTopLevelSigningWorkflows("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The studio line publishes from one workflow. This is not a restatement of
+	// the contract — it is read from the call graph, so a second workflow that
+	// learns to reach SignPath fails here even if nobody widened the contract.
+	want := []string{".github/workflows/release-studio.yml"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("top-level workflows that reach SignPath = %v, want %v", got, want)
+	}
+}
+
+func TestReleaseSigningContractRejectsWildcards(t *testing.T) {
+	contract, err := loadAndValidate("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract.AllowedBuildDefinitions = []string{".github/workflows/release-*.yml"}
+	if err := validateContract("../..", contract); err == nil {
+		t.Fatal("wildcard build definition unexpectedly passed validation")
+	}
+}
+
+func TestWorkflowUsingSignPathTokenIsSigningEntryPoint(t *testing.T) {
+	workflow := []byte(`
+on: workflow_dispatch
+jobs:
+  sign:
+    runs-on: windows-latest
+    steps:
+      - shell: pwsh
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        run: ./submit-signing-request.ps1
+`)
+	info, err := parseWorkflow(workflow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.externallyTriggered || !info.directSigning {
+		t.Fatalf("token-backed workflow was not classified as a signing entry point: %+v", info)
+	}
+}

--- a/scripts/complete-signpath-request.ps1
+++ b/scripts/complete-signpath-request.ps1
@@ -1,0 +1,161 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern("^[0-9a-fA-F-]{36}$")]
+    [string]$OrganizationId,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern("^[0-9a-fA-F-]{36}$")]
+    [string]$SigningRequestId,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ExpectedSigningPolicySlug,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$OutputArtifactDirectory,
+
+    [ValidateNotNullOrEmpty()]
+    [string]$ApiUrl = "https://app.signpath.io/api",
+
+    [ValidateRange(30, 7200)]
+    [int]$TimeoutSeconds = 1800,
+
+    [ValidateRange(1, 60)]
+    [int]$PollIntervalSeconds = 5,
+
+    [switch]$WaitForExternalApproval
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$apiToken = $env:SIGNPATH_API_TOKEN
+if ([string]::IsNullOrWhiteSpace($apiToken)) {
+    throw "SIGNPATH_API_TOKEN is required to approve and download a SignPath request."
+}
+
+$parsedApiUrl = $null
+if (
+    -not [Uri]::TryCreate($ApiUrl, [UriKind]::Absolute, [ref]$parsedApiUrl) -or
+    $parsedApiUrl.Scheme -ne "https"
+) {
+    throw "ApiUrl must be an absolute HTTPS URL."
+}
+
+$workspace = if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+    [IO.Path]::GetFullPath((Get-Location).Path)
+} else {
+    [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE)
+}
+$outputDirectory = if ([IO.Path]::IsPathRooted($OutputArtifactDirectory)) {
+    [IO.Path]::GetFullPath($OutputArtifactDirectory)
+} else {
+    [IO.Path]::GetFullPath((Join-Path $workspace $OutputArtifactDirectory))
+}
+$workspacePrefix = $workspace.TrimEnd(
+    [IO.Path]::DirectorySeparatorChar,
+    [IO.Path]::AltDirectorySeparatorChar
+) + [IO.Path]::DirectorySeparatorChar
+if (-not $outputDirectory.StartsWith($workspacePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "OutputArtifactDirectory must resolve inside GITHUB_WORKSPACE."
+}
+
+$headers = @{
+    Authorization = "Bearer $apiToken"
+}
+$requestBaseUrl = (
+    $ApiUrl.TrimEnd("/") +
+    "/v1/$OrganizationId/SigningRequests/$SigningRequestId"
+)
+
+$request = Invoke-RestMethod `
+    -Method Get `
+    -Uri $requestBaseUrl `
+    -Headers $headers
+if ($request.signingPolicySlug -ne $ExpectedSigningPolicySlug) {
+    throw (
+        "SignPath request policy mismatch: got '$($request.signingPolicySlug)', " +
+        "expected '$ExpectedSigningPolicySlug'."
+    )
+}
+
+$deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
+$approvalSubmitted = $false
+$externalApprovalNoticeWritten = $false
+while ($true) {
+    $status = Invoke-RestMethod `
+        -Method Get `
+        -Uri "$requestBaseUrl/Status" `
+        -Headers $headers
+    Write-Host (
+        "SignPath request $SigningRequestId status: " +
+        "$($status.status) ($($status.workflowStatus))"
+    )
+
+    if ($status.isFinalStatus) {
+        if ($status.status -ne "Completed") {
+            throw (
+                "SignPath request ended with status '$($status.status)' " +
+                "and workflow status '$($status.workflowStatus)'."
+            )
+        }
+        break
+    }
+
+    if ($status.status -eq "WaitingForApproval" -and -not $approvalSubmitted) {
+        if ($WaitForExternalApproval) {
+            if (-not $externalApprovalNoticeWritten) {
+                Write-Host (
+                    "Waiting for an authorized SignPath user to approve request " +
+                    "$SigningRequestId."
+                )
+                $externalApprovalNoticeWritten = $true
+            }
+        } else {
+            Invoke-RestMethod `
+                -Method Post `
+                -Uri "$requestBaseUrl/Approve" `
+                -Headers $headers | Out-Null
+            $approvalSubmitted = $true
+            Write-Host "Approved SignPath request $SigningRequestId through the release CI identity."
+        }
+    }
+
+    if ([DateTimeOffset]::UtcNow -ge $deadline) {
+        throw "Timed out waiting for SignPath request $SigningRequestId."
+    }
+    Start-Sleep -Seconds $PollIntervalSeconds
+}
+
+$temporaryRoot = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+    [IO.Path]::GetTempPath()
+} else {
+    $env:RUNNER_TEMP
+}
+$temporaryArchive = Join-Path $temporaryRoot "signpath-$SigningRequestId.zip"
+try {
+    Invoke-WebRequest `
+        -Method Get `
+        -Uri "$requestBaseUrl/SignedArtifact" `
+        -Headers $headers `
+        -OutFile $temporaryArchive
+    if (-not (Test-Path -LiteralPath $temporaryArchive -PathType Leaf)) {
+        throw "SignPath did not return a signed artifact."
+    }
+    if ((Get-Item -LiteralPath $temporaryArchive).Length -eq 0) {
+        throw "SignPath returned an empty signed artifact."
+    }
+
+    New-Item -ItemType Directory -Force -Path $outputDirectory | Out-Null
+    Expand-Archive `
+        -LiteralPath $temporaryArchive `
+        -DestinationPath $outputDirectory `
+        -Force
+} finally {
+    Remove-Item -LiteralPath $temporaryArchive -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Downloaded and extracted signed artifact to $outputDirectory."

--- a/scripts/studio-build.sh
+++ b/scripts/studio-build.sh
@@ -112,16 +112,11 @@ build_nsis() {
 		echo "==> skipping installer: makensis is not installed" >&2
 		return 0
 	}
-	# The payload sits under the repo rather than /tmp: MSYS maps /tmp through the
-	# user profile and hands makensis an 8.3 short path it cannot open, while a
-	# path under $ROOT converts to a plain drive path.
-	local payload="$ROOT/dist/nsis-payload-$arch"
-	rm -rf "$payload"
-	mkdir -p "$payload"
-	cp "$src/$BINNAME.exe" "$payload/$BINNAME.exe"
-	cp -R "$src/frontend-next" "$payload/frontend-next"
-	cp "$ROOT/desktop/next/build/windows/appicon.ico" "$payload/appicon.ico"
-
+	# src is the payload directory itself, already assembled by windows_payload.
+	# Signing happens between the two, so this must package the bytes it is
+	# handed rather than re-copying from a build tree that holds the unsigned
+	# binary.
+	local payload="$src"
 	local webview2="$payload/MicrosoftEdgeWebview2Setup.exe" webview2_def=()
 	if curl --fail --location --silent --show-error --connect-timeout 30 --max-time 120 \
 		--output "$webview2" "https://go.microsoft.com/fwlink/p/?LinkId=2124703" &&
@@ -148,11 +143,63 @@ build_nsis() {
 		"-DOUTFILE=$ROOT/dist/${APPNAME}-windows-${arch}-installer.exe" \
 		"${webview2_def[@]}" \
 		"$ROOT/desktop/next/build/windows/installer/studio.nsi"
-	rm -rf "$payload"
 	[ -s "$ROOT/dist/${APPNAME}-windows-${arch}-installer.exe" ] || {
 		echo "makensis produced no installer" >&2
 		return 1
 	}
+}
+
+# The SPA every platform packages. Named because the split Windows stages build
+# it once, in the payload stage: packaging from an already-signed payload must
+# not rebuild the assets underneath it.
+build_frontend() {
+	echo "==> frontend"
+	(cd "$ROOT/desktop/frontend-next" && pnpm install --frozen-lockfile && pnpm build)
+	[ -f "$ROOT/desktop/frontend-next/dist/index.html" ] || {
+		echo "frontend build produced no dist/index.html" >&2
+		return 1
+	}
+}
+
+# The Windows release is packaged twice around a signature. windows_payload
+# builds what a user runs and stops; the executable is Authenticode-signed while
+# it is still a loose file; windows_package then builds the zip and the installer
+# from those exact bytes. Signing only the finished installer would leave
+# reasonix-studio.exe unsigned on disk after installation, which is what
+# reputation heuristics quarantine.
+#
+# The directory sits under the repo rather than /tmp: MSYS maps /tmp through the
+# user profile and hands makensis an 8.3 short path it cannot open, while a path
+# under $ROOT converts to a plain drive path.
+windows_payload_dir() { echo "$ROOT/dist/windows-payload-$1"; }
+
+windows_payload() {
+	local arch="$1" version="$2"
+	local payload
+	payload=$(windows_payload_dir "$arch")
+	rm -rf "$payload"
+	mkdir -p "$payload/frontend-next"
+	build_shell windows "$arch" "$version" "$payload/$BINNAME.exe"
+	cp -R "$ROOT/desktop/frontend-next/dist" "$payload/frontend-next/dist"
+	cp "$ROOT/desktop/next/build/windows/appicon.ico" "$payload/appicon.ico"
+	echo "==> payload $payload"
+}
+
+# The zip carries no appicon.ico: it is an installer resource, and a portable
+# archive that unpacks a stray icon beside the binary reads as a broken build.
+windows_package() {
+	local arch="$1" version="$2" payload="$3"
+	[ -s "$payload/$BINNAME.exe" ] || {
+		echo "no $BINNAME.exe in $payload" >&2
+		return 1
+	}
+	local staging
+	staging=$(mktemp -d)
+	cp "$payload/$BINNAME.exe" "$staging/$BINNAME.exe"
+	cp -R "$payload/frontend-next" "$staging/frontend-next"
+	make_zip "$ROOT/dist/${APPNAME}-windows-${arch}.zip" "$staging"
+	rm -rf "$staging"
+	build_nsis "$arch" "$version" "$payload"
 }
 
 # build_deb packages the Linux payload for dpkg. The .deb is what makes Studio
@@ -289,17 +336,30 @@ if [ "${1:-}" = "--shell-only" ]; then
 	exit 0
 fi
 
-PLATFORM="${1:?usage: studio-build.sh <os/arch> <version> | --shell-only}"
+PLATFORM="${1:?usage: studio-build.sh <os/arch> <version> | --shell-only | --windows-payload <arch> <version> | --windows-package <arch> <version> <payload-dir>}"
+
+# The two halves of the Windows release, exposed so a signature can be taken
+# between them. Running the whole platform in one go still works and is what a
+# maintainer and every unsigned build do; these exist for the release workflow.
+if [ "$PLATFORM" = "--windows-payload" ] || [ "$PLATFORM" = "--windows-package" ]; then
+	stage="$PLATFORM"
+	arch="${2:?usage: studio-build.sh $stage <arch> <version> [payload-dir]}"
+	VERSION="${3:?usage: studio-build.sh $stage <arch> <version> [payload-dir]}"
+	mkdir -p "$ROOT/dist"
+	if [ "$stage" = "--windows-payload" ]; then
+		build_frontend
+		windows_payload "$arch" "$VERSION"
+	else
+		windows_package "$arch" "$VERSION" "${4:-$(windows_payload_dir "$arch")}"
+	fi
+	exit 0
+fi
+
 VERSION="${2:?usage: studio-build.sh <os/arch> <version> | --shell-only}"
 os="${PLATFORM%/*}"
 arch="${PLATFORM#*/}"
 
-echo "==> frontend"
-(cd "$ROOT/desktop/frontend-next" && pnpm install --frozen-lockfile && pnpm build)
-[ -f "$ROOT/desktop/frontend-next/dist/index.html" ] || {
-	echo "frontend build produced no dist/index.html" >&2
-	exit 1
-}
+build_frontend
 
 staging=$(mktemp -d)
 trap 'rm -rf "$staging"' EXIT
@@ -307,11 +367,8 @@ mkdir -p "$ROOT/dist"
 
 case "$os" in
 windows)
-	build_shell windows "$arch" "$VERSION" "$staging/$BINNAME.exe"
-	mkdir -p "$staging/frontend-next"
-	cp -R "$ROOT/desktop/frontend-next/dist" "$staging/frontend-next/dist"
-	make_zip "$ROOT/dist/${APPNAME}-windows-${arch}.zip" "$staging"
-	build_nsis "$arch" "$VERSION" "$staging"
+	windows_payload "$arch" "$VERSION"
+	windows_package "$arch" "$VERSION" "$(windows_payload_dir "$arch")"
 	;;
 darwin)
 	# LaunchServices only treats a process as a GUI app inside a bundle with an

--- a/scripts/verify-windows-authenticode.ps1
+++ b/scripts/verify-windows-authenticode.ps1
@@ -1,0 +1,124 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PayloadDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [string]$InstallerPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PortableArchivePath,
+
+    [switch]$RequireTrusted
+)
+
+$ErrorActionPreference = "Stop"
+
+$expectedPayload = @(
+    "reasonix-desktop.exe",
+    "reasonix-guard.exe",
+    "reasonix-launcher.exe",
+    "reasonix-update-helper.exe",
+    "reasonix-cli.exe",
+    "reasonix-uninstall.exe"
+)
+
+function Assert-AuthenticodeSignature {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Signed Windows artifact is missing: $Path"
+    }
+    $signature = Get-AuthenticodeSignature -LiteralPath $Path
+    if ($null -eq $signature.SignerCertificate -or $signature.SignatureType -eq "None") {
+        throw "Authenticode signature is missing: $Path"
+    }
+    if ($RequireTrusted -and $signature.Status -ne "Valid") {
+        throw "Authenticode signature is not trusted for $Path`: $($signature.Status) $($signature.StatusMessage)"
+    }
+    Write-Host "Authenticode $($signature.Status): $Path"
+}
+
+$payloadFiles = @(Get-ChildItem -LiteralPath $PayloadDirectory -File -Filter "*.exe")
+if ($payloadFiles.Count -ne $expectedPayload.Count) {
+    throw "Payload must contain exactly $($expectedPayload.Count) executables, found $($payloadFiles.Count)"
+}
+foreach ($name in $expectedPayload) {
+    Assert-AuthenticodeSignature -Path (Join-Path $PayloadDirectory $name)
+}
+Assert-AuthenticodeSignature -Path $InstallerPath
+
+$extractRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("reasonix-authenticode-" + [guid]::NewGuid().ToString("N"))
+try {
+    Expand-Archive -LiteralPath $PortableArchivePath -DestinationPath $extractRoot
+
+    # Legacy portable releases kept all six executables at InstallRoot. The
+    # versioned-v1 layout deliberately keeps only the launcher aliases and CLI
+    # at the root, while the active Desktop, update helper, and CLI live under
+    # versions/vX.Y.Z/. Verify the exact layout selected by current.json instead
+    # of treating the three versioned executables as missing.
+    $currentPath = Join-Path $extractRoot "current.json"
+    if (Test-Path -LiteralPath $currentPath -PathType Leaf) {
+        $current = Get-Content -LiteralPath $currentPath -Raw | ConvertFrom-Json
+        if ($current.schemaVersion -ne 1) {
+            throw "Portable current.json schemaVersion must be 1"
+        }
+        $activeVersion = [string]$current.activeVersion
+        $activeDir = [string]$current.activeDir
+        if ($activeVersion -notmatch '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?$' -or
+            [string]::IsNullOrWhiteSpace($activeDir) -or
+            $activeDir.Replace("\", "/") -ne "versions/$activeVersion") {
+            throw "Portable current.json must bind activeVersion to versions/<activeVersion>"
+        }
+
+        $activePath = [System.IO.Path]::GetFullPath((Join-Path $extractRoot $activeDir))
+        $extractPrefix = [System.IO.Path]::GetFullPath($extractRoot).TrimEnd([char[]]@('\', '/')) + [System.IO.Path]::DirectorySeparatorChar
+        if (-not $activePath.StartsWith($extractPrefix, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not (Test-Path -LiteralPath $activePath -PathType Container)) {
+            throw "Portable current.json activeDir escapes or is missing: $activeDir"
+        }
+
+        $portableSources = @(
+            [pscustomobject]@{ Portable = "reasonix-launcher.exe"; Payload = "reasonix-launcher.exe" },
+            [pscustomobject]@{ Portable = "Reasonix.exe"; Payload = "reasonix-launcher.exe" },
+            [pscustomobject]@{ Portable = "reasonix-cli.exe"; Payload = "reasonix-cli.exe" },
+            [pscustomobject]@{ Portable = (Join-Path $activeDir "reasonix-desktop.exe"); Payload = "reasonix-desktop.exe" },
+            [pscustomobject]@{ Portable = (Join-Path $activeDir "reasonix-update-helper.exe"); Payload = "reasonix-update-helper.exe" },
+            [pscustomobject]@{ Portable = (Join-Path $activeDir "reasonix-cli.exe"); Payload = "reasonix-cli.exe" }
+        )
+    }
+    else {
+        $portableSources = @(
+            [pscustomobject]@{ Portable = "reasonix-desktop.exe"; Payload = "reasonix-desktop.exe" },
+            [pscustomobject]@{ Portable = "reasonix-guard.exe"; Payload = "reasonix-guard.exe" },
+            [pscustomobject]@{ Portable = "reasonix-launcher.exe"; Payload = "reasonix-launcher.exe" },
+            [pscustomobject]@{ Portable = "Reasonix.exe"; Payload = "reasonix-launcher.exe" },
+            [pscustomobject]@{ Portable = "reasonix-update-helper.exe"; Payload = "reasonix-update-helper.exe" },
+            [pscustomobject]@{ Portable = "reasonix-cli.exe"; Payload = "reasonix-cli.exe" }
+        )
+    }
+
+    $portableFiles = @(Get-ChildItem -LiteralPath $extractRoot -Recurse -File -Filter "*.exe")
+    if ($portableFiles.Count -ne 6) {
+        throw "Portable archive must contain exactly 6 executables, found $($portableFiles.Count)"
+    }
+
+    foreach ($entry in $portableSources) {
+        $portablePath = Join-Path $extractRoot $entry.Portable
+        Assert-AuthenticodeSignature -Path $portablePath
+        $portableHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $portablePath).Hash
+        $payloadHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $PayloadDirectory $entry.Payload)).Hash
+        if ($portableHash -ne $payloadHash) {
+            throw "Portable $($entry.Portable) does not match signed payload $($entry.Payload)"
+        }
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $extractRoot) {
+        Remove-Item -LiteralPath $extractRoot -Recurse -Force
+    }
+}
+
+Write-Host "Windows Authenticode release contract verified."


### PR DESCRIPTION
## Why

Studio's Windows artifacts are unsigned by construction. `release-studio.yml` said so in its own header: the production SignPath policy trusts exactly one origin — protected `main-v2` — so a build from this branch cannot request the certificate.

The header called the consequence "a SmartScreen warning". On a managed Windows endpoint it is not a warning. Reported in the field and reproduced on a corporate machine running Kaspersky Endpoint Security:

- `ReasonixStudio-windows-amd64-installer.exe` — file intact, exactly the published 17,672,986 bytes, valid PE, readable, `BUILTIN\Users: ReadAndExecute`, no Mark-of-the-Web.
- No Windows policy blocking it: AppLocker present with zero rules, SRP key empty, **zero** Defender ASR rules, Controlled Folder Access off, no SmartScreen override.
- `Get-AuthenticodeSignature` → **NotSigned**.
- Result: refused at `CreateProcess` by the AV filter driver. Windows surfaces that as *"无法访问指定设备、路径或文件。你可能没有适当的权限访问该项目。"* — which reads as a permissions problem and is not one.

Every Windows user on a managed endpoint hits this, not just the reporter.

## What

The desktop line's mechanism, adapted to what Studio ships.

**Two stages, for the reason `main-v2` states.** Signing only the finished NSIS container leaves `reasonix-studio.exe` unsigned on disk after installation — precisely what reputation/ML heuristics quarantine. So:

1. `--windows-payload` builds the executable and stops → SignPath `studio-windows-payload` → signed binary goes back into the payload directory.
2. `--windows-package` rebuilds the zip and installer from those exact bytes → SignPath `studio-windows-installer` → signed container.

Stage two's artifact configuration carries `<authenticode-verify>` on `reasonix-studio.exe`, so an installer built from an unsigned binary is refused by SignPath rather than discovered by a user after installing it. The ordering is enforced by the contract, not by this workflow's step order.

**The build script grows a seam, not a fork.** The one-shot `windows` path now composes the two stages, so an unsigned build and a maintainer's local run produce byte-identical output to before. Verified locally: payload stage emits `reasonix-studio.exe` + `frontend-next/` + `appicon.ico`; package stage emits the zip (no stray `appicon.ico` in it) and, where `makensis` exists, the installer.

**The contract gates the build.** `.signpath/contracts/release-signing.yml` declares this line's origin — branch `studio`, workflow `release-studio.yml` — and `cmd/signpath-contract validate` + `fingerprint` run before anything is built, so a widened origin fails at the gate rather than at the signing request. Its branch pin is `studio` in Go rather than read from the contract: a guard that reads its own answer out of the file it is checking cannot guard. Its call-graph test likewise asserts the *discovered* set of signing workflows, so a second workflow that learns to reach SignPath fails even if nobody touched the contract.

**Forks still build.** Signing engages only when `SIGNPATH_API_TOKEN` is set, mirroring the existing `APPLE_*` gate.

## This does not work on the repo side alone

Merging this is necessary and **not sufficient**. Before the next release can be signed, in SignPath's console:

- [ ] Add the studio origin to the `release-signing` policy's trusted build system: repository `esengine/DeepSeek-Reasonix`, branch `studio`, workflow `.github/workflows/release-studio.yml`. Until this exists, every request from this workflow is rejected.
- [ ] Provision the two artifact configurations: `studio-windows-payload` and `studio-windows-installer` (XML in `.signpath/artifact-configurations/`).
- [ ] Confirm `SIGNPATH_API_TOKEN` / `SIGNPATH_ORGANIZATION_ID` are readable from this workflow.

The desktop line pairs its contract with a `SIGNPATH_RELEASE_SIGNING_ATTESTATION` repo variable recorded by a `signing_preflight` run. That is deliberately **not** ported here — it belongs with a preflight input this workflow does not have yet, and adding a half of it would be an attestation nothing verifies. Worth a follow-up once the origin is live.

## Verified / not verified

- ✅ `go run ./cmd/signpath-contract validate` passes; `fingerprint` → `v1:ade3cd24…`
- ✅ `go test ./cmd/signpath-contract/` passes
- ✅ Both build stages run end-to-end locally and produce the expected artifacts
- ✅ Workflow YAML parses; `gofmt`, `go vet`, `make lint` (golangci-lint + repolint) clean
- ❌ **The signing path itself is untested** — it needs SignPath credentials and a real release run. The first exercise of it should be a throwaway tag, not a user-facing release.

Closes the Windows half of the "unsigned artifacts" gap for the studio line.