### PR TITLE
docs(release): include v1.32.0 archive reliability fix

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -439,6 +439,22 @@
               "desktop"
             ],
             "title": {
+              "en": "Reliable session archiving",
+              "zh": "可靠的会话归档"
+            },
+            "body": {
+              "en": "Session archiving now tolerates brief local lock handoffs without reporting that the session is still in use.",
+              "zh": "会话归档现在可容忍短暂的本地锁交接，不会误报会话仍在使用中。"
+            },
+            "refs": [
+              9502
+            ]
+          },
+          {
+            "targets": [
+              "desktop"
+            ],
+            "title": {
               "en": "Topic metadata migration",
               "zh": "主题元数据迁移"
             },


### PR DESCRIPTION
## Summary

- add the user-visible #9502 session-archiving reliability fix to the v1.32.0 bilingual release catalog
- keep the final release notes aligned with the actual latest main-v2 candidate
- change release documentation only; no runtime or workflow behavior changes

## Validation

- node scripts/release-notes.mjs validate
- node --test scripts/release-notes.test.mjs
- rendered v1.32.0 notes and verified the bilingual item and #9502 link
- git diff --check

Documentation-impact: release notes only; no additional product documentation changes are required.