### PR TITLE
fix(desktop): bound live reasoning height and throttle tail re-aim during streaming / 限高 live reasoning 并节流流式期间 tail 重瞄

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
@@ -271,5 +271,47 @@ check(
   "manual reading suppresses viewport-shrink pinning",
 );
 
+// Per-frame streaming growth (reasoning tokens, small tool-card arrivals)
+// below the re-arm threshold must not re-aim the tail writer: the viewport
+// otherwise chases a target that moves every frame (#9208/#8688 jitter).
+const subThresholdGrowth = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "LAYOUT_HEIGHT_CHANGED", deltaHeight: 12 },
+  { type: "LAYOUT_HEIGHT_CHANGED", deltaHeight: 12 },
+  { type: "LAYOUT_HEIGHT_CHANGED", deltaHeight: 12 },
+]);
+check(
+  subThresholdGrowth.commands.length === 0,
+  "sub-threshold layout growth does not re-aim the tail writer",
+);
+
+const thresholdGrowth = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "LAYOUT_HEIGHT_CHANGED", deltaHeight: 48 },
+]);
+check(
+  thresholdGrowth.commands.join(",") === "AUTOSCROLL_TO_BOTTOM",
+  "above-threshold layout growth still re-aims the tail writer",
+);
+
+const legacyGrowth = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "LAYOUT_HEIGHT_CHANGED" },
+]);
+check(
+  legacyGrowth.commands.join(",") === "AUTOSCROLL_TO_BOTTOM",
+  "layout events without a measured delta keep the legacy re-aim behaviour",
+);
+
+const subThresholdManual = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "USER_SCROLL_INTENT", canClaimTail: false },
+  { type: "LAYOUT_HEIGHT_CHANGED", deltaHeight: 12 },
+]);
+check(
+  subThresholdManual.commands.length === 0 && subThresholdManual.state.mode === "manual",
+  "sub-threshold growth never disturbs manual reading",
+);
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/transcriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/transcriptScrollArbiter.ts
@@ -46,7 +46,7 @@ export type TranscriptScrollEvent =
   | { type: "SCROLL_DELIVERED"; atBottom: boolean; scrollable: boolean; substantial?: boolean }
   | { type: "TAIL_CONTENT_CHANGED" }
   | { type: "CONTENT_SHRANK" }
-  | { type: "LAYOUT_HEIGHT_CHANGED" }
+  | { type: "LAYOUT_HEIGHT_CHANGED"; deltaHeight?: number }
   | { type: "VIEWPORT_RESIZED" }
   | { type: "USER_RESIZE_BEGIN" }
   | { type: "USER_RESIZE_END" }
@@ -106,6 +106,14 @@ export function isTranscriptContentShrink(delta: number): boolean {
 // the bottom) no longer re-enters (#8709/#9099); only an explicit
 // JUMP_TO_BOTTOM bypasses the hold.
 export const TRANSCRIPT_BOTTOM_HOLD_DELIVERIES = 2;
+
+// Layout growth below this many pixels does not re-aim the tail writer while
+// tail-follow is active. Per-frame streaming growth (reasoning tokens, small
+// tool-card arrivals) otherwise keeps the viewport chasing a moving target
+// (#9208/#8688 jitter); a real growth step above the threshold still re-aims
+// immediately, and deliberate jumps (JUMP_TO_BOTTOM, tail-claiming scroll)
+// bypass this gate.
+export const TRANSCRIPT_TAIL_REARM_MIN_HEIGHT_PX = 24;
 
 function transition(state: TranscriptScrollState, commands: readonly TranscriptScrollCommand[] = []): TranscriptScrollTransition {
   return { state, commands };
@@ -198,9 +206,26 @@ export function reduceTranscriptScroll(
       );
     }
     case "TAIL_CONTENT_CHANGED":
-    case "LAYOUT_HEIGHT_CHANGED":
     case "VIEWPORT_RESIZED":
+      // Tail content / viewport changes always re-aim: the user's viewport
+      // size changed, so the previous bottom target is stale by construction.
       return transition(state, state.mode === "tail-follow" ? [{ type: "AUTOSCROLL_TO_BOTTOM" }] : []);
+    case "LAYOUT_HEIGHT_CHANGED": {
+      // Per-frame content growth (streaming reasoning tokens, arriving tool
+      // cards) re-enters the tail writer for every small layout event, so the
+      // viewport chases a target that is itself moving (jitter/flash, #9208,
+      // #8688). Ignore sub-threshold growth; real growth above the threshold
+      // still re-aims immediately. Events without a measured delta keep the
+      // legacy re-aim behaviour.
+      if (
+        state.mode === "tail-follow"
+        && event.deltaHeight !== undefined
+        && event.deltaHeight < TRANSCRIPT_TAIL_REARM_MIN_HEIGHT_PX
+      ) {
+        return transition(state);
+      }
+      return transition(state, state.mode === "tail-follow" ? [{ type: "AUTOSCROLL_TO_BOTTOM" }] : []);
+    }
     case "CONTENT_SHRANK":
       // Auto-fold collapse shortens the transcript. Keep tail ownership but
       // let the browser's native scrollTop clamp settle the new bottom; a

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -599,6 +599,7 @@ export function useTranscriptScrollArbiter({
       followFrameRef.current = null;
       if (generationRef.current !== generation || scrollRef.current !== scrollElement) return;
       const element = scrollRef.current;
+      let deltaHeight = 0;
       if (element) {
         const scrollHeight = element.scrollHeight;
         const previous = followGeometryRef.current.contentExtent;
@@ -608,8 +609,9 @@ export function useTranscriptScrollArbiter({
           anchorCompensation.schedule();
           return;
         }
+        deltaHeight = previous != null ? Math.max(0, scrollHeight - previous) : 0;
       }
-      dispatch({ type: "LAYOUT_HEIGHT_CHANGED" });
+      dispatch({ type: "LAYOUT_HEIGHT_CHANGED", deltaHeight });
       anchorCompensation.schedule();
     });
   }, [anchorCompensation, dispatch, readerExtent, tailSettle]);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -5292,6 +5292,16 @@ button.reasoning-summary:focus-visible {
   line-height: 1.72;
   white-space: pre-wrap;
 }
+
+/* A live turn's streaming reasoning grows every token; bounding the region
+   with internal scrolling stops the live footer (and thus the tail-follow
+   target) from moving every frame (#9208/#8688 jitter), while the full text
+   stays reachable inside the region. */
+.turn-collapse__inline-reasoning {
+  max-height: min(40vh, 480px);
+  overflow-y: auto;
+}
+
 .reasoning__body > .md,
 .turn-collapse__inline-reasoning > .md,
 .tool__subagent-preview-text--markdown > .md {


### PR DESCRIPTION
## Summary

During a live turn with `reasoning_display_mode=auto`, streaming reasoning renders as an unbounded `<pre>` inside the live turn footer, and each new tool card arrives below it. The footer — and therefore the tail-follow target — grows every frame, so the viewport chases a moving bottom and visibly jumps (#9208/#8688 family). This is an **incremental mitigation**, not the full rework #9208 documents.

### Changes

1. **Bound the live reasoning region** (`styles.css`): `.turn-collapse__inline-reasoning` now caps at `min(40vh, 480px)` with internal scrolling. The footer stops changing height on every reasoning token (full text stays reachable inside the region), which removes the per-frame growth that re-armed the tail settle loop.
2. **Throttle tail re-aim for sub-threshold growth** (`transcriptScrollArbiter.ts`): `LAYOUT_HEIGHT_CHANGED` carries a measured `deltaHeight`; growth below `TRANSCRIPT_TAIL_REARM_MIN_HEIGHT_PX` (24px) no longer re-arms the tail writer while tail-follow is active. Events without a measured delta keep the legacy behaviour; above-threshold growth and deliberate jumps (JUMP_TO_BOTTOM, tail-claiming scroll) bypass the gate.
3. **Tests** (`transcript-scroll-release.test.ts`): sub-threshold suppression, above-threshold re-aim, legacy no-delta behaviour, manual-reading preservation.

### Verification

- `node --import tsx src/__tests__/transcript-scroll-release.test.ts` → 47 passed, 0 failed
- `transcript-state-snapshot.test.ts` (15), `transcript-layout-recovery.test.ts` (9), `transcript-reader-extent-stability.test.ts`, `transcript-anchor-compensation-race.test.tsx` (19) → all pass
- `npx tsc --noEmit` → clean
- `git diff --check` → clean
- Full suite: `composer-goal-toggle.test.tsx` fails identically on unmodified main-v2 (pre-existing flaky, unrelated)

## Related

- #9208 (transcript tail bounce/jitter — documents the larger rendering-model fix; this is the incremental mitigation)
- #7849 (reasoning force-expanded while streaming)
- #8688 scrollbar flicker while thinking is printed

---

## 摘要

live turn（`reasoning_display_mode=auto`）时，流式 thinking 作为无界 `<pre>` 渲染在 live footer 内，工具卡在其下方不断出现——footer（也就是 tail-follow 目标）每帧增长，视口追着一个移动的底部目标 → 画面上下跳动（#9208/#8688 家族）。本 PR 是**增量缓解**，不是 #9208 描述的完整渲染模型重构。

### 改动

1. **live reasoning 区域限高**（`styles.css`）：`.turn-collapse__inline-reasoning` 上限 `min(40vh, 480px)` + 内部滚动。footer 不再随每个推理 token 变化高度（全文仍在区域内可达），消除了每帧增长导致的 settle 循环重入。
2. **tail 重瞄节流**（`transcriptScrollArbiter.ts`）：`LAYOUT_HEIGHT_CHANGED` 携带测量出的 `deltaHeight`；低于 `TRANSCRIPT_TAIL_REARM_MIN_HEIGHT_PX`（24px）的增量在 tail-follow 激活时不再重瞄。未携带 delta 的事件保持旧行为；超过阈值的大增长与显式跳转（JUMP_TO_BOTTOM / 滚到底）不受影响。
3. **测试**（`transcript-scroll-release.test.ts`）：阈值内抑制、阈值上重瞄、无 delta 旧行为、手动阅读不受扰。

### 验证

- `transcript-scroll-release.test.ts` → 47 passed, 0 failed
- `transcript-state-snapshot` / `transcript-layout-recovery` / `transcript-reader-extent-stability` / `transcript-anchor-compensation-race` → 全部通过
- `npx tsc --noEmit`、`git diff --check` 干净
- 全量套件中 `composer-goal-toggle.test.tsx` 在未修改的 main-v2 上同样失败（预存 flaky，与本次无关）

## 关联

- #9208（transcript 尾部弹跳/抖动——记录完整渲染模型修复方向；本 PR 为增量缓解）
- #7849（流式 thinking 强制展开）
- #8688（thinking 输出时滚动条闪烁）

Documentation-impact: none - 纯前端滚动行为/样式调整，现有文档仍准确
