### PR TITLE
fix(desktop): honor the backend reload fallback before the history identity check / 加载更早历史时先走后端重载回退再校验身份（#9468）

### DIFF
--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -3033,30 +3033,19 @@ export function useController() {
       if (historyOlderSeq.current.get(targetTabId) !== requestSeq) return false;
       const current = statesRef.current.get(targetTabId);
       if (!current) return false;
-      const currentRevision = current?.meta?.sessionRevision ?? current?.historyRevision;
-      const currentDigest = current?.meta?.sessionDigest ?? current?.historyDigest;
-      const fingerprintMatches = (expected: number | undefined, actual: number | undefined) =>
-        expected === undefined || expected <= 0 ? true : actual === expected;
-      const digestMatches = (expected: string | undefined, actual: string | undefined) =>
-        !expected || actual === expected;
-      // A replace-level hydrate while the page was in flight clears
-      // historyOlderLoading; a metadata or canonical-identity change also
-      // makes the page belong to a different transcript generation.
-      if (!current.historyOlderLoading || (current.meta?.sessionPath ?? "") !== sessionPath ||
-        !fingerprintMatches(sessionRevision, currentRevision) || !digestMatches(sessionDigest, currentDigest) ||
-        (result !== undefined && (!fingerprintMatches(sessionRevision, result.revisionKnown ? result.revision : undefined) ||
-          !digestMatches(sessionDigest, result.digest)))) {
-        dispatchTo(targetTabId, { type: "history_older_error", error: "history identity changed" });
-        return false;
-      }
+
+      // A "reload" result means the backend rewrote the session and already
+      // reloaded the latest page. Apply it (replace) BEFORE any fingerprint
+      // rejection: otherwise the reload's fresh revision/digest would trip the
+      // identity check below and the reload fallback would be dead code —
+      // surfacing "earlier conversation could not be loaded" with no recovery
+      // and a retry that repeats the same failure.
       if (!result) {
         // Superseded (generation moved) or nothing older left.
         dispatchTo(targetTabId, { type: "history_older_error", error: "history page unavailable" });
         return false;
       }
       if (result.kind === "reload") {
-        // The cursor went stale (session rewritten): the store reloaded the
-        // latest page; replace instead of prepend.
         dispatchTo(targetTabId, {
           type: "history_replace",
           items: result.items,
@@ -3066,21 +3055,42 @@ export function useController() {
           revision: result.revisionKnown ? result.revision : undefined,
           digest: result.digest || undefined,
         });
-      } else {
-        dispatchTo(targetTabId, {
-          type: "history_prepend",
-          items: result.prependItems,
-          removeIds: result.removeIds,
-          startTurn: result.startTurn,
-          totalTurns: result.totalTurns,
-          hasOlder: result.hasOlder,
-          revision: result.revisionKnown ? result.revision : undefined,
-          digest: result.digest || undefined,
-        });
+        addBreadcrumb(
+          "tab.hydrate",
+          `history older ${targetTabId} trigger=${trigger} kind=reload items=${result.items.length} turns=${result.startTurn}-${result.endTurn}/${result.totalTurns} ms=${Date.now() - startedAt}`,
+        );
+        return true;
       }
+
+      // Non-reload (prepend) page: identity must still match the tab's
+      // canonical revision/digest, or the two belong to different transcript
+      // generations (a replace-level hydrate in flight also disqualifies).
+      const currentRevision = current?.meta?.sessionRevision ?? current?.historyRevision;
+      const currentDigest = current?.meta?.sessionDigest ?? current?.historyDigest;
+      const fingerprintMatches = (expected: number | undefined, actual: number | undefined) =>
+        expected === undefined || expected <= 0 ? true : actual === expected;
+      const digestMatches = (expected: string | undefined, actual: string | undefined) =>
+        !expected || actual === expected;
+      if (!current.historyOlderLoading || (current.meta?.sessionPath ?? "") !== sessionPath ||
+        !fingerprintMatches(sessionRevision, currentRevision) || !digestMatches(sessionDigest, currentDigest) ||
+        !fingerprintMatches(sessionRevision, result.revisionKnown ? result.revision : undefined) ||
+        !digestMatches(sessionDigest, result.digest)) {
+        dispatchTo(targetTabId, { type: "history_older_error", error: "history identity changed" });
+        return false;
+      }
+      dispatchTo(targetTabId, {
+        type: "history_prepend",
+        items: result.prependItems,
+        removeIds: result.removeIds,
+        startTurn: result.startTurn,
+        totalTurns: result.totalTurns,
+        hasOlder: result.hasOlder,
+        revision: result.revisionKnown ? result.revision : undefined,
+        digest: result.digest || undefined,
+      });
       addBreadcrumb(
         "tab.hydrate",
-        `history older ${targetTabId} trigger=${trigger} kind=${result.kind} items=${result.kind === "prepend" ? result.prependItems.length : result.items.length} turns=${result.startTurn}-${result.endTurn}/${result.totalTurns} ms=${Date.now() - startedAt}`,
+        `history older ${targetTabId} trigger=${trigger} kind=prepend items=${result.prependItems.length} turns=${result.startTurn}-${result.endTurn}/${result.totalTurns} ms=${Date.now() - startedAt}`,
       );
       return true;
     } catch (err) {


### PR DESCRIPTION
## TL;DR (中文摘要)

修复「较早的对话加载失败 · 点重试无效」的代码层根因：`useController.ts loadOlderHistory` 里 **revision/digest 身份校验先于后端 `result.kind === "reload"` 降级**。当后端因会话被重写而重载好最新页返回 reload 时，其新 revision/digest 恰好让前端身份校验判为不匹配 → 报 `history identity changed` 并 return false，导致 reload 兜底成为永远走不到的 dead code（用户对超长/分叉会话翻历史时恒定失败、重试亦然）。

本 PR 把 `result.kind === "reload"` 的处理提前：reload 结果先走 `history_replace` 应用，prepend 普通页仍保留身份校验。

Fixes #9468

## Summary

- `desktop/frontend/src/lib/useController.ts` `loadOlderHistory`: reorder so a backend "reload" result (session rewritten, freshest page already reloaded) is applied via `history_replace` before fingerprint rejection; the identity check still guards ordinary `prepend` pages.

## Verification

- `npx tsc --noEmit` passes (frontend typecheck).
- `npx tsx src/__tests__/transcript-store.test.ts` → 68 passed, 0 failed (covers stale-cursor→reload, reload replace, resume after reload).

## Documentation impact

None (behavior-only fix).

## Cache impact

Low (no cache format change).

## System-prompt review

@SivanCola

## Guard

- Cache-impact: none- no cache format change
- Cache-guard: none- no cache reads/writes touched by this behavior-only fix
- Documentation-impact: none- behavior-only fix
- System-prompt-review: requested-from-@SivanCola