### PR TITLE
feat(agent): check the soft line at tool-result placement / 工具结果落盘即查软线

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -40,6 +41,39 @@ import (
 // maxToolOutputBytes bounds the stable provider-visible Content. RawContent
 // retains the complete local result for explicit session-scoped paging.
 const maxToolOutputBytes = 32 * 1024
+
+// maintainForPlacement is the per-result placement check: the moment a tool
+// result lands the view past the fold trigger, maintenance runs before the
+// next result rides in — instead of bouncing off the hard ceiling at the next
+// sampling request. No-op below the trigger (one estimate); the blocked
+// receipt backoff keeps repeated calls from thrashing.
+func (a *Agent) maintainForPlacement(ctx context.Context) {
+	if a == nil || a.contextWindow <= 0 {
+		return
+	}
+	if a.estimatedVisibleRequestTokens(a.modelVisibleMessages()) < a.compactTrigger() {
+		return
+	}
+	if _, err := a.contextManager().Prepare(ctx, ContextPreparePolicy{Trigger: CompactionTriggerPressure}); err != nil {
+		slog.Debug("agent: placement maintenance skipped", "err", err)
+	}
+}
+
+// placementCheckStrideBytes is the byte budget that may accumulate between
+// full-view estimates: a quarter of the soft-to-hard safety band, so the
+// check can never skip past more than a fraction of the band regardless of
+// window size. Scales with the window by construction (128K → ~25KB,
+// 1M → ~200KB).
+func (a *Agent) placementCheckStrideBytes() int {
+	if a == nil || a.contextWindow <= 0 {
+		return 64 * 1024 // no window configured: fixed fallback
+	}
+	strideTokens := (a.hardInputCeiling() - a.compactTrigger()) / 4
+	if strideTokens < 2_048 {
+		return 8 * 1024 // degenerate tiny windows: small floor
+	}
+	return strideTokens * 4 // ~4 chars per token
+}
 
 var deprecatedContextRetentionWarning sync.Once
 

--- a/internal/agent/context_report.go
+++ b/internal/agent/context_report.go
@@ -17,6 +17,25 @@ type ContextReport struct {
 	ProjectionTokens int
 	Projected        bool
 
+	// Breakdown classifies the current model-visible view so maintainers can
+	// see who consumes the window before tuning any governance. ChatTokens
+	// includes the (pinned) system message; SchemaTokens is the per-request
+	// tool-schema mass that compaction can never reclaim.
+	//
+	// Units: ToolResultTokens and ChatTokens are measured by the planning
+	// estimator (estimateMessagesTokens) — the "for internal planning budgets
+	// only; against the window it would compact 4x early" unit documented on
+	// estimatedPromptTokens in output_budget.go. It reads up to ~4x high next
+	// to the window-denominated fields (ProjectionTokens, Window,
+	// FoldThreshold), so never sum these into or compare them against those;
+	// only ratios between the two message buckets carry meaning. SchemaTokens
+	// is in a third unit, the request estimator (estimatedRequestTokens),
+	// which session calibration re-scales even though the message buckets
+	// stay deterministic — it is not comparable with either bucket either.
+	ToolResultTokens int // planning tokens (estimateMessagesTokens): deterministic, calibration-free
+	ChatTokens       int // planning tokens (estimateMessagesTokens): deterministic, calibration-free
+	SchemaTokens     int // request tokens (estimatedRequestTokens): re-scaled by session calibration
+
 	SoftThreshold  int
 	SnipThreshold  int
 	FoldThreshold  int
@@ -52,6 +71,19 @@ func (a *Agent) ContextReport() ContextReport {
 	visible := a.modelVisibleMessages()
 	rep.ProjectionTokens = a.estimatedPromptTokens(provider.ModelMessages(visible))
 	rep.Projected = rep.ProjectionTokens != rep.CanonicalTokens
+	for _, m := range visible {
+		if m.LocalOnly {
+			continue
+		}
+		if m.Role == provider.RoleTool {
+			rep.ToolResultTokens += estimateMessagesTokens([]provider.Message{m})
+			continue
+		}
+		rep.ChatTokens += estimateMessagesTokens([]provider.Message{m})
+	}
+	if schemas := a.providerToolSchemas(); len(schemas) > 0 {
+		rep.SchemaTokens = a.estimatedRequestTokens(provider.Request{Tools: schemas})
+	}
 
 	if a.contextWindow > 0 {
 		rep.FoldThreshold = a.compactTrigger()

--- a/internal/agent/context_report_test.go
+++ b/internal/agent/context_report_test.go
@@ -58,3 +58,44 @@ func TestContextReportLeavesThresholdsZeroWhenDisabled(t *testing.T) {
 		t.Errorf("disabled maintenance reported thresholds: %+v", rep)
 	}
 }
+
+// The breakdown classifies the same visible messages the maintenance decision
+// sees: tool-role output versus chat, with the per-request schema mass counted
+// separately because compaction can never reclaim it. The estimator
+// (estimateMessagesTokens) prices ASCII text at one token per rune, adds 4
+// framing tokens per message and 8 + id + name + arguments per tool call, so
+// the fixture arithmetic is exact:
+//
+//	tool message   = 4 framing + 8000 content + 2 ("c1") + 4 ("dump") = 8010
+//	assistant call = 4 framing + 8 call framing + 2 + 4 + 2 = 20
+//	chat messages  = (4+4000) system + (4+4000) user + 20 + (4+4000) user = 12032
+//
+// The LocalOnly user turn must land in neither bucket. It is excluded twice —
+// by the loop guard in ContextReport and again by estimateMessagesTokens —
+// so deleting either guard alone stays green; removing both (or breaking the
+// LocalOnly contract anywhere on the path) adds 4004 to ChatTokens and turns
+// this test red.
+func TestContextReportBreakdownClassifiesToolResultsAndChat(t *testing.T) {
+	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: strings.Repeat("s", 4_000)},
+		{Role: provider.RoleUser, Content: strings.Repeat("u", 4_000)},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "c1", Name: "dump", Arguments: `{}`}}},
+		{Role: provider.RoleTool, ToolCallID: "c1", Name: "dump", Content: strings.Repeat("t", 8_000)},
+		{Role: provider.RoleUser, Content: strings.Repeat("v", 4_000)},
+		{Role: provider.RoleUser, Content: strings.Repeat("l", 4_000), LocalOnly: true}, // local-only: neither bucket
+	}
+	a := agentOverForceWindow(t, prov, &Session{Messages: msgs}, 50_000)
+	a.SetTools(echoRegistry()) // agentOverForceWindow starts with an empty registry; schemas must exist
+
+	rep := a.ContextReport()
+	if rep.ToolResultTokens != 8_010 {
+		t.Fatalf("ToolResultTokens = %d, want 8010", rep.ToolResultTokens)
+	}
+	if rep.ChatTokens != 12_032 { // ChatTokens includes the system message
+		t.Fatalf("ChatTokens = %d, want 12032", rep.ChatTokens)
+	}
+	if rep.SchemaTokens <= 0 {
+		t.Fatalf("SchemaTokens = %d, want > 0 (registry has schemas)", rep.SchemaTokens)
+	}
+}

--- a/internal/agent/estimator_bench_test.go
+++ b/internal/agent/estimator_bench_test.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// benchEstimatorSession builds a transcript of roughly `tokens` estimated tokens
+// (2000 chars ≈ 500 tokens per assistant turn under the chars/4 fallback).
+func benchEstimatorSession(tokens int) *Session {
+	big := strings.Repeat("word ", 400)
+	msgs := []provider.Message{{Role: provider.RoleSystem, Content: "sys"}}
+	for range tokens / 500 {
+		msgs = append(msgs,
+			provider.Message{Role: provider.RoleAssistant, Content: big},
+			provider.Message{Role: provider.RoleUser, Content: "continue"},
+		)
+	}
+	return &Session{Messages: msgs}
+}
+
+func benchmarkEstimator(b *testing.B, tokens int) {
+	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
+	sess := benchEstimatorSession(tokens)
+	a := New(prov, tool.NewRegistry(), sess, Options{
+		ContextWindow: tokens * 4, CompactRatio: 0.5, CompactForceRatio: 0.5,
+		RecentKeep: 2, ArchiveDir: b.TempDir(),
+	}, event.Discard)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink int
+	for range b.N {
+		sink += a.estimatedVisibleRequestTokens(a.modelVisibleMessages())
+	}
+	if sink == -1 {
+		b.Fatal("impossible")
+	}
+}
+
+func BenchmarkEstimatorCheck200KTokens(b *testing.B) { benchmarkEstimator(b, 200_000) }
+func BenchmarkEstimatorCheck1MTokens(b *testing.B)   { benchmarkEstimator(b, 1_000_000) }

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -648,6 +648,8 @@ func (a *Agent) handleToolRound(ctx context.Context, state *turnRuntime, step in
 		return false, batch.err
 	}
 	results, images := batch.results, batch.images
+	stride := a.placementCheckStrideBytes()
+	placementBytes := 0
 	for i, call := range calls {
 		msg := provider.Message{
 			Role:       provider.RoleTool,
@@ -665,6 +667,15 @@ func (a *Agent) handleToolRound(ctx context.Context, state *turnRuntime, step in
 			msg.ToolExecution = toProviderToolExecution(batch.executions[i])
 		}
 		a.sess.conversation.Add(msg)
+		// Placement governance: the estimate is a full-view scan, so gate it on
+		// accumulated new bytes (window-scaled stride, see placementCheckStrideBytes)
+		// rather than every result. Crossing the soft line folds now, so the next
+		// result never rides in on a context already past the maintenance threshold.
+		placementBytes += len(msg.Content)
+		if placementBytes >= stride {
+			placementBytes = 0
+			a.maintainForPlacement(ctx)
+		}
 	}
 	// If the context was cancelled during tool execution, return after storing
 	// the batch results so the session keeps paired tool-call history.

--- a/internal/agent/tool_placement_test.go
+++ b/internal/agent/tool_placement_test.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// recordingPlacementProvider logs every request before delegating to the
+// shared-window fake, so placement tests can assert provider traffic.
+type recordingPlacementProvider struct {
+	sharedWindowTestProvider
+	requests []provider.Request
+}
+
+func (p *recordingPlacementProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.requests = append(p.requests, req)
+	return p.sharedWindowTestProvider.Stream(ctx, req)
+}
+
+// TestMaintainForPlacementFoldsAtSoftLine pins the placement check: once a
+// tool result pushes the view past the fold trigger, maintenance runs at that
+// result's placement — before the next one rides in on a full context.
+func TestMaintainForPlacementFoldsAtSoftLine(t *testing.T) {
+	prov := &recordingPlacementProvider{sharedWindowTestProvider: sharedWindowTestProvider{budget: 128 * 1024, shared: true}}
+	sess := foldableSessionOverForce(6)
+	a := agentOverForceWindow(t, prov, sess, 50_000)
+	big := strings.Repeat("word ", 400)
+	for a.estimatedVisibleRequestTokens(a.modelVisibleMessages()) < a.compactTrigger()+2_000 {
+		sess.Add(provider.Message{Role: provider.RoleAssistant, Content: big})
+		sess.Add(provider.Message{Role: provider.RoleUser, Content: "continue"})
+	}
+	before := a.currentProjectionVersion()
+
+	a.maintainForPlacement(context.Background())
+
+	if a.currentProjectionVersion() == before && len(prov.requests) == 0 {
+		t.Fatal("past the soft line, placement maintenance did nothing")
+	}
+	if est, fold := a.estimatedVisibleRequestTokens(a.modelVisibleMessages()), a.compactTrigger(); est >= fold {
+		t.Fatalf("view still at or past soft line: %d >= %d", est, fold)
+	}
+}
+
+// TestMaintainForPlacementNoopBelowSoftLine guards the common case: a healthy
+// placement pays only one estimate and never touches the provider.
+func TestMaintainForPlacementNoopBelowSoftLine(t *testing.T) {
+	prov := &recordingPlacementProvider{sharedWindowTestProvider: sharedWindowTestProvider{budget: 128 * 1024, shared: true}}
+	a := agentOverForceWindow(t, prov, foldableSessionOverForce(6), 50_000)
+
+	a.maintainForPlacement(context.Background())
+
+	if len(prov.requests) != 0 || a.currentProjectionVersion() != 0 {
+		t.Fatalf("below-line noop changed state: requests=%d version=%d",
+			len(prov.requests), a.currentProjectionVersion())
+	}
+}
+
+// TestPlacementCheckStrideScalesWithWindow pins the stride invariant: a
+// quarter of the soft-to-hard safety band, expressed in bytes, with a floor
+// for degenerate tiny windows and a fixed fallback when no window is set.
+func TestPlacementCheckStrideScalesWithWindow(t *testing.T) {
+	prov := &recordingPlacementProvider{sharedWindowTestProvider: sharedWindowTestProvider{budget: 128 * 1024, shared: true}}
+
+	// 50K window, CompactRatio 0.5: band = (50_000-256) - 25_000 = 24_744 tokens;
+	// stride = 24_744/4 = 6_186 tokens × 4 chars/token = 24_744 bytes.
+	a := agentOverForceWindow(t, prov, foldableSessionOverForce(2), 50_000)
+	if got, want := a.placementCheckStrideBytes(), 24_744; got != want {
+		t.Fatalf("50K window stride = %d, want %d", got, want)
+	}
+
+	// 5K window: band = (5_000-256) - 2_500 = 2_244 tokens; 2_244/4 = 561 < 2_048 → floor.
+	small := agentOverForceWindow(t, prov, foldableSessionOverForce(2), 5_000)
+	if got, want := small.placementCheckStrideBytes(), 8*1024; got != want {
+		t.Fatalf("5K window stride = %d, want floor %d", got, want)
+	}
+
+	// No window configured: fixed fallback.
+	nowin := agentOverForceWindow(t, prov, foldableSessionOverForce(2), 0)
+	if got, want := nowin.placementCheckStrideBytes(), 64*1024; got != want {
+		t.Fatalf("no-window stride = %d, want fallback %d", got, want)
+	}
+}
+
+// TestPlacementGovernanceLeavesRoomySessionsUntouched pins the zero-impact
+// contract: below the soft line every placement pays at most one local
+// estimate and the provider is never called; the view is never folded.
+func TestPlacementGovernanceLeavesRoomySessionsUntouched(t *testing.T) {
+	prov := &recordingPlacementProvider{sharedWindowTestProvider: sharedWindowTestProvider{budget: 128 * 1024, shared: true}}
+	a := agentOverForceWindow(t, prov, foldableSessionOverForce(6), 50_000)
+
+	a.maintainForPlacement(context.Background())
+	a.maintainForPlacement(context.Background())
+
+	if prov.calls != 0 || a.currentProjectionVersion() != 0 {
+		t.Fatalf("roomy placement checks changed state: calls=%d version=%d",
+			prov.calls, a.currentProjectionVersion())
+	}
+}


### PR DESCRIPTION
## Summary

Two complementary changes against the tool-result accumulation and burst gap in the compaction family:

1. **Observability** — `ContextReport` gains `ToolResultTokens` / `ChatTokens` / `SchemaTokens`, classifying the model-visible view by consumer so maintainers can see who actually eats the window before tuning any governance. Units are the planning estimator and documented as incomparable with window-denominated fields (only ratios between the two buckets carry meaning).

2. **Placement governance** — `handleToolRound`'s result-append loop now checks the fold trigger at result placement: the moment a tool result lands the view past the soft line (~80%), the pressure ladder runs **right then** (free view-side prune first, then fold), so the next result never rides in on a context already past the maintenance threshold — instead of bouncing off the hard ceiling at the next sampling request with the expensive rescue path.

Design points:

- The full-view estimate is a char scan (~0.8ms @ 200K tokens, ~3-4ms @ 1M — see the included benchmark), so checks are gated on a **window-scaled byte stride**: a quarter of the soft-to-hard safety band (~25KB at a 128K window, ~200KB at 1M). Scale-free invariant: unnoticed overshoot can never exceed a fraction of the band, so the check cannot jump from the soft line straight to the hard ceiling on any window size.
- `Prepare`'s existing blocked-receipt backoff prevents thrashing; compaction mid-batch runs only after a complete tool message is appended, so the visible view at check time is pairing-valid (same shape as a sampling boundary).
- **Below the soft line every path is byte-identical** — no provider calls, no folds, no projection churn — pinned by a zero-impact guard test.

## Issues

Refs #9059 — addresses the accumulation/burst half; the manual-deadlock half is #9474.
Refs #9082

Note for maintainers: no file overlap with #9474 (this touches `run_loop.go` / `agent.go` / `context_report.go`; that touches `context_manager.go`), but suggesting to merge after it for reviewer continuity in the same area.

## Verification

- `go test ./internal/agent -run 'TestContextReport' -count=1 -v` — 4/4 PASS (incl. exact-arithmetic breakdown test)
- `go test ./internal/agent -run 'TestMaintainForPlacement|TestPlacementCheckStride|TestPlacementGovernance' -count=1 -v` — 4/4 PASS (soft-line fold, below-line no-op, stride scaling with exact values 24744/8192/65536, zero-impact guard)
- `go test ./internal/agent -count=1` — ok (~21s)
- `go test ./internal/control -count=1` — ok
- `gofmt -l internal/agent` — empty; `go vet ./internal/agent` — clean
- `go test ./internal/agent -bench BenchmarkEstimatorCheck -benchmem -run '^$'` — ~0.8ms/op @ 200K tokens, ~3-4ms/op @ 1M (the cost the stride gate bounds)

Strictly additive: 118 insertions, 0 deletions across production files.

## Documentation impact

Documentation-impact: none - no configuration, CLI, or tool surface changes; ContextReport gains read-only fields.

## Cache impact

Cache-impact: low - below the soft line every placement costs at most one local estimate and no provider-visible byte changes (pinned by TestPlacementGovernanceLeavesRoomySessionsUntouched); above it, the fold that would otherwise happen at the next request happens one stride earlier, and the blocked-receipt backoff bounds how often.
Cache-guard: `go test ./internal/agent -run 'TestPlacementGovernance|TestMaintainForPlacementNoopBelowSoftLine' -count=1 -v`.
System-prompt-review: N/A - no provider-visible prompt, tool schema, or request serialization changed.