### PR TITLE
Add configurable notification volume / 新增可调通知音量

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -138,9 +138,10 @@ console.log("\nbundle budgets");
 // The final 0.266 KiB retains jump ownership through paint-ready instead of
 // allowing a native scrollend to release it. Keep only 0.213 KiB headroom;
 // native validation hosts and test fixtures stay outside the production graph.
-// Notification volume moves current main-v2 from 447.639 to 447.816 KiB gzip
-// (+0.177 KiB). Retain 0.084 KiB of bounded build/toolchain headroom.
-const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 447.9 : 447.9;
+// Notification volume plus per-source loudness normalization moves current
+// main-v2 from 447.639 to 447.882 KiB gzip (+0.243 KiB). Retain 0.118 KiB of
+// bounded build/toolchain headroom.
+const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 448.0 : 448.0;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -218,9 +219,10 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // raw/toolchain headroom for both owners.
 // The same transcript transaction measures 2413.012 KiB raw (+0.28%) against
 // the 2406.204 KiB baseline. Retain 0.188 KiB of bounded headroom.
-// The notification-volume control adds one persisted master gain and its
-// accessible Settings surface. Current main-v2 moves from 2413.183 to
-// 2414.737 KiB raw (+1.555 KiB); retain 0.163 KiB of bounded headroom.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_414.9 : 2_414.9;
+// The notification-volume control adds one persisted master gain, per-source
+// loudness trims, and its accessible Settings surface. Current main-v2 moves
+// from 2413.183 to 2414.879 KiB raw (+1.696 KiB); retain 0.121 KiB of bounded
+// headroom.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_415.0 : 2_415.0;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -138,7 +138,9 @@ console.log("\nbundle budgets");
 // The final 0.266 KiB retains jump ownership through paint-ready instead of
 // allowing a native scrollend to release it. Keep only 0.213 KiB headroom;
 // native validation hosts and test fixtures stay outside the production graph.
-const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 447.8 : 447.8;
+// Notification volume moves current main-v2 from 447.639 to 447.816 KiB gzip
+// (+0.177 KiB). Retain 0.084 KiB of bounded build/toolchain headroom.
+const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 447.9 : 447.9;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -216,6 +218,9 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // raw/toolchain headroom for both owners.
 // The same transcript transaction measures 2413.012 KiB raw (+0.28%) against
 // the 2406.204 KiB baseline. Retain 0.188 KiB of bounded headroom.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_413.2 : 2_413.2;
+// The notification-volume control adds one persisted master gain and its
+// accessible Settings surface. Current main-v2 moves from 2413.183 to
+// 2414.737 KiB raw (+1.555 KiB); retain 0.163 KiB of bounded headroom.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_414.9 : 2_414.9;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/__tests__/notification-volume-slider.test.tsx
+++ b/desktop/frontend/src/__tests__/notification-volume-slider.test.tsx
@@ -1,0 +1,66 @@
+// Run: tsx src/__tests__/notification-volume-slider.test.tsx
+
+import React, { act } from "react";
+import { JSDOM } from "jsdom";
+
+let passed = 0;
+let failed = 0;
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+console.log("\nnotification volume slider");
+const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Event = dom.window.Event;
+
+const [{ createRoot }, { NotificationVolumeSlider }, { LocaleProvider }] = await Promise.all([
+  import("react-dom/client"),
+  import("../components/NotificationVolumeSlider"),
+  import("../lib/i18n"),
+]);
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("missing root");
+const root = createRoot(rootElement);
+const changes: number[] = [];
+await act(async () => {
+  root.render(
+    <LocaleProvider>
+      <NotificationVolumeSlider value={70} onChange={(value) => changes.push(value)} />
+    </LocaleProvider>,
+  );
+});
+
+const input = document.querySelector<HTMLInputElement>('input[type="range"]');
+const output = document.querySelector<HTMLOutputElement>("output");
+ok(input?.getAttribute("aria-label") === "Notification volume", "slider exposes its localized purpose");
+ok(input?.min === "0" && input?.max === "100" && input?.step === "5", "slider exposes the full 0–100% keyboard range");
+ok(input?.value === "70" && input?.getAttribute("aria-valuetext") === "70%", "slider announces the default percentage");
+ok(output?.textContent === "70%" && output?.getAttribute("for") === input?.id, "visible percentage is associated with the slider");
+await act(async () => {
+  if (!input) return;
+  const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, "85");
+  input.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+  input.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+});
+ok(changes.at(-1) === 85, "dragging or using the keyboard emits the next percentage");
+
+await act(async () => root.unmount());
+dom.window.close();
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/settings-responsive-layout.test.ts
+++ b/desktop/frontend/src/__tests__/settings-responsive-layout.test.ts
@@ -54,6 +54,17 @@ eq(declaration(compactGeneralField, "gap"), "10px", "stacked general settings ke
 const compactGeneralControl = ruleBlock(generalContainer, ".settings-page--general .settings-field__control");
 eq(declaration(compactGeneralControl, "min-width"), "0", "compact general controls may shrink within the content pane");
 
+const soundContainerStart = panelStyles.indexOf("@container settings-general (max-width: 440px)");
+const soundContainerEnd = panelStyles.indexOf("@media (max-width: 980px)", soundContainerStart);
+const compactSound = panelStyles.slice(soundContainerStart, soundContainerEnd);
+const compactSoundRow = ruleBlock(compactSound, ".settings-sound-row");
+eq(declaration(compactSoundRow, "grid-template-columns"), "minmax(0, 1fr)", "narrow sound settings stack labels above their controls");
+eq(
+  compactSound.includes(".settings-sound-row .notification-volume-control") && compactSound.includes("width: 100%"),
+  true,
+  "notification volume expands without overflowing a narrow settings pane",
+);
+
 const fallbackPanel = panelStyles.slice(generalFallbackStart, panelStyles.indexOf("@media (max-width: 760px)", generalFallbackStart));
 const fallbackGeneralField = ruleBlock(fallbackPanel, ".settings-page--general .settings-field");
 eq(declaration(fallbackGeneralField, "grid-template-columns"), "1fr", "980px fallback stacks general settings without container queries");

--- a/desktop/frontend/src/__tests__/sound.test.ts
+++ b/desktop/frontend/src/__tests__/sound.test.ts
@@ -1,6 +1,20 @@
 // Run: tsx src/__tests__/sound.test.ts
 
-import { attentionChimeEventKey, clearAttentionChimeKeys, shouldPlayAttentionChimeForEvent } from "../lib/sound";
+import {
+  DEFAULT_NOTIFICATION_VOLUME,
+  NOTIFICATION_VOLUME_STORAGE_KEY,
+  attentionChimeEventKey,
+  clearAttentionChimeKeys,
+  getNotificationVolume,
+  notificationVolumeToGain,
+  normalizeNotificationVolume,
+  playAttentionChime,
+  playSuccessChime,
+  setAttentionPreference,
+  setNotificationVolume,
+  setSuccessPreference,
+  shouldPlayAttentionChimeForEvent,
+} from "../lib/sound";
 
 let passed = 0;
 let failed = 0;
@@ -16,6 +30,73 @@ function eq(a: unknown, b: unknown, label: string) {
 }
 
 console.log("\nsound notifications");
+
+const storedValues = new Map<string, string>();
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: {
+    getItem(key: string) { return storedValues.get(key) ?? null; },
+    setItem(key: string, value: string) { storedValues.set(key, value); },
+    removeItem(key: string) { storedValues.delete(key); },
+    clear() { storedValues.clear(); },
+  },
+});
+
+{
+  eq(getNotificationVolume(), DEFAULT_NOTIFICATION_VOLUME, "legacy installs without a saved volume upgrade to the 70% default");
+  eq(setNotificationVolume(85), 85, "notification volume saves a user-selected percentage");
+  eq(storedValues.get(NOTIFICATION_VOLUME_STORAGE_KEY), "85", "notification volume persists in its dedicated storage key");
+  eq(getNotificationVolume(), 85, "saved notification volume round-trips");
+  eq(setNotificationVolume(140), 100, "notification volume clamps values above 100%");
+  eq(setNotificationVolume(-10), 0, "notification volume clamps values below 0%");
+  storedValues.set(NOTIFICATION_VOLUME_STORAGE_KEY, "not-a-number");
+  eq(getNotificationVolume(), DEFAULT_NOTIFICATION_VOLUME, "invalid persisted volume recovers to the default");
+  eq(normalizeNotificationVolume(72.6), 73, "notification volume normalizes fractional values to an integer percentage");
+  eq(notificationVolumeToGain(70), 0.7, "notification volume converts percentages to Web Audio gain");
+}
+
+{
+  const synthPeaks: number[] = [];
+  class FakeAudioContext {
+    destination = {};
+    createOscillator() {
+      return {
+        type: "sine",
+        frequency: { setValueAtTime() {} },
+        connect() {},
+        start() {},
+        stop() {},
+      };
+    }
+    createGain() {
+      return {
+        gain: {
+          setValueAtTime() {},
+          linearRampToValueAtTime(value: number) { synthPeaks.push(value); },
+          exponentialRampToValueAtTime() {},
+        },
+        connect() {},
+      };
+    }
+    close() {}
+  }
+  Object.defineProperty(globalThis, "AudioContext", { configurable: true, value: FakeAudioContext });
+  const maxPeak = () => Math.round(Math.max(...synthPeaks) * 1000) / 1000;
+
+  setSuccessPreference("synth");
+  setAttentionPreference("synth");
+  setNotificationVolume(DEFAULT_NOTIFICATION_VOLUME);
+  playSuccessChime();
+  eq(maxPeak(), 0.245, "the 70% upgrade default raises the synthesized success peak above the legacy level");
+  synthPeaks.length = 0;
+  playAttentionChime();
+  eq(maxPeak(), 0.28, "the 70% upgrade default keeps attention at least as audible as success");
+  synthPeaks.length = 0;
+  setNotificationVolume(0);
+  playSuccessChime();
+  playAttentionChime();
+  eq(synthPeaks.length, 0, "0% prevents synthesized notifications from creating audio nodes");
+}
 
 {
   eq(attentionChimeEventKey({ kind: "approval_request", tabId: "tab-a", approval: { id: "approval-1" } }), "approval:tab-a:approval-1", "approval request builds a tab-scoped chime key");

--- a/desktop/frontend/src/__tests__/sound.test.ts
+++ b/desktop/frontend/src/__tests__/sound.test.ts
@@ -6,6 +6,7 @@ import {
   attentionChimeEventKey,
   clearAttentionChimeKeys,
   getNotificationVolume,
+  notificationWavGain,
   notificationVolumeToGain,
   normalizeNotificationVolume,
   playAttentionChime,
@@ -53,6 +54,15 @@ Object.defineProperty(globalThis, "localStorage", {
   eq(getNotificationVolume(), DEFAULT_NOTIFICATION_VOLUME, "invalid persisted volume recovers to the default");
   eq(normalizeNotificationVolume(72.6), 73, "notification volume normalizes fractional values to an integer percentage");
   eq(notificationVolumeToGain(70), 0.7, "notification volume converts percentages to Web Audio gain");
+  const normalizedWavGains = [
+    notificationWavGain("positive", 1),
+    notificationWavGain("correct", 1),
+    notificationWavGain("start", 1),
+    notificationWavGain("back", 1),
+  ];
+  eq(normalizedWavGains.join(","), "0.62,0.85,1,0.7", "bundled WAVs use their measured loudness-normalization trims");
+  eq(Math.max(...normalizedWavGains), 1, "WAV normalization never boosts a source above its recorded peak");
+  eq(notificationWavGain("start", 0.7), 0.7, "the master volume scales a normalized WAV after its source trim");
 }
 
 {

--- a/desktop/frontend/src/__tests__/startup-settings-contract.test.ts
+++ b/desktop/frontend/src/__tests__/startup-settings-contract.test.ts
@@ -220,6 +220,14 @@ ok(
   "the retired standalone reasoning-summary setting does not return",
 );
 ok(
+  settingsSource.includes('t("settings.notificationVolume")') &&
+    settingsSource.includes("<NotificationVolumeSlider") &&
+    [enLocaleSource, zhLocaleSource, zhTWLocaleSource].every((source) =>
+      source.includes('"settings.notificationVolume"'),
+    ),
+  "sound settings expose the persisted notification volume control in every locale",
+);
+ok(
   !/mockPreset\("deepseek-anthropic",/.test(bridgeSource),
   "browser mock hides the redundant DeepSeek Anthropic preset",
 );

--- a/desktop/frontend/src/components/NotificationVolumeSlider.tsx
+++ b/desktop/frontend/src/components/NotificationVolumeSlider.tsx
@@ -1,0 +1,37 @@
+import { useId } from "react";
+
+import { useT } from "../lib/i18n";
+import {
+  NOTIFICATION_VOLUME_MAX,
+  NOTIFICATION_VOLUME_MIN,
+  normalizeNotificationVolume,
+} from "../lib/sound";
+
+export function NotificationVolumeSlider({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  const t = useT();
+  const inputId = useId();
+  const normalized = normalizeNotificationVolume(value);
+
+  return (
+    <div className="notification-volume-control">
+      <input
+        id={inputId}
+        type="range"
+        min={NOTIFICATION_VOLUME_MIN}
+        max={NOTIFICATION_VOLUME_MAX}
+        step={5}
+        value={normalized}
+        aria-label={t("settings.notificationVolume")}
+        aria-valuetext={`${normalized}%`}
+        onChange={(event) => onChange(normalizeNotificationVolume(event.currentTarget.value))}
+      />
+      <output htmlFor={inputId}>{normalized}%</output>
+    </div>
+  );
+}

--- a/desktop/frontend/src/components/SettingsPanel.css
+++ b/desktop/frontend/src/components/SettingsPanel.css
@@ -446,6 +446,21 @@
   }
 }
 
+@container settings-general (max-width: 440px) {
+  .settings-sound-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 6px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+
+  .settings-sound-row .sound-select,
+  .settings-sound-row .notification-volume-control {
+    width: 100%;
+    justify-self: stretch;
+  }
+}
+
 @media (max-width: 980px) {
   .settings-page--general .settings-field {
     grid-template-columns: 1fr;

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -73,7 +73,8 @@ import { Tooltip } from "./Tooltip";
 import { AnchoredPopover } from "./AnchoredPopover";
 import { getGenerativePreset, setGenerativePreset, generativeMusic, type GenerativePreset } from "../lib/generative-music";
 import { SoundSelect } from "./SoundSelect";
-import { getSuccessPreference, setSuccessPreference, getAttentionPreference, setAttentionPreference, playSuccessChime, playAttentionChime, type SoundWavPref } from "../lib/sound";
+import { getSuccessPreference, setSuccessPreference, getAttentionPreference, setAttentionPreference, getNotificationVolume, setNotificationVolume as persistNotificationVolume, playSuccessChime, playAttentionChime, type SoundWavPref } from "../lib/sound";
+import { NotificationVolumeSlider } from "./NotificationVolumeSlider";
 import { ModalCloseButton } from "./ModalCloseButton";
 import { ShortcutComboDisplay } from "./ShortcutComboDisplay";
 import { SettingsNavigation, SETTINGS_NAV_TABS } from "./SettingsNavigation";
@@ -1644,10 +1645,11 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
   const [genMusicPreset, setGenMusicPreset] = useState<GenerativePreset>(getGenerativePreset());
   const [soundPref, setSoundPref] = useState<SoundWavPref>(getSuccessPreference());
   const [attentionPref, setAttentionPref] = useState<SoundWavPref>(getAttentionPreference());
+  const [notificationVolume, setNotificationVolume] = useState(getNotificationVolume);
   const [soundExpanded, setSoundExpanded] = useState(false);
   const statusBarStyle = normalizeStatusBarStyle(s.statusBarStyle);
   const statusBarItems = normalizeStatusBarItems(s.statusBarItems);
-  const soundStatus = summarizeSoundStatus(genMusicPreset, soundPref, attentionPref);
+  const soundStatus = summarizeSoundStatus(genMusicPreset, soundPref, attentionPref, notificationVolume);
   const applyStatusBarItems = (items: StatusBarItemId[]) => {
     const contentScrollTop = document.querySelector<HTMLElement>(".settings-center__content")?.scrollTop ?? 0;
     const navScrollTop = document.querySelector<HTMLElement>(".settings-center__nav")?.scrollTop ?? 0;
@@ -1842,6 +1844,13 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
                 />
               </div>
               <div className="settings-sound-row">
+                <span className="settings-sound-row__label">{t("settings.notificationVolume")}</span>
+                <NotificationVolumeSlider
+                  value={notificationVolume}
+                  onChange={(next) => setNotificationVolume(persistNotificationVolume(next))}
+                />
+              </div>
+              <div className="settings-sound-row">
                 <span className="settings-sound-row__label">{t("settings.notificationSoundSuccess")}</span>
                 <SoundSelect
                   value={soundPref}
@@ -1910,8 +1919,14 @@ function summarizeSoundStatus(
   music: GenerativePreset,
   success: SoundWavPref,
   attention: SoundWavPref,
+  notificationVolume: number,
 ): "allOff" | "enabled" | "custom" {
-  const enabledCount = [music !== "off", success !== "off", attention !== "off"].filter(Boolean).length;
+  const notificationsAudible = notificationVolume > 0;
+  const enabledCount = [
+    music !== "off",
+    notificationsAudible && success !== "off",
+    notificationsAudible && attention !== "off",
+  ].filter(Boolean).length;
   if (enabledCount === 0) return "allOff";
   if (enabledCount === 1) return "enabled";
   return "custom";

--- a/desktop/frontend/src/lib/sound.ts
+++ b/desktop/frontend/src/lib/sound.ts
@@ -5,6 +5,7 @@
  * 两个场景的偏好分别存入 localStorage:
  *   notificationSoundSuccess  —— 生成完成
  *   notificationSoundAttention —— AI 提问
+ *   notificationSoundVolume —— 统一通知音量（0–100）
  *   值："off" | "synth" | "positive" | "correct" | "start" | "back"
  */
 
@@ -12,6 +13,10 @@ export type SoundWavPref = "off" | "synth" | "positive" | "correct" | "start" | 
 
 const SUCCESS_KEY = "notificationSoundSuccess";
 const ATTENTION_KEY = "notificationSoundAttention";
+export const NOTIFICATION_VOLUME_STORAGE_KEY = "notificationSoundVolume";
+export const NOTIFICATION_VOLUME_MIN = 0;
+export const NOTIFICATION_VOLUME_MAX = 100;
+export const DEFAULT_NOTIFICATION_VOLUME = 70;
 
 function readPref(key: string): SoundWavPref {
   if (typeof localStorage === "undefined") return "off";
@@ -30,6 +35,40 @@ export function getSuccessPreference(): SoundWavPref { return readPref(SUCCESS_K
 export function setSuccessPreference(pref: SoundWavPref): void { writePref(SUCCESS_KEY, pref); }
 export function getAttentionPreference(): SoundWavPref { return readPref(ATTENTION_KEY); }
 export function setAttentionPreference(pref: SoundWavPref): void { writePref(ATTENTION_KEY, pref); }
+
+export function normalizeNotificationVolume(value: unknown): number {
+  const raw = typeof value === "string" ? value.trim() : value;
+  if (raw === "" || raw === null || raw === undefined) return DEFAULT_NOTIFICATION_VOLUME;
+  const numeric = Number(raw);
+  if (!Number.isFinite(numeric)) return DEFAULT_NOTIFICATION_VOLUME;
+  return Math.min(NOTIFICATION_VOLUME_MAX, Math.max(NOTIFICATION_VOLUME_MIN, Math.round(numeric)));
+}
+
+export function getNotificationVolume(): number {
+  if (typeof localStorage === "undefined") return DEFAULT_NOTIFICATION_VOLUME;
+  try {
+    const value = localStorage.getItem(NOTIFICATION_VOLUME_STORAGE_KEY);
+    return value === null ? DEFAULT_NOTIFICATION_VOLUME : normalizeNotificationVolume(value);
+  } catch {
+    return DEFAULT_NOTIFICATION_VOLUME;
+  }
+}
+
+export function setNotificationVolume(volume: number): number {
+  const normalized = normalizeNotificationVolume(volume);
+  try {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(NOTIFICATION_VOLUME_STORAGE_KEY, String(normalized));
+    }
+  } catch {
+    // Private browsing and locked-down WebViews may reject localStorage writes.
+  }
+  return normalized;
+}
+
+export function notificationVolumeToGain(volume: unknown): number {
+  return normalizeNotificationVolume(volume) / NOTIFICATION_VOLUME_MAX;
+}
 
 function soundFilePath(pref: SoundWavPref): string {
   switch (pref) {
@@ -97,20 +136,20 @@ function playSynthNote(ctx: AudioContext, dest: AudioNode, freq: number, startTi
   shimmer.stop(startTime + duration);
 }
 
-function playSynthSuccess(ctx: AudioContext): void {
-  playSynthNote(ctx, ctx.destination, 1318.5, 0, 0.20, 0.12);
-  playSynthNote(ctx, ctx.destination, 1568.0, 0.07, 0.22, 0.10);
-  playSynthNote(ctx, ctx.destination, 2093.0, 0.14, 0.30, 0.08);
+function playSynthSuccess(ctx: AudioContext, outputVolume: number): void {
+  playSynthNote(ctx, ctx.destination, 1318.5, 0, 0.20, outputVolume * 0.35);
+  playSynthNote(ctx, ctx.destination, 1568.0, 0.07, 0.22, outputVolume * 0.30);
+  playSynthNote(ctx, ctx.destination, 2093.0, 0.14, 0.30, outputVolume * 0.24);
 }
 
-function playSynthAttention(ctx: AudioContext): void {
-  playSynthNote(ctx, ctx.destination, 1760.0, 0, 0.14, 0.10);
-  playSynthNote(ctx, ctx.destination, 1318.5, 0.09, 0.22, 0.08);
+function playSynthAttention(ctx: AudioContext, outputVolume: number): void {
+  playSynthNote(ctx, ctx.destination, 1760.0, 0, 0.14, outputVolume * 0.40);
+  playSynthNote(ctx, ctx.destination, 1318.5, 0.09, 0.22, outputVolume * 0.34);
 }
 
 // ── Play helpers ─────────────────────────────────────────────────────────────
 
-async function playWav(pref: SoundWavPref, volume: number, fallback: (ctx: AudioContext) => void): Promise<void> {
+async function playWav(pref: SoundWavPref, volume: number, fallback: (ctx: AudioContext, outputVolume: number) => void): Promise<void> {
   const url = soundFilePath(pref);
   if (!url) return;
   const ctx = new AudioContext();
@@ -119,10 +158,10 @@ async function playWav(pref: SoundWavPref, volume: number, fallback: (ctx: Audio
     if (buf) {
       playBuffer(ctx, buf, volume);
     } else {
-      fallback(ctx);
+      fallback(ctx, volume);
     }
   } catch {
-    fallback(ctx);
+    fallback(ctx, volume);
   }
   setTimeout(() => ctx.close(), 2000);
 }
@@ -132,28 +171,32 @@ async function playWav(pref: SoundWavPref, volume: number, fallback: (ctx: Audio
 export function playSuccessChime(): void {
   const pref = getSuccessPreference();
   if (pref === "off") return;
+  const volume = notificationVolumeToGain(getNotificationVolume());
+  if (volume <= 0) return;
   if (pref === "synth") {
     try {
       const ctx = new AudioContext();
-      playSynthSuccess(ctx);
+      playSynthSuccess(ctx, volume);
       setTimeout(() => ctx.close(), 600);
     } catch { /* silent */ }
   } else {
-    void playWav(pref, 0.35, playSynthSuccess);
+    void playWav(pref, volume, playSynthSuccess);
   }
 }
 
 export function playAttentionChime(): void {
   const pref = getAttentionPreference();
   if (pref === "off") return;
+  const volume = notificationVolumeToGain(getNotificationVolume());
+  if (volume <= 0) return;
   if (pref === "synth") {
     try {
       const ctx = new AudioContext();
-      playSynthAttention(ctx);
+      playSynthAttention(ctx, volume);
       setTimeout(() => ctx.close(), 500);
     } catch { /* silent */ }
   } else {
-    void playWav(pref, 0.25, playSynthAttention);
+    void playWav(pref, volume, playSynthAttention);
   }
 }
 

--- a/desktop/frontend/src/lib/sound.ts
+++ b/desktop/frontend/src/lib/sound.ts
@@ -70,6 +70,25 @@ export function notificationVolumeToGain(volume: unknown): number {
   return normalizeNotificationVolume(volume) / NOTIFICATION_VOLUME_MAX;
 }
 
+type WavSoundPref = Exclude<SoundWavPref, "off" | "synth">;
+
+// The bundled WAV files differ by up to 4.1 LUFS. These trims normalize them
+// to the quietest source (-18.9 LUFS) without boosting any asset above its
+// recorded peak. The master volume is applied after the source trim.
+const WAV_LOUDNESS_TRIM: Record<WavSoundPref, number> = {
+  positive: 0.62,
+  correct: 0.85,
+  start: 1,
+  back: 0.70,
+};
+
+export function notificationWavGain(pref: WavSoundPref, outputVolume: number): number {
+  const safeVolume = Number.isFinite(outputVolume)
+    ? Math.min(1, Math.max(0, outputVolume))
+    : 0;
+  return safeVolume * WAV_LOUDNESS_TRIM[pref];
+}
+
 function soundFilePath(pref: SoundWavPref): string {
   switch (pref) {
     case "positive": return "./sounds/mixkit-positive-notification-951.wav";
@@ -149,14 +168,14 @@ function playSynthAttention(ctx: AudioContext, outputVolume: number): void {
 
 // ── Play helpers ─────────────────────────────────────────────────────────────
 
-async function playWav(pref: SoundWavPref, volume: number, fallback: (ctx: AudioContext, outputVolume: number) => void): Promise<void> {
+async function playWav(pref: WavSoundPref, volume: number, fallback: (ctx: AudioContext, outputVolume: number) => void): Promise<void> {
   const url = soundFilePath(pref);
   if (!url) return;
   const ctx = new AudioContext();
   try {
     const buf = await loadBuffer(ctx, url);
     if (buf) {
-      playBuffer(ctx, buf, volume);
+      playBuffer(ctx, buf, notificationWavGain(pref, volume));
     } else {
       fallback(ctx, volume);
     }

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1907,6 +1907,7 @@ export const en = {
   "settings.soundCollapse": "Collapse sound settings",
   "settings.notificationSound": "Notification sounds",
   "settings.notificationSoundHint": "Choose different sounds for each event",
+  "settings.notificationVolume": "Notification volume",
   "settings.notificationSoundSuccess": "Generation complete",
   "settings.notificationSoundAttention": "Awaiting response",
   "settings.notificationSound.synth": "Synthesized",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2856,6 +2856,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.soundCollapse": "收起聲音設定",
   "settings.notificationSound": "通知音效",
   "settings.notificationSoundHint": "為不同事件選擇不同的音效",
+  "settings.notificationVolume": "通知音量",
   "settings.notificationSoundSuccess": "生成完成",
   "settings.notificationSoundAttention": "等待操作",
   "settings.notificationSound.synth": "合成音效",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1909,6 +1909,7 @@ export const zh: Record<DictKey, string> = {
   "settings.soundCollapse": "折叠声音设置",
   "settings.notificationSound": "通知音效",
   "settings.notificationSoundHint": "为不同事件选择不同的音效",
+  "settings.notificationVolume": "通知音量",
   "settings.notificationSoundSuccess": "生成完成",
   "settings.notificationSoundAttention": "等待操作",
   "settings.notificationSound.synth": "合成音效",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -16624,6 +16624,42 @@ body > .mermaid-diagram--fullscreen {
   justify-self: end;
 }
 
+.settings-sound-row .notification-volume-control {
+  width: clamp(190px, 36vw, 260px);
+  min-width: 0;
+  justify-self: end;
+}
+
+.notification-volume-control {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) 42px;
+  align-items: center;
+  gap: 10px;
+}
+
+.notification-volume-control input[type="range"] {
+  --wails-draggable: no-drag;
+  width: 100%;
+  margin: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.notification-volume-control input[type="range"]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.notification-volume-control output {
+  min-width: 42px;
+  color: var(--fg);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  line-height: 1;
+  text-align: right;
+}
+
 .sound-select {
   display: flex;
   align-items: center;

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -123,7 +123,7 @@
       "file-size": 141
     },
     "desktop/frontend/src/components/SettingsPanel.tsx": {
-      "file-size": 7269
+      "file-size": 7284
     },
     "desktop/frontend/src/components/StatusBar.tsx": {
       "file-size": 43


### PR DESCRIPTION
## Summary

- Add an accessible 0–100% notification-volume slider to Desktop Sound settings, with a 70% upgrade default and local persistence.
- Route completion and attention WAV/synth playback through one master gain, removing the previous 35%/25% per-event attenuation and keeping synthesized attention at least as audible as completion.
- Normalize the four bundled WAV sources to the quietest measured asset (-18.9 LUFS) with conservative per-source trims; this closes their previous 4.1 LUFS spread without boosting recorded peaks.
- Cover upgrade defaults, invalid-value recovery, synthesized peak levels, WAV normalization, mute behavior, responsive layout, interaction semantics, and all supported locales.
- Record the measured startup-size delta against current `main-v2`: 447.639 → 447.882 KiB gzip and 2413.183 → 2414.879 KiB raw, with narrowly rounded budget updates to 448.0/2415.0 KiB.
- Ratchet only the existing `SettingsPanel` file-size baseline from 7269 to 7284 (+15 weighted units); the slider implementation remains extracted while its state and row wiring stay with the General settings owner.

## Issues

N/A — this addresses direct user feedback that recent Desktop notification prompts are too quiet to hear over music.

## Verification

- `pnpm build`
- `pnpm exec tsx src/__tests__/sound.test.ts` (29 passed)
- `pnpm exec tsx src/__tests__/notification-volume-slider.test.tsx` (5 passed)
- `pnpm exec tsx src/__tests__/settings-responsive-layout.test.ts` (27 passed)
- `pnpm exec tsx src/__tests__/startup-settings-contract.test.ts` (50 passed)
- `pnpm typecheck`
- `pnpm lint:hooks`
- `go run ./tools/repolint`
- FFmpeg EBU R128 audit of bundled WAVs: positive -14.8, correct -17.5, back -15.8, and start -18.9 LUFS; playback trims normalize all four to approximately -18.9 LUFS before applying the user's master volume.
- Real browser DOM/layout verification: Sound settings render `Background music → Notification volume 70% → Generation complete → Awaiting response`.
- `git diff --check`

Broad-suite note: after rebasing to current `main-v2` (`1288082ac`), both a clean base worktree and this branch reproduce the same unrelated `topic-activation` result (24/25, `reattached thinking session stays marked running`). This PR changes no topic/session runtime files.

## Compatibility

- Existing installs without the new key use 70%; malformed or out-of-range values recover or clamp safely.
- Existing success/attention sound-selection keys and meanings are unchanged.
- Previous Desktop versions ignore the unknown localStorage key, so downgrade does not corrupt existing preferences.
- The setting is local to the Desktop WebView; there is no shared-file or cross-process writer contract.

## Security and concurrency

- No dependencies, network calls, bridge APIs, filesystem access, credentials, commands, permissions, or sandbox boundaries change.
- Slider writes are synchronous numeric localStorage updates; playback reads the latest clamped value at invocation, with no asynchronous shared-state owner or stale-completion path.

## Integration notes

- #9513, #9519, and #9515 independently update the same bundle-budget ratchets. Merge-tree checks show their functional UI/style changes auto-merge with this PR, while `check-bundle-budget.mjs` conflicts.
- Whichever PR lands later must rebase onto the latest `main-v2`, preserve both functional changes, and remeasure the combined gzip/raw result instead of selecting either budget value mechanically. #9528's locale additions auto-merge cleanly.

## Documentation impact

Documentation-impact: none - the localized in-app Sound setting is the complete user-facing workflow and no external notification-sound guide exists.

## Cache impact

Cache-impact: none - no provider-visible prompt, memory, tool schema, serialization, compaction, or reasoning bytes change.
Cache-guard: the diff is limited to Desktop frontend sound/UI code, locales, tests, and measured bundle ratchets.
System-prompt-review: N/A
