### PR TITLE
fix(serve): keep the write path alive across an in-place resume / 修复 /resume 之后 /new 报写授权缺失

### DIFF
--- a/internal/serve/new_after_resume_test.go
+++ b/internal/serve/new_after_resume_test.go
@@ -1,0 +1,61 @@
+package serve
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+)
+
+// TestNewSessionAfterResumeKeepsWritePath reproduces the field report: after
+// an in-place /resume onto a listed session, POST /new must still rotate.
+// Rebind's releaseLocked used to strip the controller's transition handler
+// while Resume left the session authority-required, so the next /new failed
+// with "bind new session: session write authority missing".
+func TestNewSessionAfterResumeKeepsWritePath(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.jsonl")
+	bPath := filepath.Join(dir, "b.jsonl")
+	saveServeTestSession(t, aPath)
+	saveServeTestSession(t, bPath)
+
+	bc := NewBroadcaster()
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, bc)
+	ctrl := control.New(control.Options{Executor: exec, Sink: bc, SessionDir: dir, SessionPath: aPath})
+	server := New(ctrl, bc, config.ServeConfig{})
+	leases := control.NewSessionLeaseKeeper()
+	defer leases.Release()
+	if err := leases.Rebind(aPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.SetSessionLeases(leases); err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(server.Handler())
+	defer srv.Close()
+
+	resumeBody, _ := json.Marshal(map[string]string{"path": bPath})
+	resp, err := http.Post(srv.URL+"/resume", "application/json", bytes.NewReader(resumeBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resumeRespBody, _ := readAll(resp)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("/resume status = %d body %q, want 204", resp.StatusCode, resumeRespBody)
+	}
+
+	newResp, err := http.Post(srv.URL+"/new", "application/json", bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	newRespBody, _ := readAll(newResp)
+	if newResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("/new after resume status = %d body %q, want 204", newResp.StatusCode, newRespBody)
+	}
+}

--- a/internal/serve/session_resume_commit.go
+++ b/internal/serve/session_resume_commit.go
@@ -38,11 +38,9 @@ func (s *Server) commitLoadedResume(w http.ResponseWriter, cur control.SessionAP
 	if !concrete {
 		return true
 	}
-	// Rebind replaced the keeper's lease, and its releaseLocked stripped the
-	// controller's transition handler along with the outgoing authority. Now
-	// that Resume made the loaded session current, re-bind the controller so
-	// the next /new, /clear, or /fork presents a live authority through the
-	// ordinary transition path instead of failing closed.
+	// Rebind dropped the controller handlers with the outgoing authority. Resume
+	// has now made loaded current, so restore its owner binding before the next
+	// /new, /clear, or /fork enters the ordinary authorized transition path.
 	if s.leases != nil {
 		if err := s.leases.BindControllerAuthority(ctrl); err != nil {
 			slog.Warn("serve: rebind controller authority after resume", "err", err)

--- a/internal/serve/session_resume_commit.go
+++ b/internal/serve/session_resume_commit.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"log/slog"
 	"net/http"
 
 	"reasonix/internal/agent"
@@ -36,6 +37,16 @@ func (s *Server) commitLoadedResume(w http.ResponseWriter, cur control.SessionAP
 	cur.Resume(loaded, realPath)
 	if !concrete {
 		return true
+	}
+	// Rebind replaced the keeper's lease, and its releaseLocked stripped the
+	// controller's transition handler along with the outgoing authority. Now
+	// that Resume made the loaded session current, re-bind the controller so
+	// the next /new, /clear, or /fork presents a live authority through the
+	// ordinary transition path instead of failing closed.
+	if s.leases != nil {
+		if err := s.leases.BindControllerAuthority(ctrl); err != nil {
+			slog.Warn("serve: rebind controller authority after resume", "err", err)
+		}
 	}
 	if tag == nil {
 		s.setControllerPath(ctrl, realPath)


### PR DESCRIPTION
## Summary

- An in-place `/resume` calls `leases.Rebind`, whose `releaseLocked` strips the controller's transition handler and clears the outgoing authority. The loaded session received a fresh authority, but nothing re-installed the handler — leaving the foreground controller authority-required with no transition path.
- The next `/new`, `/clear`, or `/fork` then failed closed with `bind new session: session write authority missing` (HTTP 500), reproduced end-to-end: `/resume` 204 → `/new` 500 on the same server.
- `commitLoadedResume` now re-binds the controller authority after `Resume` makes the loaded session current, restoring the transition handler alongside a fresh generation for the session that is actually current.

## Issues

- N/A — no tracked issue; reported as `http://127.0.0.1:<port>/new: status 500: bind new session: session write authority missing` on remote workspace sessions.

## Verification

- [x] New regression test `TestNewSessionAfterResumeKeepsWritePath` reproduces the exact field failure (`/resume` 204 → `/new` 500) and passes with the fix.
- [x] Full `internal/serve` suite passes, including the existing lease/multisession contracts.
- [x] Manual: deployed to a remote serve; the reported 500 no longer reproduces on the same project group.

## Documentation impact

Documentation-impact: none - fixes a serve-internal controller/lease handoff regression; no documented behavior change.

## Cache impact

Cache-impact: none - no provider-visible prompt, transcript, or session-cache surface is touched; only lease/handler bookkeeping around session switches.
Cache-guard: `cd internal/serve && go test . -run "TestNewSessionAfterResume|TestResume" -count=1`.
System-prompt-review: N/A - no system prompt, memory prefix, output style, or skill index behavior changes.