### PR TITLE
fix(agent): preserve projection after system prompt refresh / 系统提示刷新后保留压缩投影

### DIFF
--- a/internal/agent/projection.go
+++ b/internal/agent/projection.go
@@ -476,8 +476,9 @@ func projectionValid(st CompactionState, msgs []provider.Message, cacheKey strin
 }
 
 // projectionContentValid reports whether st's projection body still matches the
-// canonical transcript, independent of provider/model lineage. LoadProjectionSidecar
-// uses it to rebind across upgrade/model/workspace key changes.
+// canonical transcript, independent of provider/model lineage. The covered hash
+// is authoritative, except for leading system messages: those live outside the
+// folded region and may be refreshed independently after a compaction.
 func projectionContentValid(st CompactionState, msgs []provider.Message) bool {
 	if len(st.Projection.Messages) == 0 {
 		return false
@@ -490,13 +491,34 @@ func projectionContentValid(st CompactionState, msgs []provider.Message) bool {
 	if st.Projection.CoveredPrefixHash == "" {
 		return false
 	}
-	if coveredPrefixHash(msgs, n) != st.Projection.CoveredPrefixHash {
+	if coveredPrefixHash(msgs, n) == st.Projection.CoveredPrefixHash {
+		return true
+	}
+	return projectionMatchesAfterSystemRefresh(st, msgs, n)
+}
+
+// projectionMatchesAfterSystemRefresh verifies a covered-prefix mismatch by
+// substituting the projection's previous leading system messages into the
+// current canonical prefix. A match proves that only the dynamic system prompt
+// changed; any user, assistant, tool, image, or signed-reasoning edit still
+// fails closed.
+func projectionMatchesAfterSystemRefresh(st CompactionState, msgs []provider.Message, n int) bool {
+	if n <= 0 || n > len(msgs) || len(st.Projection.Messages) == 0 {
 		return false
 	}
-	// TranscriptVersion is a process-local CAS generation that resets on load.
-	// The covered prefix hash is the durable identity across append-only growth
-	// and exact tail truncation.
-	return true
+	candidate := append([]provider.Message(nil), msgs[:n]...)
+	systems := 0
+	for systems < len(candidate) && candidate[systems].Role == provider.RoleSystem {
+		if systems >= len(st.Projection.Messages) || st.Projection.Messages[systems].Role != provider.RoleSystem {
+			return false
+		}
+		candidate[systems] = st.Projection.Messages[systems]
+		systems++
+	}
+	if systems == 0 || (systems < len(st.Projection.Messages) && st.Projection.Messages[systems].Role == provider.RoleSystem) {
+		return false
+	}
+	return coveredPrefixHash(candidate, len(candidate)) == st.Projection.CoveredPrefixHash
 }
 
 // modelVisibleFromProjection splices the projection with any messages appended
@@ -506,6 +528,12 @@ func modelVisibleFromProjection(proj ContextProjection, canonical []provider.Mes
 		return nil
 	}
 	out := append([]provider.Message(nil), proj.Messages...)
+	// Leading system messages are outside every fold. Refresh them from canonical
+	// so memory/tool/environment prompt updates do not serve a stale prefix or
+	// force a full-history replay.
+	for i := 0; i < len(canonical) && i < len(out) && canonical[i].Role == provider.RoleSystem && out[i].Role == provider.RoleSystem; i++ {
+		out[i] = canonical[i]
+	}
 	if proj.CoveredCount >= 0 && proj.CoveredCount < len(canonical) {
 		out = append(out, canonical[proj.CoveredCount:]...)
 	}

--- a/internal/agent/projection_valid_test.go
+++ b/internal/agent/projection_valid_test.go
@@ -49,6 +49,95 @@ func TestProjectionValidRejectsEditedPrefix(t *testing.T) {
 	}
 }
 
+func TestProjectionSurvivesDynamicSystemRefresh(t *testing.T) {
+	canonical := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system-v1"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleAssistant, Content: "done"},
+		{Role: provider.RoleUser, Content: "next"},
+	}
+	const key = "ws|session|model"
+	st := CompactionState{
+		TranscriptVersion: 4,
+		PromptCacheKey:    key,
+		Projection: ContextProjection{
+			Messages: []provider.Message{
+				{Role: provider.RoleSystem, Content: "system-v1"},
+				formatSummaryMessage("earlier task completed"),
+			},
+			TranscriptVersion: 4,
+			CoveredCount:      3,
+			CoveredPrefixHash: coveredPrefixHash(canonical, 3),
+		},
+	}
+
+	if !projectionValid(st, canonical, key) {
+		t.Fatal("matching projection should be valid")
+	}
+
+	refreshed := append([]provider.Message(nil), canonical...)
+	refreshed[0].Content = "system-v2"
+	if !projectionValid(st, refreshed, key) {
+		t.Fatal("dynamic system-only refresh invalidated the projection")
+	}
+	visible := modelVisibleFromProjection(st.Projection, refreshed)
+	if len(visible) == 0 || visible[0].Content != "system-v2" {
+		t.Fatalf("visible system = %+v, want refreshed system-v2", visible)
+	}
+	if len(visible) < 2 || !isCompactionSummary(visible[1]) {
+		t.Fatalf("projection summary was not retained: %+v", visible)
+	}
+
+	edited := append([]provider.Message(nil), refreshed...)
+	edited[1].Content = "different task"
+	if projectionValid(st, edited, key) {
+		t.Fatal("covered user edit was mistaken for a system-only refresh")
+	}
+}
+
+func TestLoadProjectionSidecarRestoresAfterDynamicSystemRefresh(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	original := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system-v1"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleAssistant, Content: "done"},
+		{Role: provider.RoleUser, Content: "next"},
+	}
+	key := promptCacheKey("ws", BranchID(path), "m")
+	if err := SaveCompactionState(path, CompactionState{
+		PromptCacheKey: key,
+		Projection: ContextProjection{
+			Messages: []provider.Message{
+				{Role: provider.RoleSystem, Content: "system-v1"},
+				formatSummaryMessage("earlier task completed"),
+			},
+			CoveredCount:      3,
+			CoveredPrefixHash: coveredPrefixHash(original, 3),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	sess := NewSession("system-v2")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "task"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "done"})
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "next"})
+	a := New(nil, nil, sess, Options{
+		SessionPath: path,
+		WorkspaceID: "ws",
+		ModelRef:    "m",
+	}, event.Discard)
+
+	if a.sess.checkpointState != "restored" {
+		t.Fatalf("checkpointState = %q, want restored", a.sess.checkpointState)
+	}
+	visible := a.modelVisibleMessages()
+	if len(visible) != 3 || visible[0].Content != "system-v2" || !isCompactionSummary(visible[1]) || visible[2].Content != "next" {
+		t.Fatalf("restored visible projection = %+v", visible)
+	}
+}
+
 func TestProjectionValidRejectsCacheKeyMismatch(t *testing.T) {
 	msgs := []provider.Message{
 		{Role: provider.RoleSystem, Content: "sys"},


### PR DESCRIPTION
## Summary

- keep a valid compaction projection when only its leading dynamic system message changed
- splice the latest canonical system prefix into the projected model view, so refreshed memory/tool/environment context is current without replaying the full canonical transcript
- fail closed for every non-system covered-prefix edit, and cover both live validation and restart/sidecar restoration

This deliberately does not duplicate the manual over-ceiling rescue in #9474. It addresses the projection-invalidation half of #9059 and makes the post-compaction system refresh proposed in #9450 retain the digest it just created.

## Issues

Refs #9059
Refs #9447
Refs #9450
Refs #9474

## Verification

- `go test -p 1 ./internal/agent -run 'Test(ProjectionSurvivesDynamicSystemRefresh|LoadProjectionSidecarRestoresAfterDynamicSystemRefresh|ProjectionValidRejectsEditedPrefix|ProjectionValidRejectsCacheKeyMismatch)$' -count=1` — PASS
- `go test -p 1 -vet=off ./internal/agent -count=1` — PASS (150.415s)
- `git diff --check` — clean

## Documentation impact

Documentation-impact: none - this repairs internal projection reuse and does not change CLI, Desktop, configuration, provider, permission, or tool documentation.

## Cache impact

Cache-impact: low - ordinary turns are byte-identical; when the leading system prompt changes, the cache already resets, and this change keeps the compacted digest instead of falling back to full canonical history.
Cache-guard: focused live-validation and restart-sidecar tests above assert the refreshed system prefix, retained digest, verbatim tail, and fail-closed covered user edits.
System-prompt-review: @SivanCola - no prompt text is added or rewritten; the latest existing system prefix is paired with the existing compacted projection after a low-frequency system refresh.