### PR TITLE
fix(desktop): retire completed Todo shelf / 完成待办后自动收起面板

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,6 +393,7 @@ jobs:
           pnpm --dir frontend test:motion
           pnpm --dir frontend test:motion-browser
           pnpm --dir frontend test:composer
+          pnpm --dir frontend test:todo-visibility
           pnpm --dir frontend test:transcript
           xvfb-run -a env REASONIX_TRANSCRIPT_NATIVE_THUMB=1 pnpm --dir frontend test:transcript-browser
 

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -13,7 +13,7 @@
     "check:css": "node scripts/check-css-syntax.mjs src/styles.css src/components/RemoteConnectWizard.css && node scripts/check-z-index-tokens.mjs src/styles.css src/components/RemoteConnectWizard.css && node scripts/check-theme-token-contract.mjs",
     "check:waapi": "node scripts/check-waapi-contract.mjs",
     "lint:hooks": "eslint \"src/**/*.{ts,tsx}\"",
-    "test:todo-visibility": "node scripts/test-todo-visibility.mjs",
+    "test:todo-visibility": "node scripts/test-todo-visibility.mjs && tsx src/__tests__/todo-panel-lifecycle.test.tsx",
     "typecheck": "tsc --noEmit",
     "test:terminal": "tsx src/__tests__/terminal-events.test.ts && tsx src/__tests__/terminal-store.test.ts && tsx src/__tests__/terminal-output.test.ts && tsx src/__tests__/terminal-theme.test.ts && tsx src/__tests__/terminal-selection.test.ts && tsx src/__tests__/workspace-layout.test.ts",
     "test:usage-stats": "tsx src/__tests__/usage-stats-format.test.ts && tsx src/__tests__/usage-stats-panel.test.tsx",

--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -87,7 +87,7 @@ assert.equal(
 assert.equal(
   shouldShowTodoPanel("todo-final", null, completedTodos),
   true,
-  "a completed todo list stays visible in collapsed form until the user dismisses it",
+  "a completed batch remains mounted so TodoPanel can distinguish restore from a live transition",
 );
 assert.equal(
   shouldShowTodoPanel("todo-active", null, [{ content: "Run tests", status: "in_progress" }]),

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2064,11 +2064,11 @@ export default function App() {
   // not advance the canonical panel state. Incomplete lists are always shown so
   // a stale local dismissal cannot hide work that still blocks final readiness;
   // every new list starts collapsed while its header keeps showing live progress
-  // and the current task; completed lists can then be dismissed. The dismissal
-  // key is still based on stable todo content/state so history reloads do not
-  // resurrect the same finished list under a different event id. The batch key
-  // ignores status so progress in the same list is not a new batch. Dismissal
-  // is scoped per session/topic/tab and also persisted on the session sidecar.
+  // and the current task. Live completion briefly shows 3/3 before retirement;
+  // restored completed lists stay in transcript only. The dismissal key is
+  // still based on stable todo content/state so history reloads do not
+  // resurrect the same finished list. The status-agnostic batch key prevents
+  // false new batches; dismissal remains session-scoped and sidecar-persisted.
   const todoEntry = useMemo(() => {
     for (let i = visibleRuntimeState.items.length - 1; i >= 0; i--) {
       const it = visibleRuntimeState.items[i];

--- a/desktop/frontend/src/__tests__/todo-panel-lifecycle.test.tsx
+++ b/desktop/frontend/src/__tests__/todo-panel-lifecycle.test.tsx
@@ -1,0 +1,148 @@
+// Run: tsx src/__tests__/todo-panel-lifecycle.test.tsx
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import React, { act } from "react";
+import { JSDOM } from "jsdom";
+import { createRoot } from "react-dom/client";
+
+import { TodoPanel } from "../components/TodoPanel";
+import { LocaleProvider } from "../lib/i18n";
+
+const todoCss = readFileSync(new URL("../styles.css", import.meta.url), "utf8");
+assert.match(
+  todoCss,
+  /\.todo-exit\s*\{[^}]*animation:\s*shelf-in 240ms 900ms ease reverse both;/s,
+  "the completion animation holds for 900ms before its 240ms fade",
+);
+
+const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+globalThis.Node = dom.window.Node;
+globalThis.HTMLElement = dom.window.HTMLElement;
+
+interface ScheduledTimer {
+  id: number;
+  at: number;
+  callback: () => void;
+}
+
+let now = 0;
+let nextTimerId = 1;
+let timers: ScheduledTimer[] = [];
+Object.defineProperty(window, "setTimeout", {
+  configurable: true,
+  value: (callback: () => void, delay = 0) => {
+    const id = nextTimerId++;
+    timers.push({ id, at: now + Number(delay), callback });
+    return id;
+  },
+});
+Object.defineProperty(window, "clearTimeout", {
+  configurable: true,
+  value: (id: number) => {
+    timers = timers.filter((timer) => timer.id !== id);
+  },
+});
+
+function advanceTimersBy(ms: number): void {
+  const target = now + ms;
+  while (true) {
+    timers.sort((a, b) => a.at - b.at || a.id - b.id);
+    const timer = timers[0];
+    if (!timer || timer.at > target) break;
+    timers.shift();
+    now = timer.at;
+    timer.callback();
+  }
+  now = target;
+}
+
+const host = document.getElementById("root");
+if (!host) throw new Error("missing test root");
+const root = createRoot(host);
+let dismissCount = 0;
+const onDismiss = () => { dismissCount += 1; };
+
+await act(async () => {
+  root.render(
+    <LocaleProvider>
+      <TodoPanel
+        key="restored"
+        stateKey="session:restored\0batch"
+        todos={[
+          { content: "Inspect", status: "completed" },
+          { content: "Verify", status: "completed" },
+          { content: "Ship", status: "completed" },
+        ]}
+        running={false}
+        pendingPrompt={false}
+        onDismiss={onDismiss}
+      />
+    </LocaleProvider>,
+  );
+});
+assert.equal(host.querySelector(".prompt-shelf"), null, "a restored completed batch does not reattach above the composer");
+assert.equal(timers.length, 0, "a restored completed batch does not schedule a stale fade");
+
+await act(async () => {
+  root.render(
+    <LocaleProvider>
+      <TodoPanel
+        key="live"
+        stateKey="session:test\0batch"
+        todos={[
+          { content: "Inspect", status: "completed" },
+          { content: "Verify", status: "in_progress" },
+          { content: "Ship", status: "pending" },
+        ]}
+        running
+        pendingPrompt={false}
+        onDismiss={onDismiss}
+      />
+    </LocaleProvider>,
+  );
+});
+assert.ok(host.querySelector(".prompt-shelf"), "an incomplete batch renders above the composer");
+
+await act(async () => {
+  root.render(
+    <LocaleProvider>
+      <TodoPanel
+        key="live"
+        stateKey="session:test\0batch"
+        todos={[
+          { content: "Inspect", status: "completed" },
+          { content: "Verify", status: "completed" },
+          { content: "Ship", status: "completed" },
+        ]}
+        running={false}
+        pendingPrompt={false}
+        onDismiss={onDismiss}
+      />
+    </LocaleProvider>,
+  );
+});
+assert.equal(host.textContent?.includes("3/3"), true, "the final completed count remains visible during the hold");
+assert.ok(host.querySelector(".todo-exit"), "the completed shelf owns the delayed fade animation");
+
+await act(async () => advanceTimersBy(899));
+assert.ok(host.querySelector(".prompt-shelf"), "completion does not exit before the 900ms hold");
+
+await act(async () => advanceTimersBy(1));
+assert.ok(host.querySelector(".prompt-shelf"), "fade starts before the completion exit");
+
+await act(async () => advanceTimersBy(239));
+assert.ok(host.querySelector(".prompt-shelf"), "completion exit waits for the 240ms fade");
+await act(async () => advanceTimersBy(1));
+assert.equal(host.querySelector(".prompt-shelf"), null, "the completed shelf exits after its 1.14s completion transition");
+assert.equal(dismissCount, 0, "automatic completion does not persist a manual-dismissal record");
+
+await act(async () => root.unmount());
+console.log("todo panel lifecycle checks passed");

--- a/desktop/frontend/src/components/TodoPanel.tsx
+++ b/desktop/frontend/src/components/TodoPanel.tsx
@@ -10,6 +10,8 @@ import { PromptBadge, PromptHeaderAction, PromptShelf } from "./PromptShelf";
 
 const STORAGE_KEY = "todoPanel:openStates";
 const MAX_STORED_OPEN_STATES = 80;
+const COMPLETION_HOLD_MS = 900;
+const COMPLETION_FADE_MS = 240;
 
 function loadOpenStates(): Record<string, boolean> {
   try {
@@ -47,7 +49,9 @@ function saveOpenState(stateKey: string, open: boolean): void {
 // latest todo_write call drives it, and it updates in place as the agent flips
 // items to in_progress / completed. Each new todo batch starts collapsed so the
 // header can show live progress and the current task without occupying extra
-// space. Manual expand/collapse is restored only for the same batch.
+// space. A batch that just reached completion briefly shows its final count,
+// then leaves the composer shelf; the transcript tool call remains.
+// Manual expand/collapse is restored only for the same batch.
 export function TodoPanel({
   stateKey,
   todos,
@@ -71,25 +75,33 @@ export function TodoPanel({
   const allDone = todos.length > 0 && done === todos.length;
   const summary = current?.activeForm || current?.content || todos[todos.length - 1]?.content || "";
   const [open, setOpen] = useState(() => loadOpenState(stateKey, shouldOpenTodoPanelByDefault()));
-  const wasAllDoneRef = useRef(allDone);
+  const [visible, setVisible] = useState(!allDone);
 
   useEffect(() => {
-    if (allDone && !wasAllDoneRef.current) {
-      saveOpenState(stateKey, false);
-      setOpen(false);
+    if (!allDone) {
+      setVisible(true);
+      return;
     }
-    wasAllDoneRef.current = allDone;
-  }, [allDone, stateKey]);
+    if (!visible) return;
+
+    saveOpenState(stateKey, false);
+    setOpen(false);
+    const dismissTimer = window.setTimeout(() => setVisible(false), COMPLETION_HOLD_MS + COMPLETION_FADE_MS);
+    return () => {
+      window.clearTimeout(dismissTimer);
+    };
+  }, [allDone, stateKey, visible]);
 
   useEffect(() => {
     if (!open) return;
     currentRef.current?.scrollIntoView({ block: "nearest" });
   }, [open, current?.content, current?.activeForm]);
 
-  if (todos.length === 0) return null;
+  if (todos.length === 0 || !visible) return null;
 
   return (
     <PromptShelf
+      className={allDone ? "todo-exit" : undefined}
       titleId="todo-shelf-title"
       title={t("todo.title")}
       badges={<PromptBadge>{done}/{todos.length}</PromptBadge>}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -9055,6 +9055,9 @@ body > .mermaid-diagram--fullscreen {
   margin: 0 auto 10px;
   animation: shelf-in var(--dur-slow) var(--ease-out) both;
 }
+.todo-exit {
+  animation: shelf-in 240ms 900ms ease reverse both;
+}
 @keyframes shelf-in {
   from {
     opacity: 0;


### PR DESCRIPTION
## Summary

- Keep incomplete Todo shelves pinned above the composer with the existing progress and Continue behavior.
- When the mounted batch reaches completion, retain the final count for 900 ms and fade it out over 240 ms.
- Do not reattach already-completed batches when a session is restored; the original `todo_write` record remains in transcript history.
- Keep automatic retirement separate from the persisted manual-dismissal contract.

## Root cause

The app-level visibility gate intentionally kept completed batches mounted, while `TodoPanel` only collapsed their contents. As a result, a final `3/3` shelf remained above the composer until the user explicitly closed it, and restored sessions could show finished work again.

## Verification

- `pnpm test:todo-visibility`
- `pnpm lint:hooks`
- `pnpm typecheck`
- `pnpm test:typecheck`
- `pnpm check:css`
- `pnpm exec vite build`
- `node scripts/check-bundle-budget.mjs`
- `pnpm exec tsx src/__tests__/transcript-reader-extent-race.test.tsx`
- `go run ./tools/repolint`
- In-app browser verification confirmed the emitted completion animation is `900ms` hold plus `240ms` reverse fade.

## Integration notes

- Footer-height changes continue through the existing transcript tail-follow owner; the deterministic footer-resize race test passes.
- No provider payload, prompt, tool schema, persistence schema, dependency, or network behavior changes.

## Documentation impact

Documentation-impact: none - existing docs remain correct because this is a bounded correction to the already-documented desktop Todo shelf behavior.

## Cache impact

Cache-impact: none — frontend-local state, CSS, and tests only.

Cache-guard: N/A

System-prompt-review: N/A
