### PR TITLE
fix(desktop): Retry transient session removal contention / 重试短暂会话删除争用

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -9516,24 +9516,23 @@ func sessionPathAfterSnapshot(ctrl control.SessionAPI, fallback string) string {
 
 var (
 	// sessionLeaseContentionRetryInterval and sessionLeaseContentionRetryAttempts
-	// bound the retry window for startup session-lease binds that hit a
-	// transient in-process holder. CleanupStaleRunning probes a running
-	// sub-agent's parent session lease inside every controller build, holding
-	// it only for the duration of a metadata rewrite (sub-millisecond); a
-	// concurrent tab build that races that probe must not surface a spurious
-	// "already open in another Reasonix window" error for a lease that is
-	// genuinely free once the probe releases it. A lease held by another
-	// window or process stays held for its whole lifetime, so the bounded
-	// retry still fails fast there.
+	// bound the retry window for lease or removal-guard acquisition that hits a
+	// transient in-process holder. CleanupStaleRunning and catalog persistence
+	// can hold the session lease or save lock briefly while a concurrent tab
+	// bind or archive begins; those callers must not surface a spurious
+	// "already open in another Reasonix window" error for ownership that is
+	// genuinely free once the short operation finishes. A lease held by another
+	// window or process stays held for its whole lifetime, so the bounded retry
+	// still fails fast there.
 	sessionLeaseContentionRetryInterval = 50 * time.Millisecond
 	sessionLeaseContentionRetryAttempts = 2
 )
 
 // withSessionLeaseContentionRetry retries acquire while it fails with
 // agent.ErrSessionLeaseHeld, absorbing sub-second contention windows created
-// by transient in-process lease probes. Any other error is returned
-// immediately, and a lease that remains held after the bounded retries is
-// reported as-is.
+// by transient in-process lease or save-lock holders. Any other error is
+// returned immediately, and a lease that remains held after the bounded
+// retries is reported as-is.
 func withSessionLeaseContentionRetry[T any](acquire func() (T, error)) (T, error) {
 	var zero T
 	for attempt := 0; ; attempt++ {

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -192,7 +192,9 @@ var errSessionBusyElsewhere = errors.New("session is in use by another Reasonix 
 // would let another process acquire the lease in between and then lose its
 // freshly locked lease file, breaking cross-process mutual exclusion.
 func acquireSessionRemovalGuard(sessionPath string) (*agent.SessionRemovalGuard, error) {
-	guard, err := agent.TryAcquireSessionRemovalGuard(sessionPath)
+	guard, err := withSessionLeaseContentionRetry(func() (*agent.SessionRemovalGuard, error) {
+		return agent.TryAcquireSessionRemovalGuard(sessionPath)
+	})
 	if err != nil {
 		if errors.Is(err, agent.ErrSessionLeaseHeld) {
 			return nil, errSessionBusyElsewhere

--- a/desktop/startup_lease_contention_test.go
+++ b/desktop/startup_lease_contention_test.go
@@ -79,3 +79,38 @@ func TestEnsureTabSessionLeaseForRebuildSurvivesTransientHolder(t *testing.T) {
 		t.Fatalf("tab lease key = %q, want %q", key, sessionRuntimeKey(path))
 	}
 }
+
+func TestAcquireSessionRemovalGuardSurvivesTransientHolder(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "contended-removal.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"keep"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+
+	lease, err := agent.TryAcquireSessionLease(sessionRuntimeKey(path))
+	if err != nil {
+		t.Fatalf("transient lease acquire: %v", err)
+	}
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		lease.Release()
+		close(released)
+	}()
+
+	started := time.Now()
+	guard, err := acquireSessionRemovalGuard(path)
+	if err != nil {
+		<-released
+		t.Fatalf("removal guard failed against a transient holder: %v", err)
+	}
+	defer guard.Release()
+	<-released
+	if elapsed := time.Since(started); elapsed < sessionLeaseContentionRetryInterval {
+		t.Fatalf("removal guard did not exercise contention retry: elapsed=%s", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

- reuse the existing 2 × 50 ms bounded lease-contention retry when acquiring a destructive session removal guard
- avoid reporting a false cross-window busy error when catalog persistence or another short in-process holder is just releasing the session lock
- preserve the existing refusal for a persistent foreign holder, adding at most 100 ms before the same sanitized error
- add a deterministic regression test that holds and releases a transient lease during removal-guard acquisition

## Release blocker evidence

The exact `main-v2` release candidate failed `desktop-windows` twice in `TestRestoreGlobalTopicSessionReindexesProjectTree` with `session is in use by another Reasonix window or process`. The same test reproduced locally once in 50 normal runs, while slower race runs passed, confirming a timing window rather than a release-note or Windows-path assertion issue.

## Verification

- `go test -run '^TestRestoreGlobalTopicSessionReindexesProjectTree$' -count=100`
- `go test -race -run '^(TestAcquireSessionRemovalGuardSurvivesTransientHolder|TestRestoreGlobalTopicSessionReindexesProjectTree|TestTrashTopicForeignLeaseFailsBeforeCleanupCommit)$' -count=20`
- targeted lease/removal tests with `-count=10`
- `cd desktop && go test ./...`
- `git diff --check`

## Documentation impact

Documentation-impact: none - existing session archive documentation remains correct because persistent holders still fail closed with the same public error; this only retries a transient internal lock for at most 100 ms.

## Risk

Persistent holders still fail closed through the same removal guard and sanitized error. The change only absorbs the already-defined 100 ms transient contention window.