### PR TITLE
fix(evidence): classify kill_shell as host-state-only / kill_shell 归类为仅主机状态变更 (#9564)

### DIFF
--- a/internal/agent/workspace_lease_regression_test.go
+++ b/internal/agent/workspace_lease_regression_test.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"reasonix/internal/event"
+	"reasonix/internal/jobs"
 	"reasonix/internal/provider"
+	"reasonix/internal/tool/builtin"
 	"reasonix/internal/workspacelease"
 )
 
@@ -110,6 +114,60 @@ func TestFleetMetaToolDoesNotTakeOuterWorkspaceLease(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("fleet did not return after release")
+	}
+}
+
+func TestKillShellDoesNotWaitForBackgroundWriterLease(t *testing.T) {
+	root, locks := t.TempDir(), t.TempDir()
+	owner, err := workspacelease.New(root, locks, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner.BeginRun()
+	defer owner.EndRun()
+
+	manager := jobs.NewManager(event.Discard)
+	defer manager.Close()
+	leaseHeld := make(chan struct{})
+	job := manager.StartForSession("parent-session", "task", "writer", func(ctx context.Context, _ io.Writer) (string, error) {
+		release, err := owner.HoldWriteForPath(ctx, filepath.Join(root, "held.go"))
+		if err != nil {
+			return "", err
+		}
+		defer release()
+		close(leaseHeld)
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	select {
+	case <-leaseHeld:
+	case <-time.After(time.Second):
+		t.Fatal("background writer did not acquire its path lease")
+	}
+
+	tools := (builtin.Workspace{Dir: root}).Tools("kill_shell")
+	if len(tools) != 1 {
+		t.Fatalf("kill_shell tools = %d, want 1", len(tools))
+	}
+	a := deliveryLeaseTestAgent(t, owner, tools[0])
+	a.svc.jobs = manager
+	a.writeWorkspaceRoot = root
+
+	ctx := jobs.WithManager(context.Background(), manager)
+	ctx = jobs.WithSession(ctx, "parent-session")
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	args, err := json.Marshal(map[string]string{"job_id": job.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := a.executeOne(ctx, &a.turn, provider.ToolCall{ID: "kill", Name: "kill_shell", Arguments: string(args)})
+	if out.blocked || out.errMsg != "" {
+		t.Fatalf("kill_shell waited for the background writer lease: %+v", out)
+	}
+	result := manager.WaitForSession(context.Background(), "parent-session", []string{job.ID}, 1)
+	if len(result) != 1 || result[0].Status != jobs.Killed {
+		t.Fatalf("background job after kill_shell = %+v, want killed", result)
 	}
 }
 

--- a/internal/evidence/classify_profile.go
+++ b/internal/evidence/classify_profile.go
@@ -21,9 +21,9 @@ func ClassifyEffect(in EffectInput) EffectProfile {
 		return readOnlyProfile(targetsFrom(in, nil), ReasonReadOnly)
 	}
 	switch name {
-	case "ask", "todo_write", "complete_step", "bash_output", "wait", "kill_shell":
+	case "ask", "todo_write", "complete_step", "bash_output", "wait":
 		return readOnlyProfile(nil, ReasonReadOnly)
-	case "remember", "forget", "set_session_title":
+	case "remember", "forget", "set_session_title", "kill_shell":
 		return EffectProfile{Known: true, HostState: true, Reason: ReasonHostState}
 	}
 	profile := writerProfile(in)

--- a/internal/evidence/classify_profile.go
+++ b/internal/evidence/classify_profile.go
@@ -21,7 +21,7 @@ func ClassifyEffect(in EffectInput) EffectProfile {
 		return readOnlyProfile(targetsFrom(in, nil), ReasonReadOnly)
 	}
 	switch name {
-	case "ask", "todo_write", "complete_step", "bash_output", "wait":
+	case "ask", "todo_write", "complete_step", "bash_output", "wait", "kill_shell":
 		return readOnlyProfile(nil, ReasonReadOnly)
 	case "remember", "forget", "set_session_title":
 		return EffectProfile{Known: true, HostState: true, Reason: ReasonHostState}

--- a/internal/evidence/effects_test.go
+++ b/internal/evidence/effects_test.go
@@ -48,6 +48,7 @@ func TestClassifyToolCallSeparatesMutationDomains(t *testing.T) {
 		{"trusted reader", "read_file", `{}`, true, ToolEffects{Known: true}},
 		{"fleet meta tool", "fleet", `{}`, false, ToolEffects{Known: true}},
 		{"session title", "set_session_title", `{"title":"Current task"}`, false, ToolEffects{Known: true, StateMutation: true, Reason: "host session metadata write"}},
+		{"background kill", "kill_shell", `{"job_id":"task-1"}`, false, ToolEffects{Known: true, StateMutation: true}},
 		{"generic writer", "edit_file", `{}`, false, ToolEffects{Known: true, StateMutation: true, WorkspaceMutation: true, ContentMutation: true}},
 	}
 	for _, tt := range tests {

--- a/internal/evidence/profile_test.go
+++ b/internal/evidence/profile_test.go
@@ -64,6 +64,17 @@ func TestClassifyEffectFileAndMCP(t *testing.T) {
 	}
 }
 
+func TestClassifyEffectKillShellIsHostStateOnly(t *testing.T) {
+	profile := ClassifyEffect(EffectInput{ToolName: "kill_shell", Args: json.RawMessage(`{"job_id":"task-1"}`)})
+	if !profile.Known || profile.ReadOnly || !profile.HostState || profile.WorkspaceWrite || profile.RepoMetadata || profile.ExternalState {
+		t.Fatalf("kill_shell profile = %+v, want host-state-only mutation", profile)
+	}
+	effects := profile.ToolEffects()
+	if !effects.StateMutation || effects.WorkspaceMutation || effects.ContentMutation || effects.RepositoryMutation {
+		t.Fatalf("kill_shell effects = %+v, want state mutation without workspace mutation", effects)
+	}
+}
+
 func TestClassifyWriteScopeScratchWriteFile(t *testing.T) {
 	workspace := t.TempDir()
 	scratchPath := filepath.Join(os.TempDir(), "reasonix-scope-probe.py")


### PR DESCRIPTION
## Summary

`kill_shell` previously fell through to the workspace-writer evidence profile. As a result, terminating a background job could wait for a workspace path lease held by the same job, creating a self-blocking lifecycle operation.

This change classifies `kill_shell` as a host-state-only operation:

- `StateMutation` remains `true`, preserving permission and runtime-policy semantics for an operation with observable process state effects.
- `WorkspaceMutation` is `false`, so `kill_shell` does not enter workspace write coordination or wait for the target job's path lease.
- Evidence-domain tests and a deterministic agent regression test cover both the classification and the real background-job termination path.

## Issue

Fixes #9564

## Verification

- `go test ./internal/evidence ./internal/agent ./internal/runtimepolicy ./internal/tool/builtin -count=1`
- `go test -race ./internal/evidence ./internal/agent ./internal/runtimepolicy ./internal/jobs -count=1`
- `go test ./... -count=1` on the merge tree with the latest `main-v2`
- `go vet ./...` on the merge tree with the latest `main-v2`
- `git diff --check`

## Compatibility

No persisted-data, provider-visible schema, system-prompt, or user-facing documentation changes.

Cache-impact: none - host-state classification and tests only
Cache-guard: unchanged - provider-visible schemas and prompts are unchanged
Documentation-impact: none - internal runtime classification only
System-prompt-review: none - no prompt text changes
