### PR TITLE
fix(desktop): keep the new-session blank row visible in remote groups / 远端项目组新会话行稳定显示

### DIFF
--- a/desktop/remote_listing.go
+++ b/desktop/remote_listing.go
@@ -363,12 +363,9 @@ func (a *App) remoteProjectSessions(ctx context.Context, client *http.Client, ba
 		}
 	}
 	if !hasCurrent {
-		// The foreground session is invisible to the serve listing whenever its
-		// transcript is not on disk yet (a just-rotated /new session until its
-		// first save). That — not the tab's transient reset flag — is the real
-		// condition for synthesizing the current blank row: the status poll
-		// clears reset as soon as Serve names the session, long before the
-		// listing can see it.
+		// A fresh foreground session stays absent from /sessions until its first
+		// transcript save. Synthesize it from the live route rather than reset,
+		// which status clears as soon as Serve names the not-yet-listed session.
 		a.remoteTabMu.Lock()
 		listedPaths := make(map[string]bool, len(entries))
 		for _, e := range entries {

--- a/desktop/remote_listing.go
+++ b/desktop/remote_listing.go
@@ -363,12 +363,34 @@ func (a *App) remoteProjectSessions(ctx context.Context, client *http.Client, ba
 		}
 	}
 	if !hasCurrent {
+		// The foreground session is invisible to the serve listing whenever its
+		// transcript is not on disk yet (a just-rotated /new session until its
+		// first save). That — not the tab's transient reset flag — is the real
+		// condition for synthesizing the current blank row: the status poll
+		// clears reset as soon as Serve names the session, long before the
+		// listing can see it.
 		a.remoteTabMu.Lock()
+		listedPaths := make(map[string]bool, len(entries))
+		for _, e := range entries {
+			listedPaths[e.Path] = true
+		}
 		var blank *RemoteSessionView
 		for _, tab := range a.remoteTabs {
-			if tab.ref.HostID == hostID && tab.ref.Workspace == workspace && tab.session.reset {
-				blank = &RemoteSessionView{Name: "", Path: tab.routing.currentPath, Title: tab.topicTitle, Current: true, Running: tab.runtime.running, LastActivityAt: time.Now().UnixMilli()}
-				break
+			if tab.ref.HostID != hostID || tab.ref.Workspace != workspace {
+				continue
+			}
+			if tab.state != "ready" || blank != nil {
+				continue
+			}
+			// Known current path: blank while the serve listing cannot see it
+			// yet. Unknown path (a legacy /new without a path header): blank
+			// while the fresh-session marker is still set.
+			if path := tab.routing.currentPath; path != "" {
+				if !listedPaths[path] {
+					blank = &RemoteSessionView{Name: "", Path: path, Title: tab.topicTitle, Current: true, Running: tab.runtime.running, LastActivityAt: time.Now().UnixMilli()}
+				}
+			} else if tab.session.reset {
+				blank = &RemoteSessionView{Name: "", Title: tab.topicTitle, Current: true, Running: tab.runtime.running, LastActivityAt: time.Now().UnixMilli()}
 			}
 		}
 		a.remoteTabMu.Unlock()

--- a/desktop/remote_projects.go
+++ b/desktop/remote_projects.go
@@ -667,22 +667,32 @@ func (a *App) bootstrapRemoteTab(tabID, hostID, workspace string) {
 		return
 	}
 	openTab.session.reset = entered && opts.NewSession
-	if openTab.session.reset {
+	freshSession := openTab.session.reset
+	if freshSession {
 		// A bootstrapped fresh session carries the localized default title,
 		// same as the live-tab reset path.
 		openTab.topicTitle = a.localizedDefaultTopicTitle()
 	}
-	meta := remoteTabMetaLocked(openTab)
 	a.remoteTabMu.Unlock()
 	if !a.publishRemoteTabAttachedReady(tabID, gen) {
 		return
 	}
-	if openTab.session.reset {
-		// A fresh session has no transcript on the serve yet, so the sidebar's
-		// listing cannot see it until the first turn lands. Publish the tab
-		// update so the sidebar re-pulls and synthesizes the blank row — the
-		// ready-only state event does not trigger that listing.
+	if freshSession {
+		// A fresh session has no transcript in /sessions until its first save.
+		// The ready-only event does not refresh that listing, so publish the
+		// current ready meta in route/status order to prevent stale overwrites.
+		openTab.routeEventMu.Lock()
+		a.remoteTabMu.Lock()
+		current := a.remoteTabs[tabID]
+		if current != openTab || current.gen != gen || current.state != "ready" {
+			a.remoteTabMu.Unlock()
+			openTab.routeEventMu.Unlock()
+			return
+		}
+		meta := remoteTabMetaLocked(current)
+		a.remoteTabMu.Unlock()
 		a.emitRemoteEvent("remote-tab:updated", meta)
+		openTab.routeEventMu.Unlock()
 	}
 	// The confirmed /events pump makes the session usable without losing prompts.
 	// Saving the explorer default is auxiliary and cannot downgrade a healthy tab.

--- a/desktop/remote_projects.go
+++ b/desktop/remote_projects.go
@@ -672,9 +672,17 @@ func (a *App) bootstrapRemoteTab(tabID, hostID, workspace string) {
 		// same as the live-tab reset path.
 		openTab.topicTitle = a.localizedDefaultTopicTitle()
 	}
+	meta := remoteTabMetaLocked(openTab)
 	a.remoteTabMu.Unlock()
 	if !a.publishRemoteTabAttachedReady(tabID, gen) {
 		return
+	}
+	if openTab.session.reset {
+		// A fresh session has no transcript on the serve yet, so the sidebar's
+		// listing cannot see it until the first turn lands. Publish the tab
+		// update so the sidebar re-pulls and synthesizes the blank row — the
+		// ready-only state event does not trigger that listing.
+		a.emitRemoteEvent("remote-tab:updated", meta)
 	}
 	// The confirmed /events pump makes the session usable without losing prompts.
 	// Saving the explorer default is auxiliary and cannot downgrade a healthy tab.

--- a/desktop/remote_projects_test.go
+++ b/desktop/remote_projects_test.go
@@ -122,15 +122,49 @@ func TestRemoteRootWorkspaceContainsAbsoluteDescendants(t *testing.T) {
 // update leaves the new project group empty.
 func TestBootstrapNewSessionPublishesTabUpdateForSidebarBlankRow(t *testing.T) {
 	fs := newFakeServe(t, "s3cret", nil)
+	const freshPath = "/remote/sessions/fresh.jsonl"
+	fs.mu.Lock()
+	fs.newSessionPath = freshPath
+	fs.mu.Unlock()
 	kernel := &fakeRemoteKernel{
 		statuses:   []RemoteConnectionStatusView{{HostID: "box", State: "connected"}},
 		ensureView: RemoteServerView{HostID: "box", State: "ready", LocalURL: fs.server.URL}, ensureToken: "s3cret",
 	}
 	seedBridgeTestHost(t, "box")
 	log := &eventLog{}
-	a := &App{remoteRuntime: kernel, remoteEventHook: log.add}
+	updates := make(chan TabMeta, 4)
+	a := &App{remoteRuntime: kernel, remoteEventHook: func(name string, payload any) {
+		log.add(name, payload)
+		if name != "remote-tab:updated" {
+			return
+		}
+		meta, ok := payload.(TabMeta)
+		if !ok {
+			return
+		}
+		select {
+		case updates <- meta:
+		default:
+		}
+	}}
 	cleanupRemoteTabPumps(t, a)
-	meta := openReadyRemoteTab(t, a, RemoteTabOpenOptions{NewSession: true})
+	meta, err := a.OpenRemoteProjectTab("box", "~/app", RemoteTabOpenOptions{NewSession: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	var update TabMeta
+	for update.ID != meta.ID {
+		select {
+		case update = <-updates:
+		case <-timer.C:
+			t.Fatalf("bootstrap emitted no remote-tab:updated for tab %q, events: %v", meta.ID, log.recorded())
+		}
+	}
+	if !update.Ready || update.RemoteState != "ready" {
+		t.Fatalf("bootstrap update state = ready:%v remote:%q, want ready/ready", update.Ready, update.RemoteState)
+	}
 
 	a.remoteTabMu.Lock()
 	reset := a.remoteTabs[meta.ID].session.reset
@@ -138,23 +172,42 @@ func TestBootstrapNewSessionPublishesTabUpdateForSidebarBlankRow(t *testing.T) {
 	if !reset {
 		t.Fatal("bootstrap did not mark the fresh session as reset")
 	}
-	// The tab update trails the ready state event on the same goroutine
-	// handoff; wait briefly instead of racing the emit.
-	updates := 0
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		updates = 0
-		for _, event := range log.recorded() {
-			if strings.HasPrefix(event, "remote-tab:updated ") && strings.Contains(event, meta.ID) {
-				updates++
-			}
-		}
-		if updates >= 1 || time.Now().After(deadline) {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
+	sessions, err := a.RemoteProjectSessions("box", "~/app")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if updates < 1 {
-		t.Fatalf("bootstrap emitted no remote-tab:updated for tab %q, events: %v", meta.ID, log.recorded())
+	if len(sessions) != 1 || sessions[0].Name != "" || sessions[0].Path != freshPath || !sessions[0].Current {
+		t.Fatalf("unlisted fresh session = %+v, want one synthetic current blank", sessions)
+	}
+
+	fs.mu.Lock()
+	fs.statusPayload = `{"sessionName":"fresh","sessionPath":"/remote/sessions/fresh.jsonl","running":false}`
+	fs.mu.Unlock()
+	if _, err := a.RemoteTabStatus(meta.ID); err != nil {
+		t.Fatal(err)
+	}
+	a.remoteTabMu.Lock()
+	reset = a.remoteTabs[meta.ID].session.reset
+	a.remoteTabMu.Unlock()
+	if reset {
+		t.Fatal("named status did not clear the fresh-session reset marker")
+	}
+	sessions, err = a.RemoteProjectSessions("box", "~/app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].Name != "" || sessions[0].Path != freshPath || !sessions[0].Current {
+		t.Fatalf("named but unlisted fresh session = %+v, want the synthetic current blank", sessions)
+	}
+
+	fs.mu.Lock()
+	fs.sessions = []serveSessionEntry{{Name: "fresh", Path: freshPath, Title: "Fresh", Current: true}}
+	fs.mu.Unlock()
+	sessions, err = a.RemoteProjectSessions("box", "~/app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].Name != "fresh" || sessions[0].Path != freshPath || !sessions[0].Current {
+		t.Fatalf("materialized fresh session = %+v, want the real current row", sessions)
 	}
 }

--- a/desktop/remote_projects_test.go
+++ b/desktop/remote_projects_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"reasonix/internal/config"
 )
@@ -110,5 +111,50 @@ func TestRemoteRootWorkspaceContainsAbsoluteDescendants(t *testing.T) {
 	}
 	if isRemoteSubpath("/", "/") || isRemoteSubpath("/", "relative/path") {
 		t.Fatal("root containment must stay strict and absolute")
+	}
+}
+
+// TestBootstrapNewSessionPublishesTabUpdateForSidebarBlankRow pins the
+// sidebar's only signal for a brand-new remote session: the fresh session has
+// no transcript on the serve, so the session listing synthesizes a blank row
+// from the tab's reset flag — but only after the sidebar re-pulls, which it
+// does on remote-tab:updated. A bootstrap that reaches ready without that
+// update leaves the new project group empty.
+func TestBootstrapNewSessionPublishesTabUpdateForSidebarBlankRow(t *testing.T) {
+	fs := newFakeServe(t, "s3cret", nil)
+	kernel := &fakeRemoteKernel{
+		statuses:   []RemoteConnectionStatusView{{HostID: "box", State: "connected"}},
+		ensureView: RemoteServerView{HostID: "box", State: "ready", LocalURL: fs.server.URL}, ensureToken: "s3cret",
+	}
+	seedBridgeTestHost(t, "box")
+	log := &eventLog{}
+	a := &App{remoteRuntime: kernel, remoteEventHook: log.add}
+	cleanupRemoteTabPumps(t, a)
+	meta := openReadyRemoteTab(t, a, RemoteTabOpenOptions{NewSession: true})
+
+	a.remoteTabMu.Lock()
+	reset := a.remoteTabs[meta.ID].session.reset
+	a.remoteTabMu.Unlock()
+	if !reset {
+		t.Fatal("bootstrap did not mark the fresh session as reset")
+	}
+	// The tab update trails the ready state event on the same goroutine
+	// handoff; wait briefly instead of racing the emit.
+	updates := 0
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		updates = 0
+		for _, event := range log.recorded() {
+			if strings.HasPrefix(event, "remote-tab:updated ") && strings.Contains(event, meta.ID) {
+				updates++
+			}
+		}
+		if updates >= 1 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if updates < 1 {
+		t.Fatalf("bootstrap emitted no remote-tab:updated for tab %q, events: %v", meta.ID, log.recorded())
 	}
 }


### PR DESCRIPTION
## Summary

- Opening a new session on a remote workspace flashed a row in the sidebar and immediately dropped it. Two halves:
- Bootstrap only emitted the ready-only per-tab state event after a fresh attach; the sidebar's listing never re-pulled, so the synthesized blank row had no trigger. Bootstrap now publishes `remote-tab:updated` for a fresh session, like the live-tab `/new` rotation already did.
- The blank row's synthesis keyed on the tab's transient reset flag, which the status poll clears as soon as Serve names the new session — long before the transcript reaches the serve listing. Synthesize the row while a ready tab's current session is invisible to the listing (reset stays the fallback for legacy `/new` without a path header), so the row lives exactly as long as the session is unlisted.
<img width="469" height="117" alt="6fc771c1b9893129a50ce2592637a16e" src="https://github.com/user-attachments/assets/feca5ad8-e8ea-4ad6-aa9b-b697fb1ddc8b" />

## Issues


## Verification

- [x] New regression test `TestBootstrapNewSessionPublishesTabUpdateForSidebarBlankRow` pins that a bootstrap reaching ready emits `remote-tab:updated` for the fresh session.
- [x] Existing `TestRemoteTabNewSessionResetsServeSession` covers the listing side (blank leads the listing, rename retitle, reuse, and resume-clear).
- [x] Full `desktop` package suite passes.

## Documentation impact

Documentation-impact: none - sidebar listing behavior only; no documented CLI, configuration, or tool behavior changes.

## Cache impact

Cache-impact: none - no provider-visible prompt, transcript, or session-cache surface is touched; only remote session-listing synthesis in the desktop sidebar.
Cache-guard: `cd desktop && go test . -run "TestBootstrapNewSession|TestRemoteTabNewSessionResetsServeSession" -count=1`.
System-prompt-review: N/A - no system prompt, memory prefix, output style, or skill index behavior changes.