### PR TITLE
fix(projection): isolate memory catalogs and flush roots / 隔离内存索引并排空根队列

### DIFF
--- a/internal/historycatalog/catalog.go
+++ b/internal/historycatalog/catalog.go
@@ -304,11 +304,18 @@ func (c *Catalog) drainPending(ctx context.Context) {
 			delete(c.paths, path)
 			c.mu.Unlock()
 			_ = c.indexPath(ctx, queued.root, path, 0, queued.appendFrom)
+		case path := <-c.rootCh:
+			c.mu.Lock()
+			root, ok := c.roots[path]
+			c.mu.Unlock()
+			if ok {
+				_ = c.reconcileRoot(ctx, root)
+			}
 		default:
 			c.mu.Lock()
 			empty := len(c.paths) == 0 && len(c.dirtyRoots) == 0
 			c.mu.Unlock()
-			if empty && len(c.queue) == 0 {
+			if empty && len(c.queue) == 0 && len(c.rootCh) == 0 {
 				return
 			}
 			// Another goroutine may have enqueued between checks; yield once.
@@ -316,7 +323,7 @@ func (c *Catalog) drainPending(ctx context.Context) {
 			c.mu.Lock()
 			empty = len(c.paths) == 0 && len(c.dirtyRoots) == 0
 			c.mu.Unlock()
-			if empty && len(c.queue) == 0 {
+			if empty && len(c.queue) == 0 && len(c.rootCh) == 0 {
 				return
 			}
 		}

--- a/internal/historycatalog/catalog_test.go
+++ b/internal/historycatalog/catalog_test.go
@@ -50,6 +50,30 @@ func TestReconcileAndSearchFTSWithoutStoredBody(t *testing.T) {
 	}
 }
 
+func TestDrainPendingIncludesRegisteredRoots(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	path := filepath.Join(root, "pending-root.jsonl")
+	saveMessages(t, path, provider.Message{Role: provider.RoleUser, Content: "registered root flush marker"})
+	catalog, err := Open(ctx, Options{InMemory: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Stop the background consumer so this test exercises drainPending's own
+	// contract deterministically instead of racing the worker's select loop.
+	catalog.cancel()
+	catalog.wg.Wait()
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	if !catalog.RegisterRoot(Root{Path: root, Scope: "global"}) {
+		t.Fatal("registered root was not queued")
+	}
+	catalog.drainPending(ctx)
+	result, err := catalog.Search(ctx, SearchRequest{Query: "marker", Roots: []string{root}})
+	if err != nil || len(result.Items) != 1 || result.Items[0].SessionPath != path {
+		t.Fatalf("drained root result=%#v err=%v", result, err)
+	}
+}
+
 func TestRewriteRemovesOldTerms(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/historycatalog/govern_test.go
+++ b/internal/historycatalog/govern_test.go
@@ -94,18 +94,6 @@ func sourceHealth(t *testing.T, catalog *Catalog, path string) string {
 	return health
 }
 
-func waitForCondition(t *testing.T, what string, ok func() bool) {
-	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if ok() {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("%s: condition not met within 5s", what)
-}
-
 // checkpoint folds the WAL so file-size-based caps are measured post-fold.
 func checkpoint(t *testing.T, catalog *Catalog) {
 	t.Helper()
@@ -304,25 +292,38 @@ func TestOpenTriggersBackgroundWipeWhenFarOverCap(t *testing.T) {
 		t.Fatal(err)
 	}
 	size := historyDBFileSize(dbPath)
-	reopened, err := Open(ctx, Options{Path: dbPath, MaxBytes: size / 4})
+	rebuildDone := make(chan struct{}, 1)
+	reopened, err := Open(ctx, Options{Path: dbPath, MaxBytes: size / 4, OnRevision: func(_ Status, _ []string, reason string) {
+		if reason == "rebuild-oversize" {
+			select {
+			case rebuildDone <- struct{}{}:
+			default:
+			}
+		}
+	}})
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = reopened.Close(context.Background()) })
-	waitForCondition(t, "background wipe", func() bool {
-		var count int
-		if err := reopened.db.QueryRow(`SELECT COUNT(*) FROM history_documents`).Scan(&count); err != nil {
-			return false
-		}
-		return count == 0
-	})
+	select {
+	case <-rebuildDone:
+	case <-time.After(20 * time.Second):
+		t.Fatal("background wipe did not publish rebuild completion within 20s")
+	}
 	// The wipe must be followed by a rescan that rebuilds the index (now with
 	// truncated tool payloads) without blocking startup.
-	reopened.RegisterRoot(Root{Path: root, Scope: "global"})
-	waitForCondition(t, "rebuild rescan", func() bool {
-		result, err := reopened.Search(ctx, SearchRequest{Query: "alphamarker", Kinds: []string{"tool_output"}, Roots: []string{root}})
-		return err == nil && len(result.Items) == 1
-	})
+	if !reopened.RegisterRoot(Root{Path: root, Scope: "global"}) {
+		t.Fatal("register rebuilt root was not queued")
+	}
+	flushCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	if err := reopened.Flush(flushCtx); err != nil {
+		t.Fatalf("flush rebuilt root: %v", err)
+	}
+	result, err := reopened.Search(ctx, SearchRequest{Query: "alphamarker", Kinds: []string{"tool_output"}, Roots: []string{root}})
+	if err != nil || len(result.Items) != 1 {
+		t.Fatalf("rebuild rescan result=%#v err=%v", result, err)
+	}
 }
 
 func TestEvictedSessionStaysEvictedWhenUnchangedAndReindexesOnChange(t *testing.T) {

--- a/internal/projectiondb/projectiondb.go
+++ b/internal/projectiondb/projectiondb.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"reasonix/internal/filelock"
@@ -22,6 +23,8 @@ import (
 )
 
 type Mode string
+
+var memoryDatabaseSequence atomic.Uint64
 
 const (
 	ModeDisk   Mode = "disk"
@@ -195,7 +198,11 @@ func diskFileDSN(path string) string {
 func open(ctx context.Context, opts OpenOptions, mode Mode) (*sql.DB, error) {
 	var dsn string
 	if mode == ModeMemory {
-		dsn = fmt.Sprintf("file:reasonix-%s-%d?mode=memory&cache=shared", url.PathEscape(opts.MemoryName), opts.Now().UnixNano())
+		// time.Now has coarse resolution on some platforms, notably Windows.
+		// A process-local sequence prevents concurrently opened projections with
+		// the same logical name from sharing one SQLite memory database by accident.
+		dsn = fmt.Sprintf("file:reasonix-%s-%d-%d?mode=memory&cache=shared", url.PathEscape(opts.MemoryName),
+			opts.Now().UnixNano(), memoryDatabaseSequence.Add(1))
 	} else {
 		dsn = diskFileDSN(opts.Path)
 	}

--- a/internal/projectiondb/projectiondb_test.go
+++ b/internal/projectiondb/projectiondb_test.go
@@ -195,6 +195,34 @@ func TestMemoryOpenUsesOneConnectionDespiteRequestedPool(t *testing.T) {
 	}
 }
 
+func TestMemoryOpenIsolatesHandlesWithSameNameAndClock(t *testing.T) {
+	t.Parallel()
+	fixedNow := func() time.Time { return time.Unix(123, 456) }
+	opts := OpenOptions{
+		InMemory: true, MemoryName: "same-name", Migrations: testMigrations(), Now: fixedNow,
+	}
+	first, err := Open(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = first.DB.Close() })
+	second, err := Open(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = second.DB.Close() })
+	if _, err := first.DB.Exec(`INSERT INTO values_table(value) VALUES('first-only')`); err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	if err := second.DB.QueryRow(`SELECT COUNT(*) FROM values_table`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("second memory projection contains %d rows from first handle, want isolated database", count)
+	}
+}
+
 func TestRebuildRequireDiskSurfacesOpenErrors(t *testing.T) {
 	t.Parallel()
 	// RequireDisk rebuild of an unwritable parent should not silently memory-open.


### PR DESCRIPTION
## Summary

- append a process-local atomic sequence to shared-memory SQLite identities so same-name catalogs cannot collide under coarse Windows clocks
- make history Flush consume registered-root work as well as dirty roots and queued paths
- synchronize oversize rebuild coverage on the published rebuild event and the owning flush contract instead of fixed polling

## Release-gate failures addressed

- Windows final-candidate full suite: TestIndexSessionPathSkipsUnchangedProjection raced duplicate schema migrations after two in-memory catalogs received the same DSN
- Windows final-candidate full suite: TestOpenTriggersBackgroundWipeWhenFarOverCap timed out while polling for a registered-root rescan that Flush did not own

## Verification

- projection isolation regression: 20/20
- history drain and oversize rebuild regressions: 20/20
- original session-catalog regression: 20/20
- go test ./internal/projectiondb ./internal/sessioncatalog ./internal/historycatalog
- go test -race ./internal/projectiondb ./internal/sessioncatalog ./internal/historycatalog
- go test ./...
- go run ./tools/repolint
- git diff --check

Documentation-impact: none - the change hardens internal disposable projection concurrency and test synchronization; existing user documentation remains correct

Cache-impact: none (only process-local disposable SQLite projection identity changed; provider prompt prefixes, serialization, request routing, and cache keys are unchanged)

Compatibility-impact: none (no public API, persisted format, migration version, or on-disk projection behavior changed)