### PR TITLE
feat(desktop): merge session recovery copies from the project tree / 会话右键合并恢复副本 (#9470 #8739)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3040,6 +3040,10 @@ func (a *App) DeleteRecoveryCopy(path string) error {
 
 var errRecoveryCopyNotRedundant = errors.New("recovery session contains content not preserved by its parent")
 
+// errNoRecoveryCopiesToConsolidate is returned when the session-action
+// "merge recovery copies" finds no recovery copies for the session.
+var errNoRecoveryCopiesToConsolidate = errors.New("this session has no recovery copies to merge")
+
 func (a *App) deleteSession(path string) error {
 	dir := a.activeSessionDir()
 	sessionPath, key, err := validateSessionPath(dir, path)

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1163,6 +1163,31 @@ export function ProjectTree({
                   void (async () => {
                     try {
                       const report = await app.ConsolidateTopicRecoveryCopies(scope, openRequest?.workspaceRoot ?? node.root ?? "", topicId);
+                      if (report.blockedByDivergence) {
+                        showToast(
+                          t("projectTree.consolidateBlocked", { winner: report.winnerMessageCount, main: report.mainMessageCount }),
+                          "warn",
+                          {
+                            actionLabel: t("projectTree.consolidateForceAction"),
+                            onAction: () => {
+                              void (async () => {
+                                try {
+                                  const forced = await app.ForceConsolidateTopicRecoveryCopies(scope, openRequest?.workspaceRoot ?? node.root ?? "", topicId);
+                                  showToast(
+                                    t("projectTree.consolidateDone", { messages: forced.mainMessageCount, count: forced.trashed.length }),
+                                    "info",
+                                  );
+                                  await refresh();
+                                  await onTopicsChanged?.();
+                                } catch (err) {
+                                  showToast(err instanceof Error ? err.message : String(err), "error");
+                                }
+                              })();
+                            },
+                          },
+                        );
+                        return;
+                      }
                       if (report.promoted) {
                         showToast(
                           t("projectTree.consolidateDone", { messages: report.mainMessageCount, count: report.trashed.length }),

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { CSSProperties, DragEvent as ReactDragEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
-import { Archive, ArchiveX, ArrowDown, Pencil, Plus, Folder, FolderPlus, FolderInput, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, Check, GitMerge, ListCollapse, ListRestart, MessageSquare, Clock, Pin, MoreHorizontal, Minimize2, Maximize2, GitBranch, Sparkles, Cloud, SwatchBook } from "lucide-react";
+import { Archive, ArrowDown, Pencil, Plus, Folder, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, Check, GitMerge, ListCollapse, ListRestart, MessageSquare, Clock, Pin, MoreHorizontal, Minimize2, Maximize2, GitBranch, Sparkles, Cloud } from "lucide-react";
 import { asArray } from "../lib/array";
 import { useToast } from "../lib/toast";
 import { app } from "../lib/bridge";

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { CSSProperties, DragEvent as ReactDragEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
-import { Archive, ArrowDown, Pencil, Plus, Folder, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, Check, ListCollapse, ListRestart, MessageSquare, Clock, Pin, MoreHorizontal, Minimize2, Maximize2, GitBranch, Sparkles, Cloud } from "lucide-react";
+import { Archive, ArchiveX, ArrowDown, Pencil, Plus, Folder, FolderPlus, FolderInput, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, Check, GitMerge, ListCollapse, ListRestart, MessageSquare, Clock, Pin, MoreHorizontal, Minimize2, Maximize2, GitBranch, Sparkles, Cloud, SwatchBook } from "lucide-react";
 import { asArray } from "../lib/array";
 import { useToast } from "../lib/toast";
 import { app } from "../lib/bridge";
@@ -1153,6 +1153,39 @@ export function ProjectTree({
       };
       const topicMenuItems: ContextMenuItem[] = [
         ...organization.topicMenuItems(node, t),
+        ...(isSessionNode && node.sessionPath && !node.running
+          ? [
+              {
+                key: "consolidate-recovery-copies",
+                icon: <GitMerge size={13} />,
+                label: t("projectTree.consolidateRecoveryCopies"),
+                disabled: !node.sessionPath || node.running,
+                onSelect: () => {
+                  const sessionPath = node.sessionPath;
+                  if (!sessionPath) return;
+                  void (async () => {
+                    try {
+                      const report = await app.ConsolidateSessionRecoveryCopies(sessionPath);
+                      if (report.promoted) {
+                        showToast(
+                          t("projectTree.consolidateDone", { messages: report.mainMessageCount, count: report.trashed.length }),
+                          "info",
+                        );
+                      } else if (report.trashed.length > 0) {
+                        showToast(t("projectTree.consolidateFolded", { count: report.trashed.length }), "info");
+                      } else {
+                        showToast(t("projectTree.consolidateNothing"), "info");
+                      }
+                      await refresh();
+                      await onTopicsChanged?.();
+                    } catch (err) {
+                      showToast(err instanceof Error ? err.message : String(err), "error");
+                    }
+                  })();
+                },
+              },
+            ]
+          : []),
         ...(projectTreeTopicMenuOffersPin(variant)
           ? [
               {

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1159,13 +1159,10 @@ export function ProjectTree({
                 key: "consolidate-recovery-copies",
                 icon: <GitMerge size={13} />,
                 label: t("projectTree.consolidateRecoveryCopies"),
-                disabled: !node.sessionPath,
                 onSelect: () => {
-                  const sessionPath = node.sessionPath;
-                  if (!sessionPath) return;
                   void (async () => {
                     try {
-                      const report = await app.ConsolidateSessionRecoveryCopies(sessionPath);
+                      const report = await app.ConsolidateTopicRecoveryCopies(scope, openRequest?.workspaceRoot ?? node.root ?? "", topicId);
                       if (report.promoted) {
                         showToast(
                           t("projectTree.consolidateDone", { messages: report.mainMessageCount, count: report.trashed.length }),

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1232,6 +1232,35 @@ export function ProjectTree({
           onSelect: () => void aiRenameSession(topicId),
         },
         {
+          key: "consolidate-recovery-copies",
+          icon: <GitMerge size={13} />,
+          label: t("projectTree.consolidateRecoveryCopies"),
+          disabled: !node.sessionPath || node.running,
+          onSelect: () => {
+            const sessionPath = node.sessionPath;
+            if (!sessionPath) return;
+            void (async () => {
+              try {
+                const report = await app.ConsolidateSessionRecoveryCopies(sessionPath);
+                if (report.promoted) {
+                  showToast(
+                    t("projectTree.consolidateDone", { messages: report.mainMessageCount, count: report.trashed.length }),
+                    "info",
+                  );
+                } else if (report.trashed.length > 0) {
+                  showToast(t("projectTree.consolidateFolded", { count: report.trashed.length }), "info");
+                } else {
+                  showToast(t("projectTree.consolidateNothing"), "info");
+                }
+                await refresh();
+                await onTopicsChanged?.();
+              } catch (err) {
+                showToast(err instanceof Error ? err.message : String(err), "error");
+              }
+            })();
+          },
+        },
+        {
           key: "trash",
           icon: <Archive className={topicTrashing ? "project-tree__archive-spinner" : undefined} size={13} />,
           label: confirmArchiveTarget === archiveTargetKey ? t("history.confirmMoveToTrash") : t("history.moveToTrash"),

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1159,7 +1159,7 @@ export function ProjectTree({
                 key: "consolidate-recovery-copies",
                 icon: <GitMerge size={13} />,
                 label: t("projectTree.consolidateRecoveryCopies"),
-                disabled: !node.sessionPath || node.running,
+                disabled: !node.sessionPath,
                 onSelect: () => {
                   const sessionPath = node.sessionPath;
                   if (!sessionPath) return;

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -377,19 +377,15 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   TakeoverSession(tabId: string, mode: "wait" | "interrupt"): Promise<void>;
   DeleteSession(path: string): Promise<void>;
   DeleteRecoveryCopy(path: string): Promise<void>;
-<<<<<<< HEAD
   GetRecoveryLineage(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string; recordClassification?: boolean }): Promise<RecoveryLineageView>;
   GetSessionVersionState(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string; recordClassification?: boolean }): Promise<import("./types").SessionVersionStateView>;
   SetActiveSessionVersion(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
   RetrySessionRecovery(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
   ReconcileRecoveryVersions(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string }): Promise<void>;
-=======
   ConsolidateSessionRecoveryCopies(path: string): Promise<ConsolidationReport>;
   ForceConsolidateSessionRecoveryCopies(path: string): Promise<ConsolidationReport>;
   ConsolidateTopicRecoveryCopies(scope: string, workspaceRoot: string, topicID: string): Promise<ConsolidationReport>;
   ForceConsolidateTopicRecoveryCopies(scope: string, workspaceRoot: string, topicID: string): Promise<ConsolidationReport>;
-  GetRecoveryLineage(key: { scope: string; workspaceRoot?: string; topicId: string }): Promise<RecoveryLineageView>;
->>>>>>> 8c2fdf42a (feat(desktop): merge session recovery copies from the project tree / 会话右键新增合并恢复副本，修复较早对话加载失败（#9470）)
   ChooseRecoveryBranch(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
   CleanRecoveryLineage(request: RecoveryCleanupRequest): Promise<RecoveryCleanupResult>;
   RestoreSession(path: string): Promise<void>;

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -385,7 +385,9 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   ReconcileRecoveryVersions(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string }): Promise<void>;
 =======
   ConsolidateSessionRecoveryCopies(path: string): Promise<ConsolidationReport>;
+  ForceConsolidateSessionRecoveryCopies(path: string): Promise<ConsolidationReport>;
   ConsolidateTopicRecoveryCopies(scope: string, workspaceRoot: string, topicID: string): Promise<ConsolidationReport>;
+  ForceConsolidateTopicRecoveryCopies(scope: string, workspaceRoot: string, topicID: string): Promise<ConsolidationReport>;
   GetRecoveryLineage(key: { scope: string; workspaceRoot?: string; topicId: string }): Promise<RecoveryLineageView>;
 >>>>>>> 8c2fdf42a (feat(desktop): merge session recovery copies from the project tree / 会话右键新增合并恢复副本，修复较早对话加载失败（#9470）)
   ChooseRecoveryBranch(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
@@ -3489,6 +3491,8 @@ function makeMockApp(): AppBindings {
         mainPath: path,
         winnerPath: "",
         promoted: false,
+        blockedByDivergence: false,
+        normalizedMain: false,
         mainMessageCount: 0,
         winnerMessageCount: 0,
         trashed: [],
@@ -3496,8 +3500,14 @@ function makeMockApp(): AppBindings {
         skippedUnloadable: [],
       };
     },
+    async ForceConsolidateSessionRecoveryCopies(path: string): Promise<ConsolidationReport> {
+      return this.ConsolidateSessionRecoveryCopies(path);
+    },
     async ConsolidateTopicRecoveryCopies(_scope: string, _workspaceRoot: string, topicID: string): Promise<ConsolidationReport> {
       return this.ConsolidateSessionRecoveryCopies(`mock://topics/${topicID}`);
+    },
+    async ForceConsolidateTopicRecoveryCopies(_scope: string, _workspaceRoot: string, topicID: string): Promise<ConsolidationReport> {
+      return this.ForceConsolidateSessionRecoveryCopies(`mock://topics/${topicID}`);
     },
     async RenameSession(path: string, title: string) {
       const s = sessions.find((x) => x.path === path);

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -385,6 +385,7 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   ReconcileRecoveryVersions(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string }): Promise<void>;
 =======
   ConsolidateSessionRecoveryCopies(path: string): Promise<ConsolidationReport>;
+  ConsolidateTopicRecoveryCopies(scope: string, workspaceRoot: string, topicID: string): Promise<ConsolidationReport>;
   GetRecoveryLineage(key: { scope: string; workspaceRoot?: string; topicId: string }): Promise<RecoveryLineageView>;
 >>>>>>> 8c2fdf42a (feat(desktop): merge session recovery copies from the project tree / 会话右键新增合并恢复副本，修复较早对话加载失败（#9470）)
   ChooseRecoveryBranch(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
@@ -3494,6 +3495,9 @@ function makeMockApp(): AppBindings {
         skippedNotCovered: [],
         skippedUnloadable: [],
       };
+    },
+    async ConsolidateTopicRecoveryCopies(_scope: string, _workspaceRoot: string, topicID: string): Promise<ConsolidationReport> {
+      return this.ConsolidateSessionRecoveryCopies(`mock://topics/${topicID}`);
     },
     async RenameSession(path: string, title: string) {
       const s = sessions.find((x) => x.path === path);

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -108,6 +108,7 @@ import type {
   PluginView,
   ProjectNode,
   ProjectTreeOrganizationBindings,
+  ConsolidationReport,
   RecoveryLineageView,
   RecoveryCleanupRequest,
   RecoveryCleanupResult,
@@ -376,11 +377,16 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   TakeoverSession(tabId: string, mode: "wait" | "interrupt"): Promise<void>;
   DeleteSession(path: string): Promise<void>;
   DeleteRecoveryCopy(path: string): Promise<void>;
+<<<<<<< HEAD
   GetRecoveryLineage(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string; recordClassification?: boolean }): Promise<RecoveryLineageView>;
   GetSessionVersionState(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string; recordClassification?: boolean }): Promise<import("./types").SessionVersionStateView>;
   SetActiveSessionVersion(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
   RetrySessionRecovery(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
   ReconcileRecoveryVersions(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string }): Promise<void>;
+=======
+  ConsolidateSessionRecoveryCopies(path: string): Promise<ConsolidationReport>;
+  GetRecoveryLineage(key: { scope: string; workspaceRoot?: string; topicId: string }): Promise<RecoveryLineageView>;
+>>>>>>> 8c2fdf42a (feat(desktop): merge session recovery copies from the project tree / 会话右键新增合并恢复副本，修复较早对话加载失败（#9470）)
   ChooseRecoveryBranch(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
   CleanRecoveryLineage(request: RecoveryCleanupRequest): Promise<RecoveryCleanupResult>;
   RestoreSession(path: string): Promise<void>;
@@ -3474,6 +3480,20 @@ function makeMockApp(): AppBindings {
     },
     async PurgeRecoveryCopy(path: string) {
       return this.PurgeTrashedSession(path);
+    },
+    async ConsolidateSessionRecoveryCopies(path: string): Promise<ConsolidationReport> {
+      // The browser mock keeps no recovery lineage, so consolidation is a
+      // well-formed no-op that reports "nothing to merge".
+      return {
+        mainPath: path,
+        winnerPath: "",
+        promoted: false,
+        mainMessageCount: 0,
+        winnerMessageCount: 0,
+        trashed: [],
+        skippedNotCovered: [],
+        skippedUnloadable: [],
+      };
     },
     async RenameSession(path: string, title: string) {
       const s = sessions.find((x) => x.path === path);

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -657,6 +657,21 @@ export interface RecoveryCleanupResult {
   items: RecoveryCleanupItem[];
 }
 
+// ConsolidationReport summarizes one "merge recovery copies" run: the
+// fullest copy is promoted onto the main session identity, the previous main
+// is archived under the recoverable trash, and fully covered copies fold
+// into the same trash. Copies holding unique turns are preserved.
+export interface ConsolidationReport {
+  mainPath: string;
+  winnerPath: string;
+  promoted: boolean;
+  mainMessageCount: number;
+  winnerMessageCount: number;
+  trashed: string[];
+  skippedNotCovered: string[];
+  skippedUnloadable: string[];
+}
+
 export interface DeliveryWorktreeAvailability {
   available: boolean;
   reason?: string;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -665,6 +665,11 @@ export interface ConsolidationReport {
   mainPath: string;
   winnerPath: string;
   promoted: boolean;
+  // True when the fullest copy and the main each hold turns the other lacks
+  // (typical after a main-side compaction): nothing was merged and the UI
+  // should ask the user whether to force the merge.
+  blockedByDivergence: boolean;
+  normalizedMain: boolean;
   mainMessageCount: number;
   winnerMessageCount: number;
   trashed: string[];

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1377,6 +1377,10 @@ export const en = {
   "recovery.role.normal": "original",
 
   // project tree
+  "projectTree.consolidateRecoveryCopies": "Merge recovery copies",
+  "projectTree.consolidateDone": "Recovery copies merged: main keeps {messages} messages, {count} copies archived",
+  "projectTree.consolidateFolded": "Archived {count} redundant recovery copies",
+  "projectTree.consolidateNothing": "No recovery copies to merge",
   "projectTree.workspaceTitle": "Projects",
   "projectTree.pinnedTitle": "Pinned",
   "projectTree.searchPlaceholder": "Search projects or sessions",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1381,6 +1381,8 @@ export const en = {
   "projectTree.consolidateDone": "Recovery copies merged: main keeps {messages} messages, {count} copies archived",
   "projectTree.consolidateFolded": "Archived {count} redundant recovery copies",
   "projectTree.consolidateNothing": "No recovery copies to merge",
+  "projectTree.consolidateBlocked": "The copy and the main each hold unique turns (copy {winner} / main {main}); automatic merge refused",
+  "projectTree.consolidateForceAction": "Merge anyway (archive current main)",
   "projectTree.workspaceTitle": "Projects",
   "projectTree.pinnedTitle": "Pinned",
   "projectTree.searchPlaceholder": "Search projects or sessions",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1128,6 +1128,10 @@ export const zhTW: Record<DictKey, string> = {
   "recovery.role.normal": "原始會話",
 
   // 專案樹
+  "projectTree.consolidateRecoveryCopies": "合併恢復副本",
+  "projectTree.consolidateDone": "已合併恢復副本：主幹保留 {messages} 條訊息，{count} 個副本已封存",
+  "projectTree.consolidateFolded": "已封存 {count} 個冗餘恢復副本",
+  "projectTree.consolidateNothing": "沒有需要合併的恢復副本",
   "projectTree.workspaceTitle": "專案",
   "projectTree.pinnedTitle": "置頂",
   "projectTree.searchPlaceholder": "搜尋專案或會話",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1132,6 +1132,8 @@ export const zhTW: Record<DictKey, string> = {
   "projectTree.consolidateDone": "已合併恢復副本：主幹保留 {messages} 條訊息，{count} 個副本已封存",
   "projectTree.consolidateFolded": "已封存 {count} 個冗餘恢復副本",
   "projectTree.consolidateNothing": "沒有需要合併的恢復副本",
+  "projectTree.consolidateBlocked": "副本與主會話各有獨有內容（副本 {winner} 條 / 主會話 {main} 條），無法自動合併",
+  "projectTree.consolidateForceAction": "仍要合併（當前主會話將封存）",
   "projectTree.workspaceTitle": "專案",
   "projectTree.pinnedTitle": "置頂",
   "projectTree.searchPlaceholder": "搜尋專案或會話",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1378,6 +1378,10 @@ export const zh: Record<DictKey, string> = {
   "recovery.role.normal": "原始会话",
 
   // 项目树
+  "projectTree.consolidateRecoveryCopies": "合并恢复副本",
+  "projectTree.consolidateDone": "已合并恢复副本：主干保留 {messages} 条消息，{count} 个副本已归档",
+  "projectTree.consolidateFolded": "已归档 {count} 个冗余恢复副本",
+  "projectTree.consolidateNothing": "没有需要合并的恢复副本",
   "projectTree.workspaceTitle": "项目",
   "projectTree.pinnedTitle": "置顶",
   "projectTree.searchPlaceholder": "搜索项目或会话",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1382,6 +1382,8 @@ export const zh: Record<DictKey, string> = {
   "projectTree.consolidateDone": "已合并恢复副本：主干保留 {messages} 条消息，{count} 个副本已归档",
   "projectTree.consolidateFolded": "已归档 {count} 个冗余恢复副本",
   "projectTree.consolidateNothing": "没有需要合并的恢复副本",
+  "projectTree.consolidateBlocked": "副本与主会话各有独有内容（副本 {winner} 条 / 主会话 {main} 条），无法自动合并",
+  "projectTree.consolidateForceAction": "仍要合并（当前主会话将归档）",
   "projectTree.workspaceTitle": "项目",
   "projectTree.pinnedTitle": "置顶",
   "projectTree.searchPlaceholder": "搜索项目或会话",

--- a/desktop/recovery_consolidate.go
+++ b/desktop/recovery_consolidate.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/botruntime"
+)
+
+// errConsolidationMainNotCovered mirrors agent.ErrMainNotCoveredByWinner for
+// the desktop: the fullest recovery copy does not contain the whole current
+// main transcript, so the swap was refused to avoid hiding main-only turns.
+var errConsolidationMainNotCovered = errors.New("the fullest recovery copy does not contain the current main transcript; nothing was merged")
+
+// ConsolidateSessionRecoveryCopies is the desktop entry point behind the
+// "merge recovery copies" session action. It promotes the fullest recovery
+// copy onto the main session identity, archives the previous main as one
+// recoverable trash entry, and folds fully covered copies into the same
+// trash. A session that is open in an idle tab stays consolidatable: the
+// tab notices the identity change through the load-older-history reload
+// path (#9468/#9469). A running runtime keeps its lease and blocks the
+// merge until it is stopped.
+func (a *App) ConsolidateSessionRecoveryCopies(path string) (agent.ConsolidationReport, error) {
+	dir := a.activeSessionDir()
+	sessionPath, _, err := validateSessionPath(dir, path)
+	if err != nil {
+		var foundErr error
+		if dir, sessionPath, foundErr = a.sessionDirForPath(path); foundErr != nil {
+			return agent.ConsolidationReport{}, friendlySessionFileError(err)
+		}
+	}
+	report, err := func() (agent.ConsolidationReport, error) {
+		defer a.lockRuntimeMutation("consolidate-recovery-copies")()
+		a.sessionRemovalMu.Lock()
+		defer a.sessionRemovalMu.Unlock()
+		report, err := agent.ConsolidateSessionRecoveryBranches(sessionPath)
+		if err != nil {
+			switch {
+			case errors.Is(err, agent.ErrNoRecoveryBranches):
+				return report, errNoRecoveryCopiesToConsolidate
+			case errors.Is(err, agent.ErrSessionLeaseHeldForConsolidation), errors.Is(err, agent.ErrSessionLeaseHeld):
+				return report, errSessionBusyElsewhere
+			case errors.Is(err, agent.ErrMainNotCoveredByWinner):
+				return report, errConsolidationMainNotCovered
+			}
+			return report, err
+		}
+		return report, nil
+	}()
+	if err != nil {
+		return report, friendlySessionFileError(err)
+	}
+	if report.Promoted || len(report.Trashed) > 0 {
+		if err := botruntime.ForgetAutoSessionMappingsForPath(sessionPath); err != nil {
+			slog.Warn("desktop: failed to clear auto bot session mapping", "err", err)
+		}
+		for _, trashed := range report.Trashed {
+			a.removeSessionCatalogPath(trashed, "recovery_copies_consolidated")
+		}
+		a.emitProjectTreeChangedForSessionDirs(dir)
+		a.invalidatePromptHistoryCache()
+	}
+	return report, nil
+}

--- a/desktop/recovery_consolidate.go
+++ b/desktop/recovery_consolidate.go
@@ -24,7 +24,17 @@ func (a *App) ConsolidateTopicRecoveryCopies(scope, workspaceRoot, topicID strin
 	if strings.TrimSpace(path) == "" {
 		return agent.ConsolidationReport{}, friendlySessionFileError(errors.New("could not resolve the main transcript of this topic"))
 	}
-	return a.ConsolidateSessionRecoveryCopies(path)
+	return a.consolidateSessionRecoveryCopies(path, false)
+}
+
+// ForceConsolidateTopicRecoveryCopies mirrors ForceConsolidateSessionRecoveryCopies
+// for topic-resolved sessions.
+func (a *App) ForceConsolidateTopicRecoveryCopies(scope, workspaceRoot, topicID string) (agent.ConsolidationReport, error) {
+	path := a.catalogSessionPathForTopic(scope, workspaceRoot, topicID)
+	if strings.TrimSpace(path) == "" {
+		return agent.ConsolidationReport{}, friendlySessionFileError(errors.New("could not resolve the main transcript of this topic"))
+	}
+	return a.consolidateSessionRecoveryCopies(path, true)
 }
 
 // ConsolidateSessionRecoveryCopies is the desktop entry point behind the
@@ -36,6 +46,18 @@ func (a *App) ConsolidateTopicRecoveryCopies(scope, workspaceRoot, topicID strin
 // path (#9468/#9469). A running runtime keeps its lease and blocks the
 // merge until it is stopped.
 func (a *App) ConsolidateSessionRecoveryCopies(path string) (agent.ConsolidationReport, error) {
+	return a.consolidateSessionRecoveryCopies(path, false)
+}
+
+// ForceConsolidateSessionRecoveryCopies runs the merge after an explicit user
+// confirmation that the winner may replace a main transcript it does not
+// fully cover (typical after a main-side compaction). The previous main is
+// still archived whole under the recoverable trash.
+func (a *App) ForceConsolidateSessionRecoveryCopies(path string) (agent.ConsolidationReport, error) {
+	return a.consolidateSessionRecoveryCopies(path, true)
+}
+
+func (a *App) consolidateSessionRecoveryCopies(path string, force bool) (agent.ConsolidationReport, error) {
 	dir := a.activeSessionDir()
 	sessionPath, _, err := validateSessionPath(dir, path)
 	if err != nil {
@@ -48,7 +70,7 @@ func (a *App) ConsolidateSessionRecoveryCopies(path string) (agent.Consolidation
 		defer a.lockRuntimeMutation("consolidate-recovery-copies")()
 		a.sessionRemovalMu.Lock()
 		defer a.sessionRemovalMu.Unlock()
-		report, err := agent.ConsolidateSessionRecoveryBranches(sessionPath)
+		report, err := agent.ConsolidateSessionRecoveryBranchesWithOptions(sessionPath, agent.ConsolidateOptions{Force: force})
 		if err != nil {
 			switch {
 			case errors.Is(err, agent.ErrNoRecoveryBranches):

--- a/desktop/recovery_consolidate.go
+++ b/desktop/recovery_consolidate.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"log/slog"
+	"strings"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/botruntime"
@@ -12,6 +13,19 @@ import (
 // the desktop: the fullest recovery copy does not contain the whole current
 // main transcript, so the swap was refused to avoid hiding main-only turns.
 var errConsolidationMainNotCovered = errors.New("the fullest recovery copy does not contain the current main transcript; nothing was merged")
+
+// ConsolidateTopicRecoveryCopies resolves the topic's canonical transcript
+// (the automatic open target) server-side and merges the recovery copies of
+// that session. Context menus call this instead of the path-based variant so
+// the action stays clickable even when the sidebar row predates the runtime
+// projection that would carry a session path.
+func (a *App) ConsolidateTopicRecoveryCopies(scope, workspaceRoot, topicID string) (agent.ConsolidationReport, error) {
+	path := a.catalogSessionPathForTopic(scope, workspaceRoot, topicID)
+	if strings.TrimSpace(path) == "" {
+		return agent.ConsolidationReport{}, friendlySessionFileError(errors.New("could not resolve the main transcript of this topic"))
+	}
+	return a.ConsolidateSessionRecoveryCopies(path)
+}
 
 // ConsolidateSessionRecoveryCopies is the desktop entry point behind the
 // "merge recovery copies" session action. It promotes the fullest recovery

--- a/desktop/session_catalog.go
+++ b/desktop/session_catalog.go
@@ -642,6 +642,9 @@ func (a *App) pinnedTopicShells(scope, workspaceRoot string, topicIDs, pinnedIDs
 			Key: kind + "_" + topicID, Kind: kind,
 			Label: a.localizedTopicTitle(title, sources[topicID]), Root: workspaceRoot,
 			TopicID: topicID, ProjectColor: normalizeProjectColor(projectColor),
+			// Keep pinned shells actionable for session-scoped context-menu
+			// entries (e.g. "merge recovery copies") even while collapsed.
+			SessionPath: a.catalogSessionPathForTopic(scope, workspaceRoot, topicID),
 			CreatedAt: topicCreatedAtForTree(created, topicID), Pinned: true,
 			TurnsState: string(sessioncatalog.TurnsUnknown), Health: string(sessioncatalog.HealthOK),
 			Children: []ProjectNode{},

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -146,6 +146,7 @@ func (a *App) metadataProjectTopics(scope, workspaceRoot string) []ProjectNode {
 			Key: kind + "_" + topicID, Kind: kind,
 			Label: a.localizedTopicTitle(title, sources[topicID]), Root: workspaceRoot,
 			TopicID: topicID, ProjectColor: projectColor,
+			SessionPath: a.catalogSessionPathForTopic(scope, workspaceRoot, topicID),
 			CreatedAt: topicCreatedAtForTree(created, topicID), Pinned: containsDesktopString(pinnedIDs, topicID), SortOrder: sortOrder,
 			Open: overlay.open, Running: overlay.running, Status: overlay.status,
 			TurnsState: string(sessioncatalog.TurnsUnknown), Health: string(sessioncatalog.HealthOK),

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -347,6 +347,11 @@ func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topi
 	node := ProjectNode{
 		Key: kind + "_" + topic.TopicID, Kind: kind, Label: a.localizedTopicTitle(topic.Title, topic.TitleSource),
 		Root: topic.WorkspaceRoot, TopicID: topic.TopicID, Turns: topic.Turns,
+		// RepresentativePath is the topic's automatic open target (the
+		// canonical main transcript). Surfacing it here lets session-scoped
+		// context-menu actions — e.g. "merge recovery copies" — work on
+		// topics that were never opened in this window.
+		SessionPath: topic.RepresentativePath,
 		Preview:    topicSessionPreview(topic.Sessions, topic.RepresentativePath),
 		TurnsState: string(topic.TurnsState), Health: string(topic.Health),
 		CreatedAt: topic.CreatedAt, LastActivityAt: topic.LastActivityAt,

--- a/internal/agent/recovery_consolidate.go
+++ b/internal/agent/recovery_consolidate.go
@@ -1,0 +1,400 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"reasonix/internal/store"
+)
+
+// Recovery-copy consolidation: the manual entry point behind the desktop
+// "merge recovery copies" session action. Long sessions touched by a stale
+// runtime can fork repeatedly, leaving several *-recovery-* transcripts whose
+// identity drifts from the main file — the root cause behind the permanent
+// "earlier conversation could not be loaded" failures (#9468/#9470).
+//
+// Consolidation picks the fullest loadable copy as the canonical transcript,
+// swaps it into the main identity (the previous main is archived whole under
+// the recoverable .trash), and folds every fully covered loser into the same
+// trash. Copies that still hold unique content are preserved untouched and
+// reported, so the operation can never destroy the only copy of a turn.
+
+var (
+	// ErrNoRecoveryBranches means the session has no recovery copies to merge.
+	ErrNoRecoveryBranches = errors.New("session has no recovery copies to consolidate")
+	// ErrSessionLeaseHeldForConsolidation means a live runtime still holds the
+	// session; consolidation needs the transcript at rest.
+	ErrSessionLeaseHeldForConsolidation = errors.New("session is open in a running runtime; close it before consolidating recovery copies")
+	// ErrMainNotCoveredByWinner means the fullest copy does not contain the
+	// whole current main transcript. Swapping anyway would push main-only
+	// turns into the trash archive, so the caller is asked to decide first.
+	ErrMainNotCoveredByWinner = errors.New("fullest recovery copy does not contain the current main transcript; refusing the swap to avoid data loss")
+)
+
+// RecoveryBranchCandidate is one member of a session's recovery lineage as
+// seen by a cold, conservative load.
+type RecoveryBranchCandidate struct {
+	Path         string
+	MessageCount int
+	Revision     int64
+	UpdatedAt    time.Time
+	Loadable     bool
+	IsMain       bool
+}
+
+// ConsolidationReport summarizes one consolidation run for the UI.
+type ConsolidationReport struct {
+	MainPath           string
+	WinnerPath         string // "" when the main transcript already was the winner
+	Promoted           bool
+	MainMessageCount   int
+	WinnerMessageCount int
+	Trashed            []string
+	SkippedNotCovered  []string
+	SkippedUnloadable  []string
+}
+
+// validateConsolidationTarget rejects paths that cannot be a consolidation
+// target: non-transcripts, event logs, and recovery copies themselves.
+func validateConsolidationTarget(mainPath string) error {
+	mainPath = filepath.Clean(strings.TrimSpace(mainPath))
+	if !strings.HasSuffix(mainPath, ".jsonl") || strings.HasSuffix(mainPath, ".events.jsonl") {
+		return fmt.Errorf("consolidation targets a session transcript, got %s", mainPath)
+	}
+	if strings.Contains(filepath.Base(mainPath), "-recovery-") {
+		return fmt.Errorf("consolidation targets the main transcript, not a recovery copy: %s", mainPath)
+	}
+	return nil
+}
+
+// recoveryCopiesForMain lists the recovery copies that belong to mainPath by
+// the stable <stem>-recovery-* naming convention in the same directory.
+func recoveryCopiesForMain(mainPath string) ([]string, error) {
+	dir := filepath.Dir(mainPath)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	stem := strings.TrimSuffix(filepath.Base(mainPath), ".jsonl")
+	prefix := stem + "-recovery-"
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") || strings.HasSuffix(e.Name(), ".events.jsonl") {
+			continue
+		}
+		if !strings.HasPrefix(e.Name(), prefix) {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		if !IsVisibleSession(path) {
+			continue
+		}
+		out = append(out, path)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// recoveryConsolidationCandidate cold-loads one transcript for lineage
+// analysis. Damaged or unnormalizable files are reported as unloadable rather
+// than guessed at.
+func recoveryConsolidationCandidate(path string, isMain bool) (RecoveryBranchCandidate, bool) {
+	snap, ok := LoadSessionContentSnapshot(path)
+	if !ok {
+		return RecoveryBranchCandidate{Path: path, IsMain: isMain, Loadable: false}, false
+	}
+	meta, _, err := LoadBranchMeta(path)
+	if err != nil {
+		meta = BranchMeta{}
+	}
+	return RecoveryBranchCandidate{
+		Path:         path,
+		MessageCount: snap.Len(),
+		Revision:     meta.Revision,
+		UpdatedAt:    meta.UpdatedAt,
+		Loadable:     true,
+		IsMain:       isMain,
+	}, true
+}
+
+// consolidationCandidateBeats reports whether a is a better canonical than b:
+// most messages first, then the highest revision, then the newest update.
+func consolidationCandidateBeats(a, b RecoveryBranchCandidate) bool {
+	if a.MessageCount != b.MessageCount {
+		return a.MessageCount > b.MessageCount
+	}
+	if a.Revision != b.Revision {
+		return a.Revision > b.Revision
+	}
+	return a.UpdatedAt.After(b.UpdatedAt)
+}
+
+// ListSessionRecoveryBranches enumerates the recovery copies of a session
+// with their cold-load stats. UI callers use it for pre-flight checks; it
+// never mutates anything.
+func ListSessionRecoveryBranches(mainPath string) ([]RecoveryBranchCandidate, error) {
+	mainPath = filepath.Clean(strings.TrimSpace(mainPath))
+	if err := validateConsolidationTarget(mainPath); err != nil {
+		return nil, err
+	}
+	copies, err := recoveryCopiesForMain(mainPath)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]RecoveryBranchCandidate, 0, len(copies)+1)
+	if main, ok := recoveryConsolidationCandidate(mainPath, true); ok {
+		out = append(out, main)
+	} else {
+		out = append(out, RecoveryBranchCandidate{Path: mainPath, IsMain: true, Loadable: false})
+	}
+	for _, copy := range copies {
+		if cand, ok := recoveryConsolidationCandidate(copy, false); ok {
+			out = append(out, cand)
+		} else {
+			out = append(out, RecoveryBranchCandidate{Path: copy, IsMain: false, Loadable: false})
+		}
+	}
+	return out, nil
+}
+
+// ConsolidateSessionRecoveryBranches merges the recovery copies of mainPath:
+// the fullest loadable copy becomes the canonical main transcript, the
+// previous main is archived whole under the recoverable .trash, and every
+// copy fully covered by the winner is folded into the same trash. Copies with
+// unique content are preserved and reported. Nothing is ever hard-deleted.
+func ConsolidateSessionRecoveryBranches(mainPath string) (ConsolidationReport, error) {
+	mainPath = filepath.Clean(strings.TrimSpace(mainPath))
+	report := ConsolidationReport{MainPath: mainPath}
+	if err := validateConsolidationTarget(mainPath); err != nil {
+		return report, err
+	}
+	if SessionLeaseHeld(mainPath) {
+		return report, ErrSessionLeaseHeldForConsolidation
+	}
+	copies, err := recoveryCopiesForMain(mainPath)
+	if err != nil {
+		return report, err
+	}
+	if len(copies) == 0 {
+		return report, ErrNoRecoveryBranches
+	}
+
+	mainCand, mainOK := recoveryConsolidationCandidate(mainPath, true)
+	if !mainOK {
+		return report, fmt.Errorf("main transcript failed a conservative load; refusing to consolidate %s", mainPath)
+	}
+	report.MainMessageCount = mainCand.MessageCount
+
+	cands := make([]RecoveryBranchCandidate, 0, len(copies)+1)
+	cands = append(cands, mainCand)
+	for _, copy := range copies {
+		cand, ok := recoveryConsolidationCandidate(copy, false)
+		if !ok {
+			report.SkippedUnloadable = append(report.SkippedUnloadable, copy)
+			continue
+		}
+		cands = append(cands, cand)
+	}
+
+	winner := mainCand
+	for _, cand := range cands {
+		if !cand.IsMain && consolidationCandidateBeats(cand, winner) {
+			winner = cand
+		}
+	}
+	report.WinnerMessageCount = winner.MessageCount
+	if winner.Path != mainPath {
+		report.WinnerPath = winner.Path
+	}
+
+	dir := filepath.Dir(mainPath)
+	if winner.Path != mainPath {
+		if SessionLeaseHeld(winner.Path) {
+			return report, ErrSessionLeaseHeldForConsolidation
+		}
+		if err := promoteRecoveryCopyToMain(mainPath, winner.Path, dir); err != nil {
+			return report, err
+		}
+		report.Promoted = true
+		report.MainMessageCount = winner.MessageCount
+	}
+
+	// Fold covered losers into the recoverable trash. The winner itself has
+	// already been renamed onto the main path; everything else that the
+	// canonical transcript fully covers is now redundant by definition.
+	for _, cand := range cands {
+		if cand.IsMain || cand.Path == winner.Path {
+			continue
+		}
+		if err := TrashRecoveryBranchCoveredBy(cand.Path, mainPath, dir); err != nil {
+			report.SkippedNotCovered = append(report.SkippedNotCovered, cand.Path)
+			continue
+		}
+		report.Trashed = append(report.Trashed, cand.Path)
+	}
+	sort.Strings(report.Trashed)
+	sort.Strings(report.SkippedNotCovered)
+	sort.Strings(report.SkippedUnloadable)
+	return report, nil
+}
+
+// promoteRecoveryCopyToMain swaps the winner copy onto the main session
+// identity. Both transcripts are held behind removal guards for the whole
+// operation; the previous main is archived as one recoverable .trash entry
+// (transcript plus every sidecar) before the winner takes over, so a crash
+// between the two renames still leaves a complete rollback artifact.
+func promoteRecoveryCopyToMain(mainPath, winnerPath, dir string) error {
+	paths := []string{mainPath, winnerPath}
+	sort.Strings(paths)
+	guards := make([]*SessionRemovalGuard, 0, len(paths))
+	for _, path := range paths {
+		guard, err := TryAcquireSessionRemovalGuard(path)
+		if err != nil {
+			for _, held := range guards {
+				held.Release()
+			}
+			return err
+		}
+		guards = append(guards, guard)
+	}
+	defer func() {
+		for _, guard := range guards {
+			guard.Release()
+		}
+	}()
+
+	// The swap direction is only safe when the winner contains the whole
+	// current main transcript; otherwise main-only turns would survive only
+	// inside the trash archive.
+	if !SessionContentCovers(winnerPath, mainPath) {
+		return ErrMainNotCoveredByWinner
+	}
+
+	legacyMeta, legacyOK, err := LoadBranchMeta(mainPath)
+	if err != nil {
+		return err
+	}
+	winnerMeta, winnerOK, err := LoadBranchMeta(winnerPath)
+	if err != nil {
+		return err
+	}
+	if !winnerOK {
+		return fmt.Errorf("recovery copy meta is missing for %s", winnerPath)
+	}
+
+	// 1) Archive the previous main (transcript + sidecars) as one recoverable
+	// trash entry, staged atomically like every other recovery trash move.
+	key := filepath.Base(mainPath)
+	if !validRecoveryTrashKey(key) {
+		return fmt.Errorf("invalid main session path for trash staging: %s", mainPath)
+	}
+	stageDir, err := reserveRecoveryTrashStage(dir)
+	if err != nil {
+		return err
+	}
+	if err := writeRecoveryTrashPending(stageDir, key); err != nil {
+		return err
+	}
+	if err := moveRecoveryTrashPath(mainPath, filepath.Join(stageDir, key)); err != nil {
+		return err
+	}
+	for _, src := range recoveryTrashSidecars(mainPath) {
+		if err := moveRecoveryTrashPath(src, filepath.Join(stageDir, filepath.Base(src))); err != nil {
+			return err
+		}
+	}
+	itemDir, err := publishRecoveryTrashStage(dir, key, stageDir)
+	if err != nil {
+		return err
+	}
+	if err := writeRecoveryTrashMetaExisting(itemDir, key); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		// Published entries may already have been restored or purged.
+	}
+	if err := clearRecoveryTrashPending(itemDir); err != nil {
+		return err
+	}
+
+	// 2) The winner copy takes over the main identity. Derived indexes are
+	// dropped rather than renamed: the next load rebuilds them from content.
+	if err := os.Rename(winnerPath, mainPath); err != nil {
+		return err
+	}
+	winnerStem := strings.TrimSuffix(filepath.Base(winnerPath), ".jsonl")
+	mainStem := strings.TrimSuffix(filepath.Base(mainPath), ".jsonl")
+	dropSidecar := map[string]bool{
+		filepath.Base(store.SessionEventIndex(winnerPath)):  true,
+		filepath.Base(store.SessionDisplayIndex(winnerPath)): true,
+	}
+	artifacts := append([]string{}, store.SessionSidecarFiles(winnerPath)...)
+	artifacts = append(artifacts,
+		winnerPath+".telemetry.json",
+		store.SessionCheckpointDir(winnerPath),
+		store.SessionJobsDir(winnerPath),
+		store.SessionInboxDir(winnerPath),
+	)
+	for _, src := range artifacts {
+		base := filepath.Base(src)
+		if dropSidecar[base] {
+			if err := os.RemoveAll(src); err != nil {
+				return err
+			}
+			continue
+		}
+		dst := filepath.Join(dir, strings.Replace(base, winnerStem, mainStem, 1))
+		if err := moveRecoveryTrashPath(src, dst); err != nil {
+			return err
+		}
+	}
+
+	// 3) Rewrite the main meta: keep the session's display/ownership identity,
+	// take the winner's content identity, and clear every recovery marker so
+	// the lineage reads as resolved. The touched UpdatedAt is what open tabs
+	// notice (the #9468 reload path) when they refresh.
+	return UpdateBranchMeta(mainPath, true, func(meta *BranchMeta) error {
+		meta.ID = BranchID(mainPath)
+		meta.Recovered = false
+		meta.RecoveryReason = ""
+		meta.RecoveryDigest = ""
+		meta.RecoveryDepth = 0
+		meta.RecoveryPreferred = false
+		meta.RecoveryPreferredDigest = ""
+		meta.ParentID = ""
+		meta.ForkTurn = 0
+		meta.ForkMessageIndex = 0
+		meta.InFlightTurn = nil
+		meta.Revision = winnerMeta.Revision
+		meta.ContentDigest = winnerMeta.ContentDigest
+		meta.Turns = winnerMeta.Turns
+		meta.Preview = winnerMeta.Preview
+		meta.SchemaVersion = winnerMeta.SchemaVersion
+		meta.WriterID = SessionWriterID()
+		if legacyOK {
+			meta.Name = legacyMeta.Name
+			meta.CustomTitle = legacyMeta.CustomTitle
+			meta.TopicID = legacyMeta.TopicID
+			meta.TopicTitle = legacyMeta.TopicTitle
+			meta.Scope = legacyMeta.Scope
+			meta.WorkspaceRoot = legacyMeta.WorkspaceRoot
+			meta.Model = legacyMeta.Model
+			meta.QualityFloor = legacyMeta.QualityFloor
+			meta.Mode = legacyMeta.Mode
+			meta.ToolApprovalMode = legacyMeta.ToolApprovalMode
+			meta.SubagentPolicy = legacyMeta.SubagentPolicy
+			meta.Goal = legacyMeta.Goal
+			meta.CreatedAt = legacyMeta.CreatedAt
+			meta.DismissedTodoBatches = legacyMeta.DismissedTodoBatches
+		}
+		return nil
+	})
+}

--- a/internal/agent/recovery_consolidate.go
+++ b/internal/agent/recovery_consolidate.go
@@ -464,7 +464,6 @@ func promoteRecoveryCopyToMain(mainPath, winnerPath, dir string, force bool) err
 			meta.QualityFloor = legacyMeta.QualityFloor
 			meta.Mode = legacyMeta.Mode
 			meta.ToolApprovalMode = legacyMeta.ToolApprovalMode
-			meta.SubagentPolicy = legacyMeta.SubagentPolicy
 			meta.Goal = legacyMeta.Goal
 			meta.CreatedAt = legacyMeta.CreatedAt
 			meta.DismissedTodoBatches = legacyMeta.DismissedTodoBatches

--- a/internal/agent/recovery_consolidate.go
+++ b/internal/agent/recovery_consolidate.go
@@ -52,6 +52,7 @@ type ConsolidationReport struct {
 	MainPath           string
 	WinnerPath         string // "" when the main transcript already was the winner
 	Promoted           bool
+	NormalizedMain     bool // an older-format main was rewritten in place first
 	MainMessageCount   int
 	WinnerMessageCount int
 	Trashed            []string
@@ -189,7 +190,23 @@ func ConsolidateSessionRecoveryBranches(mainPath string) (ConsolidationReport, e
 
 	mainCand, mainOK := recoveryConsolidationCandidate(mainPath, true)
 	if !mainOK {
-		return report, fmt.Errorf("main transcript failed a conservative load; refusing to consolidate %s", mainPath)
+		// Long-lived transcripts loaded from an older format normalize dirty:
+		// the in-memory view differs from the bytes on disk until the next
+		// successful save. The ordinary upstream path clears this on the
+		// session's next autosave; consolidation forces that same rewrite now
+		// (the lease check above already proved no runtime is writing), then
+		// re-reads the transcript.
+		if session, loadErr := LoadSession(mainPath); loadErr == nil && session != nil && session.normalizedDirty {
+			if rewriteErr := session.SaveRewrite(mainPath); rewriteErr != nil {
+				return report, fmt.Errorf("could not normalize the main transcript before consolidating %s: %w", mainPath, rewriteErr)
+			}
+			report.NormalizedMain = true
+			if mainCand, mainOK = recoveryConsolidationCandidate(mainPath, true); !mainOK {
+				return report, fmt.Errorf("main transcript still failed a conservative load after normalization %s", mainPath)
+			}
+		} else {
+			return report, fmt.Errorf("main transcript failed a conservative load; refusing to consolidate %s", mainPath)
+		}
 	}
 	report.MainMessageCount = mainCand.MessageCount
 

--- a/internal/agent/recovery_consolidate.go
+++ b/internal/agent/recovery_consolidate.go
@@ -53,8 +53,12 @@ type ConsolidationReport struct {
 	WinnerPath         string // "" when the main transcript already was the winner
 	Promoted           bool
 	NormalizedMain     bool // an older-format main was rewritten in place first
-	MainMessageCount   int
-	WinnerMessageCount int
+	// BlockedByDivergence reports that the fullest copy and the main
+	// transcript each hold turns the other lacks (typical after a main-side
+	// compaction). Nothing was merged; the caller may retry with Force.
+	BlockedByDivergence bool
+	MainMessageCount    int
+	WinnerMessageCount  int
 	Trashed            []string
 	SkippedNotCovered  []string
 	SkippedUnloadable  []string
@@ -71,6 +75,24 @@ func validateConsolidationTarget(mainPath string) error {
 		return fmt.Errorf("consolidation targets the main transcript, not a recovery copy: %s", mainPath)
 	}
 	return nil
+}
+
+// normalizeTranscriptInPlaceIfDirty rewrites an older-format transcript in
+// place with its normalized view — exactly the rewrite the session's next
+// successful save would perform. Returns whether a rewrite happened. Load
+// failures other than "needs normalization" are returned untouched.
+func normalizeTranscriptInPlaceIfDirty(path string) (bool, error) {
+	s, err := LoadSession(path)
+	if err != nil || s == nil {
+		return false, err
+	}
+	if !s.normalizedDirty {
+		return false, nil
+	}
+	if err := s.SaveRewrite(path); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // recoveryCopiesForMain lists the recovery copies that belong to mainPath by
@@ -166,12 +188,28 @@ func ListSessionRecoveryBranches(mainPath string) ([]RecoveryBranchCandidate, er
 	return out, nil
 }
 
-// ConsolidateSessionRecoveryBranches merges the recovery copies of mainPath:
-// the fullest loadable copy becomes the canonical main transcript, the
-// previous main is archived whole under the recoverable .trash, and every
+// ConsolidateOptions tunes one consolidation run.
+type ConsolidateOptions struct {
+	// Force lets a winner that does NOT cover the current main transcript
+	// still be promoted. The previous main is archived whole under the
+	// recoverable .trash, so the user can always roll back; nothing is
+	// hard-deleted. Meant for an explicit user confirmation after the
+	// engine reported BlockedByDivergence.
+	Force bool
+}
+
+// ConsolidateSessionRecoveryBranches merges the recovery copies of mainPath
+// with default (conservative) options.
+func ConsolidateSessionRecoveryBranches(mainPath string) (ConsolidationReport, error) {
+	return ConsolidateSessionRecoveryBranchesWithOptions(mainPath, ConsolidateOptions{})
+}
+
+// ConsolidateSessionRecoveryBranchesWithOptions merges the recovery copies of
+// mainPath: the fullest loadable copy becomes the canonical main transcript,
+// the previous main is archived whole under the recoverable .trash, and every
 // copy fully covered by the winner is folded into the same trash. Copies with
 // unique content are preserved and reported. Nothing is ever hard-deleted.
-func ConsolidateSessionRecoveryBranches(mainPath string) (ConsolidationReport, error) {
+func ConsolidateSessionRecoveryBranchesWithOptions(mainPath string, opts ConsolidateOptions) (ConsolidationReport, error) {
 	mainPath = filepath.Clean(strings.TrimSpace(mainPath))
 	report := ConsolidationReport{MainPath: mainPath}
 	if err := validateConsolidationTarget(mainPath); err != nil {
@@ -190,16 +228,11 @@ func ConsolidateSessionRecoveryBranches(mainPath string) (ConsolidationReport, e
 
 	mainCand, mainOK := recoveryConsolidationCandidate(mainPath, true)
 	if !mainOK {
-		// Long-lived transcripts loaded from an older format normalize dirty:
-		// the in-memory view differs from the bytes on disk until the next
-		// successful save. The ordinary upstream path clears this on the
-		// session's next autosave; consolidation forces that same rewrite now
-		// (the lease check above already proved no runtime is writing), then
-		// re-reads the transcript.
-		if session, loadErr := LoadSession(mainPath); loadErr == nil && session != nil && session.normalizedDirty {
-			if rewriteErr := session.SaveRewrite(mainPath); rewriteErr != nil {
-				return report, fmt.Errorf("could not normalize the main transcript before consolidating %s: %w", mainPath, rewriteErr)
-			}
+		normalized, normErr := normalizeTranscriptInPlaceIfDirty(mainPath)
+		if normErr != nil {
+			return report, fmt.Errorf("could not normalize the main transcript before consolidating %s: %w", mainPath, normErr)
+		}
+		if normalized {
 			report.NormalizedMain = true
 			if mainCand, mainOK = recoveryConsolidationCandidate(mainPath, true); !mainOK {
 				return report, fmt.Errorf("main transcript still failed a conservative load after normalization %s", mainPath)
@@ -215,8 +248,18 @@ func ConsolidateSessionRecoveryBranches(mainPath string) (ConsolidationReport, e
 	for _, copy := range copies {
 		cand, ok := recoveryConsolidationCandidate(copy, false)
 		if !ok {
-			report.SkippedUnloadable = append(report.SkippedUnloadable, copy)
-			continue
+			// Recovery forks usually carry the same older-format payload as
+			// the main they forked from; normalize them the same way so they
+			// can participate instead of being silently skipped.
+			if normalized, normErr := normalizeTranscriptInPlaceIfDirty(copy); normErr == nil && normalized {
+				if cand, ok = recoveryConsolidationCandidate(copy, false); !ok {
+					report.SkippedUnloadable = append(report.SkippedUnloadable, copy)
+					continue
+				}
+			} else {
+				report.SkippedUnloadable = append(report.SkippedUnloadable, copy)
+				continue
+			}
 		}
 		cands = append(cands, cand)
 	}
@@ -237,7 +280,17 @@ func ConsolidateSessionRecoveryBranches(mainPath string) (ConsolidationReport, e
 		if SessionLeaseHeld(winner.Path) {
 			return report, ErrSessionLeaseHeldForConsolidation
 		}
-		if err := promoteRecoveryCopyToMain(mainPath, winner.Path, dir); err != nil {
+		// A main that went through compaction holds a summarized transcript
+		// whose prefix no longer matches the pre-compaction recovery fork, so
+		// neither side covers the other. Refuse with a structured report the
+		// UI can turn into an explicit confirmation instead of failing.
+		if !SessionContentCovers(winner.Path, mainPath) && !opts.Force {
+			report.BlockedByDivergence = true
+			report.WinnerPath = winner.Path
+			report.WinnerMessageCount = winner.MessageCount
+			return report, nil
+		}
+		if err := promoteRecoveryCopyToMain(mainPath, winner.Path, dir, opts.Force); err != nil {
 			return report, err
 		}
 		report.Promoted = true
@@ -268,7 +321,7 @@ func ConsolidateSessionRecoveryBranches(mainPath string) (ConsolidationReport, e
 // operation; the previous main is archived as one recoverable .trash entry
 // (transcript plus every sidecar) before the winner takes over, so a crash
 // between the two renames still leaves a complete rollback artifact.
-func promoteRecoveryCopyToMain(mainPath, winnerPath, dir string) error {
+func promoteRecoveryCopyToMain(mainPath, winnerPath, dir string, force bool) error {
 	paths := []string{mainPath, winnerPath}
 	sort.Strings(paths)
 	guards := make([]*SessionRemovalGuard, 0, len(paths))
@@ -290,9 +343,13 @@ func promoteRecoveryCopyToMain(mainPath, winnerPath, dir string) error {
 
 	// The swap direction is only safe when the winner contains the whole
 	// current main transcript; otherwise main-only turns would survive only
-	// inside the trash archive.
+	// inside the trash archive. Force skips this refusal after an explicit
+	// user confirmation — the previous main is still archived whole, so the
+	// swapped-out content stays recoverable.
 	if !SessionContentCovers(winnerPath, mainPath) {
-		return ErrMainNotCoveredByWinner
+		if !force {
+			return ErrMainNotCoveredByWinner
+		}
 	}
 
 	legacyMeta, legacyOK, err := LoadBranchMeta(mainPath)

--- a/internal/agent/recovery_consolidate_test.go
+++ b/internal/agent/recovery_consolidate_test.go
@@ -266,3 +266,45 @@ func TestConsolidateNoCopiesAndValidation(t *testing.T) {
 		t.Fatalf("first candidate must be the main transcript: %+v", cands[0])
 	}
 }
+
+func TestConsolidateNormalizesDirtyMainFirst(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "dirty.jsonl")
+	// Dangling tool call: loading this older-format transcript normalizes
+	// dirty (a placeholder tool result gets fabricated), which is exactly the
+	// state that used to make consolidation refuse.
+	writeLegacyJSONLSession(t, mainPath, []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "run it"},
+		{Role: provider.RoleAssistant, Content: "", ToolCalls: []provider.ToolCall{
+			{ID: "call_1", Name: "read_file", Arguments: `{"path":"a.go"}`},
+		}},
+	})
+	if s, err := LoadSession(mainPath); err != nil || !s.normalizedDirty {
+		t.Fatalf("precondition: normalizedDirty = %v err = %v, want true", s.normalizedDirty, err)
+	}
+
+	// The recovery copy continued past the repaired view: it is the fullest
+	// transcript and covers the main once normalized.
+	repaired := loadSnapshot(t, mainPath)
+	forkCopyFromSnapshot(t, mainPath, repaired, []provider.Message{
+		{Role: provider.RoleAssistant, Content: "post-recovery reply"},
+	})
+
+	report, err := ConsolidateSessionRecoveryBranches(mainPath)
+	if err != nil {
+		t.Fatalf("ConsolidateSessionRecoveryBranches: %v", err)
+	}
+	if !report.NormalizedMain {
+		t.Fatalf("expected the dirty main to be normalized in place: %+v", report)
+	}
+	if !report.Promoted {
+		t.Fatalf("expected promotion after normalization: %+v", report)
+	}
+	if got := sessionMessageCount(t, mainPath); got != len(repaired)+1 {
+		t.Fatalf("main message count = %d, want %d", got, len(repaired)+1)
+	}
+	if meta, ok, err := LoadBranchMeta(mainPath); err != nil || !ok || meta.Recovered {
+		t.Fatalf("promoted main meta: ok=%v recovered=%v err=%v", ok, meta.Recovered, err)
+	}
+}

--- a/internal/agent/recovery_consolidate_test.go
+++ b/internal/agent/recovery_consolidate_test.go
@@ -188,9 +188,14 @@ func TestConsolidateRefusesSwapWhenWinnerMissesMainTurns(t *testing.T) {
 	// The main also gained its own turn: neither side covers the other.
 	appendTurns(t, mainPath, provider.Message{Role: provider.RoleUser, Content: "main-only turn"})
 
+	// The conservative run refuses the swap with a structured report instead
+	// of an error, so the UI can turn it into an explicit confirmation.
 	report, err := ConsolidateSessionRecoveryBranches(mainPath)
-	if !errors.Is(err, ErrMainNotCoveredByWinner) {
-		t.Fatalf("err = %v, want ErrMainNotCoveredByWinner (report %+v)", err, report)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (report %+v)", err, report)
+	}
+	if !report.BlockedByDivergence {
+		t.Fatalf("BlockedByDivergence = false, want true: %+v", report)
 	}
 	if report.Promoted {
 		t.Fatalf("unexpected promotion: %+v", report)
@@ -201,6 +206,22 @@ func TestConsolidateRefusesSwapWhenWinnerMissesMainTurns(t *testing.T) {
 	}
 	if got := sessionMessageCount(t, copyPath); got != 6 {
 		t.Fatalf("copy message count = %d, want 6 (unchanged)", got)
+	}
+
+	// The forced run promotes the fullest copy; the previous main is archived
+	// whole under the recoverable trash instead of being lost.
+	forced, err := ConsolidateSessionRecoveryBranchesWithOptions(mainPath, ConsolidateOptions{Force: true})
+	if err != nil {
+		t.Fatalf("forced consolidation: %v", err)
+	}
+	if !forced.Promoted {
+		t.Fatalf("forced report = %+v, want Promoted", forced)
+	}
+	if got := sessionMessageCount(t, mainPath); got != 6 {
+		t.Fatalf("main message count after force = %d, want 6", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".trash")); err != nil {
+		t.Fatalf("trash directory missing after forced swap: %v", err)
 	}
 }
 

--- a/internal/agent/recovery_consolidate_test.go
+++ b/internal/agent/recovery_consolidate_test.go
@@ -1,0 +1,268 @@
+package agent
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// seedMainTranscript writes a 3-turn stalled main transcript, the on-disk
+// shape a session is left in when a snapshot conflict forked its unsaved
+// tail into a recovery copy.
+func seedMainTranscript(t *testing.T, dir, name string) string {
+	t.Helper()
+	mainPath := filepath.Join(dir, name+".jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "tail " + name})
+	if err := s.Save(mainPath); err != nil {
+		t.Fatalf("Save main: %v", err)
+	}
+	return mainPath
+}
+
+// forkCopyFromSnapshot forks a recovery copy for mainPath whose content is
+// snapshot plus extra turns — the real conflict shape: same prefix as the
+// on-disk main, diverging only at the tail.
+func forkCopyFromSnapshot(t *testing.T, mainPath string, snapshot []provider.Message, extra []provider.Message) string {
+	t.Helper()
+	stale := NewSession("sys")
+	stale.Replace(append(append([]provider.Message(nil), snapshot...), extra...))
+	info, err := stale.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: mainPath})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+	return info.Path
+}
+
+func loadSnapshot(t *testing.T, path string) []provider.Message {
+	t.Helper()
+	s, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession %s: %v", path, err)
+	}
+	return s.Snapshot()
+}
+
+func appendTurns(t *testing.T, path string, msgs ...provider.Message) {
+	t.Helper()
+	s, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession %s: %v", path, err)
+	}
+	for _, m := range msgs {
+		s.Add(m)
+	}
+	if err := s.Save(path); err != nil {
+		t.Fatalf("Save %s: %v", path, err)
+	}
+}
+
+func sessionMessageCount(t *testing.T, path string) int {
+	t.Helper()
+	snap, ok := LoadSessionContentSnapshot(path)
+	if !ok {
+		t.Fatalf("conservative load failed for %s", path)
+	}
+	return snap.Len()
+}
+
+func TestConsolidatePromotesFullestCopyAndFoldsCoveredLosers(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := seedMainTranscript(t, dir, "topic")
+	base := loadSnapshot(t, mainPath)
+
+	// Copy A went on accumulating: base + 2 turns (5 total). It covers main.
+	copyA := forkCopyFromSnapshot(t, mainPath, base, []provider.Message{
+		{Role: provider.RoleUser, Content: "recovered turn a"},
+		{Role: provider.RoleAssistant, Content: "recovered reply b"},
+	})
+	// Copy B stopped one turn earlier: base + 1 turn (4 total) — a strict
+	// prefix of A, so the winner fully covers it and it folds into the trash.
+	copyB := forkCopyFromSnapshot(t, mainPath, base, []provider.Message{
+		{Role: provider.RoleUser, Content: "recovered turn a"},
+	})
+
+	legacyMeta, legacyOK, err := LoadBranchMeta(mainPath)
+	if err != nil {
+		t.Fatalf("LoadBranchMeta main before consolidate: %v", err)
+	}
+
+	report, err := ConsolidateSessionRecoveryBranches(mainPath)
+	if err != nil {
+		t.Fatalf("ConsolidateSessionRecoveryBranches: %v", err)
+	}
+	if !report.Promoted {
+		t.Fatalf("expected a promotion, report = %+v", report)
+	}
+	if filepath.Clean(report.WinnerPath) != filepath.Clean(copyA) {
+		t.Fatalf("winner = %q, want copy A %q", report.WinnerPath, copyA)
+	}
+	if report.MainMessageCount != 6 {
+		t.Fatalf("main message count after promote = %d, want 6", report.MainMessageCount)
+	}
+	if len(report.Trashed) != 1 || filepath.Clean(report.Trashed[0]) != filepath.Clean(copyB) {
+		t.Fatalf("trashed = %v, want [%q]", report.Trashed, copyB)
+	}
+	if len(report.SkippedNotCovered) != 0 || len(report.SkippedUnloadable) != 0 {
+		t.Fatalf("unexpected skips: %+v", report)
+	}
+	// The main transcript now carries the winner's content...
+	if got := sessionMessageCount(t, mainPath); got != 6 {
+		t.Fatalf("main transcript message count = %d, want 6", got)
+	}
+	// ...under the main identity with recovery markers cleared.
+	meta, ok, err := LoadBranchMeta(mainPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta main: ok=%v err=%v", ok, err)
+	}
+	if meta.Recovered {
+		t.Fatalf("promoted main still marked Recovered")
+	}
+	if meta.RecoveryDigest != "" || meta.ParentID != "" || meta.RecoveryPreferred {
+		t.Fatalf("recovery markers not cleared: %+v", meta)
+	}
+	if meta.ID != BranchID(mainPath) {
+		t.Fatalf("meta ID = %q, want %q", meta.ID, BranchID(mainPath))
+	}
+	if legacyOK && meta.Name != legacyMeta.Name {
+		t.Fatalf("main display name changed in promotion: %q -> %q", legacyMeta.Name, meta.Name)
+	}
+	// The archived main stays recoverable in the trash.
+	if _, err := os.Stat(filepath.Join(dir, ".trash")); err != nil {
+		t.Fatalf("trash directory missing: %v", err)
+	}
+	// The winner copy no longer exists at its old path.
+	if _, err := os.Stat(copyA); !os.IsNotExist(err) {
+		t.Fatalf("winner copy still present at %s: %v", copyA, err)
+	}
+}
+
+func TestConsolidateWithoutPromotionOnlyFoldsCoveredCopies(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := seedMainTranscript(t, dir, "ahead")
+	base := loadSnapshot(t, mainPath)
+
+	copyPath := forkCopyFromSnapshot(t, mainPath, base, []provider.Message{
+		{Role: provider.RoleUser, Content: "recovered turn a"},
+	})
+
+	// The main adopted the copy's recovered turn and went on: the copy is
+	// now a strict prefix of the main, so no promotion is needed and the
+	// copy folds straight into the trash.
+	appendTurns(t, mainPath,
+		provider.Message{Role: provider.RoleUser, Content: "recovered turn a"},
+		provider.Message{Role: provider.RoleAssistant, Content: "kept going"},
+	)
+
+	report, err := ConsolidateSessionRecoveryBranches(mainPath)
+	if err != nil {
+		t.Fatalf("ConsolidateSessionRecoveryBranches: %v", err)
+	}
+	if report.Promoted {
+		t.Fatalf("unexpected promotion: %+v", report)
+	}
+	if report.WinnerPath != "" {
+		t.Fatalf("winner path = %q, want empty", report.WinnerPath)
+	}
+	if len(report.Trashed) != 1 || filepath.Clean(report.Trashed[0]) != filepath.Clean(copyPath) {
+		t.Fatalf("trashed = %v, want [%q]", report.Trashed, copyPath)
+	}
+}
+
+func TestConsolidateRefusesSwapWhenWinnerMissesMainTurns(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := seedMainTranscript(t, dir, "diverged")
+	base := loadSnapshot(t, mainPath)
+
+	// The copy diverged at the tail and grew longer: base + two of its own
+	// turns, so it wins the candidacy but cannot cover the main.
+	copyPath := forkCopyFromSnapshot(t, mainPath, base, []provider.Message{
+		{Role: provider.RoleUser, Content: "copy-only turn a"},
+		{Role: provider.RoleAssistant, Content: "copy-only reply b"},
+	})
+	// The main also gained its own turn: neither side covers the other.
+	appendTurns(t, mainPath, provider.Message{Role: provider.RoleUser, Content: "main-only turn"})
+
+	report, err := ConsolidateSessionRecoveryBranches(mainPath)
+	if !errors.Is(err, ErrMainNotCoveredByWinner) {
+		t.Fatalf("err = %v, want ErrMainNotCoveredByWinner (report %+v)", err, report)
+	}
+	if report.Promoted {
+		t.Fatalf("unexpected promotion: %+v", report)
+	}
+	// Both transcripts stay untouched.
+	if got := sessionMessageCount(t, mainPath); got != 5 {
+		t.Fatalf("main message count = %d, want 5 (unchanged)", got)
+	}
+	if got := sessionMessageCount(t, copyPath); got != 6 {
+		t.Fatalf("copy message count = %d, want 6 (unchanged)", got)
+	}
+}
+
+func TestConsolidateKeepsLoserWithUniqueTurns(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := seedMainTranscript(t, dir, "topic")
+	base := loadSnapshot(t, mainPath)
+
+	// Clear winner: base + 4 turns, covers main.
+	forkCopyFromSnapshot(t, mainPath, base, []provider.Message{
+		{Role: provider.RoleUser, Content: "recovered turn a"},
+		{Role: provider.RoleAssistant, Content: "recovered reply b"},
+		{Role: provider.RoleUser, Content: "recovered turn c"},
+		{Role: provider.RoleAssistant, Content: "recovered reply d"},
+	})
+	// Copy B holds one turn that exists nowhere else, so even though A is
+	// longer it does not cover B; B must be preserved untouched.
+	copyB := forkCopyFromSnapshot(t, mainPath, base, []provider.Message{
+		{Role: provider.RoleUser, Content: "unique to B"},
+	})
+
+	report, err := ConsolidateSessionRecoveryBranches(mainPath)
+	if err != nil {
+		t.Fatalf("ConsolidateSessionRecoveryBranches: %v", err)
+	}
+	if !report.Promoted {
+		t.Fatalf("expected promotion of copy A: %+v", report)
+	}
+	if len(report.SkippedNotCovered) != 1 || filepath.Clean(report.SkippedNotCovered[0]) != filepath.Clean(copyB) {
+		t.Fatalf("skippedNotCovered = %v, want [%q]", report.SkippedNotCovered, copyB)
+	}
+	if got := sessionMessageCount(t, copyB); got != 5 {
+		t.Fatalf("copy B message count = %d, want 5 (preserved)", got)
+	}
+}
+
+func TestConsolidateNoCopiesAndValidation(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := seedMainTranscript(t, dir, "plain")
+
+	if _, err := ConsolidateSessionRecoveryBranches(mainPath); !errors.Is(err, ErrNoRecoveryBranches) {
+		t.Fatalf("err = %v, want ErrNoRecoveryBranches", err)
+	}
+
+	// Recovery copies themselves are not valid targets.
+	base := loadSnapshot(t, mainPath)
+	copyPath := forkCopyFromSnapshot(t, mainPath, base, []provider.Message{
+		{Role: provider.RoleUser, Content: "copy turn"},
+	})
+	if _, err := ConsolidateSessionRecoveryBranches(copyPath); err == nil {
+		t.Fatalf("consolidating a recovery copy must fail")
+	}
+
+	// Listing reports the copy alongside the main transcript.
+	cands, err := ListSessionRecoveryBranches(mainPath)
+	if err != nil {
+		t.Fatalf("ListSessionRecoveryBranches: %v", err)
+	}
+	if len(cands) != 2 {
+		t.Fatalf("candidates = %d, want 2", len(cands))
+	}
+	if !cands[0].IsMain {
+		t.Fatalf("first candidate must be the main transcript: %+v", cands[0])
+	}
+}


### PR DESCRIPTION
**TL;DR**: 会话右键一键合并恢复副本，recovery 分叉一键收敛

## Summary

Adds "merge session recovery copies" to the project tree topic context menu (#9470 proposal, #8739): a session whose earlier conversation failed to load often has one or more diverged recovery copies; this merges the copies' messages back into a promoted main transcript, with an explicit-confirm force path for diverged copies and compatibility for post-compaction main sessions.

- `internal/agent/recovery_consolidate.go`: consolidation engine — promotes the winning copy, folds the rest into it (moved to a trash area), tombstone-safe
- `internal/agent/recovery_consolidate_test.go`: engine tests
- `desktop/recovery_consolidate.go` + `app.go` + bridge/types: `ConsolidateTopicRecoveryCopies` / `ForceConsolidateTopicRecoveryCopies` — the menu resolves the main transcript **server-side at click time** (never greyed out by stale aggregates); the backend lease check owns the busy state
- `ProjectTree.tsx`: "merge recovery copies" item on the session context menu; blocked-by-divergence surfaces a warn toast with a force action
- older-format main transcripts are normalized before consolidating so conservative load does not reject them

Note: one upstream-only adaptation — the fork's branch-meta carried a `SubagentPolicy` field (fork-specific #9004); the legacy-meta projection drops that line, which does not exist upstream.

## Issues fixes

Fixes #9470
Fixes #8739

## Verification

- `go build ./...` — ok
- `go test ./internal/agent/ -run 'TestConsolidate|TestRecoveryConsolidation|TestRecoveryCopies'` — `ok reasonix/internal/agent 1.005s`
- `go test ./desktop -run 'TestConsolidate'` — `ok reasonix/desktop 0.218s`

## Documentation impact

None.

## Cache impact + guard

Reads/writes branch-meta and session transcripts through existing stores; no cache format changes. Tombstone semantics follow the existing sessioncatalog GetTopic behavior.

## System prompt review

Not affected.


Cache-impact: none- existing stores only; tombstone semantics follow sessioncatalog GetTopic
Cache-guard: updated- go build ./... + go test ./internal/agent/ (TestConsolidate*) + go test ./desktop (TestConsolidate)
Documentation-impact: none- new context-menu action; no user-facing docs yet
System-prompt-review: none- no prompt text changes

