### PR TITLE
test(frontend): stabilize browser gesture gates / 稳定浏览器手势门禁

### DIFF
--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -1410,17 +1410,46 @@ try {
     requestAnimationFrame(sample);
   });
   let stormReached = false;
-  for (let attempt = 0; attempt < 60 && !stormReached; attempt += 1) {
+  let stormAttempts = 0;
+  let stagnantGestures = 0;
+  const stormDeadline = Date.now() + 20_000;
+  while (Date.now() < stormDeadline && !stormReached) {
+    if (stormAttempts > 0 && (stormAttempts % 6 === 0 || stagnantGestures >= 2)) {
+      // Patch delivery can replace the row under the pointer without replacing
+      // the scroller. Re-resolve reserved row padding so subsequent wheel
+      // events still belong to the outer reader instead of an emptied/nested
+      // target. A genuine pull-back remains observable by the frame probe.
+      await moveToOuterReaderGutter(page, stormTranscript, false);
+      stagnantGestures = 0;
+    }
+    const before = await stormTranscript.evaluate((element) => element.scrollTop);
     await page.mouse.wheel(0, 640);
     await page.waitForTimeout(60);
     // Every sixth gesture, pause into scroll idle — the moment the pre-fix
     // chain fired its revision-driven remount mid-approach.
-    if (attempt % 6 === 5) await page.waitForTimeout(500);
-    stormReached = await stormTranscript.evaluate((element) =>
-      element.dataset.scrollMode === "tail-follow"
-      && element.scrollHeight - element.scrollTop - element.clientHeight <= 1);
+    if (stormAttempts % 6 === 5) await page.waitForTimeout(500);
+    const current = await stormTranscript.evaluate((element) => ({
+      mode: element.dataset.scrollMode,
+      top: element.scrollTop,
+      distance: element.scrollHeight - element.scrollTop - element.clientHeight,
+    }));
+    stormReached = current.mode === "tail-follow" && current.distance <= 1;
+    stagnantGestures = current.top <= before + 1 && !stormReached ? stagnantGestures + 1 : 0;
+    stormAttempts += 1;
   }
-  assert(stormReached, "repeated downward wheels reach the physical bottom through the ref-resolution storm (#8657)");
+  const stormApproach = await stormTranscript.evaluate((element) => ({
+    writes: window.__stormProbe?.writes.length ?? null,
+    mode: element.dataset.scrollMode,
+    top: Math.round(element.scrollTop),
+    height: Math.round(element.scrollHeight),
+    clientHeight: element.clientHeight,
+    distance: Math.round(element.scrollHeight - element.scrollTop - element.clientHeight),
+  }));
+  stormApproach.gestures = stormAttempts;
+  assert(
+    stormReached,
+    `repeated downward wheels reach the physical bottom through the ref-resolution storm (#8657; ${JSON.stringify(stormApproach)})`,
+  );
   await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.scrollMode === "tail-follow", undefined, { timeout: 5_000 });
   // The storm keeps resolving after the user lands; the tail must hold.
   await page.waitForFunction(

--- a/desktop/frontend/bench/transcript-selection.mjs
+++ b/desktop/frontend/bench/transcript-selection.mjs
@@ -104,9 +104,28 @@ async function findVisibleTurnTarget(page, turnPredicate) {
         && rect.height > 0 && rect.bottom > viewport.top && rect.top < viewport.bottom;
     });
     if (!root) return null;
-    const rect = root.getBoundingClientRect();
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const textRects = [];
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      if (!node.textContent?.trim()) continue;
+      const range = document.createRange();
+      range.selectNodeContents(node);
+      textRects.push(...range.getClientRects());
+    }
+    const rect = textRects.find((candidate) =>
+      candidate.width > 8
+      && candidate.height > 0
+      && candidate.bottom > viewport.top
+      && candidate.top < viewport.bottom
+    );
+    if (!rect) return null;
+    const visibleLeft = Math.max(rect.left, viewport.left);
+    const visibleRight = Math.min(rect.right, viewport.right);
+    if (visibleRight - visibleLeft < 4) return null;
+    const width = visibleRight - visibleLeft;
     return {
-      x: Math.min(rect.right - 2, rect.left + Math.max(rect.width * 0.45, 24)),
+      x: visibleLeft + width * 0.7,
+      probeX: visibleLeft + width * 0.35,
       y: (Math.max(rect.top, viewport.top) + Math.min(rect.bottom, viewport.bottom)) / 2,
     };
   }, turnPredicate);
@@ -600,7 +619,11 @@ try {
   assert(forwardFocus != null, "downward logical drag settles over a visible 20+ turn target");
   let forwardPromoted = false;
   for (let attempt = 0; attempt < 5 && !forwardPromoted; attempt += 1) {
-    await page.mouse.move(forwardFocus.x + 24, forwardFocus.y, { steps: 4 });
+    // Stay inside a real text client rect. The selectable row is a full-width
+    // block, so its geometric center can be empty padding on slower layouts;
+    // moving there does not extend the browser Range and cannot promote the
+    // cross-row gesture to the logical selection owner.
+    await page.mouse.move(forwardFocus.probeX, forwardFocus.y, { steps: 4 });
     await page.mouse.move(forwardFocus.x, forwardFocus.y, { steps: 8 });
     forwardPromoted = await waitForLogicalSelection(page, 3_000);
     if (!forwardPromoted) forwardFocus = (await findVisibleTurnTarget(page, { min: forwardTargetTurn })) ?? forwardFocus;


### PR DESCRIPTION
## Summary

- target cross-page selection at an actual visible text client rect instead of full-width row padding
- reacquire outer-reader wheel ownership when ref-resolution patches replace the row under the pointer
- retain bounded deadlines plus pull-back, remount, and recovery-write assertions with actionable diagnostics

## Release-gate failures addressed

- Linux final-candidate attempt 1: `#8657` storm did not reach the physical bottom within a fixed gesture count
- Linux final-candidate attempt 2: downward cross-page drag found a row but landed on padding and did not promote to logical selection

## Verification

- selection browser replay: 5/5
- scroll-stability browser replay: 5/5
- full `pnpm test:transcript-browser`
- `pnpm test:performance`
- `go run ./tools/repolint`
- `git diff --check`

Documentation-impact: none - only browser test harnesses changed; existing user documentation remains correct because runtime behavior and user-facing controls are unchanged

Cache-impact: none (no prompt, schema, provider request, or cache-key path changed)

Compatibility-impact: none (test-only changes; runtime interfaces and persisted formats are unchanged)