### PR TITLE
Fix stalled Standard todos / 修复 Standard 待办停滞

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -125,7 +125,10 @@ console.log("\nbundle budgets");
 // headroom with the smallest existing decimal ratchet.
 // Direct pending-prompt recovery and authoritative remote Goal state bring the
 // measured path to 445.473 KiB. Retain 0.027 KiB of bounded headroom.
-const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 445.5 : 445.5;
+// Runtime-aware Todo presentation plus exact-tab continuation adds 0.3 KiB gzip
+// to the always-mounted footer path. Keep the state/routing guard with a narrow
+// 0.4 KiB ratchet rather than showing idle restored work as actively running.
+const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 445.9 : 445.9;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -195,7 +198,9 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // remaining review fences measure 2383.2 KiB; retain 0.1 KiB of headroom.
 // Final remote-runtime parity measures 2384.4 KiB raw. The current main-v2
 // runtime additions bring the combined path to 2404.364 KiB; retain 0.136 KiB
-// of bounded headroom alongside the gzip ratchet above.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_404.5 : 2_404.5;
+// of bounded headroom alongside the gzip ratchet above. Runtime-aware Todo
+// status and exact-tab continuation bring the measured payload to 2405.5 KiB;
+// retain 0.2 KiB of raw/toolchain headroom for the same footer owner.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_405.7 : 2_405.7;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -26,8 +26,10 @@ const {
   shouldOpenTodoPanelByDefault,
   shouldShowTodoPanel,
   todoBatchKey,
+  todoContinueTarget,
   todoDismissalKey,
   todoPanelScope,
+  todoPresentationStatus,
 } = await import(moduleUrl);
 
 const completedTodos = [
@@ -38,6 +40,15 @@ const activeTodos = [
   { content: "Inspect the report", status: "in_progress" },
   { content: "Ship the fix", status: "pending" },
 ];
+
+assert.equal(todoPresentationStatus("in_progress", { running: true, pendingPrompt: false }), "in_progress", "an active turn renders its current todo as in progress");
+assert.equal(todoPresentationStatus("in_progress", { running: false, pendingPrompt: false }), "paused", "an idle or restored turn renders a stale current todo as ready to continue");
+assert.equal(todoPresentationStatus("in_progress", { running: true, pendingPrompt: true }), "waiting", "a prompt-blocked turn renders its current todo as waiting for the user");
+assert.equal(todoPresentationStatus("completed", { running: false, pendingPrompt: false }), "completed", "completed todos remain completed");
+assert.equal(todoContinueTarget("tab-a", "tab-a", { ready: true, running: false, pendingPrompt: false }), "tab-a", "continue targets the exact idle visible tab");
+assert.equal(todoContinueTarget("tab-a", "tab-b", { ready: true, running: false, pendingPrompt: false }), null, "a rapid tab switch prevents stale todo routing");
+assert.equal(todoContinueTarget("tab-a", "tab-a", { ready: true, running: true, pendingPrompt: false }), null, "running turns cannot receive a duplicate continue submission");
+assert.equal(todoContinueTarget("tab-a", "tab-a", { ready: true, running: false, pendingPrompt: true }), null, "pending prompts must be answered instead of bypassed by continue");
 
 assert.deepEqual(
   resolveTodoPanelTodos([], undefined),

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -85,6 +85,7 @@ import {
   scopedTodoDismissalKey,
   shouldShowTodoPanel,
   todoBatchKey,
+  todoContinueTarget,
   todoDismissalKey,
   todoPanelScope,
 } from "./lib/todoVisibility";
@@ -2108,6 +2109,21 @@ export default function App() {
     });
     if (!remoteSurfaceActive && activeTabId && todoBatch) void app.DismissTodoBatchForTab(activeTabId, todoBatch).catch(() => undefined);
   }, [activeTabId, remoteSurfaceActive, scopedTodoKey, todoBatch]);
+  const handleTodoContinue = useCallback(() => {
+    const targetTabId = todoContinueTarget(activeTabId, activeTabIdRef.current, {
+      ready: remoteSurfaceActive ? remoteComposerReady : controllerReady,
+      readOnly: Boolean(activeTab?.readOnly),
+      running: visibleRuntimeState.running,
+      pendingPrompt: visibleRuntimeState.pendingPrompt,
+    });
+    if (!targetTabId) return;
+    const prompt = t("todo.continue");
+    if (remoteSurfaceActive) {
+      void remoteSend(prompt);
+      return;
+    }
+    void sendToTab(targetTabId, prompt);
+  }, [activeTab?.readOnly, activeTabId, controllerReady, remoteComposerReady, remoteSend, remoteSurfaceActive, sendToTab, t, visibleRuntimeState.pendingPrompt, visibleRuntimeState.running]);
 
   const sessionTitle = topicTitle(activeTab);
   const exportItems = remoteSurfaceActive ? remoteSession.transcript.items : state.items;
@@ -4944,6 +4960,9 @@ export default function App() {
                 key={scopedTodoBatch}
                 stateKey={scopedTodoBatch}
                 todos={todos}
+                running={visibleRuntimeState.running}
+                pendingPrompt={visibleRuntimeState.pendingPrompt}
+                onContinue={activeTabId && !activeTab?.readOnly && (remoteSurfaceActive ? remoteComposerReady : controllerReady) ? handleTodoContinue : undefined}
                 onDismiss={dismissTodos}
               />
             )}

--- a/desktop/frontend/src/components/TodoPanel.tsx
+++ b/desktop/frontend/src/components/TodoPanel.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 import { useT } from "../lib/i18n";
 import type { Todo } from "../lib/tools";
-import { shouldOpenTodoPanelByDefault } from "../lib/todoVisibility";
+import {
+  shouldOpenTodoPanelByDefault,
+  todoPresentationStatus,
+  type TodoPresentationStatus,
+} from "../lib/todoVisibility";
 import { PromptBadge, PromptHeaderAction, PromptShelf } from "./PromptShelf";
 
 const STORAGE_KEY = "todoPanel:openStates";
@@ -47,10 +51,16 @@ function saveOpenState(stateKey: string, open: boolean): void {
 export function TodoPanel({
   stateKey,
   todos,
+  running,
+  pendingPrompt,
+  onContinue,
   onDismiss,
 }: {
   stateKey: string;
   todos: Todo[];
+  running: boolean;
+  pendingPrompt: boolean;
+  onContinue?: () => void;
   onDismiss: () => void;
 }) {
   const t = useT();
@@ -93,29 +103,32 @@ export function TodoPanel({
         saveOpenState(stateKey, next);
         return next;
       })}
-      headerActions={
-        allDone && (
-          <PromptHeaderAction onClick={onDismiss}>
-            {t("common.close")}
-          </PromptHeaderAction>
-        )
-      }
+      headerActions={allDone ? (
+        <PromptHeaderAction onClick={onDismiss}>
+          {t("common.close")}
+        </PromptHeaderAction>
+      ) : current && !running && !pendingPrompt && onContinue ? (
+        <PromptHeaderAction onClick={onContinue}>
+          {t("todo.continue")}
+        </PromptHeaderAction>
+      ) : undefined}
     >
       {open && (
         <ul className="todobar__list">
           {todos.map((todo, index) => {
-            const status = normalizeTodoStatus(todo.status);
+            const sourceStatus = normalizeTodoStatus(todo.status);
+            const status = todoPresentationStatus(sourceStatus, { running, pendingPrompt });
             return (
               <li
                 key={index}
-                ref={status === "in_progress" ? currentRef : undefined}
+                ref={sourceStatus === "in_progress" ? currentRef : undefined}
                 className={`todobar__item todobar__item--${status}${todo.level ? " todobar__item--sub" : ""}`}
               >
                 <span className={`todobar__status todobar__status--${status}`}>
                   {t(todoStatusLabelKey(status))}
                 </span>
                 <span className="todobar__text">
-                  {status === "in_progress" && todo.activeForm ? todo.activeForm : todo.content}
+                  {sourceStatus === "in_progress" && todo.activeForm ? todo.activeForm : todo.content}
                 </span>
               </li>
             );
@@ -137,12 +150,16 @@ function normalizeTodoStatus(status: Todo["status"]): "pending" | "in_progress" 
   }
 }
 
-function todoStatusLabelKey(status: "pending" | "in_progress" | "completed"): "todo.pending" | "todo.inProgress" | "todo.completed" {
+function todoStatusLabelKey(status: TodoPresentationStatus): "todo.pending" | "todo.inProgress" | "status.runtimePendingPrompt" | "todo.paused" | "todo.completed" {
   switch (status) {
     case "completed":
       return "todo.completed";
     case "in_progress":
       return "todo.inProgress";
+    case "waiting":
+      return "status.runtimePendingPrompt";
+    case "paused":
+      return "todo.paused";
     default:
       return "todo.pending";
   }

--- a/desktop/frontend/src/lib/todoVisibility.ts
+++ b/desktop/frontend/src/lib/todoVisibility.ts
@@ -12,6 +12,39 @@ export interface TodoPanelScopeInput {
   eventChannel?: string | null;
 }
 
+export type TodoPresentationStatus = "pending" | "in_progress" | "waiting" | "paused" | "completed";
+
+export interface TodoRuntimePresentation {
+  running: boolean;
+  pendingPrompt: boolean;
+}
+
+export function todoPresentationStatus(
+  status: Todo["status"],
+  runtime: TodoRuntimePresentation,
+): TodoPresentationStatus {
+  switch (todoStatus(status)) {
+    case "completed":
+      return "completed";
+    case "in_progress":
+      if (runtime.pendingPrompt) return "waiting";
+      return runtime.running ? "in_progress" : "paused";
+    default:
+      return "pending";
+  }
+}
+
+export function todoContinueTarget(
+  targetTabId: string | null | undefined,
+  activeTabId: string | null | undefined,
+  runtime: TodoRuntimePresentation & { ready: boolean; readOnly?: boolean },
+): string | null {
+  const target = String(targetTabId ?? "").trim();
+  if (!target || target !== String(activeTabId ?? "").trim()) return null;
+  if (!runtime.ready || runtime.readOnly || runtime.running || runtime.pendingPrompt) return null;
+  return target;
+}
+
 export function resolveTodoPanelTodos(
   canonical: Todo[] | null | undefined,
   live?: Todo[] | null,

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2949,7 +2949,9 @@ export const en = {
   "todo.dismiss": "Dismiss the task list",
   "todo.pending": "Pending",
   "todo.inProgress": "In progress",
+  "todo.paused": "Ready to continue",
   "todo.completed": "Completed",
+  "todo.continue": "Continue",
 
   // slash menu tags
   "slash.project": "project",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2052,7 +2052,9 @@ export const zhTW: Record<DictKey, string> = {
   "todo.dismiss": "關閉待辦列表",
   "todo.pending": "待處理",
   "todo.inProgress": "進行中",
+  "todo.paused": "待繼續",
   "todo.completed": "已完成",
+  "todo.continue": "繼續",
 
   // 斜線選單標籤
   "slash.project": "專案",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2952,7 +2952,9 @@ export const zh: Record<DictKey, string> = {
   "todo.dismiss": "关闭待办列表",
   "todo.pending": "待处理",
   "todo.inProgress": "进行中",
+  "todo.paused": "待继续",
   "todo.completed": "已完成",
+  "todo.continue": "继续",
 
   // 斜杠菜单标签
   "slash.project": "项目",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -21565,6 +21565,14 @@ body > .mermaid-diagram--fullscreen {
   border-color: color-mix(in srgb, var(--accent) 32%, var(--border-soft));
   color: var(--accent);
 }
+.todobar__status--waiting {
+  border-color: color-mix(in srgb, var(--warn) 32%, var(--border-soft));
+  color: var(--warn);
+}
+.todobar__status--paused {
+  border-color: color-mix(in srgb, var(--fg-dim) 32%, var(--border-soft));
+  color: var(--fg-dim);
+}
 .todobar__text {
   min-width: 0;
 }
@@ -21574,6 +21582,11 @@ body > .mermaid-diagram--fullscreen {
 }
 .todobar__item--in_progress .todobar__text {
   color: var(--fg);
+  font-weight: 500;
+}
+.todobar__item--waiting .todobar__text,
+.todobar__item--paused .todobar__text {
+  color: var(--fg-dim);
   font-weight: 500;
 }
 .todobar__item--pending .todobar__text {

--- a/docs/GOAL_ENFORCEMENT.zh-CN.md
+++ b/docs/GOAL_ENFORCEMENT.zh-CN.md
@@ -153,17 +153,22 @@ Delivery 收敛为纯 readiness 服务，宿主可消费的结构化结果为
 - Project checks（来自 AGENTS.md 的 verify 指令）
 - Delivery 专属验收项（mutation、verification、review、complete_step 签收、capability 门禁）
 
-Delivery 和 Standard 都不会注入隐藏模型消息做 readiness 重试。普通回合在可见模型回合结束后
-立即停止并返回结构化缺口；Delivery 由前端展示显式的 `Continue checks` 恢复入口，只有用户
-主动操作才会启动恢复回合。Standard 的 verification/review/signoff 缺口只作为完成提示处理。
-Goal + Delivery 或 approved Plan 回合仍由 Goal/Plan FSM 自动续轮，不显示需要用户点击的重复卡片。
+Delivery 和 Standard 都不会注入通用的隐藏模型消息做 readiness 重试。Delivery 在可见模型回合
+结束后返回结构化缺口，由前端展示显式的 `Continue checks` 恢复入口，只有用户主动操作才会启动
+恢复回合；Standard 的 verification/review/signoff 缺口仍只作为完成提示处理。Standard 另有一个
+不属于 readiness 的同回合一致性保护：仅当可信宿主判定用户要求执行、当前回合刚成功写入唯一
+`in_progress` Todo、写工具可用且不处于 Plan/Goal/Delivery/只读/恢复边界时，允许在同一个前台
+`Agent.Run` 内追加一次固定续做提示；只有产生新的宿主 receipt 才允许第二次，最多两次。它不会
+把历史 Todo 隐式变成新任务，也不会跨回合自动执行。Goal + Delivery 或 approved Plan 回合仍由
+Goal/Plan FSM 自动续轮，不显示需要用户点击的重复卡片。
 
 ### 进展签名
 
 Goal 的停滞计数只由宿主可验证且对当前 Goal **新颖**的信息重置：新的读取/搜索结果、Todo
 状态变化、新的有效 mutation/verification/review/signoff receipt、Delivery checkpoint 变化或
-终态 `update_goal` 报告。普通 Standard/Delivery 不再维护 task-progress 自动续跑指纹；用户的
-显式恢复回合会重新建立当前 evidence 上下文。
+终态 `update_goal` 报告。Delivery 不维护 task-progress 自动续跑指纹；Standard 只在上述同一
+`Agent.Run` 的 Todo 一致性保护中保存一个临时 receipt 指纹，用于阻止无进展的第二次提示，回合
+结束即清零。用户的显式恢复回合会重新建立当前 evidence 上下文。
 
 ### Todo 状态流
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -576,6 +576,12 @@ setting does not change desktop or web text fields.
 
 ### Desktop GUI
 
+The Desktop Todo shelf derives its label from both `todo_write` and the owning
+tab's runtime: active work is **In progress**, an approval or question is
+**Waiting for input**, and an idle/restored current item is **Ready to continue**.
+The latter exposes a **Continue** action that rechecks the captured tab before
+sending, so a rapid tab switch cannot route stale work into another session.
+
 Desktop shortcuts are managed from **Settings → Shortcuts**. Pick a configurable
 row, press a new key combination, and Reasonix saves it for the desktop app.
 Standard editing shortcuts such as Undo and Redo are shown as locked rows because
@@ -1421,14 +1427,20 @@ Reasonix uses **fact-driven execution**. Ordinary requests always enter the
 executor. There is no automatic task mode. The one session role is the quality floor: standard (default) or delivery; facts can still raise it. Planner,
 Goal, permission, sandbox, and the task contract are independent states.
 
-Standard and Delivery stop after the visible model turn. Readiness gaps are
-reported as a recoverable result and never trigger a hidden follow-up request.
-Delivery exposes the existing `Continue checks` action; the user must activate
-it before another recovery turn starts. Standard keeps verification, review and
-sign-off gaps as completion attention, while Goal and approved Plan retain their
-own state-machine continuation. Historical canonical todos remain visible, and
-provider-level stream/truncation recovery remains independent of final-readiness
-recovery.
+Standard and Delivery do not perform general hidden final-readiness retries.
+Delivery returns readiness gaps as recoverable results and exposes the existing
+`Continue checks` action; the user must activate it before another recovery turn
+starts. Standard keeps verification, review and sign-off gaps as completion
+attention. Separately, a Standard execution turn that successfully writes one
+current `in_progress` todo may continue inside the same foreground `Agent.Run`
+when the trusted host knows the user asked for execution. This repair is excluded
+from Plan, Goal, Delivery, read-only, recovery, cancellation, and queued-user-work
+boundaries. It sends one fixed continuation prompt, permits a second only after a
+new host receipt, and never exceeds two prompts. Goal and approved Plan retain
+their own state-machine continuation. Historical canonical todos remain visible
+but idle ones render as Ready to continue rather than In progress; their Continue
+action targets the exact visible session. Provider-level stream/truncation
+recovery remains independent of final-readiness recovery.
 
 Every task shares the same provider-visible core tool surface: direct
 read/bash/edit/write, background-shell lifecycle tools, `ask`/`compress` when

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -458,6 +458,10 @@ CLI/TUI 文本输入可通过 `[ui].cursor_shape` 设置光标形状，支持 `u
 
 ### 桌面端 GUI
 
+桌面端 Todo 面板会同时依据 `todo_write` 和所属标签页的运行态显示状态：真实执行时为「进行中」，
+等待审批或回答时为「等待输入」，回合空闲或恢复历史后为「待继续」。后者提供「继续」按钮；发送前
+会再次核对创建该按钮的标签页，因此快速切换标签页不会把旧待办误发到另一个会话。
+
 桌面端快捷键在 **设置 → 快捷键** 中管理。选择可配置的行后按下新的组合键，Reasonix 会为桌面端保存该绑定。
 撤销、重做等标准编辑快捷键会以锁定行展示，因为 WebView 的原生文本历史依赖这些平台组合键。
 如果新组合键和已有动作冲突，会拒绝保存，避免一个快捷键触发两个动作。按 `?` 或点击 topic bar
@@ -1089,11 +1093,15 @@ server 无法在这里提升权限。严格只读边界比独立 Planner 更窄�
 Reasonix 使用**事实驱动执行**。普通请求一律进入 executor，没有自动任务模式；
 唯一的会话角色是质量底线（standard/delivery），事实仍可能高于它。Plan、Goal、permission、sandbox 与任务合同是互相独立的状态。
 
-Standard 和 Delivery 都在可见模型回合结束后停止。readiness 缺口只作为可恢复结果返回，
-不会再触发隐藏的后续模型请求。Delivery 展示现有的「继续检查」入口，只有用户主动点击后
-才会启动恢复回合；Standard 的验证、复核和签收缺口仍作为完成提示处理。Goal 和已批准
-Plan 继续由各自状态机控制连续执行；provider 层的流中断/截断恢复与 final-readiness 恢复
-相互独立。历史 canonical Todo 继续显示，但不会被普通回合隐式变成新的自动任务。
+Standard 和 Delivery 都不会执行通用的隐藏 final-readiness 重试。Delivery 把 readiness 缺口
+作为可恢复结果返回并展示现有的「继续检查」入口，只有用户主动点击后才会启动恢复回合；
+Standard 的验证、复核和签收缺口仍作为完成提示处理。除此之外，Standard 有一个同一前台
+`Agent.Run` 内的 Todo 一致性保护：可信宿主确认用户要求执行、当前回合成功写入唯一
+`in_progress` Todo 且写工具可用时，会追加一次固定续做提示；只有产生新的宿主 receipt 才允许
+第二次，并且最多两次。Plan、Goal、Delivery、只读、恢复、取消和已有排队用户输入都会禁用该
+保护。Goal 和已批准 Plan 继续由各自状态机控制连续执行；provider 层的流中断/截断恢复与
+final-readiness 恢复相互独立。历史 canonical Todo 继续显示，但空闲时标记为「待继续」而不是
+「进行中」；用户点击「继续」只会发送到当前可见会话，不会把历史 Todo 隐式变成后台任务。
 
 所有任务共享同一套 provider 可见核心工具面（直接读/bash/编辑/写入、后台 shell
 生命周期工具，以及稳定的 `use_capability` 代理）。可选工具（搜索、MCP、skills、

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -257,6 +257,7 @@ const (
 	HostRecoveryGuidanceToolFailedPrefix = "A tool failed. Use read-only diagnosis as needed"
 	HostRecoveryGuidanceTransientPrefix  = "The tool timed out or hit a transient execution limit."
 	ReadinessContinuationPrefix          = "This turn ended with work still outstanding:"
+	StandardTodoContinuationPrefix       = "The current task list still has an in-progress item."
 )
 
 // SyntheticUserPrefixes lists the openings of host-injected user-role messages
@@ -272,6 +273,7 @@ var SyntheticUserPrefixes = []string{
 	"Plan approved — plan mode is off",
 	"Host final-answer readiness check failed",
 	ReadinessContinuationPrefix,
+	StandardTodoContinuationPrefix,
 	"You are already in the executor phase",
 	"The previous assistant response was interrupted while a tool call",
 	"The previous assistant response was interrupted during streaming",

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -593,6 +593,10 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, tex
 		a.contextManager().ObserveUsage(usage)
 		return true, nil
 	}
+	if a.continueStandardTodo(ctx, state) {
+		a.contextManager().ObserveUsage(usage)
+		return true, nil
+	}
 	if readiness.applies || a.turn.readinessRecovered {
 		event.RecordReadinessAudit(a.svc.sink, readiness.audit(evidence.ReadinessAllowed, a.turn.readinessRecovered))
 	}

--- a/internal/agent/standard_todo_continuation.go
+++ b/internal/agent/standard_todo_continuation.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"context"
+	"strings"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/provider"
+	"reasonix/internal/taskcontract"
+)
+
+const maxStandardTodoContinuations = 2
+
+// StandardTodoContinuationPolicy is trusted host metadata for one Run. It is
+// intentionally absent from model-visible prompts and schemas: the controller
+// decides whether the pristine user turn expects execution, while Agent still
+// owns every runtime/evidence exclusion.
+type StandardTodoContinuationPolicy struct {
+	ExecutionExpected bool
+	ShouldYield       func() bool
+}
+
+type standardTodoContinuationPolicyKey struct{}
+
+// WithStandardTodoContinuation arms the narrow Standard same-Run continuation
+// seam. Direct Agent callers preserve the historical single-final behavior
+// unless a trusted host explicitly opts in.
+func WithStandardTodoContinuation(ctx context.Context, policy StandardTodoContinuationPolicy) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, standardTodoContinuationPolicyKey{}, policy)
+}
+
+func standardTodoContinuationPolicyFromContext(ctx context.Context) (StandardTodoContinuationPolicy, bool) {
+	if ctx == nil {
+		return StandardTodoContinuationPolicy{}, false
+	}
+	policy, ok := ctx.Value(standardTodoContinuationPolicyKey{}).(StandardTodoContinuationPolicy)
+	return policy, ok
+}
+
+func (a *Agent) continueStandardTodo(ctx context.Context, state *turnRuntime) bool {
+	policy, ok := standardTodoContinuationPolicyFromContext(ctx)
+	if !ok || !policy.ExecutionExpected || !a.standardTodoContinuationEligible(state) {
+		return false
+	}
+	if ctx.Err() != nil || policy.ShouldYield != nil && policy.ShouldYield() {
+		return false
+	}
+
+	progress := a.task.ledger.SuccessfulProgressFingerprint()
+	if state.standardTodoContinuations > 0 && progress == state.standardTodoProgress {
+		return false
+	}
+	state.standardTodoContinuations++
+	state.standardTodoProgress = progress
+	a.sess.conversation.Add(provider.Message{
+		Role:    provider.RoleUser,
+		Content: a.withTurnPreferences(standardTodoContinuationMessage()),
+	})
+	return true
+}
+
+func (a *Agent) standardTodoContinuationEligible(state *turnRuntime) bool {
+	if a == nil || state == nil || a.task.ledger == nil || state.standardTodoContinuations >= maxStandardTodoContinuations {
+		return false
+	}
+	if a.subagentDepth > 0 || a.readOnlyExecution || a.planMode.Load() || a.turn.constraints.ForbidMutation || a.turn.constraints.PlanModeReadOnly {
+		return false
+	}
+	if a.turn.constraints.PolicyFloor == taskcontract.PolicyFloorDelivery || a.closedLoopActive() || a.planContractSnapshot() != nil {
+		return false
+	}
+	if state.graceRound || state.recoveryGraceRound || a.loopGuardAllowsFinal() || !registryHasWriterTools(a.svc.tools) {
+		return false
+	}
+	todos, ok := a.task.ledger.LatestTodos()
+	if !ok || len(evidence.IncompleteTodos(todos)) == 0 {
+		return false
+	}
+	active := 0
+	for _, todo := range todos {
+		if strings.TrimSpace(todo.Status) == "in_progress" {
+			active++
+		}
+	}
+	return active == 1
+}
+
+func standardTodoContinuationMessage() string {
+	return StandardTodoContinuationPrefix + " Continue that item now using available tools. Do not create another plan or end with another promise to act. If blocked, use the appropriate user-input or approval mechanism. Do not repeat external or destructive actions, and do not expand scope."
+}

--- a/internal/agent/standard_todo_continuation_test.go
+++ b/internal/agent/standard_todo_continuation_test.go
@@ -1,0 +1,161 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+	"reasonix/internal/provider"
+	"reasonix/internal/runtimepolicy"
+	"reasonix/internal/taskcontract"
+	"reasonix/internal/tool"
+)
+
+func standardTodoTestAgent(t *testing.T, turns [][]provider.Chunk) (*Agent, *scriptedProvider) {
+	t.Helper()
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	reg.Add(todoWrite)
+	prov := &scriptedProvider{name: "p", turns: turns}
+	return New(prov, reg, NewSession("stable-system-prefix"), Options{}, event.Discard), prov
+}
+
+func standardTodoContext() context.Context {
+	return WithStandardTodoContinuation(context.Background(), StandardTodoContinuationPolicy{ExecutionExpected: true})
+}
+
+func TestStandardTodoContinuationCompletesInsideSameRun(t *testing.T) {
+	a, prov := standardTodoTestAgent(t, [][]provider.Chunk{
+		{toolCallChunk("todo-1", "todo_write", `{"todos":[{"content":"Edit code","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "I will edit it next."}, {Type: provider.ChunkDone}},
+		{
+			toolCallChunk("write-1", "write_file", `{"path":"main.go"}`),
+			toolCallChunk("todo-2", "todo_write", `{"todos":[{"content":"Edit code","status":"completed"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "Implemented."}, {Type: provider.ChunkDone}},
+	})
+
+	if err := a.Run(standardTodoContext(), "实施这个修改"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 4 {
+		t.Fatalf("provider calls = %d, want 4", prov.call)
+	}
+	foundSynthetic := false
+	for _, message := range a.Session().Snapshot() {
+		if message.Role == provider.RoleUser && IsSyntheticUserText(message.Content) {
+			foundSynthetic = true
+		}
+	}
+	if !foundSynthetic {
+		t.Fatal("same-Run continuation was not persisted as a hidden synthetic turn")
+	}
+}
+
+func TestStandardTodoContinuationStopsAfterOneStalledNudge(t *testing.T) {
+	a, prov := standardTodoTestAgent(t, [][]provider.Chunk{
+		{toolCallChunk("todo-1", "todo_write", `{"todos":[{"content":"Edit code","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "I will do it."}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "Still planning to do it."}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "must not be consumed"}, {Type: provider.ChunkDone}},
+	})
+
+	if err := a.Run(standardTodoContext(), "实施这个修改"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 3 {
+		t.Fatalf("provider calls = %d, want 3 (one nudge, then stop on no progress)", prov.call)
+	}
+}
+
+func TestStandardTodoContinuationAllowsOneProgressGatedSecondNudge(t *testing.T) {
+	a, prov := standardTodoTestAgent(t, [][]provider.Chunk{
+		{toolCallChunk("todo-1", "todo_write", `{"todos":[{"content":"Edit code","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "I will do it."}, {Type: provider.ChunkDone}},
+		{toolCallChunk("write-1", "write_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "There is more."}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "Stopped after bounded repair."}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "must not be consumed"}, {Type: provider.ChunkDone}},
+	})
+
+	if err := a.Run(standardTodoContext(), "实施这个修改"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 5 {
+		t.Fatalf("provider calls = %d, want 5 (hard maximum of two nudges)", prov.call)
+	}
+}
+
+func TestStandardTodoContinuationRequiresTrustedExecutionIntent(t *testing.T) {
+	a, prov := standardTodoTestAgent(t, [][]provider.Chunk{
+		{toolCallChunk("todo-1", "todo_write", `{"todos":[{"content":"Edit code","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "Stopping here."}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "must not be consumed"}, {Type: provider.ChunkDone}},
+	})
+
+	if err := a.Run(context.Background(), "实施这个修改"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 2 {
+		t.Fatalf("provider calls = %d, want historical two-call behavior without host policy", prov.call)
+	}
+}
+
+func TestStandardTodoContinuationExcludesClosedLoopAndReadOnlyBoundaries(t *testing.T) {
+	newEligibleAgent := func() *Agent {
+		ledger := evidence.NewLedger()
+		ledger.Record(evidence.Receipt{
+			ToolName: "todo_write",
+			Success:  true,
+			Todos:    []evidence.TodoItem{{Content: "Edit code", Status: "in_progress"}},
+		})
+		reg := tool.NewRegistry()
+		reg.Add(fakeTool{name: "write_file", readOnly: false})
+		return &Agent{
+			svc:  agentServices{tools: reg},
+			task: taskRuntime{ledger: ledger},
+			turn: turnRuntime{engine: runtimepolicy.NewEngine(runtimepolicy.Constraints{})},
+		}
+	}
+
+	if !newEligibleAgent().standardTodoContinuationEligible(&turnRuntime{}) {
+		t.Fatal("baseline Standard writer turn should be eligible")
+	}
+	tests := []struct {
+		name  string
+		apply func(*Agent, *turnRuntime)
+	}{
+		{name: "subagent", apply: func(a *Agent, _ *turnRuntime) { a.subagentDepth = 1 }},
+		{name: "read-only executor", apply: func(a *Agent, _ *turnRuntime) { a.readOnlyExecution = true }},
+		{name: "plan mode", apply: func(a *Agent, _ *turnRuntime) { a.planMode.Store(true) }},
+		{name: "forbid mutation", apply: func(a *Agent, _ *turnRuntime) { a.turn.constraints.ForbidMutation = true }},
+		{name: "delivery floor", apply: func(a *Agent, _ *turnRuntime) { a.turn.constraints.PolicyFloor = taskcontract.PolicyFloorDelivery }},
+		{name: "goal scope", apply: func(a *Agent, _ *turnRuntime) { a.turn.deliveryScopeActive = true }},
+		{name: "loop guard", apply: func(a *Agent, _ *turnRuntime) { a.turn.loopGuardArmed = true }},
+		{name: "grace boundary", apply: func(_ *Agent, state *turnRuntime) { state.graceRound = true }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newEligibleAgent()
+			state := &turnRuntime{}
+			tc.apply(a, state)
+			if a.standardTodoContinuationEligible(state) {
+				t.Fatalf("%s boundary must not auto-continue", tc.name)
+			}
+		})
+	}
+
+	noWriter := newEligibleAgent()
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	noWriter.svc.tools = reg
+	if noWriter.standardTodoContinuationEligible(&turnRuntime{}) {
+		t.Fatal("read-only registry must not auto-continue")
+	}
+}

--- a/internal/agent/turnruntime.go
+++ b/internal/agent/turnruntime.go
@@ -28,6 +28,11 @@ type turnRuntime struct {
 	trackingTodoProgress bool
 	todoStallRounds      int
 	seenTodoProgress     map[string]struct{}
+	// standardTodoContinuations is the bounded same-Run repair for a Standard
+	// execution turn that wrote an active todo and then tried to stop. The
+	// fingerprint gates the optional second nudge on new host-observed work.
+	standardTodoContinuations int
+	standardTodoProgress      string
 
 	executorHandoff bool
 	input           string

--- a/internal/control/planner_gate.go
+++ b/internal/control/planner_gate.go
@@ -10,6 +10,7 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/runtimepolicy"
+	"reasonix/internal/taskcontract"
 )
 
 const (
@@ -59,18 +60,49 @@ func (c *Controller) withPlannerTurnMetadata(ctx context.Context, userText strin
 	text := strings.TrimSpace(agent.StripTransientUserBlocks(userText))
 	constraints := runtimepolicy.ParseConstraints(runtimepolicy.StripQuotedConstraints(text))
 	constraints.PolicyFloor = c.qualityFloorConstraint()
-	if c.PlanMode() {
+	planMode := c.PlanMode()
+	if planMode {
 		constraints.PlanModeReadOnly = true
 		constraints.ForbidMutation = true
 	}
 	ctx = runtimepolicy.WithContext(ctx, constraints)
+	ctx = agent.WithStandardTodoContinuation(ctx, agent.StandardTodoContinuationPolicy{
+		ExecutionExpected: standardTodoExecutionExpected(text, synthetic, priorMessages, planMode, constraints),
+		ShouldYield:       c.hasPendingUserWork,
+	})
 	return withPlannerTurnMetadata(ctx, plannerTurnMetadata{
 		UserText:               userText,
 		Synthetic:              synthetic,
-		ExplicitPlanMode:       c.PlanMode(),
+		ExplicitPlanMode:       planMode,
 		ExplicitGoalStart:      c.consumeExplicitGoalStart(),
 		HasConversationContext: priorMessages > 1,
 	})
+}
+
+func standardTodoExecutionExpected(text string, synthetic bool, priorMessages int, planMode bool, constraints runtimepolicy.Constraints) bool {
+	if synthetic || planMode || !constraints.AllowsMutation() || constraints.PolicyFloor == taskcontract.PolicyFloorDelivery {
+		return false
+	}
+	lower := normalizePlannerText(text)
+	if requestsPlanOnly(lower) || requestsPlanApproval(lower) {
+		return false
+	}
+	if NeedsMutation(text) {
+		return true
+	}
+	return priorMessages > 1 && (isExecutionContinuationReply(text) || isContextDependentAction(text))
+}
+
+func isExecutionContinuationReply(text string) bool {
+	if !isContextDependentShortReply(text) {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(text)) {
+	case "no", "n":
+		return false
+	default:
+		return true
+	}
 }
 
 // DecidePlannerRoute applies deterministic precedence rules to a pristine user

--- a/internal/control/planner_gate_test.go
+++ b/internal/control/planner_gate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/runtimepolicy"
 )
 
 func TestTaskWarrantsPlanner(t *testing.T) {
@@ -143,5 +144,19 @@ func TestPlannerPolicyUsesPristineMetadataInsteadOfInjectedContext(t *testing.T)
 	got := DecidePlannerRoute(ctx, input)
 	if got.Route != agent.PlannerRouteExecutorOnly {
 		t.Fatalf("decision used injected context instead of pristine user text: %+v", got)
+	}
+}
+
+func TestStandardTodoExecutionIntentRejectsNegativeShortReplies(t *testing.T) {
+	constraints := runtimepolicy.Constraints{}
+	for _, text := range []string{"no", "n"} {
+		if standardTodoExecutionExpected(text, false, 2, false, constraints) {
+			t.Fatalf("negative reply %q must not arm Standard Todo continuation", text)
+		}
+	}
+	for _, text := range []string{"continue", "开始", "2", "按这个改"} {
+		if !standardTodoExecutionExpected(text, false, 2, false, constraints) {
+			t.Fatalf("execution reply %q should arm Standard Todo continuation with context", text)
+		}
 	}
 }

--- a/internal/control/readiness_manual_recovery_test.go
+++ b/internal/control/readiness_manual_recovery_test.go
@@ -56,6 +56,67 @@ func TestStandardStopsAfterOneVisibleTurn(t *testing.T) {
 	}
 }
 
+func TestStandardStartReplyContinuesCurrentTodoInsideVisibleTurn(t *testing.T) {
+	c, prov := manualReadinessController(t, [][]provider.Chunk{
+		{toolCallChunk("todo-1", "todo_write", `{"todos":[{"content":"重写第 4 节","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
+		textTurn("让我先列出待办，接下来会重写。"),
+		{
+			toolCallChunk("write-1", "write_file", `{"path":"PRD.md"}`),
+			toolCallChunk("todo-2", "todo_write", `{"todos":[{"content":"重写第 4 节","status":"completed"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		textTurn("第 4 节已经完成重写。"),
+	})
+	if err := c.SetQualityFloor(QualityFloorStandard); err != nil {
+		t.Fatalf("SetQualityFloor: %v", err)
+	}
+	c.executor.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "让我写完整新第 4 节。"})
+
+	if err := newTurnOrchestrator(c).runGoalLoopWithRawDisplay(context.Background(), "开始", "开始", "开始"); err != nil {
+		t.Fatalf("standard start reply returned %v", err)
+	}
+	if prov.call != 4 {
+		t.Fatalf("provider calls = %d, want Todo stop repaired inside the same visible turn", prov.call)
+	}
+	if got := syntheticUserTurnCount(c.executor.Session().Snapshot()); got != 1 {
+		t.Fatalf("synthetic user turns = %d, want one hidden Todo continuation", got)
+	}
+}
+
+func TestStandardStartWithoutConversationDoesNotArmTodoContinuation(t *testing.T) {
+	c, prov := manualReadinessController(t, [][]provider.Chunk{
+		{toolCallChunk("todo-1", "todo_write", `{"todos":[{"content":"重写第 4 节","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
+		textTurn("等待下一步。"),
+		textTurn("不应被隐藏续跑消费"),
+	})
+
+	if err := newTurnOrchestrator(c).runGoalLoopWithRawDisplay(context.Background(), "开始", "开始", "开始"); err != nil {
+		t.Fatalf("standard start reply returned %v", err)
+	}
+	if prov.call != 2 {
+		t.Fatalf("provider calls = %d, want no continuation without prior context", prov.call)
+	}
+}
+
+func TestStandardTodoContinuationYieldsToPendingUserWork(t *testing.T) {
+	c, prov := manualReadinessController(t, [][]provider.Chunk{
+		{toolCallChunk("todo-1", "todo_write", `{"todos":[{"content":"重写第 4 节","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
+		textTurn("等待下一步。"),
+		textTurn("不应被隐藏续跑消费"),
+	})
+	c.executor.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "让我写完整新第 4 节。"})
+	c.mu.Lock()
+	c.canceling = true
+	c.mu.Unlock()
+
+	if err := newTurnOrchestrator(c).runGoalLoopWithRawDisplay(context.Background(), "开始", "开始", "开始"); err != nil {
+		t.Fatalf("standard start reply returned %v", err)
+	}
+	if prov.call != 2 {
+		t.Fatalf("provider calls = %d, want pending user work to preempt continuation", prov.call)
+	}
+}
+
 func TestDeliveryStopsAtReadinessAndWaitsForExplicitRecovery(t *testing.T) {
 	c, prov := manualReadinessController(t, [][]provider.Chunk{
 		{toolCallChunk("write", "write_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},

--- a/internal/control/standard_todo_continuation.go
+++ b/internal/control/standard_todo_continuation.go
@@ -1,0 +1,45 @@
+package control
+
+import "reasonix/internal/sessioninbox"
+
+// hasPendingUserWork reads only already-owned state and an already open inbox.
+// It never creates an inbox or holds a Controller lock while taking an
+// Agent/Store lock. A busy or unreadable durable inbox conservatively yields to
+// potential user work, which must win over an automatic Todo nudge.
+func (c *Controller) hasPendingUserWork() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	canceling := c.canceling
+	parked := len(c.parkedTurns) > 0
+	executor := c.executor
+	c.mu.Unlock()
+	if canceling || parked {
+		return true
+	}
+	if executor != nil && executor.HasUnappliedSteer() {
+		return true
+	}
+	c.inbox.mu.Lock()
+	store := c.inbox.store
+	c.inbox.mu.Unlock()
+	if store == nil {
+		return false
+	}
+	snapshot, err := store.TryFreshSnapshot()
+	if err != nil || snapshot.Readonly {
+		return true
+	}
+	for _, item := range snapshot.Items {
+		if item.RunID != "" && item.RunID != sessioninbox.ProcessRunID() {
+			return true
+		}
+		switch item.State {
+		case sessioninbox.StateQueued, sessioninbox.StateBlocked,
+			sessioninbox.StateUncertain, sessioninbox.StateSteerAccepted:
+			return true
+		}
+	}
+	return false
+}

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -66,7 +66,7 @@
       "essay": 2
     },
     "desktop/frontend/src/App.tsx": {
-      "file-size": 4728
+      "file-size": 4747
     },
     "desktop/frontend/src/__tests__/app-chrome-tabs.test.ts": {
       "test-file-size": 27


### PR DESCRIPTION
## Problem

In Standard mode, a turn can successfully write a task list with one current `in_progress` item, answer with only a promise to act, and then end the foreground Run. The persisted Todo shelf continues to say the work is in progress even though the owning tab is idle, which matches the Todo-specific failure shape reported in #9453 and the repeated-prompt symptoms in #9166.

## Root cause

General hidden final-readiness retries were intentionally removed from Standard turns, but there was no narrower consistency guard for a current-Run Todo that the model had just marked active. Independently, the desktop Todo shelf rendered persisted Todo status without combining it with the owning tab's runtime state.

## Fix

### Agent and controller

- Derive execution expectation from the pristine user turn in the trusted controller. Direct mutation requests and affirmative/contextual actions such as `开始` or `continue` qualify; negative replies, synthetic turns, Plan-only requests, approval boundaries, and Delivery do not.
- At the Standard final boundary, continue only when the current Run has a successful `todo_write`, exactly one `in_progress` item, and writer tools are available.
- Send one fixed, scope-bounded continuation prompt. Permit a second only after a new host-observed progress fingerprint, and never exceed two prompts.
- Yield to cancellation, parked turns, unapplied steer, or durable inbox work. Plan, Goal, Delivery, read-only, subagent, loop-guard, grace, and recovery boundaries remain excluded.

### Desktop

- Derive Todo presentation from both canonical Todo state and the owning tab runtime:
  - running -> **In progress**
  - approval/question pending -> **Waiting for input**
  - idle/restored -> **Ready to continue**
- Offer **Continue** only for an idle, ready, writable tab, and recheck the exact captured tab before routing either a local or remote submission.
- Document the bounded Standard behavior and the runtime-aware Todo states in the English and Chinese guides.

## Safety, concurrency, and compatibility

- The synthetic prompt is fixed text and never interpolates Todo content or user input, limiting prompt-injection amplification.
- Pending user work always wins over an automatic Todo nudge. The inbox check is non-blocking and conservatively yields on busy, unreadable, or forward-schema state.
- The frontend exact-tab check prevents a stale Todo action from being sent after a rapid tab switch.
- No dependency, Wails binding, persisted schema, provider serialization, tool schema, system prompt, permission, network, or filesystem contract changes.

## Cache and request cost

The stable provider-visible prefix is unchanged. This adds a tail request only after the narrow Standard Todo failure shape is observed: normally one extra request, with a second allowed only after new host evidence. Ordinary turns, cache keys, schemas, and serialization are unchanged.

## Frontend capacity

- Initial JavaScript gzip budget: 445.5 -> 445.9 KiB, a +0.4 KiB (+0.09%) ratchet. The built result is 445.8 KiB.
- Initial raw JavaScript and CSS budget: 2404.5 -> 2405.7 KiB, a +1.2 KiB (+0.05%) ratchet. The built result is 2405.5 KiB.
- Deferred app-shell CSS remains 115.0 KiB gzip against the unchanged 116.0 KiB budget.
- `App.tsx` repolint file-size baseline: 4728 -> 4747 (+19 lines). The added lines are the owner-layer exact-tab/runtime recheck needed before local or remote continuation routing; no unrelated debt baseline was changed.

The increase belongs to the always-mounted Todo runtime-state and exact-tab routing guard; it is kept as a narrow owner-specific ratchet.

## Verification

- `go test ./...`
- `go test -race ./internal/agent ./internal/control -run 'TestStandardTodoContinuation|TestStandardStartReply|TestStandardTodoExecutionIntent|TestStandardTodoContinuationYields|TestStandardStopsAfterOneVisibleTurn|TestDeliveryStopsAtReadiness' -count=1`
- `go vet ./internal/agent ./internal/control`
- `(cd desktop && go test ./...)`
- `(cd desktop/frontend && pnpm build && pnpm test:typecheck && pnpm test:todo-visibility)`
- Real-browser mock: `/todo-preview` rendered the idle current item as **待继续**; clicking **继续** submitted to the visible session, changed the item to **进行中**, removed the Continue action while running, and restored **待继续** after completion. No application console errors or warnings were observed; the local dev server had only its existing missing-favicon 404.

## Related work

- #9462 changes Todo continuity-error snapshots.
- #9308 changes stale Todo sign-off notices.
- #9444 changes real-time steer admission.

Those PRs touch adjacent Todo/control concepts but not this final-boundary and runtime-presentation path.

Addresses #9453. Related: #9166.

Documentation-impact: updated - documented the bounded Standard Todo continuation and runtime-aware Desktop Todo states in the English and Chinese guides.
Cache-impact: low - the stable provider prefix, system prompt, tool schemas, and serialization stay unchanged; only the narrow failure path adds one or at most two tail requests.
Cache-guard: focused Standard Todo continuation tests plus review of `SyntheticUserPrefixes`, controller metadata, and provider-visible message placement.
System-prompt-review: N/A - no system prompt, memory prefix, output style, or skill index bytes change.
