### PR TITLE
feat(agent): run mixed mutation+verification commands in standard mode / 标准模式放行「变更+验证」混合命令

### DIFF
--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -386,15 +386,15 @@ func (a *Agent) applyDeliveryPolicyGates(turn *turnRuntime, plan *toolCallPlan) 
 				execution: shellPreflightExecution(plan, true),
 			}, true
 		}
-		mixed := evidence.BashToolCallMixesMutationAndMaskableVerification
-		if closedLoop {
-			mixed = evidence.BashToolCallMixesMutationAndVerification
-		}
-		if mixed(plan.evidenceArgs) {
-			msg := evidence.ShellContractPreflightMessage("mixed")
-			if closedLoop {
-				msg = "blocked: this command mixes a verification check with a segment that may write state. Run the state-changing preparation separately while a todo is in_progress, then run a read-only verification command. For generated input, prefer a host-recognized read-only pipeline into the verifier (for example: tail ... | head ... | node --check -) instead of writing a temporary file."
-			}
+		// Standard (non-closed-loop) turns never block a bash command for mixing
+		// a mutation with a verification segment. This mirrors Codex: bash
+		// already exposes each segment's status (&&/;/| semantics are transparent
+		// to the model), and a combined step avoids the extra agent round trips a
+		// split would cost with no real safety gain. Only closed-loop turns keep
+		// the strict barrier, because there a mutation invalidates the
+		// verification receipt even when the exit status is honest.
+		if closedLoop && evidence.BashToolCallMixesMutationAndVerification(plan.evidenceArgs) {
+			msg := "blocked: this command mixes a verification check with a segment that may write state. Run the state-changing preparation separately while a todo is in_progress, then run a read-only verification command. For generated input, prefer a host-recognized read-only pipeline into the verifier (for example: tail ... | head ... | node --check -) instead of writing a temporary file."
 			return toolOutcome{
 				output:    msg,
 				blocked:   true,

--- a/internal/agent/shell_contract_test.go
+++ b/internal/agent/shell_contract_test.go
@@ -15,10 +15,12 @@ import (
 	"reasonix/internal/tool/builtin"
 )
 
-func TestOrdinaryModeBlocksMixedMutationAndVerification(t *testing.T) {
-	// Preflight runs before Execute, so a fake bash is enough — the process
-	// must never start for a mixed mutation+verification command. `;` is the
-	// shape that matters: the verifier's exit status replaces go generate's.
+func TestOrdinaryModeRunsMixedMutationAndVerification(t *testing.T) {
+	// Standard (non-delivery) turns do NOT block mixed mutation+verification
+	// commands, mirroring Codex. `;` is the shape that had been blocked before:
+	// the verifier's exit status replaces go generate's. Even so, bash exposes
+	// the real outcome to the model, and forcing a split would add round trips
+	// with no safety gain. Only closed-loop turns keep the strict barrier.
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "bash", readOnly: false})
 	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
@@ -30,25 +32,35 @@ func TestOrdinaryModeBlocksMixedMutationAndVerification(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := toolResultByID(a.sess.conversation, "m1")
+	if !strings.Contains(got, "bash done") {
+		t.Fatalf("mixed command was not executed in ordinary mode: result = %q", got)
+	}
+	if strings.Contains(got, "blocked:") {
+		t.Fatalf("ordinary mode blocked a mixed command: %q", got)
+	}
+}
+
+func TestClosedLoopBlocksMixedMutationAndVerification(t *testing.T) {
+	// A closed-loop (delivery-floor) turn must still block the mixed shape:
+	// there a mutation invalidates the verification receipt even when the exit
+	// status is honest, so the command may not run as verification evidence.
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("m1", "bash", `{"command":"go generate ./... ; go test ./..."}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "ok"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+	if err := a.Run(withClosedLoopContext(context.Background()), "test"); err != nil {
+		t.Fatal(err)
+	}
+	got := toolResultByID(a.sess.conversation, "m1")
 	if strings.Contains(got, "bash done") {
-		t.Fatal("mixed command was executed")
+		t.Fatal("closed-loop ran a mixed command")
 	}
-	if !strings.Contains(got, "state-changing segment") {
-		t.Fatalf("result = %q, want ordinary-mode mixed block", got)
+	if !strings.Contains(got, "blocked:") {
+		t.Fatalf("result = %q, want closed-loop mixed block", got)
 	}
-	for _, msg := range a.sess.conversation.Snapshot() {
-		if msg.ToolCallID != "m1" {
-			continue
-		}
-		if msg.ToolExecution == nil || msg.ToolExecution.State != tool.ShellStateNotRun {
-			t.Fatalf("execution = %+v, want not_run", msg.ToolExecution)
-		}
-		if msg.ToolExecution.FailurePhase != tool.ShellPhasePreflight {
-			t.Fatalf("phase = %q", msg.ToolExecution.FailurePhase)
-		}
-		return
-	}
-	t.Fatal("tool result missing")
 }
 
 // TestOrdinaryModeRunsShortCircuitBuildAndVerify guards the everyday shape the


### PR DESCRIPTION
## TL;DR (中文摘要)

标准（非交付）回合放行「变更段 + 验证段」混合的一条 bash 命令（如 `go build ./... ; go test ./...`），不再拦 `blocked: mixed mutation and verification command`。对齐 Codex：bash 的 `&&`/`;`/`|` 语义对模型透明，拆成多段并不更安全，反而增加往返；仅交付（closed-loop）保留严格拦截（变更会污染验证 receipt）。

Closes #9471

## Summary

- `internal/agent/execute_one.go` `applyDeliveryPolicyGates`: mixed gate 改为 `closedLoop && evidence.BashToolCallMixesMutationAndVerification(plan.evidenceArgs)`——标准模式放行混合命令，交付模式保留严格判定。
- `internal/agent/shell_contract_test.go`: `TestOrdinaryModeBlocksMixedMutationAndVerification` → `...Runs...`（标准模式放行 `;` 混合），新增 `TestClosedLoopBlocksMixedMutationAndVerification`。

## Verification

- `go build ./...` 通过。
- `go test ./internal/agent/ -run "OrdinaryModeRunsMixedMutationAndVerification|ClosedLoopBlocksMixedMutationAndVerification|OrdinaryModeRunsShortCircuitBuildAndVerify"` → 全部 PASS（含 `&&` 短路链子用例）。

## Documentation impact

None（行为修复，无文档变更）。

## Cache impact

Low。

## System-prompt review

@SivanCola

## Guard

- Cache-impact: none- no cache format change
- Cache-guard: none- no cache reads/writes touched by this behavior change
- Documentation-impact: none- behavior fix
- System-prompt-review: requested-from-@SivanCola