### PR TITLE
fix(desktop): pure-number inline math renders by default; currency dollars escaped at source / 纯数字行内公式默认渲染，货币美元在源码层转义

### DIFF
--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -146,27 +146,15 @@ check("$p = +\\alpha$", () => isLikelyInlineMath("p = +\\alpha") === true);
 check("$+$", () => isLikelyInlineMath("+") === true);
 check("$=$", () => isLikelyInlineMath("=") === true);
 
-console.log("\nisLikelyInlineMath — numeric syntax and contextual currency");
-check("$5 defaults to literal without math context", () => isLikelyInlineMath("5") === false);
-check("$10 defaults to literal without math context", () => isLikelyInlineMath("10") === false);
-check("$10.50 defaults to literal without math context", () => isLikelyInlineMath("10.50") === false);
+console.log("\nisLikelyInlineMath — numeric syntax");
+check("$5 is math by default (glued $ delimiters)", () => isLikelyInlineMath("5") === true);
+check("$10 is math by default", () => isLikelyInlineMath("10") === true);
+check("$10.50 is math by default", () => isLikelyInlineMath("10.50") === true);
 check("$100% defaults to math", () => isLikelyInlineMath("100%") === true);
-check("costs $5$ is contextual currency", () =>
-  classifyInlineMath("5", { before: "it costs ", after: " today" }) === "currency");
-check("price is $10.50$ each is contextual currency", () =>
-  classifyInlineMath("10.50", { before: "price is ", after: " each" }) === "currency");
-check("10–$20$ MeV remains math", () =>
-  classifyInlineMath("20", { before: "10–", after: " MeV" }) === "math");
-check("$20$ MeV uses a scientific unit as positive math context", () =>
-  classifyInlineMath("20", { after: " MeV" }) === "math");
-check("$5$ cm uses an SI-prefixed unit as positive math context", () =>
-  classifyInlineMath("5", { after: " cm" }) === "math");
-check("$2$ L uses a scientific unit symbol as positive math context", () =>
-  classifyInlineMath("2", { after: " L" }) === "math");
-check("$3$ dB uses a common scientific unit as positive math context", () =>
-  classifyInlineMath("3", { after: " dB" }) === "math");
-check("x = $2$ uses an operator as positive math context", () =>
-  classifyInlineMath("2", { before: "x = " }) === "math");
+check("assistant-ui parity: price-word context no longer demotes pure numbers", () =>
+  classifyInlineMath("5") === "math" && classifyInlineMath("10.50") === "math");
+check("range/unit/operator context is irrelevant now: pure numbers are always math", () =>
+  classifyInlineMath("20") === "math" && classifyInlineMath("1") === "math");
 check("URL", () => isLikelyInlineMath("https://example.com") === false);
 check("prose text", () => isLikelyInlineMath("hello world today") === false);
 check("prose $x y z$ (spaces)", () => isLikelyInlineMath("x y z") === false);
@@ -193,11 +181,11 @@ check("$[\\mathbf{56}]$ → math", () => isLikelyInlineMath("[\\mathbf{56}]") ==
 
 console.log("\nisLikelyInlineMath — minimal LaTeX patterns (regression)");
 // LLMs frequently emit minimal LaTeX in math contexts that the older
-// classifier rejected as currency / word tokens. These tests pin down the
-// deliberately-permissive rules for common math patterns while keeping
-// context-free pure numbers literal until the AST policy sees a math signal.
-check("single-digit $1$, $2$, $5$ → literal without context", () => isLikelyInlineMath("1") === false);
-check("multi-digit $42$ → literal without context", () => isLikelyInlineMath("42") === false);
+// classifier rejected as word tokens. These tests pin down the
+// deliberately-permissive rules for common math patterns; pure numbers are
+// math by default (assistant-ui parity).
+check("single-digit $1$, $2$, $5$ → math by default", () => isLikelyInlineMath("1") === true);
+check("multi-digit $42$ → math by default", () => isLikelyInlineMath("42") === true);
 check("$2.5x$ is math (number with variable)", () => isLikelyInlineMath("2.5x") === true);
 check("$10\%$ is math (percentage with LaTeX)", () => isLikelyInlineMath("10\\%") === true);
 check("$2.5x dollars$ → NOT math (prefix-only numeric variable)", () => isLikelyInlineMath("2.5x dollars") === false);
@@ -340,7 +328,7 @@ eq(normalizeMath("solve $x^2 + y^2 = z^2$ please"), "solve $x^2 + y^2 = z^2$ ple
 eq(normalizeMath("$\\alpha + \\beta$"), "$\\alpha + \\beta$", "$\\alpha+\\beta$ is math");
 eq(normalizeMath("price is $10.50$ each"), "price is $10.50$ each", "$10.50$ preserved for contextual classification");
 eq(normalizeMath("$I$ think"), "$I$ think", "$I$ is math (uppercase single letter)");
-eq(normalizeMath("it costs $5 and $10 total"), "it costs $5 and $10 total", "multiple prose dollars preserved for parser-aware policy");
+eq(normalizeMath("it costs $5 and $10 total"), "it costs \\$5 and \\$10 total", "cross-amount prose dollars escaped by the currency pre-pass");
 
 console.log("\nnormalizeMath — Markdown code regions stay literal");
 eq(normalizeMath("`$PATH$`"), "`$PATH$`", "inline code with env token");
@@ -480,7 +468,7 @@ for (const [src, label] of e2e) {
 console.log("\nnormalizeMath — non-math inputs pass through");
 type Passthrough = { src: string; expected: string; label: string };
 const passthrough: Passthrough[] = [
-  { src: "costs $100$ today", expected: "costs $100$ today", label: "multi-digit currency preserved for AST policy" },
+  { src: "costs $100$ today", expected: "costs $100$ today", label: "multi-digit pair passes through the pre-pass untouched" },
   { src: "line break \\\\[4pt] here", expected: "line break \\\\[4pt] here", label: "LaTeX line-break spacing" },
   { src: "hello world", expected: "hello world", label: "plain text" },
 ];
@@ -505,65 +493,67 @@ function renderHtml(src: string): string {
   );
 }
 
-check("currency '$5 and $6' renders as literal dollars, not math", () => {
+check("cross-amount pairing '$5 and $6' renders as literal dollars, not math", () => {
   const html = renderHtml("These two apples cost $5 and $6");
   return !html.includes("katex") && html.includes("$5") && html.includes("$6");
 });
-check("paired currency 'costs $1$ today' drops the spurious closing delimiter", () => {
-  const html = renderHtml("costs $1$ today");
-  return !html.includes("katex") && html.includes("$1 today") && !html.includes("$1$");
+// Assistant-ui `escapeCurrencyDollars` parity: a glued $N$ pair is math even
+// when price words or currency units sit next to it. Humans and models that
+// want literal dollars write `\$5` (escaped) or a single `$5`; the cross-
+// amount prose pair above is the real-world currency artifact, and it stays
+// literal via the classifier catch-all rather than this demotion.
+const PARITY_MATH_CASES: ReadonlyArray<readonly [string, string]> = [
+  ["costs $1$ today", "1"],
+  ["price is $10.50$ each", "10.50"],
+  ["价格是$5$", "5"],
+  ["价格：$5$", "5"],
+  ["The price ($5$) includes tax.", "5"],
+  ["The price {$5$} includes tax.", "5"],
+  ["The price ‘$5$’ includes tax.", "5"],
+  ["价格（$5$）含税。", "5"],
+  ["It is $5$ (USD).", "5"],
+  ["It is $5$—cash.", "5"],
+  ["I have $5$ in cash", "5"],
+  ["costs **$5$** today", "5"],
+  ["price is *$10.50$* each", "10.50"],
+];
+for (const [src, num] of PARITY_MATH_CASES) {
+  check(`assistant-ui parity: "${src}" renders as math`, () => {
+    const html = renderHtml(src);
+    return html.includes("katex") && html.includes(`<mn>${num}</mn>`);
+  });
+}
+check("escaped \\$ dollars stay literal and never pair", () => {
+  const html = renderHtml("It costs \\$5 today, not \\$6");
+  return !html.includes("katex") && html.includes("$5") && html.includes("$6");
 });
-check("paired decimal currency uses surrounding price context", () => {
-  const html = renderHtml("price is $10.50$ each");
-  return !html.includes("katex") && html.includes("$10.50 each") && !html.includes("$10.50$");
+// Currency pre-pass (assistant-ui escapeCurrencyDollars parity): a `$`
+// followed by a digit is escaped unless its span to the next `$` reads as a
+// math body, so a stray amount can no longer swallow a later formula.
+check("lone unpaired $5 stays literal", () => {
+  const html = renderHtml("It costs $5 today.");
+  return !html.includes("katex") && html.includes("$5 today.");
 });
-check("Chinese paired currency uses localized price context", () => {
-  const html = renderHtml("价格是$5$");
-  return !html.includes("katex") && html.includes("价格是$5") && !html.includes("$5$");
+check("currency $ escapes so a later math span renders: 'budget is $100 … $42$'", () => {
+  const html = renderHtml("The budget is $100 and the answer is $42$.");
+  return html.includes("katex") && html.includes("<mn>42</mn>")
+    && html.includes("$100") && !html.includes("$42$");
 });
-check("full-width punctuation keeps paired currency literal", () => {
-  const html = renderHtml("价格：$5$");
-  return !html.includes("katex") && html.includes("价格：$5") && !html.includes("$5$");
+check("currency $ escapes so a later symbol formula renders", () => {
+  const html = renderHtml("It costs $5, and $x+y$ is the formula.");
+  return html.includes("katex") && !html.includes("$x+y$");
 });
-check("parentheses do not hide preceding currency context", () => {
-  const html = renderHtml("The price ($5$) includes tax.");
-  return !html.includes("katex") && html.includes("The price ($5) includes tax.");
+check("digit-led math bodies survive currency escaping", () => {
+  const html = renderHtml("digit-led $2x$ and $5x = 10$ both render");
+  return html.includes("katex") && !html.includes("$2x$") && !html.includes("$5x = 10$");
 });
-check("braces do not hide preceding currency context", () => {
-  const html = renderHtml("The price {$5$} includes tax.");
-  return !html.includes("katex") && html.includes("The price {$5} includes tax.");
-});
-check("curly quotes do not hide preceding currency context", () => {
-  const html = renderHtml("The price ‘$5$’ includes tax.");
-  return !html.includes("katex") && html.includes("The price ‘$5’ includes tax.");
-});
-check("full-width parentheses do not hide Chinese currency context", () => {
-  const html = renderHtml("价格（$5$）含税。");
-  return !html.includes("katex") && html.includes("价格（$5）含税。");
-});
-check("parenthesized suffix currency unit repairs paired dollars", () => {
-  const html = renderHtml("It is $5$ (USD).");
-  return !html.includes("katex") && html.includes("It is $5 (USD).");
-});
-check("dash-separated cash suffix repairs paired dollars", () => {
-  const html = renderHtml("It is $5$—cash.");
-  return !html.includes("katex") && html.includes("It is $5—cash.");
-});
-check("cash context keeps paired currency literal", () => {
-  const html = renderHtml("I have $5$ in cash");
-  return !html.includes("katex") && html.includes("$5 in cash") && !html.includes("$5$");
-});
-check("bold markup does not hide preceding currency context", () => {
-  const html = renderHtml("costs **$5$** today");
-  return !html.includes("katex") && html.includes("<strong>$5</strong>");
-});
-check("emphasis does not hide surrounding currency context", () => {
-  const html = renderHtml("price is *$10.50$* each");
-  return !html.includes("katex") && html.includes("<em>$10.50</em>");
-});
-check("ambiguous paired numbers remain literal without positive math context", () => {
+eq(normalizeMath("The budget is $100 and the answer is $42$."),
+  "The budget is \\$100 and the answer is $42$.",
+  "currency pre-pass escapes only the amount dollar");
+check("paired numbers 'from $5$ to $10$' render as math (global default)", () => {
   const html = renderHtml("from $5$ to $10$");
-  return !html.includes("katex") && html.includes("$5$") && html.includes("$10$");
+  return html.includes("katex") && html.includes("<mn>5</mn>") && html.includes("<mn>10</mn>")
+    && !html.includes("$5$") && !html.includes("$10$");
 });
 check("env var $PATH$ renders as literal, not math", () => {
   const html = renderHtml("env $PATH$ here");
@@ -573,9 +563,49 @@ check("range endpoint 10–$20$ MeV renders numeric math", () => {
   const html = renderHtml("10–$20$ MeV");
   return html.includes("katex") && html.includes("<mn>20</mn>");
 });
-check("standalone $42$ remains literal without positive math context", () => {
+check("standalone $42$ renders as math without other context", () => {
   const html = renderHtml("$42$ elements");
-  return !html.includes("katex") && html.includes("$42$ elements");
+  return html.includes("katex") && html.includes("<mn>42</mn>") && !html.includes("$42$");
+});
+// GFM table cells: pure numbers render as math by default (GitHub and
+// assistant-ui parity), in cells and prose alike.
+check("pure number $1$ in a GFM table cell renders as math", () => {
+  const html = renderHtml([
+    "| Quantity | SU(6) prediction | Experiment |",
+    "|---|---|---|",
+    "| $\\Delta\\Sigma$ | $1$ | $1.2754$ |",
+  ].join("\n"));
+  return html.includes("katex") && html.includes("<mn>1</mn>") && html.includes("<mn>1.2754</mn>")
+    && !html.includes("$1$") && !html.includes("$1.2754$");
+});
+check("bold pure number in a GFM table cell still renders as math", () => {
+  const html = renderHtml(["| a | b |", "|---|---|", "| **$5$** | $3$ |"].join("\n"));
+  return html.includes("katex") && html.includes("<mn>5</mn>") && html.includes("<mn>3</mn>")
+    && !html.includes("$5$") && !html.includes("$3$");
+});
+check("currency prose inside a GFM table cell renders as math (parity)", () => {
+  const html = renderHtml(["| note |", "|---|", "| costs $5$ today |"].join("\n"));
+  return html.includes("katex") && html.includes("<mn>5</mn>");
+});
+// Spacing & pairing: remark-math v6 pairs $…$ greedily, even across spaces
+// and words, so these judgements live in the policy, not the tokenizer.
+// Content is trimmed before classification, and cross-word pairs restore
+// verbatim because they match no math pattern.
+check("sloppy spaced delimiters with price words still render as math (parity)", () => {
+  const html = renderHtml("It costs $ 5$ today");
+  return html.includes("katex") && html.includes("<mn>5</mn>");
+});
+check("spaced closing delimiter with cash context stays literal (assistant-ui parity)", () => {
+  const html = renderHtml("I paid $5 $ cash");
+  return !html.includes("katex") && html.includes("$5") && !html.includes("$5$");
+});
+check("cross-word $…$ pairing restores verbatim, never math", () => {
+  const html = renderHtml("from $5 to $10");
+  return !html.includes("katex") && html.includes("from $5 to $10");
+});
+check("bare number with sloppy spaced delimiters renders as math (global default)", () => {
+  const html = renderHtml("the value is $ 5$ here");
+  return html.includes("katex") && html.includes("<mn>5</mn>");
 });
 check("scientific unit makes a paired number mathematical", () => {
   const html = renderHtml("$20$ MeV");

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -1,65 +1,24 @@
-export type InlineMathDecision = "math" | "currency" | "literal";
-
-export interface InlineMathContext {
-  before?: string;
-  after?: string;
-}
+export type InlineMathDecision = "math" | "literal";
 
 const PURE_NUMBER = /^\d+(?:,\d{3})*(?:\.\d+)?$/;
-
-const CURRENCY_BEFORE =
-  /(?:\b(?:costs?|prices?|priced|pay|paid|worth|fees?|budget|salary|total|amount|spend|spent|save|saved|charge|charged|buy|bought|sell|sold|usd|dollars?)\b|(?:价格|售价|花费|成本|预算|金额|合计|总计|总价|单价|支付|付款|收费|价值|卖价|买价|薪资|工资|优惠|节省|美元|美金))\s*(?:(?:is|was|are|were|of|at)\s+|(?:是|为|达|约|共|了)\s*|[:：=]\s*)?$/i;
-
-const CURRENCY_AFTER =
-  /^\s*(?:usd\b|dollars?\b|(?:in\s+)?cash\b|each\b|per\b|\/\s*(?:day|week|month|year)\b|美元|美金|人民币|元|块钱|现金|每(?:个|天|周|月|年))/i;
-
-const NUMERIC_MATH_BEFORE =
-  /(?:\d(?:,\d{3})*(?:\.\d+)?\s*[-–—−]\s*|(?:[=<>≤≥≈≃~+*/^(,[{]|\\(?:approx|sim|le|ge|lt|gt))\s*)$/;
-
-const SCIENTIFIC_UNIT_PREFIX = String.raw`(?:da|[qryzafpnumcdhkMGTPEZYRQµμ])?`;
-const SCIENTIFIC_UNIT_SYMBOL = String.raw`(?:${SCIENTIFIC_UNIT_PREFIX}(?:eV|Hz|mol|cd|Pa|Wb|lm|lx|Bq|Gy|Sv|kat|Wh|Da|bar|m|g|s|A|K|N|J|W|C|V|F|S|T|H|L)|dB|atm|Torr|rpm|bps|Ω|ohms?|bits?|bytes?|minutes?|hours?|min|hr)`;
-const SCIENTIFIC_UNIT_BOUNDARY = String.raw`(?=$|[\s,.;:!?()[\]{}\/·⋅×^²³⁴⁵⁶⁷⁸⁹⁰-])`;
-const NUMERIC_MATH_AFTER = new RegExp(
-  String.raw`^\s*(?:[-–—−]\s*\d|${SCIENTIFIC_UNIT_SYMBOL}${SCIENTIFIC_UNIT_BOUNDARY}|°[CFK]${SCIENTIFIC_UNIT_BOUNDARY})`,
-  "i",
-);
-
-function currencyContext(context: InlineMathContext): Required<InlineMathContext> {
-  return {
-    before: (context.before ?? "").replace(/[\s()[\]{}"'“”‘’（）【】《》〈〉「」『』]+$/u, ""),
-    after: (context.after ?? "").replace(/^[\s()[\]{}"'“”‘’（）【】《》〈〉「」『』,;:，；：。、—–-]+/u, ""),
-  };
-}
 
 /**
  * Decide how an `inlineMath` node produced by remark-math should render.
  *
- * Pure-number spans remain literal unless their surrounding source provides
- * positive mathematical context (for example a range endpoint or scientific
- * unit). High-confidence currency context repairs paired input such as
- * `costs $5$ today` to the prose token `$5`. Other non-math content is
- * restored verbatim as text.
+ * Pure-number spans with glued delimiters are mathematical by default
+ * (assistant-ui `escapeCurrencyDollars` parity): prose currency pairs such
+ * as `$5 and $10` never reach this classifier with a numeric body, because
+ * their word-containing spans match no math pattern below and restore
+ * verbatim. Other non-math content is also restored verbatim as text.
  */
-export function classifyInlineMath(
-  math: string,
-  context: InlineMathContext = {},
-): InlineMathDecision {
+export function classifyInlineMath(math: string): InlineMathDecision {
   if (!math || math !== math.trim() || math.includes("\n")) return "literal";
   if (math.includes("://") || math.includes("](")) return "literal";
 
-  if (PURE_NUMBER.test(math)) {
-    const currency = currencyContext(context);
-    if (CURRENCY_BEFORE.test(currency.before) || CURRENCY_AFTER.test(currency.after)) {
-      return "currency";
-    }
-    if (NUMERIC_MATH_BEFORE.test(context.before ?? "") || NUMERIC_MATH_AFTER.test(context.after ?? "")) {
-      return "math";
-    }
-    return "literal";
-  }
+  if (PURE_NUMBER.test(math)) return "math";
 
-  // A percentage enclosed in explicit delimiters is mathematical notation,
-  // not a currency amount. latexNormalizeForKatex escapes its `%` for KaTeX.
+  // A percentage enclosed in explicit delimiters is mathematical notation.
+  // latexNormalizeForKatex escapes its `%` for KaTeX.
   if (/^\d+(?:,\d{3})*(?:\.\d+)?%$/.test(math)) return "math";
 
   // Number followed by variable: implicit multiplication (2.5x, 3y^2).

--- a/desktop/frontend/src/components/mathNormalize.ts
+++ b/desktop/frontend/src/components/mathNormalize.ts
@@ -11,8 +11,11 @@
 //      `$…$` and macros already inside math just substitute.
 //   5. Inline `$$` glued to prose gets a blank line inserted before it
 //      (CommonMark requires that block math be paragraph-separated).
-//   6. Protect pipes inside inline math before GFM table tokenisation.
-//   7. Restore placeholders for remark-math. KaTeX-specific normalisation is
+//   6. Escape currency dollars (`$5` followed by prose) so greedy single-$
+//      pairing cannot swallow a later math span or pair across amounts
+//      (assistant-ui escapeCurrencyDollars parity).
+//   7. Protect pipes inside inline math before GFM table tokenisation.
+//   8. Restore placeholders for remark-math. KaTeX-specific normalisation is
 //      handled by the AST policy after parsing.
 
 import { expandYoungDiagrams } from "./youngDiagrams";
@@ -84,6 +87,16 @@ function normalizeMathText(s: string): string {
     return math.includes("$") ? `${IM}${protectInlineMathSource(math)}${IM}` : match;
   });
 
+  // Step 5.5: escape currency dollars so a stray amount cannot pair with a
+  // later math span's opening delimiter. remark-math pairs any two `$` on a
+  // line, so `budget is $100 and the answer is $42$` would otherwise merge
+  // `$100 and the answer is $` into one junk span and destroy the math. A
+  // single `$` immediately followed by a digit is prose currency unless the
+  // span up to the next `$` reads as a math body (assistant-ui
+  // `escapeCurrencyDollars` parity). Display `$$` runs and escaped dollars
+  // (already hidden above) are never touched.
+  r = escapeCurrencyDollars(r, escapedDollarToken);
+
   // Step 6: GFM identifies table cells before remark plugins can transform the
   // AST. Normalise only inline spans containing pipes at this syntax boundary
   // so formulas such as `$|x|$` cannot be split into separate cells. A pipe is
@@ -111,6 +124,100 @@ function protectInlineMathPipesForGfm(s: string): string {
     }
     return hasUnescapedPipe ? `$${protectInlineMathSource(math)}$` : match;
   });
+}
+
+// ── currency-dollar escaping (assistant-ui escapeCurrencyDollars parity) ─────
+
+const MATH_BODY_BLANK_LINE = /\n\s*\n/;
+const MATH_BODY_LATEX = /\\[A-Za-z]+|[\^_{}]/;
+const MATH_BODY_ADJACENT_WORDS = /[A-Za-z0-9]\s+[A-Za-z0-9]/;
+const MATH_BODY_DANGLING_OPERATOR = /[+\-*/=<>~^_]$/;
+
+/**
+ * Whether the text between two single `$` reads as an inline math expression
+ * rather than the prose separating two currency amounts. A body that ends
+ * the way prose between amounts does (mid-sentence space, dangling operator)
+ * is rejected even when it carries LaTeX-looking syntax, since such prose may
+ * itself contain `_` or `\word`; otherwise LaTeX syntax accepts the span and
+ * two adjacent words reject it.
+ */
+function isCurrencySafeMathBody(body: string): boolean {
+  if (body.length === 0) return false;
+  if (MATH_BODY_BLANK_LINE.test(body)) return false;
+  if (/\s$/.test(body) && !/^\s/.test(body)) return false;
+  if (MATH_BODY_DANGLING_OPERATOR.test(body)) return false;
+  if (MATH_BODY_LATEX.test(body)) return true;
+  return !MATH_BODY_ADJACENT_WORDS.test(body);
+}
+
+function isDigitChar(char: string | undefined): boolean {
+  return char !== undefined && char >= "0" && char <= "9";
+}
+
+function dollarRunLength(s: string, index: number): number {
+  let length = 0;
+  while (s[index + length] === "$") length += 1;
+  return length;
+}
+
+function nextSingleDollar(s: string, from: number): number {
+  let index = from;
+  while (index < s.length) {
+    if (s[index] === "$") {
+      // A `$$` run is a display delimiter, not an inline closer.
+      return dollarRunLength(s, index) >= 2 ? -1 : index;
+    }
+    index += 1;
+  }
+  return -1;
+}
+
+/**
+ * Escapes a `$` that opens a currency amount (`$5`, `$19.99`, `$1,299`) so
+ * remark-math's greedy single-dollar pairing cannot consume it — either as a
+ * junk span with a later math delimiter or as one half of a cross-amount
+ * pair. A `$` followed by a digit is currency unless the span up to the next
+ * `$` is a plausible math body, so `$42$` and `$5x = 10$` survive while
+ * `$5 and $7` and `budget is $100 … $42$` stay literal/functional.
+ * Escaping via `escapedDollarToken` keeps the emitted text free of `$` so
+ * later `$`-scanning steps (pipe protection, remark-math) cannot re-pair it.
+ */
+function escapeCurrencyDollars(s: string, escapedDollar: string): string {
+  let out = "";
+  let index = 0;
+  while (index < s.length) {
+    const char = s[index];
+    // Escaped characters (LaTeX commands, \\) pass through untouched.
+    if (char === "\\") {
+      out += s.slice(index, index + 2);
+      index += 2;
+      continue;
+    }
+    if (char !== "$") {
+      out += char;
+      index += 1;
+      continue;
+    }
+    const run = dollarRunLength(s, index);
+    if (run >= 2) {
+      out += s.slice(index, index + run);
+      index += run;
+      continue;
+    }
+    const close = nextSingleDollar(s, index + 1);
+    const body = close === -1 ? null : s.slice(index + 1, close);
+    const opensMath = body !== null
+      && !isDigitChar(s[close + 1])
+      && isCurrencySafeMathBody(body);
+    if (opensMath) {
+      out += s.slice(index, close + 1);
+      index = close + 1;
+      continue;
+    }
+    out += isDigitChar(s[index + 1]) ? escapedDollar : "$";
+    index += 1;
+  }
+  return out;
 }
 
 function protectInlineMathSource(source: string): string {

--- a/desktop/frontend/src/components/remarkMathPolicy.ts
+++ b/desktop/frontend/src/components/remarkMathPolicy.ts
@@ -27,44 +27,6 @@ type VFileLike = {
   value: unknown;
 };
 
-function siblingText(parent: ParentWithChildren, index: number, offset: -1 | 1): string {
-  const sibling = parent.children[index + offset];
-  if (sibling?.type !== "text" || typeof sibling.value !== "string") return "";
-  return offset < 0 ? sibling.value.slice(-120) : sibling.value.slice(0, 120);
-}
-
-function stripAdjacentMarkdown(text: string, side: -1 | 1): string {
-  let current = text;
-  while (true) {
-    const next = side < 0
-      ? current.replace(/(?:[*_~]{1,3}|\[)\s*$/, "")
-      : current.replace(/^\s*(?:[*_~]{1,3}|\])/, "");
-    if (next === current) return current;
-    current = next;
-  }
-}
-
-function inlineMathContext(
-  node: InlineMath,
-  file: VFileLike,
-  parent: ParentWithChildren,
-  index: number,
-): { before: string; after: string } {
-  const source = String(file.value ?? "");
-  const start = node.position?.start.offset;
-  const end = node.position?.end.offset;
-  if (typeof start === "number" && typeof end === "number") {
-    return {
-      before: stripAdjacentMarkdown(source.slice(Math.max(0, start - 120), start), -1),
-      after: stripAdjacentMarkdown(source.slice(end, end + 120), 1),
-    };
-  }
-  return {
-    before: siblingText(parent, index, -1),
-    after: siblingText(parent, index, 1),
-  };
-}
-
 function originalSource(node: InlineMath, file: VFileLike): string {
   const source = String(file.value ?? "");
   const start = node.position?.start.offset;
@@ -140,20 +102,14 @@ export function remarkMathPolicy() {
       const typedNode = node as InlineMath;
       const typedParent = parent as ParentWithChildren;
       const { source, rendered } = inlineMathSources(typedNode, file);
-      const classificationSource = source.trim();
-      const decision = classifyInlineMath(
-        classificationSource,
-        inlineMathContext(typedNode, file, typedParent, index),
-      );
+      const decision = classifyInlineMath(source.trim());
 
       if (decision === "math") {
         setMathValue(typedNode, source, latexNormalizeForKatex(rendered));
         return;
       }
 
-      const value = decision === "currency"
-        ? `$${classificationSource}`
-        : originalSource(typedNode, file);
+      const value = originalSource(typedNode, file);
       typedParent.children[index] = { type: "text", value } satisfies Text;
     });
 


### PR DESCRIPTION
## Summary

Pure-number inline math now renders as KaTeX by default, and currency dollars are escaped at the source so they can no longer swallow later formulas. This aligns the inline-math pipeline with the semantics that assistant-ui ships in its `escapeCurrencyDollars` pre-process helper.

## Problems being fixed

1. **Bare numbers leaked as literal text.** `$1$` outside narrow numeric context (range endpoint, operator, scientific unit) rendered as raw `$1$` — e.g. physics tables like `| $\Delta\Sigma$ | $1$ | $\approx 0.3$ |` showed literal `$1$` in the prediction column.
2. **A stray currency `$` destroyed later math.** remark-math v6 pairs any two `$` on a line with no delimiter constraints, so `The budget is $100 and the answer is $42$.` merged `$100 and the answer is $` into one junk span and rendered everything literally. The word-context currency layer could not repair this because the junk span had already replaced the real formula boundary before classification.

## Changes

| Area | Before | After |
| --- | --- | --- |
| `mathClassify.ts` | pure numbers literal unless currency/range/unit context | pure numbers with glued delimiters are math by default; context machinery removed (`-61` lines) |
| `remarkMathPolicy.ts` | sliced source context for the currency decision | policy reduced to math-vs-verbatim (`-48` lines) |
| `mathNormalize.ts` | — | new pre-pass step porting assistant-ui's `escapeCurrencyDollars`: a `$` followed by a digit is escaped unless the span to the next `$` reads as a math body; escapes emit the internal token so later `$`-scans cannot re-pair them (`+111` lines) |
| `math-golden.test.ts` | currency word-context pins | rewritten 270-case contract: glued `$N$` renders math in prose/tables/price contexts; cross-amount pairs, `\$`, `$PATH$`, junk spans restore verbatim |

## Behavior after this PR

| Input | Renders |
| --- | --- |
| `the answer is $1$`, `$1$` in table cells | math |
| `It costs $5 today.` (lone `$`), `价格是$5。` | literal |
| `It costs $5 today and $10 tomorrow.` | literal (source-level escape) |
| `The budget is $100 and the answer is $42$.` | `$100` literal **and** `$42$` as math |
| `$2x$`, `$5x = 10$`, `$$3x^2$$`, `\$5`, `$PATH$` | unchanged |

## Trade-offs (deliberate)

- This replaces the word-context currency repair from #7073 with source-level escaping. Glued pairs around amounts (`价格是$5$`, `I have $5$ in cash`) now render as math instead of being repaired to `$5` — matching assistant-ui, GitHub, and remark-math defaults. Cross-amount prose and escaped `\$` remain fully protected.
- Cross-industry context: assistant-ui (#4408), thuki (#180), wayland (#704), and bb (#512) all hit the same dollar-pairing failures and converged on source-level currency escaping; this PR adopts the most surgical of those approaches.

## Verification

- `tsc --noEmit` clean
- math golden suite: 270/270
- full frontend `run-tests.mjs`: all 229 suites pass (incl. markdown streaming worker, bundle contract, table virtualization, katex CSS)
- end-to-end render matrix (10 cases) covering every row of the behavior table


Documentation-impact: none - the inline-math rendering pipeline is an internal implementation detail; user-facing docs describe no $-delimiter or math-rendering behavior (only billing-currency config), so the behavior matrix in this PR description is the authoritative summary.
