### PR TITLE
feat(frontend): open wizard host suggestions from an explicit arrow / 通过明确的箭头打开向导主机建议

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ branch.
   readable on old sessions and are stripped from new provider context.
   Old `--preset`/`--profile` compatibility no-ops are unchanged.
 
+- **Remote connect wizard host picker:** Step 1's host field now opens the
+  saved SSH connections through an explicit chevron dropdown on the input's
+  right edge instead of the old focus-triggered popup. The dropdown lists
+  every saved connection unfiltered, appends non-standard ports to each row,
+  leads with a "saved SSH connections" caption, and closes on pick, arrow
+  toggle, Escape (before the Escape that exits the wizard), or an outside
+  pointer press. The arrow is hidden while no hosts are saved and disabled
+  while a connection is busy.
+
 ### Fixed
 
 - **Compact MCP discovery:** `use_capability(action=list)` now returns one

--- a/desktop/frontend/src/__tests__/remote-connect-wizard.test.tsx
+++ b/desktop/frontend/src/__tests__/remote-connect-wizard.test.tsx
@@ -231,7 +231,7 @@ ok(document.activeElement === hostInput, "Tab from the last action wraps to the 
 // ── Saved-host suggestion: arrow toggle → dropdown → prefill ──
 const toggleArrow = () => document.querySelector<HTMLButtonElement>(".remote-wizard__suggest-toggle");
 ok(Boolean(toggleArrow()), "host field exposes the saved-connections arrow");
-ok(toggleArrow()?.getAttribute("aria-haspopup") === "listbox", "arrow advertises its listbox popup");
+ok(toggleArrow()?.getAttribute("aria-haspopup") === "menu", "arrow advertises its saved-host menu");
 ok(toggleArrow()?.getAttribute("aria-expanded") === "false", "arrow starts collapsed");
 await act(async () => {
   hostInput?.dispatchEvent(new dom.window.Event("focusin", { bubbles: true }));
@@ -246,13 +246,33 @@ await act(async () => {
 ok(Boolean(document.querySelector(".remote-wizard__suggest-list")), "clicking the arrow lists saved SSH connections");
 ok(toggleArrow()?.getAttribute("aria-expanded") === "true", "arrow reflects the expanded state");
 ok((document.querySelector(".remote-wizard__suggest-head")?.textContent ?? "").toLowerCase().includes("ssh"), "dropdown leads with the saved-connections caption");
-const suggestion = document.querySelector<HTMLButtonElement>(".remote-wizard__suggest-list button");
+ok(document.querySelector(".remote-wizard__suggest-list")?.getAttribute("role") === "menu", "saved hosts use menu semantics");
+const menuItems = [...document.querySelectorAll<HTMLButtonElement>('.remote-wizard__suggest-list [role="menuitem"]')];
+ok(menuItems.length === savedHosts.length, "every saved host is exposed as a menu item");
+ok(document.activeElement === menuItems[0], "opening the menu moves focus to the first saved host");
+await act(async () => {
+  menuItems[0]?.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+  await Promise.resolve();
+});
+ok(document.activeElement === menuItems[1], "ArrowDown moves focus to the next saved host");
+await act(async () => {
+  document.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  await Promise.resolve();
+});
+ok(!document.querySelector(".remote-wizard__suggest-list"), "Escape closes the keyboard-opened menu");
+ok(document.activeElement === toggleArrow(), "Escape restores focus to the saved-host arrow");
+await act(async () => {
+  toggleArrow()?.click();
+  await Promise.resolve();
+});
+const suggestion = document.querySelector<HTMLButtonElement>('.remote-wizard__suggest-list [role="menuitem"]');
 await act(async () => {
   suggestion?.click();
   await Promise.resolve();
 });
 ok(hostInput?.value === "192.168.1.10", "picking a suggestion prefills the host");
 ok(!document.querySelector(".remote-wizard__suggest-list"), "picking a suggestion closes the list");
+ok(document.activeElement === hostInput, "picking a suggestion restores focus to the host input");
 const keyInput = [...document.querySelectorAll<HTMLInputElement>("input")].find((i) => i.value.includes("id_ed25519"));
 ok(Boolean(keyInput), "saved key auth switches the form to key mode with the identity file");
 await act(async () => {
@@ -313,6 +333,7 @@ ok(keyInput?.value === "/home/dev/.ssh/id_wizard", "native picker returns the ab
   });
   ok(!document.querySelector(".remote-wizard__suggest-list"), "Escape closes the open list");
   ok(!tape.includes("close"), "Escape with the list open keeps the wizard open");
+  ok(document.activeElement === toggleArrow(), "Escape from a saved host restores focus to the arrow");
   await act(async () => {
     toggleArrow()?.click();
     await Promise.resolve();

--- a/desktop/frontend/src/__tests__/remote-connect-wizard.test.tsx
+++ b/desktop/frontend/src/__tests__/remote-connect-wizard.test.tsx
@@ -228,19 +228,31 @@ ok(document.activeElement === hostInput, "Tab from the last action wraps to the 
     await Promise.resolve();
   });
 }
-// ── Saved-host suggestion: focus → dropdown → prefill ──
+// ── Saved-host suggestion: arrow toggle → dropdown → prefill ──
+const toggleArrow = () => document.querySelector<HTMLButtonElement>(".remote-wizard__suggest-toggle");
+ok(Boolean(toggleArrow()), "host field exposes the saved-connections arrow");
+ok(toggleArrow()?.getAttribute("aria-haspopup") === "listbox", "arrow advertises its listbox popup");
+ok(toggleArrow()?.getAttribute("aria-expanded") === "false", "arrow starts collapsed");
 await act(async () => {
   hostInput?.dispatchEvent(new dom.window.Event("focusin", { bubbles: true }));
   hostInput?.dispatchEvent(new dom.window.Event("focus", { bubbles: false }));
   await Promise.resolve();
 });
-const suggestion = document.querySelector<HTMLButtonElement>(".remote-wizard__suggest-list button");
-ok(Boolean(suggestion), "focusing the host input lists saved SSH connections");
+ok(!document.querySelector(".remote-wizard__suggest-list"), "focusing the host input alone no longer opens the list");
 await act(async () => {
-  suggestion?.dispatchEvent(new dom.window.Event("mousedown", { bubbles: true, cancelable: true }));
+  toggleArrow()?.click();
+  await Promise.resolve();
+});
+ok(Boolean(document.querySelector(".remote-wizard__suggest-list")), "clicking the arrow lists saved SSH connections");
+ok(toggleArrow()?.getAttribute("aria-expanded") === "true", "arrow reflects the expanded state");
+ok((document.querySelector(".remote-wizard__suggest-head")?.textContent ?? "").toLowerCase().includes("ssh"), "dropdown leads with the saved-connections caption");
+const suggestion = document.querySelector<HTMLButtonElement>(".remote-wizard__suggest-list button");
+await act(async () => {
+  suggestion?.click();
   await Promise.resolve();
 });
 ok(hostInput?.value === "192.168.1.10", "picking a suggestion prefills the host");
+ok(!document.querySelector(".remote-wizard__suggest-list"), "picking a suggestion closes the list");
 const keyInput = [...document.querySelectorAll<HTMLInputElement>("input")].find((i) => i.value.includes("id_ed25519"));
 ok(Boolean(keyInput), "saved key auth switches the form to key mode with the identity file");
 await act(async () => {
@@ -251,36 +263,89 @@ ok(tape.includes("PickRemoteIdentityFile"), "identity-file action uses the nativ
 ok(keyInput?.value === "/home/dev/.ssh/id_wizard", "native picker returns the absolute identity-file path");
 
 {
+  const listButtons = () => [...document.querySelectorAll<HTMLButtonElement>(".remote-wizard__suggest-list button")];
   await act(async () => {
     if (hostInput) setInput(hostInput, "");
     await Promise.resolve();
   });
   await act(async () => {
-    hostInput?.dispatchEvent(new dom.window.Event("focusin", { bubbles: true }));
-    hostInput?.dispatchEvent(new dom.window.Event("focus", { bubbles: false }));
+    toggleArrow()?.click();
     await Promise.resolve();
   });
-  const listed = [...document.querySelectorAll<HTMLButtonElement>(".remote-wizard__suggest-list button")].find((b) => b.textContent?.includes("pw-box"));
+  const listed = listButtons().find((b) => b.textContent?.includes("pw-box"));
   await act(async () => {
-    listed?.dispatchEvent(new dom.window.Event("mousedown", { bubbles: true, cancelable: true }));
+    listed?.click();
     await Promise.resolve();
   });
   const passwordInput = document.querySelector<HTMLInputElement>(".remote-wizard__field input[type='password']");
   ok((passwordInput?.placeholder ?? "").toLowerCase().includes("saved") || (passwordInput?.placeholder ?? "").includes("已保存"), "saved password host keeps a keep-existing placeholder");
+  // Typed text no longer filters the list: reopen with a filled host field
+  // and every saved connection must still be offered.
   await act(async () => {
-    if (hostInput) setInput(hostInput, "");
+    if (hostInput) setInput(hostInput, "10.0.0.8");
     await Promise.resolve();
   });
   await act(async () => {
-    hostInput?.dispatchEvent(new dom.window.Event("focusin", { bubbles: true }));
-    hostInput?.dispatchEvent(new dom.window.Event("focus", { bubbles: false }));
+    toggleArrow()?.click();
     await Promise.resolve();
   });
-  const gpuSuggestion = [...document.querySelectorAll<HTMLButtonElement>(".remote-wizard__suggest-list button")].find((b) => b.textContent?.includes("gpu-box"));
+  {
+    const labels = listButtons().map((b) => b.textContent ?? "");
+    ok(labels.some((l) => l.includes("gpu-box")) && labels.some((l) => l.includes("pw-box")), "typing in the host field does not filter the dropdown");
+  }
   await act(async () => {
-    gpuSuggestion?.dispatchEvent(new dom.window.Event("mousedown", { bubbles: true, cancelable: true }));
+    hostInput?.dispatchEvent(new dom.window.Event("pointerdown", { bubbles: true }));
     await Promise.resolve();
   });
+  ok(Boolean(document.querySelector(".remote-wizard__suggest-list")), "a pointer press on the host field keeps the list open");
+  await act(async () => {
+    document.body.dispatchEvent(new dom.window.Event("pointerdown", { bubbles: true }));
+    await Promise.resolve();
+  });
+  ok(!document.querySelector(".remote-wizard__suggest-list"), "a pointer press outside the field closes the list");
+  await act(async () => {
+    toggleArrow()?.click();
+    await Promise.resolve();
+  });
+  await act(async () => {
+    document.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await Promise.resolve();
+  });
+  ok(!document.querySelector(".remote-wizard__suggest-list"), "Escape closes the open list");
+  ok(!tape.includes("close"), "Escape with the list open keeps the wizard open");
+  await act(async () => {
+    toggleArrow()?.click();
+    await Promise.resolve();
+  });
+  await act(async () => {
+    toggleArrow()?.click();
+    await Promise.resolve();
+  });
+  ok(!document.querySelector(".remote-wizard__suggest-list"), "clicking the open arrow toggles the list shut");
+  // No saved hosts at all: no arrow, no list.
+  {
+    const restored = useRemoteStore.getState().hosts.slice();
+    await act(async () => {
+      useRemoteStore.getState().setHosts([]);
+      await Promise.resolve();
+    });
+    ok(!document.querySelector(".remote-wizard__suggest-toggle"), "no saved hosts hides the arrow entirely");
+    await act(async () => {
+      useRemoteStore.getState().setHosts(restored);
+      await Promise.resolve();
+    });
+    ok(Boolean(document.querySelector(".remote-wizard__suggest-toggle")), "the arrow returns once hosts exist again");
+  }
+  await act(async () => {
+    toggleArrow()?.click();
+    await Promise.resolve();
+  });
+  const gpuSuggestion = listButtons().find((b) => b.textContent?.includes("gpu-box"));
+  await act(async () => {
+    gpuSuggestion?.click();
+    await Promise.resolve();
+  });
+  ok(hostInput?.value === "192.168.1.10", "picking gpu-box from the reopened list restores its host");
 }
 // ── Next: first connect fails; the wizard stays on the connecting step ──
 await act(async () => {

--- a/desktop/frontend/src/__tests__/remote-connect-wizard.test.tsx
+++ b/desktop/frontend/src/__tests__/remote-connect-wizard.test.tsx
@@ -195,6 +195,12 @@ ok(railItems().every((item) => !item.className.includes("--done")), "no step is 
 ok(document.querySelectorAll(".remote-wizard__seg").length === 3, "auth, download, and credential mode use segmented sliders");
 const hostInput = document.querySelector<HTMLInputElement>(".remote-wizard__suggest input");
 ok(Boolean(hostInput), "config step shows the host input");
+ok(
+  hostInput?.closest("label") === null &&
+    hostInput?.labels?.length === 1 &&
+    hostInput.labels[0]?.textContent?.trim() === "Host",
+  "host input uses an exact explicit label",
+);
 ok(document.activeElement === hostInput, "opening the dialog focuses the first field");
 await act(async () => {
   document.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true }));
@@ -231,6 +237,7 @@ ok(document.activeElement === hostInput, "Tab from the last action wraps to the 
 // ── Saved-host suggestion: arrow toggle → dropdown → prefill ──
 const toggleArrow = () => document.querySelector<HTMLButtonElement>(".remote-wizard__suggest-toggle");
 ok(Boolean(toggleArrow()), "host field exposes the saved-connections arrow");
+ok(toggleArrow()?.closest("label") === null, "saved-connections arrow stays outside the host label");
 ok(toggleArrow()?.getAttribute("aria-haspopup") === "menu", "arrow advertises its saved-host menu");
 ok(toggleArrow()?.getAttribute("aria-expanded") === "false", "arrow starts collapsed");
 await act(async () => {

--- a/desktop/frontend/src/components/RemoteConnectWizard.css
+++ b/desktop/frontend/src/components/RemoteConnectWizard.css
@@ -114,7 +114,7 @@
 .remote-wizard__suggest .remote-wizard__host-box input {
   flex: 1;
   min-width: 0;
-  padding-right: 30px;
+  padding-right: 32px;
 }
 .remote-wizard__suggest-toggle {
   position: absolute;
@@ -125,8 +125,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   padding: 0;
   border: 0;
   border-radius: 5px;

--- a/desktop/frontend/src/components/RemoteConnectWizard.css
+++ b/desktop/frontend/src/components/RemoteConnectWizard.css
@@ -103,6 +103,53 @@
 .remote-wizard__suggest {
   position: relative;
 }
+.remote-wizard__host-box {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+/* Outranks the .remote-wizard__form input padding shorthand; the input
+   reserves room for the absolute toggle arrow on its right edge. */
+.remote-wizard__suggest .remote-wizard__host-box input {
+  flex: 1;
+  min-width: 0;
+  padding-right: 30px;
+}
+.remote-wizard__suggest-toggle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 4px;
+  margin-block: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--fg-faint);
+  transition: transform 0.15s ease;
+  cursor: pointer;
+}
+.remote-wizard__suggest-toggle:hover:not(:disabled) {
+  color: var(--fg-dim);
+}
+.remote-wizard__suggest-toggle:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.remote-wizard__suggest-toggle--open {
+  transform: rotate(180deg);
+}
+.remote-wizard__suggest-head {
+  padding: 6px 10px 4px;
+  color: var(--fg-dim);
+  font-size: var(--text-xs);
+}
 .remote-wizard__suggest-list {
   position: absolute;
   top: 100%;

--- a/desktop/frontend/src/components/RemoteConnectWizard.tsx
+++ b/desktop/frontend/src/components/RemoteConnectWizard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Check, FileText, Folder, Plus } from "lucide-react";
+import { Check, ChevronDown, FileText, Folder, Plus } from "lucide-react";
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import { useRemoteStore, waitForRemoteConnection } from "../store/remote";
@@ -9,6 +9,7 @@ import type { RemoteDirEntry, RemoteHostInput, RemoteHostView } from "../lib/typ
 
 type WizardStep = "config" | "connecting" | "workspace";
 const STEP_ORDER: WizardStep[] = ["config", "connecting", "workspace"];
+const HOST_LIST_ID = "remote-wizard-host-list";
 
 const blankInput: RemoteHostInput = {
   label: "",
@@ -71,7 +72,7 @@ export function RemoteConnectWizard({
   const [form, setForm] = useState<RemoteHostInput>(blankInput);
   const [authMode, setAuthMode] = useState<"password" | "key">("password");
   const [pickedHostId, setPickedHostId] = useState<string | null>(null);
-  const [hostFocus, setHostFocus] = useState(false);
+  const [hostListOpen, setHostListOpen] = useState(false);
   const [hostId, setHostId] = useState("");
   const [connectErr, setConnectErr] = useState("");
   const [startPath, setStartPath] = useState("~");
@@ -86,6 +87,7 @@ export function RemoteConnectWizard({
   const [error, setError] = useState("");
   const dialogRef = useRef<HTMLDivElement>(null);
   const hostInputRef = useRef<HTMLInputElement>(null);
+  const suggestRef = useRef<HTMLDivElement>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
   const listRequestRef = useRef(0);
   const host = hosts.find((h) => h.id === hostId) ?? null;
@@ -115,12 +117,17 @@ export function RemoteConnectWizard({
   useEffect(() => () => {
     listRequestRef.current += 1;
   }, []);
-
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
       if (event.key === "Escape" && !busy) {
         event.preventDefault();
         event.stopPropagation();
+        // With the saved-host list open, the first Escape closes the list;
+        // only the next one exits the wizard.
+        if (hostListOpen) {
+          setHostListOpen(false);
+          return;
+        }
         onClose();
         return;
       }
@@ -144,17 +151,24 @@ export function RemoteConnectWizard({
     };
     document.addEventListener("keydown", onKey, { capture: true });
     return () => document.removeEventListener("keydown", onKey, { capture: true });
-  }, [busy, onClose]);
+  }, [busy, hostListOpen, onClose]);
+
+  // The saved-host dropdown only closes on explicit dismissal: a pick, the
+  // arrow, Escape, or a pointer press outside the host field wrapper.
+  useEffect(() => {
+    if (!hostListOpen) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const wrapper = suggestRef.current;
+      if (wrapper && event.target && !wrapper.contains(event.target as Node)) {
+        setHostListOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => document.removeEventListener("pointerdown", onPointerDown, true);
+  }, [hostListOpen]);
 
   const set = <K extends keyof RemoteHostInput>(key: K, value: RemoteHostInput[K]) =>
     setForm((current) => ({ ...current, [key]: value }));
-
-  const suggestions =
-    form.host.trim() === ""
-      ? hosts
-      : hosts.filter(
-          (h) => h.host.includes(form.host.trim()) || h.label.includes(form.host.trim()),
-        );
 
   const pickSaved = (saved: RemoteHostView) => {
     setForm({
@@ -171,7 +185,8 @@ export function RemoteConnectWizard({
     });
     setAuthMode(saved.identityFile ? "key" : "password");
     setPickedHostId(saved.id);
-    setHostFocus(false);
+    setHostListOpen(false);
+    hostInputRef.current?.focus();
   };
 
   const openDir = async (id: string, path: string) => {
@@ -351,38 +366,51 @@ export function RemoteConnectWizard({
               <>
                 <div className="remote-wizard__form">
                 <div className="remote-wizard__field-row">
-                  <div className="remote-wizard__suggest">
+                  <div className="remote-wizard__suggest" ref={suggestRef}>
                     <label className="remote-wizard__field">
                       <span>{t("remote.host.host")}</span>
-                      <input
-                        ref={hostInputRef}
-                        value={form.host}
-                        disabled={busy}
-                        autoComplete="off"
-                        placeholder={t("remoteWizard.hostPlaceholder")}
-                        onFocus={() => setHostFocus(true)}
-                        onBlur={() => setHostFocus(false)}
-                        onChange={(event) => {
-                          set("host", event.target.value);
-                          setPickedHostId(null);
-                        }}
-                      />
+                      <div className="remote-wizard__host-box">
+                        <input
+                          ref={hostInputRef}
+                          value={form.host}
+                          disabled={busy}
+                          autoComplete="off"
+                          placeholder={t("remoteWizard.hostPlaceholder")}
+                          onChange={(event) => {
+                            set("host", event.target.value);
+                            setPickedHostId(null);
+                          }}
+                        />
+                        {hosts.length > 0 ? (
+                          <button
+                            type="button"
+                            className={`remote-wizard__suggest-toggle${hostListOpen ? " remote-wizard__suggest-toggle--open" : ""}`}
+                            disabled={busy}
+                            aria-haspopup="listbox"
+                            aria-expanded={hostListOpen}
+                            aria-controls={HOST_LIST_ID}
+                            title={t("remoteWizard.suggestions")}
+                            onClick={() => setHostListOpen((open) => !open)}
+                          >
+                            <ChevronDown size={14} aria-hidden="true" />
+                          </button>
+                        ) : null}
+                      </div>
                     </label>
-                    {hostFocus && suggestions.length > 0 ? (
-                      <div className="remote-wizard__suggest-list" role="listbox" aria-label={t("remoteWizard.suggestions")}>
-                        {suggestions.map((saved) => (
+                    {hostListOpen && hosts.length > 0 ? (
+                      <div className="remote-wizard__suggest-list" role="listbox" id={HOST_LIST_ID} aria-label={t("remoteWizard.suggestions")}>
+                        <div className="remote-wizard__suggest-head">{t("remoteWizard.suggestions")}</div>
+                        {hosts.map((saved) => (
                           <button
                             key={saved.id}
                             type="button"
-                            onMouseDown={(event) => {
-                              event.preventDefault();
-                              pickSaved(saved);
-                            }}
+                            onClick={() => pickSaved(saved)}
                           >
                             <span className="remote-wizard__suggest-label">{saved.label}</span>
                             <span className="remote-wizard__suggest-detail">
                               {saved.user ? `${saved.user}@` : ""}
                               {saved.host}
+                              {saved.port && saved.port !== 22 ? `:${saved.port}` : ""}
                             </span>
                           </button>
                         ))}

--- a/desktop/frontend/src/components/RemoteConnectWizard.tsx
+++ b/desktop/frontend/src/components/RemoteConnectWizard.tsx
@@ -9,6 +9,7 @@ import type { RemoteDirEntry, RemoteHostInput, RemoteHostView } from "../lib/typ
 
 type WizardStep = "config" | "connecting" | "workspace";
 const STEP_ORDER: WizardStep[] = ["config", "connecting", "workspace"];
+const HOST_INPUT_ID = "remote-wizard-host-input";
 const HOST_MENU_ID = "remote-wizard-host-menu";
 
 const blankInput: RemoteHostInput = {
@@ -393,10 +394,11 @@ export function RemoteConnectWizard({
                 <div className="remote-wizard__form">
                 <div className="remote-wizard__field-row">
                   <div className="remote-wizard__suggest" ref={suggestRef}>
-                    <label className="remote-wizard__field">
-                      <span>{t("remote.host.host")}</span>
+                    <div className="remote-wizard__field">
+                      <label htmlFor={HOST_INPUT_ID}>{t("remote.host.host")}</label>
                       <div className="remote-wizard__host-box">
                         <input
+                          id={HOST_INPUT_ID}
                           ref={hostInputRef}
                           value={form.host}
                           disabled={busy}
@@ -445,7 +447,7 @@ export function RemoteConnectWizard({
                           </button>
                         ) : null}
                       </div>
-                    </label>
+                    </div>
                     {hostListOpen && hosts.length > 0 ? (
                       <div
                         className="remote-wizard__suggest-list"

--- a/desktop/frontend/src/components/RemoteConnectWizard.tsx
+++ b/desktop/frontend/src/components/RemoteConnectWizard.tsx
@@ -9,7 +9,7 @@ import type { RemoteDirEntry, RemoteHostInput, RemoteHostView } from "../lib/typ
 
 type WizardStep = "config" | "connecting" | "workspace";
 const STEP_ORDER: WizardStep[] = ["config", "connecting", "workspace"];
-const HOST_LIST_ID = "remote-wizard-host-list";
+const HOST_MENU_ID = "remote-wizard-host-menu";
 
 const blankInput: RemoteHostInput = {
   label: "",
@@ -87,7 +87,10 @@ export function RemoteConnectWizard({
   const [error, setError] = useState("");
   const dialogRef = useRef<HTMLDivElement>(null);
   const hostInputRef = useRef<HTMLInputElement>(null);
+  const hostToggleRef = useRef<HTMLButtonElement>(null);
+  const portInputRef = useRef<HTMLInputElement>(null);
   const suggestRef = useRef<HTMLDivElement>(null);
+  const pendingHostMenuFocusRef = useRef<"first" | "last" | null>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
   const listRequestRef = useRef(0);
   const host = hosts.find((h) => h.id === hostId) ?? null;
@@ -117,6 +120,17 @@ export function RemoteConnectWizard({
   useEffect(() => () => {
     listRequestRef.current += 1;
   }, []);
+
+  useLayoutEffect(() => {
+    const edge = pendingHostMenuFocusRef.current;
+    if (!hostListOpen || !edge) return;
+    pendingHostMenuFocusRef.current = null;
+    const items = Array.from(
+      suggestRef.current?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') ?? [],
+    );
+    (edge === "first" ? items[0] : items[items.length - 1])?.focus();
+  }, [hostListOpen, hosts.length]);
+
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
       if (event.key === "Escape" && !busy) {
@@ -126,9 +140,21 @@ export function RemoteConnectWizard({
         // only the next one exits the wizard.
         if (hostListOpen) {
           setHostListOpen(false);
+          hostToggleRef.current?.focus();
           return;
         }
         onClose();
+        return;
+      }
+      if (
+        event.key === "Tab" &&
+        hostListOpen &&
+        document.activeElement instanceof HTMLElement &&
+        document.activeElement.getAttribute("role") === "menuitem"
+      ) {
+        event.preventDefault();
+        setHostListOpen(false);
+        (event.shiftKey ? hostToggleRef.current : portInputRef.current)?.focus();
         return;
       }
       if (event.key !== "Tab") return;
@@ -383,14 +409,37 @@ export function RemoteConnectWizard({
                         />
                         {hosts.length > 0 ? (
                           <button
+                            ref={hostToggleRef}
                             type="button"
                             className={`remote-wizard__suggest-toggle${hostListOpen ? " remote-wizard__suggest-toggle--open" : ""}`}
                             disabled={busy}
-                            aria-haspopup="listbox"
+                            aria-haspopup="menu"
                             aria-expanded={hostListOpen}
-                            aria-controls={HOST_LIST_ID}
+                            aria-controls={HOST_MENU_ID}
                             title={t("remoteWizard.suggestions")}
-                            onClick={() => setHostListOpen((open) => !open)}
+                            onClick={() => {
+                              if (hostListOpen) {
+                                pendingHostMenuFocusRef.current = null;
+                                setHostListOpen(false);
+                                return;
+                              }
+                              pendingHostMenuFocusRef.current = "first";
+                              setHostListOpen(true);
+                            }}
+                            onKeyDown={(event) => {
+                              if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+                              event.preventDefault();
+                              pendingHostMenuFocusRef.current = event.key === "ArrowDown" ? "first" : "last";
+                              if (hostListOpen) {
+                                const items = Array.from(
+                                  suggestRef.current?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') ?? [],
+                                );
+                                pendingHostMenuFocusRef.current = null;
+                                (event.key === "ArrowDown" ? items[0] : items[items.length - 1])?.focus();
+                              } else {
+                                setHostListOpen(true);
+                              }
+                            }}
                           >
                             <ChevronDown size={14} aria-hidden="true" />
                           </button>
@@ -398,12 +447,38 @@ export function RemoteConnectWizard({
                       </div>
                     </label>
                     {hostListOpen && hosts.length > 0 ? (
-                      <div className="remote-wizard__suggest-list" role="listbox" id={HOST_LIST_ID} aria-label={t("remoteWizard.suggestions")}>
-                        <div className="remote-wizard__suggest-head">{t("remoteWizard.suggestions")}</div>
+                      <div
+                        className="remote-wizard__suggest-list"
+                        role="menu"
+                        id={HOST_MENU_ID}
+                        aria-label={t("remoteWizard.suggestions")}
+                        onKeyDown={(event) => {
+                          if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+                          event.preventDefault();
+                          event.stopPropagation();
+                          const items = Array.from(
+                            event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+                          );
+                          if (items.length === 0) return;
+                          const current = items.indexOf(document.activeElement as HTMLButtonElement);
+                          const next =
+                            event.key === "Home"
+                              ? 0
+                              : event.key === "End"
+                                ? items.length - 1
+                                : event.key === "ArrowDown"
+                                  ? (current + 1) % items.length
+                                  : (current - 1 + items.length) % items.length;
+                          items[next]?.focus();
+                        }}
+                      >
+                        <div className="remote-wizard__suggest-head" aria-hidden="true">{t("remoteWizard.suggestions")}</div>
                         {hosts.map((saved) => (
                           <button
                             key={saved.id}
                             type="button"
+                            role="menuitem"
+                            tabIndex={-1}
                             onClick={() => pickSaved(saved)}
                           >
                             <span className="remote-wizard__suggest-label">{saved.label}</span>
@@ -420,6 +495,7 @@ export function RemoteConnectWizard({
                   <label className="remote-wizard__field">
                     <span>{t("remote.host.port")}</span>
                     <input
+                      ref={portInputRef}
                       type="text"
                       inputMode="numeric"
                       placeholder="22"


### PR DESCRIPTION
## Summary

- Step 1's host field now exposes saved SSH connections through an explicit
  chevron dropdown on the input's right edge. Previously the list only
  appeared while the input was focused and silently filtered by typed text.
- The dropdown lists every saved connection unfiltered, leads with a
  "saved SSH connections" caption, and appends non-22 ports to each
  `user@host` row.
- It closes on pick, arrow toggle, an outside pointer press, or the first
  Escape — the wizard-level Escape only fires once the list is closed. The
  arrow is hidden when no hosts are saved and disabled while connecting.
- Accessibility: the toggle carries `aria-haspopup` / `aria-expanded` /
  `aria-controls` / `title`; the focus-blur coupling and the
  `mousedown`+`preventDefault` blur-guard are gone (options are plain
  `onClick` buttons now).

## Issues

None — proactive UX improvement, no related report.

## Verification

- `cd desktop/frontend && node --import ./scripts/css-stub-register.mjs --import tsx src/__tests__/remote-connect-wizard.test.tsx` — 67/67 pass, including the new arrow-flow contract tests (focus no longer opens the list, aria state flips, unfiltered list, outside/Esc/toggle close, no arrow with zero saved hosts).
- `cd desktop/frontend && pnpm test:remote` — all pass except the pre-existing `remote-project-tree` "generation guard" source-contract failure, reproduced identically on a stashed clean baseline (unrelated to this change).
- `cd desktop/frontend && pnpm check:css && pnpm lint:hooks && pnpm test:typecheck` — pass (CSS syntax, z-index tokens, theme token contract, ESLint, tsc app+test configs).
- `cd desktop/frontend && pnpm build` — pass, including bundle-budget, WAAPI-contract, and token gates.
- Playwright drive of the real app shell in browser-preview mode (add-project → 远程连接 → wizard): 17 interaction assertions and 10 geometry/computed-style assertions pass — arrow inset within the input bounds with 30px right padding, list flush below and width-matched, elevated background+shadow+border, caption/label/detail typography, chevron rotation via CSS transform.

Not a GSAP→WAAPI/CSS migration: the only motion added is a 150ms CSS
`transform` rotation matching the existing chevron convention
(`process-card__chevron`), and `pnpm check:waapi` runs green in the build.

## Documentation impact

Documentation-impact: none - the guide describes the three-step wizard flow
(docs/GUIDE.md, docs/GUIDE.zh-CN.md) without mentioning the step-1
host-input suggestion trigger, so no documented behavior changes; the
user-visible record ships in CHANGELOG.md under Unreleased.

## Cache impact

Cache-impact: none - desktop frontend interaction only; no change to the
provider-visible system prompt, tool schemas, or any context-affecting
bytes.
Cache-guard: N/A - no context/prompt surface is touched; the bundle-budget
gate in `pnpm build` confirms no frontend payload regression.
System-prompt-review: N/A
