### PR TITLE
fix(frontend): correct blank rebound before paint / 绘制前修正空白高度回弹

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -240,6 +240,9 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // The same shell-support surface moves the merged path from 2417.526 to
 // 2422.371 KiB raw (+4.845 KiB). Retain 0.129 KiB of bounded headroom without
 // widening unrelated chunk ceilings.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_422.5 : 2_422.5;
+// The WebView2 extent rebound prepaint handoff adds 0.204 KiB raw so a native
+// scroll delivery can restore mounted coverage before the next visible frame.
+// Retain 0.096 KiB of headroom without widening gzip or chunk ceilings.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_422.8 : 2_422.8;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
@@ -82,11 +82,13 @@ Object.defineProperty(scrollElement, "scrollTop", { configurable: true, writable
 
 let scrollByCalls = 0;
 let lastScrollByTop = 0;
+let mountCoverageOnScrollBy = false;
 const virtuosoHandle = {
   scrollBy: (options?: { top?: number }) => {
     scrollByCalls += 1;
     lastScrollByTop = options?.top ?? 0;
     scrollElement.scrollTop += lastScrollByTop;
+    if (mountCoverageOnScrollBy) rowElement.getBoundingClientRect = () => rectAt(20);
   },
   scrollTo: (options?: { top?: number }) => {
     scrollElement.scrollTop = options?.top ?? scrollElement.scrollTop;
@@ -161,6 +163,36 @@ check(scrollWrites.length === 1 && scrollWrites[0].owner === "reader-stability",
   "the correction is owned by reader stability rather than recovery or tail-follow");
 check(arbiter?.modeRef.current === "manual", "the correction preserves manual reader ownership");
 reboundCoverageRow.remove();
+
+// A rebound scroll delivery can arrive before the next animation frame. If
+// the native extent has already exposed a blank viewport, spend the same
+// single correction budget synchronously so the next paint has mounted rows.
+await act(async () => arbiter?.reset());
+scrollExtent = 5_000;
+scrollElement.scrollTop = 2_000;
+rowElement.getBoundingClientRect = () => rectAt(20);
+await act(async () => arbiter?.deliverScroll());
+await act(async () => arbiter?.releaseTailFollow());
+await act(async () => arbiter?.onWheelIntent({
+  ctrlKey: false,
+  deltaMode: 0,
+  deltaX: 0,
+  deltaY: 10,
+  target: scrollElement,
+} as React.WheelEvent<HTMLElement>));
+scrollExtent = 4_000;
+scrollElement.scrollTop = 1_000;
+rowElement.getBoundingClientRect = () => rectAt(1_000);
+await act(async () => arbiter?.deliverScroll());
+scrollExtent = 5_000;
+scrollByCalls = 0;
+mountCoverageOnScrollBy = true;
+await act(async () => arbiter?.deliverScroll());
+mountCoverageOnScrollBy = false;
+check(scrollByCalls === 1 && rowElement.getBoundingClientRect().top === 20,
+  "a blank rebound delivery corrects before the next paint");
+await flushFrames();
+check(scrollByCalls === 1, "the prepaint rebound still spends one correction");
 
 // Touch movement is incremental: the second touchmove protects only its own
 // segment rather than replaying the distance from the original touchstart.

--- a/desktop/frontend/src/lib/useTranscriptReaderExtentStability.ts
+++ b/desktop/frontend/src/lib/useTranscriptReaderExtentStability.ts
@@ -22,6 +22,8 @@ type ActiveReaderExtentGuard = TranscriptReaderExtentGuard & {
   generation: number;
   deadline: number;
   frame: number | null;
+  prepaint: boolean;
+  tick?: () => void;
 };
 
 export function useTranscriptReaderExtentStability({
@@ -51,6 +53,14 @@ export function useTranscriptReaderExtentStability({
     const guard = guardRef.current;
     if (!element || guard?.element !== element) return false;
     observeTranscriptReaderExtent(guard, element);
+    if (
+      transcriptReaderExtentCanCorrect(guard, element)
+      && transcriptElementViewportIsBlank(element)
+    ) {
+      guard.prepaint = true;
+      if (guard.frame !== null) cancelAnimationFrame(guard.frame);
+      guard.tick?.();
+    }
     return transcriptReaderExtentHasCollapsed(guard);
   }, [scrollRef]);
 
@@ -70,10 +80,13 @@ export function useTranscriptReaderExtentStability({
       generation: generationRef.current,
       deadline: Date.now() + READER_EXTENT_STABILITY_MS,
       frame: null,
+      prepaint: false,
     };
     let reboundHeight: number | undefined;
     const tick = () => {
       active.frame = null;
+      const prepaint = active.prepaint;
+      active.prepaint = false;
       if (
         guardRef.current !== active
         || generationRef.current !== active.generation
@@ -89,14 +102,15 @@ export function useTranscriptReaderExtentStability({
         clientHeight: element.clientHeight,
       };
       observeTranscriptReaderExtent(active, snapshot);
-      // WebView2 can publish the restored native extent one or two paints
-      // before Virtuoso mounts rows for it. Writing during that gap moves the
-      // viewport into an empty size tree. Wait for mounted coverage and one
-      // unchanged-height interval, then spend the single correction budget.
+      // WebView2 can publish the restored native extent before Virtuoso mounts
+      // rows for it. A rebound scroll delivery spends the correction before
+      // paint; the frame fallback waits for coverage and a stable height.
+      const viewportIsBlank = transcriptElementViewportIsBlank(element);
       if (
         transcriptReaderExtentCanCorrect(active, snapshot)
-        && !transcriptElementViewportIsBlank(element)
-        && reboundHeight === snapshot.scrollHeight
+        && (prepaint
+          ? viewportIsBlank
+          : !viewportIsBlank && reboundHeight === snapshot.scrollHeight)
       ) {
         const row = active.anchor
           ? Array.from(element.querySelectorAll<HTMLElement>(".transcript__row[data-row-key]"))
@@ -128,6 +142,7 @@ export function useTranscriptReaderExtentStability({
       }
       active.frame = requestAnimationFrame(tick);
     };
+    active.tick = tick;
     guardRef.current = active;
     active.frame = requestAnimationFrame(tick);
   }, [cancel, generationRef, modeRef, scrollRef, writeCorrection]);


### PR DESCRIPTION
## Summary

- Correct a recoverable blank transcript rebound synchronously from the native scroll delivery before the next visible frame.
- Retain the covered, stable-height animation-frame path as the fallback.
- Add a regression contract proving the prepaint path still spends only one reader-stability correction.

## Problem

Final release-candidate CI run `33208608613` reproduced one blank Windows WebView2 frame while the native extent rebounded from 3192 to 5572 pixels. The next frame recovered, but the blank frame violates the mounted-coverage release gate.

## Root cause

Reader extent correction was only attempted from animation frames. A rebound scroll delivery could therefore expose a correctable empty viewport before the scheduled frame callback ran.

## Fix

When an active reader guard receives a correctable rebound delivery and the viewport is blank, cancel its queued frame and spend the same bounded correction synchronously. Normal nonblank rebounds still require mounted coverage and one unchanged-height interval.

The bounded handoff adds 0.204 KiB raw to the initial path. The raw-only budget moves from 2422.5 to 2422.8 KiB, retaining 0.096 KiB of headroom; gzip and chunk ceilings are unchanged.

## Verification

- transcript reader extent race suite: 24/24
- `pnpm test:transcript`
- `pnpm test:transcript-browser`
- transcript scroll stability browser gate: 5 consecutive passes
- `pnpm test:remote`
- `pnpm test:performance`
- `pnpm build`
- `go run ./tools/repolint`
- `git diff --check`

## Docs impact

Documentation-impact: none - This is an internal Windows WebView2 scroll-timing correctness fix; public interfaces, setup, and documented workflows are unchanged.

## Cache impact

Cache-impact: none - No prompt, tool schema, message order, or provider-visible content changes.