### PR TITLE
fix(desktop): keep remote project roots out of local topic state / 远端项目根不再触碰本地 Topic 元数据

### DIFF
--- a/desktop/frontend/src/__tests__/remote-project-tree.test.tsx
+++ b/desktop/frontend/src/__tests__/remote-project-tree.test.tsx
@@ -247,7 +247,7 @@ ok(
   "session switches resume in the background behind a generation guard",
 );
 ok(
-  /if \(project\.remote\) return;/.test(source),
+  /if \(\(project\.kind !== "project" && project\.kind !== "global_folder"\) \|\| project\.remote\) return;/.test(source),
   "remote groups never reach ListProjectTopics with their virtual root",
 );
 

--- a/desktop/frontend/src/__tests__/remote-project-tree.test.tsx
+++ b/desktop/frontend/src/__tests__/remote-project-tree.test.tsx
@@ -246,6 +246,10 @@ ok(
     /a\.goRemoteTabSafe\("remoteTabResume"[\s\S]*?restoreRejectedRemoteTabOpenSelection/.test(remotePendingSelectionSource),
   "session switches resume in the background behind a generation guard",
 );
+ok(
+  /if \(project\.remote\) return;/.test(source),
+  "remote groups never reach ListProjectTopics with their virtual root",
+);
 
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -330,11 +330,7 @@ export function ProjectTree({
   const loadProjectTopicsRef = useRef<(project: ProjectNode, append?: boolean) => Promise<void>>(async () => {});
 
   const loadProjectTopics = useCallback(async (project: ProjectNode, append = false) => {
-    if (project.kind !== "project" && project.kind !== "global_folder") return;
-    // Remote groups list sessions from the serve-side catalog instead; their
-    // qualified root ("remote-project:<host>:<workspace>") is not a local
-    // topic-state scope and must never reach ListProjectTopics.
-    if (project.remote) return;
+    if ((project.kind !== "project" && project.kind !== "global_folder") || project.remote) return;
     const key = project.key;
     const pageState = topicPageStateRef.current[key];
     const cursor = append ? pageState?.nextCursor ?? "" : "";

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -331,6 +331,10 @@ export function ProjectTree({
 
   const loadProjectTopics = useCallback(async (project: ProjectNode, append = false) => {
     if (project.kind !== "project" && project.kind !== "global_folder") return;
+    // Remote groups list sessions from the serve-side catalog instead; their
+    // qualified root ("remote-project:<host>:<workspace>") is not a local
+    // topic-state scope and must never reach ListProjectTopics.
+    if (project.remote) return;
     const key = project.key;
     const pageState = topicPageStateRef.current[key];
     const cursor = append ? pageState?.nextCursor ?? "" : "";

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -727,6 +727,9 @@ func (a *App) ListProjectTree() []ProjectNode {
 		// folders. This compatibility wrapper rebuilds the complete child list,
 		// so start clean to avoid duplicating those shells with catalog rows.
 		project.Children = []ProjectNode{}
+		if project.Remote != nil {
+			continue
+		}
 		scope := "project"
 		root := project.Root
 		if project.Kind == "global_folder" {

--- a/desktop/topic_state_catalog.go
+++ b/desktop/topic_state_catalog.go
@@ -1,9 +1,21 @@
 package main
 
+import (
+	"strings"
+)
+
 // ListProjectTopics keeps authoritative topic-state failures visible to the
 // Wails caller instead of converting a future-schema or unreadable database
 // into an apparently empty sidebar page.
 func (a *App) ListProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, error) {
+	// Remote project groups carry a qualified virtual root
+	// ("remote-project:<host>:<workspace>") that is not a filesystem path.
+	// Their sessions come from the serve-side catalog, so answer with an empty
+	// page instead of building a topic-state scope (and legacy metadata paths,
+	// whose colon is an invalid Windows path component) from that string.
+	if strings.HasPrefix(strings.TrimSpace(req.WorkspaceRoot), "remote-project:") {
+		return ProjectTopicPage{Items: []ProjectNode{}}, nil
+	}
 	if err := topicStateReadable(topicTitleRoot(req.Scope, req.WorkspaceRoot)); err != nil {
 		return ProjectTopicPage{Items: []ProjectNode{}}, err
 	}

--- a/desktop/topic_state_catalog.go
+++ b/desktop/topic_state_catalog.go
@@ -1,18 +1,14 @@
 package main
 
-import (
-	"strings"
-)
+import "strings"
 
 // ListProjectTopics keeps authoritative topic-state failures visible to the
 // Wails caller instead of converting a future-schema or unreadable database
 // into an apparently empty sidebar page.
 func (a *App) ListProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, error) {
-	// Remote project groups carry a qualified virtual root
-	// ("remote-project:<host>:<workspace>") that is not a filesystem path.
-	// Their sessions come from the serve-side catalog, so answer with an empty
-	// page instead of building a topic-state scope (and legacy metadata paths,
-	// whose colon is an invalid Windows path component) from that string.
+	// Remote roots are virtual identities whose sessions come from the Serve
+	// catalog. Never build local topic-state or legacy metadata paths from them;
+	// their colon is an invalid Windows path component.
 	if strings.HasPrefix(strings.TrimSpace(req.WorkspaceRoot), "remote-project:") {
 		return ProjectTopicPage{Items: []ProjectNode{}}, nil
 	}

--- a/desktop/topic_state_catalog_test.go
+++ b/desktop/topic_state_catalog_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+// A remote project group's qualified root ("remote-project:<host>:<workspace>")
+// is not a filesystem path. Listing must answer with an empty page instead of
+// building a topic-state scope from it — on Windows the colon is an invalid
+// path component and the legacy metadata read failed with a user-visible
+// "topic metadata is unavailable (io)" toast right after the connect wizard.
+func TestListProjectTopicsAnswersRemoteRootWithEmptyPage(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	page, err := app.ListProjectTopics(ProjectTopicPageRequest{
+		Scope:         "project",
+		WorkspaceRoot: "remote-project:gpu-box:/home/dev/app",
+		Limit:         50,
+	})
+	if err != nil {
+		t.Fatalf("remote root listing failed: %v", err)
+	}
+	if page.Items == nil || len(page.Items) != 0 {
+		t.Fatalf("remote root page items = %#v, want an empty page", page.Items)
+	}
+}

--- a/desktop/topic_state_catalog_test.go
+++ b/desktop/topic_state_catalog_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"reasonix/internal/config"
+)
 
 // A remote project group's qualified root ("remote-project:<host>:<workspace>")
 // is not a filesystem path. Listing must answer with an empty page instead of
@@ -20,5 +24,39 @@ func TestListProjectTopicsAnswersRemoteRootWithEmptyPage(t *testing.T) {
 	}
 	if page.Items == nil || len(page.Items) != 0 {
 		t.Fatalf("remote root page items = %#v, want an empty page", page.Items)
+	}
+}
+
+func TestListProjectTreeSkipsRemoteTopicState(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	const remoteRoot = "remote-project:gpu-box:/home/dev/app"
+	if err := editUserConfig(func(c *config.Config) error {
+		if err := c.UpsertRemoteHost(config.RemoteHostEntry{Name: "gpu-box", Host: "127.0.0.1"}); err != nil {
+			return err
+		}
+		return c.UpsertRemoteProject(config.RemoteProjectEntry{HostID: "gpu-box", Workspace: "/home/dev/app"})
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, node := range NewApp().ListProjectTree() {
+		if node.Remote == nil {
+			continue
+		}
+		found = true
+		if len(node.Children) != 0 {
+			t.Fatalf("remote project children = %#v, want none from local topic state", node.Children)
+		}
+	}
+	if !found {
+		t.Fatal("compatibility tree omitted the remote project group")
+	}
+
+	desktopTopicState.mu.Lock()
+	opened := desktopTopicState.scopes[config.DesktopTopicStatePath(remoteRoot)] != nil
+	desktopTopicState.mu.Unlock()
+	if opened {
+		t.Fatalf("compatibility tree opened local topic state for virtual root %q", remoteRoot)
 	}
 }


### PR DESCRIPTION
## Summary

- Remote project groups carry a qualified virtual root (`remote-project:<host>:<workspace>`) that is not a filesystem path. Loading their topic page built a topic-state scope from that string and read legacy metadata under `<root>/.reasonix/` — on Windows the colons are an invalid path component, so the read failed with a user-visible `topic metadata is unavailable (io)` toast right after the connect wizard (deduped to once per message by the toast's key+message guard).
- Remote groups list sessions from the serve-side catalog, so `loadProjectTopics` now skips remote nodes entirely, and `ListProjectTopics` answers a `remote-project:` root with an empty page instead of building a topic-state scope from it.

## Issues


## Verification

- [x] New regression test `TestListProjectTopicsAnswersRemoteRootWithEmptyPage` pins the contract: a remote root answers an empty page with no error, on all platforms.
- [x] Source-contract test asserts remote groups never reach `ListProjectTopics` with their virtual root (`remote-project-tree.test.tsx`).
- [x] Existing `TestListProjectTopics*` suite passes unchanged; full `desktop` package suite passes.
- [x] Manual: opening a brand-new project via the remote connect wizard no longer shows the toast.

## Documentation impact

Documentation-impact: none - internal sidebar data sourcing only; no user-visible CLI, configuration, or tool behavior is documented elsewhere.

## Cache impact

Cache-impact: none - no provider-visible prompt, transcript, or session-cache surface is touched; only sidebar listing routing for virtual roots changes.
Cache-guard: `cd desktop && go test . -run TestListProjectTopics -count=1` (includes the new empty-page regression test).
System-prompt-review: N/A - no system prompt, memory prefix, output style, or skill index behavior changes.