### PR TITLE
test: make release gates portable on Windows

### DIFF
--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -996,16 +996,24 @@ try {
       await page.mouse.move(nativeThumbProbe.x, candidateY);
       await page.mouse.down();
       await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.nativeScrollbarDrag === "true");
-      await page.mouse.move(nativeThumbProbe.x, candidateY + 48, { steps: 2 });
-      await page.waitForTimeout(150);
+      await page.mouse.move(nativeThumbProbe.x, candidateY + 24);
+      await page.waitForTimeout(24);
+      const midpoint = await transcript.evaluate((element) => ({
+        scrollTop: element.scrollTop,
+        clientHeight: element.clientHeight,
+      }));
+      await page.mouse.move(nativeThumbProbe.x, candidateY + 48);
+      await page.waitForTimeout(24);
       const motion = await transcript.evaluate((element) => ({
         scrollTop: element.scrollTop,
         clientHeight: element.clientHeight,
       }));
-      thumbCandidateMotions.push({ offset, scrollTop: motion.scrollTop });
-      // A 48px thumb move traverses several viewports in this fixture. A
-      // track/button press moves at most one page and is not a valid drag hit.
-      if (motion.scrollTop > motion.clientHeight * 2.5) {
+      thumbCandidateMotions.push({ offset, midpoint: midpoint.scrollTop, scrollTop: motion.scrollTop });
+      // A real thumb follows both pointer increments. A held track/button can
+      // auto-repeat across several pages and used to satisfy the old absolute
+      // distance check even though later pointer movement had no effect.
+      if (motion.scrollTop > motion.clientHeight * 2.5
+        && motion.scrollTop - midpoint.scrollTop > motion.clientHeight) {
         nativeThumbY = candidateY;
         nativeThumbDragY = candidateY + 48;
         break;
@@ -1019,6 +1027,31 @@ try {
     // Continue the same pointer transaction that proved native input was
     // delivered. Releasing, resetting, and reusing the old Y coordinate does
     // not prove the browser theme exposed the thumb at that coordinate again.
+    // Finish the browser-owned drag before asynchronous DOM probes: Chromium
+    // can stop delivering native-track movement after a held transaction is
+    // interrupted by fixture mutations even though pointer ownership remains.
+    const nativeTailSamples = [];
+    const nativeDragStepCount = 24;
+    for (let step = 1; step <= nativeDragStepCount; step += 1) {
+      const y = nativeThumbDragY + ((nativeThumbProbe.bottomY - nativeThumbDragY) * step) / nativeDragStepCount;
+      await page.mouse.move(nativeThumbProbe.x, y);
+      // Give Chromium one frame to apply each browser-owned thumb movement;
+      // coalescing one large synthetic move can skip the native track's
+      // intermediate geometry while Virtuoso swaps its mounted range.
+      await page.waitForTimeout(24);
+      const sample = await transcript.evaluate((element) => ({
+        scrollTop: element.scrollTop,
+        scrollHeight: element.scrollHeight,
+        clientHeight: element.clientHeight,
+        bottomDistance: element.scrollHeight - element.scrollTop - element.clientHeight,
+        mode: element.dataset.scrollMode,
+      }));
+      nativeTailSamples.push({ y: Math.round(y), ...sample });
+      if (sample.bottomDistance <= 4) break;
+    }
+    const nativeTailTerminal = nativeTailSamples.at(-1);
+    assert(nativeTailSamples.every((sample) => sample.mode === "native-thumb"), `native thumb retains ownership through the delivered drag (${JSON.stringify(nativeTailSamples)})`);
+    assert(nativeTailTerminal?.bottomDistance <= 4, `native thumb drag reaches the physical bottom (${JSON.stringify(nativeTailSamples)})`);
     nativeThumbProbe = await transcript.evaluate((element, input) => {
       element.querySelectorAll('[data-native-scrollbar-probe="true"]').forEach((node) => {
         if (node instanceof HTMLElement) delete node.dataset.nativeScrollbarProbe;
@@ -1091,28 +1124,6 @@ try {
     assert(duringNativeThumbDrag.knownSize === nativeDragBaseline.knownSize, `native thumb drag freezes new row measurements (${duringNativeThumbDrag.knownSize}px)`);
     assert(duringNativeThumbDrag.fixedHeight === nativeDragBaseline.fixedHeight, `native thumb drag fixes mounted row layout (${duringNativeThumbDrag.fixedHeight})`);
     assert(Math.abs(duringNativeThumbDrag.scrollHeight - nativeDragBaseline.scrollHeight) <= 8, `native thumb drag keeps the physical scroll range stable (${nativeDragBaseline.scrollHeight} → ${duringNativeThumbDrag.scrollHeight}; row ${duringNativeThumbDrag.rowHeight}; list ${duringNativeThumbDrag.listHeight})`);
-    const nativeTailSamples = [];
-    const nativeDragStepCount = 24;
-    for (let step = 1; step <= nativeDragStepCount; step += 1) {
-      const y = nativeThumbDragY + ((nativeThumbProbe.bottomY - nativeThumbDragY) * step) / nativeDragStepCount;
-      await page.mouse.move(nativeThumbProbe.x, y);
-      // Give Chromium one frame to apply each browser-owned thumb movement;
-      // coalescing one large synthetic move can skip the native track's
-      // intermediate geometry while Virtuoso swaps its mounted range.
-      await page.waitForTimeout(24);
-      const sample = await transcript.evaluate((element) => ({
-        scrollTop: element.scrollTop,
-        scrollHeight: element.scrollHeight,
-        clientHeight: element.clientHeight,
-        bottomDistance: element.scrollHeight - element.scrollTop - element.clientHeight,
-        mode: element.dataset.scrollMode,
-      }));
-      nativeTailSamples.push({ y: Math.round(y), ...sample });
-      if (sample.bottomDistance <= 4) break;
-    }
-    const nativeTailTerminal = nativeTailSamples.at(-1);
-    assert(nativeTailSamples.every((sample) => sample.mode === "native-thumb"), `native thumb retains ownership through the delivered drag (${JSON.stringify(nativeTailSamples)})`);
-    assert(nativeTailTerminal?.bottomDistance <= 4, `native thumb drag reaches the physical bottom (${JSON.stringify(nativeTailSamples)})`);
     await page.mouse.up();
     await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.nativeScrollbarDrag !== "true");
     await transcript.evaluate((element) => {

--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -320,7 +320,7 @@ try {
     max: element.scrollHeight - element.clientHeight,
   }));
   assert(hydrationStart.max > 0, `async hydration fixture is scrollable (${hydrationStart.max}px)`);
-  await page.mouse.move(hydrationBox.x + hydrationBox.width / 2, hydrationBox.y + hydrationBox.height / 2);
+  await moveToOuterReaderGutter(page, hydrationTranscript);
   await page.mouse.wheel(0, hydrationStart.top < hydrationStart.max / 2 ? 360 : -360);
   await page.waitForFunction(
     (startTop) => {

--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -1008,14 +1008,27 @@ try {
         scrollTop: element.scrollTop,
         clientHeight: element.clientHeight,
       }));
-      thumbCandidateMotions.push({ offset, midpoint: midpoint.scrollTop, scrollTop: motion.scrollTop });
-      // A real thumb follows both pointer increments. A held track/button can
-      // auto-repeat across several pages and used to satisfy the old absolute
-      // distance check even though later pointer movement had no effect.
+      await page.mouse.move(nativeThumbProbe.x, candidateY + 96);
+      await page.waitForTimeout(24);
+      const confirmation = await transcript.evaluate((element) => ({
+        scrollTop: element.scrollTop,
+        clientHeight: element.clientHeight,
+      }));
+      thumbCandidateMotions.push({
+        offset,
+        midpoint: midpoint.scrollTop,
+        scrollTop: motion.scrollTop,
+        confirmation: confirmation.scrollTop,
+      });
+      // A real thumb follows every pointer increment. A held track/button can
+      // auto-repeat across several pages and can satisfy the first two distance
+      // checks before stopping. Require a third, farther move to prove that the
+      // browser-owned control keeps following the pointer transaction.
       if (motion.scrollTop > motion.clientHeight * 2.5
-        && motion.scrollTop - midpoint.scrollTop > motion.clientHeight) {
+        && motion.scrollTop - midpoint.scrollTop > motion.clientHeight
+        && confirmation.scrollTop - motion.scrollTop > confirmation.clientHeight * 2) {
         nativeThumbY = candidateY;
-        nativeThumbDragY = candidateY + 48;
+        nativeThumbDragY = candidateY + 96;
         break;
       }
       await page.mouse.up();

--- a/desktop/transcript_selection_smoke_contract.js
+++ b/desktop/transcript_selection_smoke_contract.js
@@ -21,23 +21,50 @@
     const scoped = [...document.querySelectorAll('.transcript-selection-action[data-surface="transcript"]')];
     return scoped.length > 0 ? scoped : [...document.querySelectorAll("body > .transcript-selection-action")];
   };
+  const selectionTableTopic = () => [...document.querySelectorAll(".project-tree__topic-main")]
+    .find((element) => element.textContent?.includes("bench:selection-table"));
+  const activateSelectionTableTopic = async (timeout = 30000) => {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      const topic = selectionTableTopic();
+      if (topic?.closest(".project-tree__topic--active")) return topic;
+      if (topic) {
+        topic.click();
+        // ProjectTree intentionally delays single-click opening by 200ms so a
+        // double click can become rename. It can also render the topic before
+        // its openRequest is ready, in which case the click is ignored. Wait
+        // beyond that decision window, then retry only while still inactive.
+        const attemptDeadline = Math.min(deadline, Date.now() + 750);
+        while (Date.now() < attemptDeadline) {
+          if (selectionTableTopic()?.closest(".project-tree__topic--active")) {
+            return selectionTableTopic();
+          }
+          await wait(50);
+        }
+      } else {
+        await wait(50);
+      }
+    }
+    throw new Error("timed out activating selection table topic");
+  };
 
   const start = async () => {
-    const topic = await waitFor(
-      () => [...document.querySelectorAll(".project-tree__topic-main")]
-        .find((element) => element.textContent?.includes("bench:selection-table")),
-      "selection table topic",
-    );
-    topic.click();
+    await activateSelectionTableTopic();
     const target = await waitFor(
-      () => [...document.querySelectorAll("strong")]
-        .find((element) => element.textContent?.includes("SELECTION REPAINT TARGET")),
+      () => {
+        const target = [...document.querySelectorAll("strong")]
+          .find((element) => element.textContent?.includes("SELECTION REPAINT TARGET"));
+        if (target) return target;
+        // The marker is in the fixture's final virtual row. WebView2 can
+        // publish the active topic before Virtuoso performs its initial tail
+        // landing, leaving that row unmounted indefinitely. Keep setup on the
+        // physical bottom until the final row exists; all compositor captures
+        // still begin only after the target is centered and settled below.
+        const transcript = document.querySelector(".transcript");
+        if (transcript instanceof HTMLElement) transcript.scrollTop = transcript.scrollHeight;
+        return null;
+      },
       "selection repaint target",
-    );
-    await waitFor(
-      () => document.querySelector(".project-tree__topic--active .project-tree__topic-label")
-        ?.textContent?.includes("bench:selection-table"),
-      "active selection table topic",
     );
     await waitFor(() => !document.querySelector(".transcript-navigation-overlay"), "settled transcript navigation");
     target.scrollIntoView({ block: "center", inline: "nearest" });

--- a/internal/plugin/oauth_test.go
+++ b/internal/plugin/oauth_test.go
@@ -742,8 +742,8 @@ func TestClearedOAuthStateCannotBeResurrectedByStaleTransport(t *testing.T) {
 	if changed, err := ClearHTTPMCPOAuth(Spec{StateDir: stateDir}); err != nil || !changed {
 		t.Fatalf("ClearHTTPMCPOAuth = (%v, %v), want (true, nil)", changed, err)
 	}
-	if _, err := transport.call(context.Background(), "ping", nil); err == nil || !strings.Contains(err.Error(), "no refresh token") {
-		t.Fatalf("stale transport call error = %v, want cleared-state failure", err)
+	if _, err := transport.call(context.Background(), "ping", nil); err == nil {
+		t.Fatal("stale transport call unexpectedly succeeded after clearing OAuth state")
 	}
 	if _, err := os.Stat(filepath.Join(stateDir, mcpOAuthStateFile)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("stale transport recreated OAuth state: %v", err)

--- a/internal/serve/multisession_test.go
+++ b/internal/serve/multisession_test.go
@@ -33,6 +33,15 @@ func (replayStubController) ReplayPendingPromptsWith(factory func() event.Sink) 
 	factory().Emit(event.Event{Kind: event.ApprovalRequest})
 }
 
+func sessionPathFromFrame(t *testing.T, frame []byte) string {
+	t.Helper()
+	var wired eventwire.Event
+	if err := json.Unmarshal(frame, &wired); err != nil {
+		t.Fatalf("decode event frame: %v\nframe=%s", err, frame)
+	}
+	return wired.SessionPath
+}
+
 type replayRaceController struct {
 	control.SessionAPI
 	path     string
@@ -258,8 +267,8 @@ func TestReplayPendingPromptsBroadcastTagsFrames(t *testing.T) {
 	server.replayPendingPromptsBroadcast()
 	select {
 	case frame := <-all:
-		if !strings.Contains(string(frame), `"sessionPath":"/sessions/a.jsonl"`) {
-			t.Fatalf("replayed frame is untagged: %s", frame)
+		if got, want := sessionPathFromFrame(t, frame), agent.CanonicalSessionPath("/sessions/a.jsonl"); got != want {
+			t.Fatalf("replayed frame session path = %q, want %q: %s", got, want, frame)
 		}
 	default:
 		t.Fatal("pending prompt was not replayed")
@@ -313,7 +322,7 @@ func TestEventsReplayUsesControllerCapturedWithPath(t *testing.T) {
 		t.Fatalf("event stream ended before the next frame: %v", scanner.Err())
 		return ""
 	}
-	if first := nextData(); !strings.Contains(first, `"sessionPath":"/sessions/a.jsonl"`) {
+	if first := nextData(); sessionPathFromFrame(t, []byte(first)) != agent.CanonicalSessionPath(a.path) {
 		t.Fatalf("first frame = %s, want controller A replay", first)
 	}
 	select {
@@ -321,7 +330,7 @@ func TestEventsReplayUsesControllerCapturedWithPath(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("controller promotion remained blocked after subscription")
 	}
-	if second := nextData(); !strings.Contains(second, `"sessionPath":"/sessions/b.jsonl"`) {
+	if second := nextData(); sessionPathFromFrame(t, []byte(second)) != agent.CanonicalSessionPath(b.path) {
 		t.Fatalf("second frame = %s, want promoted controller B prompt", second)
 	}
 }
@@ -375,8 +384,8 @@ func TestSlashNewRefreshesControllerTagAndForegroundRoute(t *testing.T) {
 		if newPath == agent.CanonicalSessionPath(path) || tag.Path() != newPath || bc.CurrentSession() != newPath {
 			t.Fatalf("slash /new routing = controller %q tag %q broadcaster %q frame=%s", newPath, tag.Path(), bc.CurrentSession(), frame)
 		}
-		if !strings.Contains(string(frame), `"sessionPath":"`+newPath+`"`) {
-			t.Fatalf("slash /new notice kept the old session tag: %s", frame)
+		if got := sessionPathFromFrame(t, frame); got != newPath {
+			t.Fatalf("slash /new notice session path = %q, want %q: %s", got, newPath, frame)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("slash /new emitted no event")

--- a/internal/topicstate/store_test.go
+++ b/internal/topicstate/store_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -59,7 +60,7 @@ func TestStorePersistsAtomicTopicRecord(t *testing.T) {
 	}
 	if info, err := os.Stat(path); err != nil {
 		t.Fatal(err)
-	} else if info.Mode().Perm() != 0o600 {
+	} else if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("database mode = %o, want 600", info.Mode().Perm())
 	}
 }

--- a/internal/turnevent/ledger_test.go
+++ b/internal/turnevent/ledger_test.go
@@ -19,6 +19,20 @@ func testSessionPath(t *testing.T) string {
 	return filepath.Join(t.TempDir(), "session.jsonl")
 }
 
+func openTestLedger(t *testing.T, sessionPath, sessionID string) *Ledger {
+	t.Helper()
+	ledger, err := Open(sessionPath, sessionID)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := ledger.Close(); err != nil {
+			t.Errorf("Close test ledger: %v", err)
+		}
+	})
+	return ledger
+}
+
 func TestLedgerPersistsMonotonicEventsAndExactlyOneTerminal(t *testing.T) {
 	path := testSessionPath(t)
 	l, err := Open(path, "session")
@@ -62,10 +76,7 @@ func TestLedgerPersistsMonotonicEventsAndExactlyOneTerminal(t *testing.T) {
 
 func TestLedgerProjectionCursorReplaysOnlyActiveTurn(t *testing.T) {
 	path := testSessionPath(t)
-	l, err := Open(path, "session")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	l := openTestLedger(t, path, "session")
 	if _, err := l.Begin(); err != nil {
 		t.Fatalf("Begin first: %v", err)
 	}
@@ -88,10 +99,7 @@ func TestLedgerProjectionCursorReplaysOnlyActiveTurn(t *testing.T) {
 
 func TestLedgerSubmissionReceiptSurvivesCompletionAndIsOneShot(t *testing.T) {
 	path := testSessionPath(t)
-	l, err := Open(path, "session")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	l := openTestLedger(t, path, "session")
 	l.SetRoutingMetadata("epoch-1", "submission-1")
 	first, err := l.Begin()
 	if err != nil {
@@ -127,10 +135,7 @@ func TestLedgerSubmissionReceiptSurvivesCompletionAndIsOneShot(t *testing.T) {
 }
 
 func TestLedgerRejectsStatusRegressionAndKeepsCancellationSticky(t *testing.T) {
-	l, err := Open(testSessionPath(t), "session")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	l := openTestLedger(t, testSessionPath(t), "session")
 	if _, err := l.Begin(); err != nil {
 		t.Fatalf("Begin: %v", err)
 	}
@@ -151,10 +156,7 @@ func TestLedgerRejectsStatusRegressionAndKeepsCancellationSticky(t *testing.T) {
 
 func TestLedgerRepairsTornTailAndKeepsValidPrefix(t *testing.T) {
 	path := testSessionPath(t)
-	l, err := Open(path, "session")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	l := openTestLedger(t, path, "session")
 	if _, err := l.Begin(); err != nil {
 		t.Fatalf("Begin: %v", err)
 	}
@@ -171,10 +173,7 @@ func TestLedgerRepairsTornTailAndKeepsValidPrefix(t *testing.T) {
 	}
 	_ = f.Close()
 
-	reopened, err := Open(path, "session")
-	if err != nil {
-		t.Fatalf("reopen: %v", err)
-	}
+	reopened := openTestLedger(t, path, "session")
 	recs, err := reopened.EventsAfter(0)
 	if err != nil {
 		t.Fatalf("EventsAfter: %v", err)
@@ -193,10 +192,7 @@ func TestLedgerRepairsTornTailAndKeepsValidPrefix(t *testing.T) {
 
 func TestLedgerIsolatesNonMonotonicTail(t *testing.T) {
 	path := testSessionPath(t)
-	l, err := Open(path, "session")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	l := openTestLedger(t, path, "session")
 	if _, err := l.Begin(); err != nil {
 		t.Fatalf("Begin: %v", err)
 	}
@@ -213,10 +209,7 @@ func TestLedgerIsolatesNonMonotonicTail(t *testing.T) {
 	}
 	_ = f.Close()
 
-	reopened, err := Open(path, "session")
-	if err != nil {
-		t.Fatalf("reopen: %v", err)
-	}
+	reopened := openTestLedger(t, path, "session")
 	recs, err := reopened.EventsAfter(0)
 	if err != nil {
 		t.Fatalf("EventsAfter: %v", err)
@@ -232,10 +225,7 @@ func TestLedgerIsolatesNonMonotonicTail(t *testing.T) {
 
 func TestLedgerRecoveryClosesRunningToolsWithoutReplay(t *testing.T) {
 	path := testSessionPath(t)
-	l, err := Open(path, "session")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	l := openTestLedger(t, path, "session")
 	if _, err := l.Begin(); err != nil {
 		t.Fatalf("Begin: %v", err)
 	}
@@ -248,10 +238,7 @@ func TestLedgerRecoveryClosesRunningToolsWithoutReplay(t *testing.T) {
 		t.Fatalf("append dispatch: ok=%v err=%v", ok, err)
 	}
 
-	reopened, err := Open(path, "session")
-	if err != nil {
-		t.Fatalf("reopen: %v", err)
-	}
+	reopened := openTestLedger(t, path, "session")
 	recs, err := reopened.EventsAfter(0)
 	if err != nil {
 		t.Fatalf("EventsAfter: %v", err)
@@ -302,10 +289,7 @@ func TestLedgerBootstrapsLegacyTranscriptWithoutRewritingIt(t *testing.T) {
 
 func TestLedgerReplayEmptyArrayAndUnknownFields(t *testing.T) {
 	path := testSessionPath(t)
-	l, err := Open(path, "session")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	l := openTestLedger(t, path, "session")
 	recs, err := l.EventsAfter(99)
 	if err != nil {
 		t.Fatalf("EventsAfter empty: %v", err)
@@ -328,10 +312,7 @@ func TestLedgerReplayEmptyArrayAndUnknownFields(t *testing.T) {
 	if err := os.WriteFile(ledgerPath, data, 0o600); err != nil {
 		t.Fatalf("rewrite with unknown field: %v", err)
 	}
-	_, err = Open(path, "session")
-	if err != nil {
-		t.Fatalf("unknown fields must be ignored: %v", err)
-	}
+	openTestLedger(t, path, "session")
 }
 
 func TestLedgerPersistentHandleTerminalSyncAndProjectionAckOpenCounts(t *testing.T) {
@@ -428,10 +409,7 @@ func TestLedgerCompactionWaitsForProjectionAckAndReplayResetsAtCheckpoint(t *tes
 }
 
 func TestLedgerReplayPaginationAndOutOfRangeCursor(t *testing.T) {
-	l, err := Open(testSessionPath(t), "session")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	l := openTestLedger(t, testSessionPath(t), "session")
 	if _, err := l.Begin(); err != nil {
 		t.Fatalf("Begin: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Decode serialized event frames before comparing canonical session paths on Windows.
- Keep the SQLite mode assertion on platforms that expose Unix permission bits.
- Close persistent test ledgers before TempDir cleanup so Windows can remove their sidecars.
- Distinguish real Linux native-thumb motion from held scrollbar-track auto-repeat with sustained pointer progress.
- Route hydration wheel replay through verified outer-row padding instead of potentially nested viewport-center content.
- Retry the native WebView2 topic after each delayed-click window and keep setup at the physical tail until its final virtual target mounts.
- Assert the cleared-OAuth safety invariant without coupling the test to SDK-specific error wording.
- Production behavior is unchanged; these fixes address v1.32.0 release-gate failures from CI run 33132640627 and its exact-head follow-ups.

## Issues

No linked issue.

## Verification

- go test -p 4 -timeout=8m ./...
- go test -race ./internal/serve ./internal/topicstate ./internal/turnevent
- Windows cross-compilation of the three affected Go test packages
- cd desktop && go test ./...
- pnpm test:transcript-browser
- pnpm test:motion
- pnpm test:transcript
- pnpm build
- node --check for both browser contracts
- injected native fixture replay in Chromium at 1200x800
- go test ./internal/plugin -run TestClearedOAuthStateCannotBeResurrectedByStaleTransport -count=100
- go test -race ./internal/plugin -run TestClearedOAuthStateCannotBeResurrectedByStaleTransport -count=20
- go test ./internal/plugin -count=1
- go run ./tools/repolint

## Documentation impact

Documentation-impact: none - test portability and release-fixture correctness only; user-facing behavior and embedded documentation are unchanged.

## Cache impact

Cache-impact: none - no provider-visible prompt, memory prefix, output style, or skill index changed.
Cache-guard: not required - the diff is limited to test assertions, cleanup, and release-fixture input classification.
System-prompt-review: N/A

