### PR TITLE
fix(frontend): wait for mounted extent rebound / 等待高度恢复后的挂载覆盖

### DIFF
--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -55,9 +55,9 @@ async function moveToOuterReaderGutter(page, transcript, announce = true) {
 
 async function waitForStableTranscriptGeometry(
   page,
-  { timeout = 15_000, frames = 8, requireTail = false } = {},
+  { timeout = 15_000, frames = 8, requireTail = false, maxTailDistance = 4 } = {},
 ) {
-  await page.evaluate(({ timeout, frames, requireTail }) => new Promise((resolve, reject) => {
+  await page.evaluate(({ timeout, frames, requireTail, maxTailDistance }) => new Promise((resolve, reject) => {
     const startedAt = performance.now();
     let previous = null;
     let stableFrames = 0;
@@ -80,7 +80,7 @@ async function waitForStableTranscriptGeometry(
         stableFrames = unchanged ? stableFrames + 1 : 0;
         previous = current;
         const distance = current.height - current.top - current.clientHeight;
-        const expectedPosition = !requireTail || (current.mode === "tail-follow" && distance <= 4);
+        const expectedPosition = !requireTail || (current.mode === "tail-follow" && distance <= maxTailDistance);
         if (expectedPosition && stableFrames >= frames) {
           resolve();
           return;
@@ -96,7 +96,7 @@ async function waitForStableTranscriptGeometry(
       requestAnimationFrame(sample);
     };
     requestAnimationFrame(sample);
-  }), { timeout, frames, requireTail });
+  }), { timeout, frames, requireTail, maxTailDistance });
 }
 
 async function openGeometryContractFixture(page) {
@@ -399,7 +399,7 @@ try {
     // A hydration resize intentionally guards the reader's previous extent
     // for one intent burst. Start a fresh burst after the 180ms idle lease
     // when that boundary is reached, matching a real user's next wheel turn.
-    const stalled = Math.abs(position.top - previousDownwardTop) <= 1;
+    const stalled = position.top <= previousDownwardTop + 1;
     previousDownwardTop = position.top;
     await page.waitForTimeout(stalled ? 220 : 16);
   }
@@ -623,10 +623,11 @@ try {
   // physical bottom. Keep the crop assertions tight; only the post-resize
   // stick-to-tail check gets this slack (CI saw 7px after collapse).
   const tailAfterResizePx = 16;
-  const waitNearTailAfterResize = () => page.waitForFunction((limit) => {
-    const scroller = document.querySelector(".transcript");
-    return Boolean(scroller && scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight <= limit);
-  }, tailAfterResizePx);
+  const waitNearTailAfterResize = () => waitForStableTranscriptGeometry(page, {
+    frames: 4,
+    requireTail: true,
+    maxTailDistance: tailAfterResizePx,
+  });
 
   const collapse = page.getByRole("button", { name: /Collapse workspace|收起工作区/ });
   if (await collapse.count()) {
@@ -829,8 +830,11 @@ try {
     : `transient extent rebound uses one bounded reader-stability write (${readerStabilityWrites.length}; ${JSON.stringify(afterExtentReplay.samples)})`);
   assert(afterExtentReplay.writes.every((write) => write.owner !== "recovery"),
     "nonblank extent rebound never enters blank recovery");
-  assert(afterExtentReplay.samples.every((sample) => sample.occupied),
-    "transient extent rebound keeps mounted coverage in every sampled frame");
+  const hasContinuousExtentCoverage = afterExtentReplay.samples.every((sample) => sample.occupied);
+  assert(hasContinuousExtentCoverage,
+    hasContinuousExtentCoverage
+      ? "transient extent rebound keeps mounted coverage in every sampled frame"
+      : `transient extent rebound keeps mounted coverage in every sampled frame (${JSON.stringify(afterExtentReplay.samples)})`);
   await transcript.evaluate((element) => {
     delete element.dataset.extentReplayExpanded;
     document.getElementById("reader-extent-replay-style")?.remove();

--- a/desktop/frontend/src/__tests__/remote-project-tree.test.tsx
+++ b/desktop/frontend/src/__tests__/remote-project-tree.test.tsx
@@ -33,6 +33,7 @@ const remoteIntegrationSource = readFileSync(resolve(here, "../lib/useRemoteComp
 const topicbarMenuSource = readFileSync(resolve(here, "../components/TopicbarMoreMenuContent.tsx"), "utf8");
 const bridgeSource = readFileSync(resolve(here, "../lib/remoteProjectBridge.ts"), "utf8");
 const remoteOpenSource = readFileSync(resolve(here, "../../../remote_projects.go"), "utf8");
+const remotePendingSelectionSource = readFileSync(resolve(here, "../../../remote_tab_pending_selection.go"), "utf8");
 const explicitEnsureSource = remoteSource.match(
   /const ensureRemoteGroupSessions[\s\S]*?\n  const openRemoteWindow/,
 )?.[0] ?? "";
@@ -241,7 +242,8 @@ ok(
   "remote groups render retryable connect/error rows instead of going silent",
 );
 ok(
-  /existing\.selectionRevision\+\+[\s\S]*?a\.goRemoteTabSafe\("remoteTabResume"[\s\S]*?restoreRejectedRemoteTabOpenSelection/.test(remoteOpenSource),
+  /existing\.selectionRevision\+\+/.test(remoteOpenSource) &&
+    /a\.goRemoteTabSafe\("remoteTabResume"[\s\S]*?restoreRejectedRemoteTabOpenSelection/.test(remotePendingSelectionSource),
   "session switches resume in the background behind a generation guard",
 );
 

--- a/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
@@ -69,8 +69,12 @@ const rectAt = (top: number) => ({
 });
 const scrollElement = dom.window.document.getElementById("scroll") as HTMLDivElement;
 const rowElement = scrollElement.querySelector<HTMLElement>(".transcript__row")!;
+const reboundCoverageRow = dom.window.document.createElement("div");
+reboundCoverageRow.className = "transcript__row";
+reboundCoverageRow.dataset.rowKey = "row-ready";
 scrollElement.getBoundingClientRect = () => rectAt(0);
 rowElement.getBoundingClientRect = () => rectAt(20);
+reboundCoverageRow.getBoundingClientRect = () => rectAt(20);
 Object.defineProperty(scrollElement, "clientHeight", { configurable: true, value: 725 });
 let scrollExtent = 15_829;
 Object.defineProperty(scrollElement, "scrollHeight", { configurable: true, get: () => scrollExtent });
@@ -145,13 +149,18 @@ await act(async () => arbiter?.followGrowingTail());
 await flushFrames();
 check(scrollByCalls === 0, "the transaction waits while the native extent remains collapsed");
 scrollExtent = 15_829;
+scrollElement.append(reboundCoverageRow);
 await act(async () => arbiter?.followGrowingTail());
+await flushFrames();
+check(scrollByCalls === 0,
+  "the rebound waits for mounted coverage and stable restored geometry");
 await flushFrames();
 check(scrollByCalls === 1 && lastScrollByTop > 1_900,
   `the rebound restores the logical anchor exactly once (${lastScrollByTop}px)`);
 check(scrollWrites.length === 1 && scrollWrites[0].owner === "reader-stability",
   "the correction is owned by reader stability rather than recovery or tail-follow");
 check(arbiter?.modeRef.current === "manual", "the correction preserves manual reader ownership");
+reboundCoverageRow.remove();
 
 // Touch movement is incremental: the second touchmove protects only its own
 // segment rather than replaying the distance from the original touchstart.
@@ -173,13 +182,16 @@ await act(async () => arbiter?.onTouchMoveIntent({
 scrollExtent = 4_000;
 scrollElement.scrollTop = 1_000;
 rowElement.remove();
+scrollElement.append(reboundCoverageRow);
 await act(async () => arbiter?.deliverScroll());
 scrollExtent = 5_000;
 scrollByCalls = 0;
 lastScrollByTop = 0;
 await flushFrames();
+await flushFrames();
 check(scrollByCalls === 1 && lastScrollByTop === 1_020,
   `consecutive touch segments use incremental geometry (${lastScrollByTop}px)`);
+reboundCoverageRow.remove();
 scrollElement.append(rowElement);
 
 // Ordinary sub-viewport measurement jitter stays browser-owned, and a higher

--- a/desktop/frontend/src/lib/useTranscriptReaderExtentStability.ts
+++ b/desktop/frontend/src/lib/useTranscriptReaderExtentStability.ts
@@ -10,7 +10,10 @@ import {
 import type { TranscriptScrollMode } from "./transcriptScrollArbiter";
 import { nativeTranscriptDistanceFromBottom } from "./transcriptScrollGeometry";
 import type { TranscriptScrollWriteRecord } from "./transcriptScrollProbe";
-import { captureTranscriptLayoutAnchor } from "./transcriptVirtuosoRecovery";
+import {
+  captureTranscriptLayoutAnchor,
+  transcriptElementViewportIsBlank,
+} from "./transcriptVirtuosoRecovery";
 
 const READER_EXTENT_STABILITY_MS = 180;
 
@@ -68,6 +71,7 @@ export function useTranscriptReaderExtentStability({
       deadline: Date.now() + READER_EXTENT_STABILITY_MS,
       frame: null,
     };
+    let reboundHeight: number | undefined;
     const tick = () => {
       active.frame = null;
       if (
@@ -85,7 +89,15 @@ export function useTranscriptReaderExtentStability({
         clientHeight: element.clientHeight,
       };
       observeTranscriptReaderExtent(active, snapshot);
-      if (transcriptReaderExtentCanCorrect(active, snapshot)) {
+      // WebView2 can publish the restored native extent one or two paints
+      // before Virtuoso mounts rows for it. Writing during that gap moves the
+      // viewport into an empty size tree. Wait for mounted coverage and one
+      // unchanged-height interval, then spend the single correction budget.
+      if (
+        transcriptReaderExtentCanCorrect(active, snapshot)
+        && !transcriptElementViewportIsBlank(element)
+        && reboundHeight === snapshot.scrollHeight
+      ) {
         const row = active.anchor
           ? Array.from(element.querySelectorAll<HTMLElement>(".transcript__row[data-row-key]"))
             .find((candidate) => candidate.dataset.rowKey === active.anchor?.rowKey)
@@ -109,6 +121,7 @@ export function useTranscriptReaderExtentStability({
           return;
         }
       }
+      reboundHeight = snapshot.scrollHeight;
       if (Date.now() >= active.deadline) {
         guardRef.current = null;
         return;


### PR DESCRIPTION
## Summary

- Follow the remote session generation guard to its current Go owner in the static source contract.
- Make the transcript browser replay wait for stable geometry and preserve extent samples on failure.
- Delay reader-stability correction until the restored native extent is stable and Virtuoso has mounted viewport coverage.

## Problem

Release qualification found one stale static source assertion, a nondeterministic browser replay, and a real Windows WebView2 race where the native transcript extent could rebound before virtual rows remounted, exposing blank frames.

## Root cause

The remote guard moved from `remote_projects.go` to `remote_tab_pending_selection.go`, but its source contract still read only the former. The replay accepted transient geometry. In production, reader-stability correction was eligible on the first rebound sample without requiring mounted viewport coverage or an unchanged restored height.

## Fix

Read each guard from its owning source file, require stable replay geometry, and gate the single reader correction on a nonblank viewport plus one unchanged-height interval.

## Verification

- focused remote project tree suite: 38/38
- transcript reader extent race suite: 22/22
- `pnpm test:remote`
- `pnpm test:transcript`
- transcript scroll stability browser gate: 5 consecutive passes
- final `pnpm test:transcript-browser`
- `pnpm test:performance`
- `pnpm build`
- `go run ./tools/repolint`
- `git diff --check`

## Docs impact

Documentation-impact: none - This is an internal scroll-timing correctness fix plus test-harness maintenance; public interfaces, setup, and documented workflows are unchanged.

## Cache impact

Cache-impact: none - No prompt, tool schema, message order, or provider-visible content changes.