### PR TITLE
fix(security): enforce serve Host allowlist, preview confinement, and gitcmd clean-filter neutralization / 封堵 serve DNS 重绑定、预览越界读与 git clean 过滤器执行

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,46 @@ branch.
 
 ### Fixed
 
+- **serve Host-header allowlist:** `reasonix serve` now rejects requests whose
+  `Host` is neither loopback nor the actual listen address (HTTP 421), closing
+  the DNS-rebinding bypass of the JSON content-type CSRF guard — a rebind page
+  becomes same-origin with the loopback listener and could previously drive
+  `/bypass`, `/submit`, and read `/history`. `behind_proxy` deployments and
+  wildcard/non-loopback binds are exempt. The non-loopback plaintext-HTTP
+  startup warning now also fires — loudest — for the unauthenticated `auth =
+  none` case that used to stay silent.
+
+- **Preview read confinement:** `write_file` / `edit_file` / `multi_edit`
+  previews now apply the same `confinePreview` boundary as `delete_range` /
+  `delete_symbol`. A model-supplied absolute path outside the workspace roots
+  previously read the file (rendering its contents into the approval card and
+  session log) even though Execute would refuse the write.
+
+- **Clean-filter hardening on internal diffs:** gitcmd diff invocations now
+  neutralize every `filter.<driver>` defined in the repository's local
+  `.git/config` (`clean=` emptied, `required` forced off), so viewing a changed
+  file's diff can no longer execute a repository-configured clean filter via
+  `.gitattributes`. Emptied filters are identity pass-throughs: the diff still
+  renders the real working-tree change.
+
+- **install_source proxy SSRF parity:** the install_source SSRF dial guard now
+  also validates the request destination (IP literals) at the RoundTripper
+  boundary, so a configured HTTP/HTTPS proxy can no longer forward a blocked
+  target (cloud metadata, RFC1918, link-local, CGNAT) that the dial-time check
+  never sees — matching web_fetch's proxy-path behavior.
+
+- **awk approval classification:** the bash indirect-execution classifier now
+  treats `awk`/`gawk`/`mawk`/`nawk` with an inline program (anything not read
+  via `-f`/`--file`) like `python -c`: it always requires human approval and
+  can never be covered by a remembered reusable prefix rule. `awk
+  'BEGIN{system("…")}'` previously fell through to the reusable class.
+
+- **cargo check/doc read-only correction:** the legacy read-only command table
+  no longer lists `cargo check` / `cargo doc` as permission readers — cargo
+  executes the crate's `build.rs` for both. The effect classifier already
+  billed them as code-executing writers; the stale table entry (and its test)
+  now agree. Only `cargo search` remains read-only.
+
 - **Compact MCP discovery:** `use_capability(action=list)` now returns one
   compact summary per configured MCP server instead of expanding every cached
   tool description, including tools from disabled servers. Inspecting one

--- a/internal/cli/gitstatus.go
+++ b/internal/cli/gitstatus.go
@@ -72,10 +72,10 @@ func loadGitStatus(ctx context.Context, cwd string) (gitStatus, error) {
 }
 
 func runGit(ctx context.Context, cwd string, args ...string) (string, error) {
-	cmd := gitcmd.Command(ctx, "", args...)
-	if cwd != "" {
-		cmd.Dir = cwd
-	}
+	// cwd goes through gitcmd's dir parameter, not cmd.Dir, so the gitcmd
+	// baseline can resolve the repository's own config relative to it (the
+	// filter-driver neutralization reads <cwd>/.git/config).
+	cmd := gitcmd.Command(ctx, cwd, args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/internal/gitcmd/gitcmd.go
+++ b/internal/gitcmd/gitcmd.go
@@ -15,18 +15,26 @@
 // used to be spelled out at each call site, which is exactly how three of the
 // five sites ended up carrying them and two did not.
 //
-// Known residual: content filters (filter.<driver>.clean/smudge) and textconv
-// drivers are selected per driver name through .gitattributes, so they cannot
-// be disabled by a fixed key list the way the settings above can. Diff-side
-// drivers are covered by --no-ext-diff/--no-textconv; checkout/status-side
-// clean filters are not, and would need a different mechanism.
+// Content filters (filter.<driver>.clean/smudge) are selected per driver name
+// through .gitattributes, so they cannot be disabled by a fixed key list the
+// way the settings above can. Diff invocations instead neutralize every filter
+// driver defined in the repository's local .git/config — the only place the
+// repository's author can put one — by overriding its command to empty (which
+// git treats as "no filter": the diff renders the raw bytes on both sides).
+// Residual: filters reached through .git/config include.path chains, and
+// core.sshCommand for network transports (ls-remote/fetch/push against a
+// repository-local remote), remain the user's own configuration to vet.
 package gitcmd
 
 import (
+	"bufio"
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 
 	"reasonix/internal/proc"
 	"reasonix/internal/secrets"
@@ -65,10 +73,134 @@ func argsFor(goos, dir string, extraConfig []string, args ...string) []string {
 		}
 		out = append(out, "-c", cfg)
 	}
+	for _, cfg := range filterNeutralizingConfig(dir, args) {
+		out = append(out, "-c", cfg)
+	}
 	if dir != "" {
 		out = append(out, "-C", dir)
 	}
 	return append(out, hardenSubcommand(args)...)
+}
+
+// filterNeutralizingConfig returns -c overrides that blank every filter driver
+// command the repository's local .git/config defines, but only when args runs a
+// diff — the one gitcmd subcommand that invokes clean filters on working-tree
+// content. A diff compares the file's raw bytes, so an emptied filter is the
+// correct rendering, not a degraded one. Emptying clean alone would make a
+// filter marked required fail the diff outright, so required is forced off too.
+func filterNeutralizingConfig(dir string, args []string) []string {
+	sub, cDir := gitSubcommand(args)
+	if sub != "diff" {
+		return nil
+	}
+	if cDir != "" {
+		dir = cDir
+	}
+	drivers := localFilterDrivers(dir)
+	if len(drivers) == 0 {
+		return nil
+	}
+	out := make([]string, 0, 2*len(drivers))
+	for _, name := range drivers {
+		out = append(out,
+			"filter."+name+".clean=",
+			"filter."+name+".required=false",
+		)
+	}
+	return out
+}
+
+// gitSubcommand finds the first non-global argument — the subcommand — and the
+// directory named by a leading -C, if the caller put it inside args instead of
+// the dir parameter. Global options before the subcommand are limited to the
+// forms gitcmd's call sites use (-c v, -C d, --opt=v, --opt d); anything else
+// still terminates the scan at the first bare word.
+func gitSubcommand(args []string) (sub, cDir string) {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "-C":
+			if i+1 < len(args) {
+				cDir = args[i+1]
+				i++
+			}
+		case strings.HasPrefix(a, "-C"):
+			cDir = strings.TrimPrefix(a, "-C")
+		case a == "-c":
+			i++ // skip the key=value that follows
+		case strings.HasPrefix(a, "-"):
+			// Any other global flag; --flag=value and bare flags alike carry
+			// no value we track. The next bare word ends global options.
+		default:
+			return a, cDir
+		}
+	}
+	return "", cDir
+}
+
+// localFilterDrivers lists the filter driver names defined by sections of the
+// repository-local git config under dir. Only [filter "<name>"] sections are
+// collected: the driver's command lives in the config, and the config is the
+// part of a distributed repository its author controls. A missing or unreadable
+// config yields no drivers (nothing to neutralize). User and system config are
+// deliberately not read — those are the user's own choices.
+func localFilterDrivers(dir string) []string {
+	cfgPath := localGitConfigPath(dir)
+	if cfgPath == "" {
+		return nil
+	}
+	f, err := os.Open(cfgPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var drivers []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "[filter ") {
+			continue
+		}
+		name := strings.TrimSuffix(strings.TrimPrefix(line, "[filter "), "]")
+		name = strings.Trim(strings.TrimSpace(name), `"`)
+		if name == "" || slices.Contains(drivers, name) {
+			continue
+		}
+		drivers = append(drivers, name)
+	}
+	return drivers
+}
+
+// localGitConfigPath resolves the repository-local config for a working tree at
+// dir: .git/config when .git is a directory, or <gitdir>/config when .git is a
+// linked worktree file ("gitdir: <path>", possibly relative to dir).
+func localGitConfigPath(dir string) string {
+	if dir == "" {
+		dir = "."
+	}
+	dotGit := filepath.Join(dir, ".git")
+	info, err := os.Stat(dotGit)
+	if err != nil {
+		return ""
+	}
+	if info.IsDir() {
+		return filepath.Join(dotGit, "config")
+	}
+	data, err := os.ReadFile(dotGit)
+	if err != nil {
+		return ""
+	}
+	line := strings.TrimSpace(string(data))
+	rest, ok := strings.CutPrefix(line, "gitdir:")
+	if !ok {
+		return ""
+	}
+	gitdir := strings.TrimSpace(rest)
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(dir, gitdir)
+	}
+	return filepath.Join(gitdir, "config")
 }
 
 // hardenSubcommand adds the flags that disable repository-configured programs
@@ -108,11 +240,13 @@ func CommandWithConfig(ctx context.Context, dir string, extraConfig []string, ar
 	return cmd
 }
 
-// Env is the environment a git subprocess runs with. GIT_EXTERNAL_DIFF and
-// GIT_SSH_COMMAND are deliberately left alone: an empty value is a present
-// value to git, so clearing them would break legitimate ssh remotes rather than
-// harden anything, and --no-ext-diff already outranks both the config key and
-// the environment variable.
+// Env is the environment a git subprocess runs with. GIT_EXTERNAL_DIFF is
+// covered by --no-ext-diff on diff invocations, which outranks both the config
+// key and the environment variable. GIT_SSH_COMMAND is deliberately left
+// alone: it governs the ssh network transport (fetch/ls-remote/push), not diff
+// rendering, and clearing it would break legitimate ssh remotes; repository
+// config that sets core.sshCommand is a plugin-trust concern, not one this
+// diff-oriented baseline can address (see the package residual note).
 func Env() []string {
 	return append(secrets.ProcessEnv(),
 		// Read-only probes must not take the index lock.

--- a/internal/gitcmd/gitcmd.go
+++ b/internal/gitcmd/gitcmd.go
@@ -16,14 +16,9 @@
 // five sites ended up carrying them and two did not.
 //
 // Content filters (filter.<driver>.clean/smudge) are selected per driver name
-// through .gitattributes, so they cannot be disabled by a fixed key list the
-// way the settings above can. Diff invocations instead neutralize every filter
-// driver defined in the repository's local .git/config — the only place the
-// repository's author can put one — by overriding its command to empty (which
-// git treats as "no filter": the diff renders the raw bytes on both sides).
-// Residual: filters reached through .git/config include.path chains, and
-// core.sshCommand for network transports (ls-remote/fetch/push against a
-// repository-local remote), remain the user's own configuration to vet.
+// through .gitattributes, so diffs neutralize every driver defined in the
+// repository's local .git/config instead (see filterNeutralizingConfig).
+// include.path chains and core.sshCommand remain the user's own to vet.
 package gitcmd
 
 import (

--- a/internal/gitcmd/gitcmd.go
+++ b/internal/gitcmd/gitcmd.go
@@ -15,7 +15,7 @@
 // used to be spelled out at each call site, which is exactly how three of the
 // five sites ended up carrying them and two did not.
 //
-// Content filters (filter.<driver>.clean/smudge) are selected per driver name
+// Content filters (filter.<driver>.clean/process) are selected per driver name
 // through .gitattributes, so diffs neutralize every driver defined in the
 // repository's local .git/config instead (see filterNeutralizingConfig).
 // include.path chains and core.sshCommand remain the user's own to vet.
@@ -81,8 +81,9 @@ func argsFor(goos, dir string, extraConfig []string, args ...string) []string {
 // command the repository's local .git/config defines, but only when args runs a
 // diff — the one gitcmd subcommand that invokes clean filters on working-tree
 // content. A diff compares the file's raw bytes, so an emptied filter is the
-// correct rendering, not a degraded one. Emptying clean alone would make a
-// filter marked required fail the diff outright, so required is forced off too.
+// correct rendering, not a degraded one. Git prefers a long-running process
+// filter over clean when one is configured, so both command forms are emptied;
+// required is forced off so a disabled required filter does not fail the diff.
 func filterNeutralizingConfig(dir string, args []string) []string {
 	sub, cDir := gitSubcommand(args)
 	if sub != "diff" {
@@ -95,10 +96,11 @@ func filterNeutralizingConfig(dir string, args []string) []string {
 	if len(drivers) == 0 {
 		return nil
 	}
-	out := make([]string, 0, 2*len(drivers))
+	out := make([]string, 0, 3*len(drivers))
 	for _, name := range drivers {
 		out = append(out,
 			"filter."+name+".clean=",
+			"filter."+name+".process=",
 			"filter."+name+".required=false",
 		)
 	}
@@ -140,62 +142,77 @@ func gitSubcommand(args []string) (sub, cDir string) {
 // config yields no drivers (nothing to neutralize). User and system config are
 // deliberately not read — those are the user's own choices.
 func localFilterDrivers(dir string) []string {
-	cfgPath := localGitConfigPath(dir)
-	if cfgPath == "" {
-		return nil
-	}
-	f, err := os.Open(cfgPath)
-	if err != nil {
-		return nil
-	}
-	defer f.Close()
-
 	var drivers []string
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if !strings.HasPrefix(line, "[filter ") {
+	for _, cfgPath := range localGitConfigPaths(dir) {
+		f, err := os.Open(cfgPath)
+		if err != nil {
 			continue
 		}
-		name := strings.TrimSuffix(strings.TrimPrefix(line, "[filter "), "]")
-		name = strings.Trim(strings.TrimSpace(name), `"`)
-		if name == "" || slices.Contains(drivers, name) {
-			continue
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if len(line) < 2 || line[0] != '[' || line[len(line)-1] != ']' {
+				continue
+			}
+			section := strings.TrimSpace(line[1 : len(line)-1])
+			i := strings.IndexAny(section, " \t")
+			if i < 0 || !strings.EqualFold(section[:i], "filter") {
+				continue
+			}
+			name := strings.Trim(strings.TrimSpace(section[i:]), `"`)
+			if name == "" || slices.Contains(drivers, name) {
+				continue
+			}
+			drivers = append(drivers, name)
 		}
-		drivers = append(drivers, name)
+		_ = f.Close()
 	}
 	return drivers
 }
 
-// localGitConfigPath resolves the repository-local config for a working tree at
-// dir: .git/config when .git is a directory, or <gitdir>/config when .git is a
-// linked worktree file ("gitdir: <path>", possibly relative to dir).
-func localGitConfigPath(dir string) string {
+// localGitConfigPaths resolves the repository-local configs for a working tree.
+// Linked worktrees inherit <commondir>/config and may add
+// <gitdir>/config.worktree when extensions.worktreeConfig is enabled.
+func localGitConfigPaths(dir string) []string {
 	if dir == "" {
 		dir = "."
 	}
 	dotGit := filepath.Join(dir, ".git")
 	info, err := os.Stat(dotGit)
 	if err != nil {
-		return ""
+		return nil
 	}
-	if info.IsDir() {
-		return filepath.Join(dotGit, "config")
+	gitdir := dotGit
+	if !info.IsDir() {
+		data, readErr := os.ReadFile(dotGit)
+		if readErr != nil {
+			return nil
+		}
+		line := strings.TrimSpace(string(data))
+		rest, ok := strings.CutPrefix(line, "gitdir:")
+		if !ok {
+			return nil
+		}
+		gitdir = strings.TrimSpace(rest)
+		if !filepath.IsAbs(gitdir) {
+			gitdir = filepath.Join(dir, gitdir)
+		}
 	}
-	data, err := os.ReadFile(dotGit)
-	if err != nil {
-		return ""
+	gitdir = filepath.Clean(gitdir)
+	commonDir := gitdir
+	if data, readErr := os.ReadFile(filepath.Join(gitdir, "commondir")); readErr == nil {
+		commonDir = strings.TrimSpace(string(data))
+		if !filepath.IsAbs(commonDir) {
+			commonDir = filepath.Join(gitdir, commonDir)
+		}
+		commonDir = filepath.Clean(commonDir)
 	}
-	line := strings.TrimSpace(string(data))
-	rest, ok := strings.CutPrefix(line, "gitdir:")
-	if !ok {
-		return ""
+	paths := []string{filepath.Join(commonDir, "config")}
+	worktreeConfig := filepath.Join(gitdir, "config.worktree")
+	if worktreeConfig != paths[0] {
+		paths = append(paths, worktreeConfig)
 	}
-	gitdir := strings.TrimSpace(rest)
-	if !filepath.IsAbs(gitdir) {
-		gitdir = filepath.Join(dir, gitdir)
-	}
-	return filepath.Join(gitdir, "config")
+	return paths
 }
 
 // hardenSubcommand adds the flags that disable repository-configured programs

--- a/internal/gitcmd/gitcmd_test.go
+++ b/internal/gitcmd/gitcmd_test.go
@@ -211,6 +211,7 @@ func TestDiffDoesNotRunRepositoryCleanFilters(t *testing.T) {
 	run("add", ".gitattributes", "secret.bin")
 	run("commit", "--quiet", "-m", "initial")
 	run("config", "filter.pwn.clean", payload)
+	run("config", "filter.pwn.process", payload)
 	run("config", "filter.pwn.required", "true")
 	if err := os.WriteFile(filepath.Join(repo, "secret.bin"), []byte("secret\nchanged\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -245,6 +246,7 @@ func TestFilterNeutralizingConfigOnlyForDiff(t *testing.T) {
 	bare = false
 [filter "lfs"]
 	clean = git-lfs clean -- %f
+	process = git-lfs filter-process
 	required = true
 [filter "pwn"]
 	smudge = whatever
@@ -253,7 +255,10 @@ func TestFilterNeutralizingConfigOnlyForDiff(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, want := range []string{"filter.lfs.clean=", "filter.lfs.required=false", "filter.pwn.clean=", "filter.pwn.required=false"} {
+	for _, want := range []string{
+		"filter.lfs.clean=", "filter.lfs.process=", "filter.lfs.required=false",
+		"filter.pwn.clean=", "filter.pwn.process=", "filter.pwn.required=false",
+	} {
 		args := argsFor("linux", repo, nil, "diff", "HEAD")
 		if !hasConfig(args, want) {
 			t.Fatalf("diff args = %v, want -c %s", args, want)

--- a/internal/gitcmd/gitcmd_test.go
+++ b/internal/gitcmd/gitcmd_test.go
@@ -167,3 +167,166 @@ func TestRepositoryConfigCannotRunCommandsDuringInspection(t *testing.T) {
 		t.Fatalf("stat marker: %v", err)
 	}
 }
+
+// The clean-filter residual from the advisory: a .gitattributes entry plus a
+// filter.<driver>.clean command in the repository's local config makes
+// `git diff` run that command to produce the "clean" working-tree side, and
+// neither --no-ext-diff nor --no-textconv covers it. Diff invocations must
+// neutralize every locally-defined driver while still rendering a correct
+// diff (the emptied filter is an identity pass-through, not a content wipe).
+func TestDiffDoesNotRunRepositoryCleanFilters(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("payload script is POSIX shell")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+
+	repo := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	run := func(args ...string) {
+		t.Helper()
+		if out, err := Command(ctx, repo, args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "--quiet")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "test")
+
+	marker := filepath.Join(t.TempDir(), "executed")
+	payload := filepath.Join(t.TempDir(), "clean.sh")
+	script := "#!/bin/sh\ntouch " + marker + "\ncat\n"
+	if err := os.WriteFile(payload, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".gitattributes"), []byte("secret.bin filter=pwn\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "secret.bin"), []byte("secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".gitattributes", "secret.bin")
+	run("commit", "--quiet", "-m", "initial")
+	run("config", "filter.pwn.clean", payload)
+	run("config", "filter.pwn.required", "true")
+	if err := os.WriteFile(filepath.Join(repo, "secret.bin"), []byte("secret\nchanged\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// The exact shape desktop/workspace_changes.go builds: -C inside args.
+	out, err := Command(ctx, "", "-C", repo, "diff", "--no-ext-diff", "--no-textconv", "--relative", "HEAD", "--", filepath.FromSlash("secret.bin")).CombinedOutput()
+	if err != nil {
+		t.Fatalf("diff failed: %v: %s", err, out)
+	}
+	if !strings.Contains(string(out), "changed") {
+		t.Fatalf("diff output lost the working-tree change (filter neutralization must pass content through):\n%s", out)
+	}
+	// And the shape internal/cli/gitstatus.go builds: dir parameter + diff.
+	if out, err = Command(ctx, repo, "diff", "--numstat", "HEAD", "--").CombinedOutput(); err != nil {
+		t.Fatalf("numstat diff failed: %v: %s", err, out)
+	}
+
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("repository clean filter ran during a diff")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat marker: %v", err)
+	}
+}
+
+func TestFilterNeutralizingConfigOnlyForDiff(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	config := `[core]
+	bare = false
+[filter "lfs"]
+	clean = git-lfs clean -- %f
+	required = true
+[filter "pwn"]
+	smudge = whatever
+`
+	if err := os.WriteFile(filepath.Join(repo, ".git", "config"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"filter.lfs.clean=", "filter.lfs.required=false", "filter.pwn.clean=", "filter.pwn.required=false"} {
+		args := argsFor("linux", repo, nil, "diff", "HEAD")
+		if !hasConfig(args, want) {
+			t.Fatalf("diff args = %v, want -c %s", args, want)
+		}
+	}
+
+	// The -C-inside-args form workspace_changes.go uses resolves the same repo.
+	args := argsFor("linux", "", nil, "-C", repo, "diff", "--no-ext-diff")
+	if !hasConfig(args, "filter.lfs.clean=") {
+		t.Fatalf("args with -C inside = %v, want filter.lfs.clean= override", args)
+	}
+
+	// Non-diff subcommands carry no filter overrides, and a repo without
+	// filter sections adds nothing even for diff.
+	for _, sub := range []string{"status", "rev-parse", "diff-tree"} {
+		if args := argsFor("linux", repo, nil, sub, "--porcelain=v1"); hasConfig(args, "filter.lfs.clean=") {
+			t.Fatalf("%s args = %v, must not carry diff-only filter overrides", sub, args)
+		}
+	}
+	clean := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(clean, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(clean, ".git", "config"), []byte("[core]\n\tbare = false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if args := argsFor("linux", clean, nil, "diff"); slices.Contains(args, "filter.") {
+		t.Fatalf("filter-free repo diff args = %v, want no filter overrides", args)
+	}
+}
+
+// A linked worktree keeps its config next to the gitdir the .git file points
+// at; the neutralization must follow the link.
+func TestLocalFilterDriversFollowsWorktreeLink(t *testing.T) {
+	main := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(main, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	wt := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wt, ".git"), []byte("gitdir: "+filepath.Join(main, ".git")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(main, ".git", "config"), []byte("[filter \"x\"]\n\tclean = cmd\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := localFilterDrivers(wt); !slices.Equal(got, []string{"x"}) {
+		t.Fatalf("localFilterDrivers(worktree) = %v, want [x]", got)
+	}
+	args := argsFor("linux", wt, nil, "diff")
+	if !hasConfig(args, "filter.x.clean=") {
+		t.Fatalf("worktree diff args = %v, want filter.x.clean= override", args)
+	}
+}
+
+func TestGitSubcommandSkipsGlobalOptions(t *testing.T) {
+	for _, tt := range []struct {
+		args []string
+		sub  string
+		cDir string
+	}{
+		{args: []string{"status"}, sub: "status"},
+		{args: []string{"diff", "HEAD"}, sub: "diff"},
+		{args: []string{"-C", "/repo", "diff"}, sub: "diff", cDir: "/repo"},
+		{args: []string{"-C/repo", "status"}, sub: "status", cDir: "/repo"},
+		{args: []string{"-c", "a=b", "-C", "/r", "log"}, sub: "log", cDir: "/r"},
+		{args: []string{"--no-pager", "status"}, sub: "status"},
+		{args: []string{}},
+		{args: []string{"-c", "a=b"}},
+	} {
+		sub, cDir := gitSubcommand(tt.args)
+		if sub != tt.sub || cDir != tt.cDir {
+			t.Fatalf("gitSubcommand(%v) = (%q, %q), want (%q, %q)", tt.args, sub, cDir, tt.sub, tt.cDir)
+		}
+	}
+}

--- a/internal/gitcmd/gitcmd_worktree_test.go
+++ b/internal/gitcmd/gitcmd_worktree_test.go
@@ -1,0 +1,45 @@
+package gitcmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestLocalFilterDriversReadsRealLinkedWorktreeConfigs(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	main := t.TempDir()
+	linked := filepath.Join(t.TempDir(), "linked")
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmdArgs := append([]string{"-C", dir}, args...)
+		if out, err := exec.Command("git", cmdArgs...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run(main, "init", "--quiet")
+	if err := os.WriteFile(filepath.Join(main, "tracked.txt"), []byte("initial\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run(main, "add", "tracked.txt")
+	run(main, "-c", "user.name=Reasonix Test", "-c", "user.email=reasonix@example.invalid", "commit", "--quiet", "-m", "initial")
+	run(main, "config", "extensions.worktreeConfig", "true")
+	run(main, "config", "filter.common.process", "malicious-process")
+	run(main, "worktree", "add", "--quiet", "--detach", linked, "HEAD")
+	run(linked, "config", "--worktree", "filter.local.clean", "malicious-clean")
+
+	want := []string{"common", "local"}
+	if got := localFilterDrivers(linked); !slices.Equal(got, want) {
+		t.Fatalf("localFilterDrivers(real linked worktree) = %v, want %v", got, want)
+	}
+	args := argsFor("linux", linked, nil, "diff", "HEAD")
+	for _, cfg := range []string{"filter.common.process=", "filter.local.process="} {
+		if !hasConfig(args, cfg) {
+			t.Fatalf("linked worktree diff args = %v, want -c %s", args, cfg)
+		}
+	}
+}

--- a/internal/installsource/ssrf.go
+++ b/internal/installsource/ssrf.go
@@ -15,11 +15,9 @@ import (
 // runs at dial time on the resolved IP and then dials that vetted IP, so a
 // public host that DNS-rebinds to an internal address is caught too.
 //
-// When the transport routes through an HTTP/HTTPS proxy, the dial-time check
-// only ever sees the proxy's address, so the request-level wrapper below also
-// rejects IP-literal destinations before anything is forwarded. That is the
-// same boundary web_fetch's proxy path enforces: hostname targets are resolved
-// by the proxy, which cannot be re-validated locally.
+// When the transport routes through an HTTP/HTTPS proxy the dial-time check
+// only sees the proxy address, so the request-level wrapper below also rejects
+// IP-literal destinations before forwarding — web_fetch's proxy boundary.
 //
 // This mirrors web_fetch's guard (internal/tool/builtin/webfetch.go); the
 // install_source tool fetches the same kind of untrusted URLs and must not be

--- a/internal/installsource/ssrf.go
+++ b/internal/installsource/ssrf.go
@@ -15,6 +15,12 @@ import (
 // runs at dial time on the resolved IP and then dials that vetted IP, so a
 // public host that DNS-rebinds to an internal address is caught too.
 //
+// When the transport routes through an HTTP/HTTPS proxy, the dial-time check
+// only ever sees the proxy's address, so the request-level wrapper below also
+// rejects IP-literal destinations before anything is forwarded. That is the
+// same boundary web_fetch's proxy path enforces: hostname targets are resolved
+// by the proxy, which cannot be re-validated locally.
+//
 // This mirrors web_fetch's guard (internal/tool/builtin/webfetch.go); the
 // install_source tool fetches the same kind of untrusted URLs and must not be
 // the one un-guarded path. Kept in sync by hand — both block the same set.
@@ -27,15 +33,29 @@ func ssrfGuardClient(base *http.Client) *http.Client {
 			inner = (&net.Dialer{}).DialContext
 		}
 		ct.DialContext = ssrfDial(inner)
-		guarded.Transport = ct
+		guarded.Transport = &ssrfRequestGuard{base: ct}
 	} else {
 		// Non-*http.Transport (or nil Transport): build a fresh guarded transport.
 		// The real paths — boot's netclient and the tests' httptest client — are
 		// always *http.Transport, so this branch only covers a bare &http.Client{}.
-		guarded.Transport = &http.Transport{DialContext: ssrfDial((&net.Dialer{}).DialContext)}
+		guarded.Transport = &ssrfRequestGuard{base: &http.Transport{DialContext: ssrfDial((&net.Dialer{}).DialContext)}}
 	}
 	return &guarded
 }
+
+// ssrfRequestGuard vetoes requests whose destination is a blocked IP literal
+// before the transport dials anything — including, and mainly for, the proxy
+// path, where the wrapped DialContext would otherwise validate only the proxy.
+func (rt *ssrfRequestGuard) RoundTrip(req *http.Request) (*http.Response, error) {
+	if host := req.URL.Hostname(); host != "" {
+		if ip := net.ParseIP(host); ip != nil && blockedFetchIP(ip) {
+			return nil, fmt.Errorf("refusing to fetch internal address %s", host)
+		}
+	}
+	return rt.base.RoundTrip(req)
+}
+
+type ssrfRequestGuard struct{ base http.RoundTripper }
 
 func ssrfDial(inner func(context.Context, string, string) (net.Conn, error)) func(context.Context, string, string) (net.Conn, error) {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/internal/installsource/ssrf_test.go
+++ b/internal/installsource/ssrf_test.go
@@ -1,0 +1,130 @@
+package installsource
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingProxy is a dummy HTTP proxy: it accepts absolute-form requests,
+// records the destination the client asked it to reach, and answers 200. It
+// never contacts the destination, so tests can assert what would have been
+// forwarded without touching a real internal service.
+type recordingProxy struct {
+	mu    sync.Mutex
+	dests []string
+
+	listener net.Listener
+}
+
+func newRecordingProxy(t *testing.T) *recordingProxy {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	p := &recordingProxy{listener: l}
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go p.serve(conn)
+		}
+	}()
+	t.Cleanup(func() { _ = l.Close() })
+	return p
+}
+
+func (p *recordingProxy) serve(conn net.Conn) {
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	req, err := http.ReadRequest(bufio.NewReader(conn))
+	if err != nil {
+		return
+	}
+	if req.URL != nil && req.URL.IsAbs() {
+		p.mu.Lock()
+		p.dests = append(p.dests, req.URL.String())
+		p.mu.Unlock()
+	}
+	_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"))
+}
+
+func (p *recordingProxy) destinations() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.dests...)
+}
+
+func (p *recordingProxy) URL() string {
+	return "http://" + p.listener.Addr().String()
+}
+
+func TestSSRFGuardRejectsBlockedIPLiteralThroughProxy(t *testing.T) {
+	proxy := newRecordingProxy(t)
+	transport := &http.Transport{Proxy: func(*http.Request) (*url.URL, error) {
+		return url.Parse(proxy.URL())
+	}}
+	client := ssrfGuardClient(&http.Client{Transport: transport, Timeout: 5 * time.Second})
+
+	for _, target := range []string{
+		"http://169.254.169.254/latest/meta-data/",
+		"http://10.0.0.1/mcp",
+		"http://192.168.0.1/mcp",
+		"http://100.64.0.1/mcp",
+	} {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			t.Fatalf("request to %s through proxy succeeded; want SSRF refusal", target)
+		}
+	}
+	if got := proxy.destinations(); len(got) != 0 {
+		t.Fatalf("proxy was asked to reach %v; want the guard to refuse before forwarding", got)
+	}
+}
+
+func TestSSRFGuardRejectsBlockedIPLiteralDirect(t *testing.T) {
+	client := ssrfGuardClient(&http.Client{Timeout: 2 * time.Second})
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://169.254.169.254/latest/meta-data/", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if _, err := client.Do(req); err == nil {
+		t.Fatal("direct request to blocked IP succeeded; want SSRF refusal")
+	}
+}
+
+func TestSSRFGuardAllowsLoopbackThroughProxy(t *testing.T) {
+	proxy := newRecordingProxy(t)
+	transport := &http.Transport{Proxy: func(*http.Request) (*url.URL, error) {
+		return url.Parse(proxy.URL())
+	}}
+	client := ssrfGuardClient(&http.Client{Transport: transport, Timeout: 5 * time.Second})
+
+	// Loopback is deliberately allowed by this guard; the request must reach
+	// the proxy carrying its destination intact.
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1:8799/mcp", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("loopback request through proxy: %v", err)
+	}
+	_ = resp.Body.Close()
+	if got := proxy.destinations(); len(got) != 1 || got[0] != "http://127.0.0.1:8799/mcp" {
+		t.Fatalf("proxy destinations = %v; want exactly the loopback target", got)
+	}
+}

--- a/internal/permission/bash_approval.go
+++ b/internal/permission/bash_approval.go
@@ -108,6 +108,13 @@ func isIndirectExecution(fields []string) bool {
 		return hasAnyFoldedArg(args, "-r")
 	case "find":
 		return hasAnyFoldedArg(args, "-exec", "-execdir", "-ok", "-okdir")
+	case "awk", "gawk", "mawk", "nawk":
+		// awk has no inline-code flag: the program is the first positional
+		// argument unless it comes from a script via -f/--file. An inline
+		// program can run shell commands (system(), "| getline"), so it gets
+		// the same treatment as python -c; awk -f script.awk stays reusable
+		// like python script.py.
+		return !hasAnyFoldedArg(args, "-f", "--file")
 	default:
 		return false
 	}

--- a/internal/permission/bash_approval.go
+++ b/internal/permission/bash_approval.go
@@ -109,11 +109,9 @@ func isIndirectExecution(fields []string) bool {
 	case "find":
 		return hasAnyFoldedArg(args, "-exec", "-execdir", "-ok", "-okdir")
 	case "awk", "gawk", "mawk", "nawk":
-		// awk has no inline-code flag: the program is the first positional
-		// argument unless it comes from a script via -f/--file. An inline
-		// program can run shell commands (system(), "| getline"), so it gets
-		// the same treatment as python -c; awk -f script.awk stays reusable
-		// like python script.py.
+		// awk has no inline-code flag: an inline program (no -f/--file) can
+		// run shell commands (system(), "| getline"), so it is treated like
+		// python -c; awk -f script.awk stays reusable like python script.py.
 		return !hasAnyFoldedArg(args, "-f", "--file")
 	default:
 		return false

--- a/internal/permission/bash_approval.go
+++ b/internal/permission/bash_approval.go
@@ -112,10 +112,43 @@ func isIndirectExecution(fields []string) bool {
 		// awk has no inline-code flag: an inline program (no -f/--file) can
 		// run shell commands (system(), "| getline"), so it is treated like
 		// python -c; awk -f script.awk stays reusable like python script.py.
-		return !hasAnyFoldedArg(args, "-f", "--file")
+		return !awkUsesOnlyScriptFiles(args)
 	default:
 		return false
 	}
+}
+
+func awkUsesOnlyScriptFiles(args []string) bool {
+	hasFile := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-f" || arg == "--file":
+			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
+				return false
+			}
+			hasFile = true
+			i++
+		case strings.HasPrefix(arg, "-f") && len(arg) > 2:
+			hasFile = true
+		case strings.HasPrefix(arg, "--file="):
+			if strings.TrimPrefix(arg, "--file=") == "" {
+				return false
+			}
+			hasFile = true
+		case arg == "-E" || arg == "--exec":
+			return i+1 < len(args)
+		case strings.HasPrefix(arg, "-E") && len(arg) > 2:
+			return true
+		case strings.HasPrefix(arg, "--exec="):
+			return strings.TrimPrefix(arg, "--exec=") != ""
+		case arg == "-e" || arg == "--source",
+			strings.HasPrefix(arg, "-e") && len(arg) > 2,
+			strings.HasPrefix(arg, "--source="):
+			return false
+		}
+	}
+	return hasFile
 }
 
 func hasEnvWrapperAssignment(fields []string) bool {

--- a/internal/permission/bash_approval_test.go
+++ b/internal/permission/bash_approval_test.go
@@ -43,6 +43,11 @@ func TestBashSubjectRequiresExplicitApproval(t *testing.T) {
 		{name: "ruby attached inline code", subject: `ruby -eFile.write('x','')`, wantHuman: true, wantExact: true},
 		{name: "cmd attached command string", subject: `cmd /cecho x`, wantHuman: true, wantExact: true},
 		{name: "find exec", subject: `find . -exec touch {} ;`, wantHuman: true, wantExact: true},
+		{name: "awk inline system call", subject: `awk 'BEGIN{system("touch /tmp/x")}'`, wantHuman: true, wantExact: true},
+		{name: "awk inline getline pipe", subject: `awk '{"touch /tmp/x" | getline line}' file`, wantHuman: true, wantExact: true},
+		{name: "awk variant inline program", subject: `gawk '{print $1}' file`, wantHuman: true, wantExact: true},
+		{name: "awk script file", subject: `awk -f transform.awk input.txt`},
+		{name: "awk long script file", subject: `awk --file=transform.awk input.txt`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/permission/bash_approval_test.go
+++ b/internal/permission/bash_approval_test.go
@@ -46,8 +46,15 @@ func TestBashSubjectRequiresExplicitApproval(t *testing.T) {
 		{name: "awk inline system call", subject: `awk 'BEGIN{system("touch /tmp/x")}'`, wantHuman: true, wantExact: true},
 		{name: "awk inline getline pipe", subject: `awk '{"touch /tmp/x" | getline line}' file`, wantHuman: true, wantExact: true},
 		{name: "awk variant inline program", subject: `gawk '{print $1}' file`, wantHuman: true, wantExact: true},
+		{name: "awk field separator is not a script file", subject: `awk -F: 'BEGIN{system("touch /tmp/x")}' /etc/passwd`, wantHuman: true, wantExact: true},
+		{name: "awk separate field separator is not a script file", subject: `awk -F : 'BEGIN{system("touch /tmp/x")}' /etc/passwd`, wantHuman: true, wantExact: true},
+		{name: "gawk inline source overrides script file", subject: `gawk -f safe.awk -e 'BEGIN{system("touch /tmp/x")}'`, wantHuman: true, wantExact: true},
+		{name: "gawk long inline source overrides script file", subject: `gawk --file=safe.awk --source='BEGIN{system("touch /tmp/x")}'`, wantHuman: true, wantExact: true},
 		{name: "awk script file", subject: `awk -f transform.awk input.txt`},
+		{name: "awk attached script file", subject: `mawk -ftransform.awk input.txt`},
 		{name: "awk long script file", subject: `awk --file=transform.awk input.txt`},
+		{name: "gawk exec script file", subject: `gawk -E transform.awk input.txt`},
+		{name: "gawk long exec script file", subject: `gawk --exec=transform.awk input.txt`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/serve/auth.go
+++ b/internal/serve/auth.go
@@ -661,13 +661,17 @@ func isLoopbackHost(hostport string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-// PlainHTTPAuthWarning reports whether serve is exposing authenticated access
-// over a non-loopback plain-HTTP listener. The listener may still be valid for a
-// trusted LAN or reverse-proxy setup, but users should see the risk explicitly.
+// PlainHTTPAuthWarning returns a warning string when serve is exposed on a
+// non-loopback plain-HTTP listener. The listener may still be valid for a
+// trusted LAN or reverse-proxy setup, but users should see the risk explicitly
+// — loudest for the unauthenticated case, which used to be the silent one.
 func PlainHTTPAuthWarning(cfg config.ServeConfig, addr string) string {
 	mode, err := NormalizeAuthMode(cfg.AuthMode)
-	if err != nil || mode == "none" || isLoopbackHost(addr) {
+	if err != nil || isLoopbackHost(addr) {
 		return ""
+	}
+	if mode == "none" {
+		return "warning: serve is listening on non-loopback HTTP with authentication disabled; anyone on this network can drive the agent — bind to 127.0.0.1 or set serve.auth_mode"
 	}
 	return "warning: authenticated serve is listening on non-loopback HTTP; use HTTPS via a trusted reverse proxy or bind to 127.0.0.1 for local-only access"
 }

--- a/internal/serve/auth_test.go
+++ b/internal/serve/auth_test.go
@@ -731,8 +731,8 @@ func TestAuthCookieSecurePolicy(t *testing.T) {
 }
 
 func TestPlainHTTPAuthWarning(t *testing.T) {
-	if got := PlainHTTPAuthWarning(config.ServeConfig{AuthMode: "none"}, "0.0.0.0:8787"); got != "" {
-		t.Fatalf("none auth warning = %q, want empty", got)
+	if got := PlainHTTPAuthWarning(config.ServeConfig{AuthMode: "none"}, "0.0.0.0:8787"); !strings.Contains(got, "authentication disabled") {
+		t.Fatalf("none auth warning = %q, want the loudest unauthenticated warning", got)
 	}
 	if got := PlainHTTPAuthWarning(config.ServeConfig{AuthMode: "password"}, "127.0.0.1:8787"); got != "" {
 		t.Fatalf("loopback warning = %q, want empty", got)

--- a/internal/serve/hostguard.go
+++ b/internal/serve/hostguard.go
@@ -25,9 +25,10 @@ func (s *Server) setListenAddr(addr string) {
 	}
 	host = strings.Trim(host, "[]")
 	s.hostGate = hostGateState{
-		behindProxy: s.auth != nil && s.auth.behindProxy,
-		listenHost:  strings.ToLower(host),
-		allowAny:    isUnspecifiedHost(host),
+		behindProxy: s.auth != nil && s.auth.behindProxy &&
+			(s.auth.mode == authToken || s.auth.mode == authPassword),
+		listenHost: strings.ToLower(host),
+		allowAny:   isUnspecifiedHost(host),
 	}
 }
 

--- a/internal/serve/hostguard.go
+++ b/internal/serve/hostguard.go
@@ -1,0 +1,93 @@
+package serve
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// hostGateState captures which Host headers hostGuard accepts, derived from
+// the listen address. Wildcard and non-loopback binds deliberately expose the
+// server beyond this machine, so Host policing there adds nothing and is off.
+type hostGateState struct {
+	behindProxy bool
+	allowAny    bool
+	listenHost  string // specific, non-wildcard host the server is bound to
+}
+
+// setListenAddr derives hostGate from the address Run-style entry points will
+// listen on. It must be called before Handler(); a later call only affects
+// servers whose Handler is rebuilt.
+func (s *Server) setListenAddr(addr string) {
+	host := addr
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	s.hostGate = hostGateState{
+		behindProxy: s.auth != nil && s.auth.behindProxy,
+		listenHost:  strings.ToLower(host),
+		allowAny:    isUnspecifiedHost(host),
+	}
+}
+
+func isUnspecifiedHost(host string) bool {
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsUnspecified()
+}
+
+// hostGuard rejects requests whose Host header names neither a loopback
+// interface nor the address serve actually listens on.
+//
+// csrfGuard's application/json requirement only holds while an attacker's page
+// stays cross-origin: a DNS-rebinding page is served from evil.example, which
+// is then re-pointed at 127.0.0.1, making every subsequent fetch same-origin —
+// no preflight, any Content-Type, and full read access to responses. Such a
+// page can drive the unauthenticated agent endpoints (POST /bypass, /submit)
+// and read /history verbatim. Pinning Host to the interfaces we serve breaks
+// that: the rebound name never matches the allowlist.
+//
+// Exemptions: behind_proxy deployments send the reverse proxy's public
+// hostname and must instead run an authenticated mode; wildcard / non-loopback
+// binds (allowAny) intentionally expose the server. Requests with no Host at
+// all (raw HTTP/1.0 clients) pass — nothing to validate.
+func (s *Server) hostGuard(next http.Handler) http.Handler {
+	gate := s.hostGate
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host := r.Host
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
+		}
+		host = strings.ToLower(strings.Trim(host, "[]"))
+		if host == "" || gate.behindProxy || gate.allowAny ||
+			isLoopbackHost(host) || host == gate.listenHost {
+			next.ServeHTTP(w, r)
+			return
+		}
+		http.Error(w, "misdirected request: Host is not a serve listen address",
+			http.StatusMisdirectedRequest)
+	})
+}
+
+// csrfGuard rejects state-changing requests that don't carry a JSON content type.
+// The command endpoints have no auth and bind to localhost, so a page the user
+// visits could otherwise drive them with a simple cross-origin POST (text/plain,
+// no preflight) — submitting prompts or auto-approving tool calls. Requiring
+// application/json forces a CORS preflight the unauthenticated server never
+// answers, blocking cross-site requests; the same-origin frontend (which always
+// sends JSON) is unaffected.
+func csrfGuard(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			ct := r.Header.Get("Content-Type")
+			if i := strings.IndexByte(ct, ';'); i >= 0 {
+				ct = ct[:i]
+			}
+			if !strings.EqualFold(strings.TrimSpace(ct), "application/json") {
+				http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/serve/hostguard_test.go
+++ b/internal/serve/hostguard_test.go
@@ -106,6 +106,22 @@ func TestHostGuardExemptsBehindProxy(t *testing.T) {
 	}
 }
 
+func TestHostGuardDoesNotExemptUnauthenticatedProxyMode(t *testing.T) {
+	s := New(control.New(control.Options{}), NewBroadcaster(), config.ServeConfig{
+		AuthMode:    "none",
+		BehindProxy: true,
+	})
+	s.setListenAddr("127.0.0.1:8787")
+
+	req := httptest.NewRequest(http.MethodGet, "/history", nil)
+	req.Host = "evil.example:8787"
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusMisdirectedRequest {
+		t.Fatalf("GET /history = %d, want %d", rec.Code, http.StatusMisdirectedRequest)
+	}
+}
+
 func TestSetListenAddrBracketedIPv6(t *testing.T) {
 	s := New(control.New(control.Options{}), NewBroadcaster(), config.ServeConfig{})
 	s.setListenAddr("[::1]:8787")

--- a/internal/serve/hostguard_test.go
+++ b/internal/serve/hostguard_test.go
@@ -1,0 +1,125 @@
+package serve
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+)
+
+// The DNS-rebinding scenario from the advisory: a page served from
+// evil.example is re-pointed at 127.0.0.1, so its fetches arrive same-origin
+// with Host: evil.example:8787. hostGuard must reject them before csrfGuard
+// or any route sees the request — the content-type check is worthless once
+// the attacker is same-origin.
+func TestHostGuardBlocksReboundHost(t *testing.T) {
+	s := New(control.New(control.Options{}), NewBroadcaster(), config.ServeConfig{})
+	h := s.Handler()
+
+	for _, host := range []string{"evil.example", "evil.example:8787", "10.0.0.99", "[::ffff:10.0.0.99]:8787"} {
+		req := httptest.NewRequest(http.MethodPost, "/bypass", strings.NewReader(`{"on":true}`))
+		req.Host = host
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusMisdirectedRequest {
+			t.Fatalf("POST /bypass with Host %q = %d, want %d", host, rec.Code, http.StatusMisdirectedRequest)
+		}
+
+		req = httptest.NewRequest(http.MethodGet, "/history", nil)
+		req.Host = host
+		rec = httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusMisdirectedRequest {
+			t.Fatalf("GET /history with Host %q = %d, want %d", host, rec.Code, http.StatusMisdirectedRequest)
+		}
+	}
+}
+
+func TestHostGuardAllowsLoopbackHosts(t *testing.T) {
+	s := New(control.New(control.Options{}), NewBroadcaster(), config.ServeConfig{})
+	h := s.Handler()
+
+	for _, host := range []string{"127.0.0.1", "127.0.0.1:8787", "localhost", "localhost:8787", "[::1]:8787", ""} {
+		req := httptest.NewRequest(http.MethodGet, "/status", nil)
+		req.Host = host
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code == http.StatusMisdirectedRequest {
+			t.Fatalf("GET /status with Host %q rejected as misdirected", host)
+		}
+	}
+}
+
+func TestHostGuardAllowsListenHostAndWildcardBind(t *testing.T) {
+	s := New(control.New(control.Options{}), NewBroadcaster(), config.ServeConfig{})
+	s.setListenAddr("10.1.2.3:8787")
+	h := s.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	req.Host = "10.1.2.3:8787"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code == http.StatusMisdirectedRequest {
+		t.Fatal("request via the specific listen host was rejected")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/status", nil)
+	req.Host = "192.168.0.20:8787"
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMisdirectedRequest {
+		t.Fatal("request via an unrelated LAN host was accepted")
+	}
+
+	// A wildcard bind deliberately exposes the server; Host policing is off.
+	wild := New(control.New(control.Options{}), NewBroadcaster(), config.ServeConfig{})
+	wild.setListenAddr("0.0.0.0:8787")
+	req = httptest.NewRequest(http.MethodGet, "/status", nil)
+	req.Host = "anything.example:8787"
+	rec = httptest.NewRecorder()
+	wild.Handler().ServeHTTP(rec, req)
+	if rec.Code == http.StatusMisdirectedRequest {
+		t.Fatal("wildcard bind rejected a foreign Host")
+	}
+}
+
+func TestHostGuardExemptsBehindProxy(t *testing.T) {
+	s := New(control.New(control.Options{}), NewBroadcaster(), config.ServeConfig{
+		AuthMode:    "token",
+		Token:       "serve-token",
+		BehindProxy: true,
+	})
+	s.setListenAddr("127.0.0.1:8787")
+	h := s.Handler()
+
+	// The public hostname passes the host guard; auth still applies.
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	req.Host = "agent.internal.example:8787"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code == http.StatusMisdirectedRequest {
+		t.Fatal("behind_proxy deployment rejected on public hostname")
+	}
+}
+
+func TestSetListenAddrBracketedIPv6(t *testing.T) {
+	s := New(control.New(control.Options{}), NewBroadcaster(), config.ServeConfig{})
+	s.setListenAddr("[::1]:8787")
+	if s.hostGate.listenHost != "::1" {
+		t.Fatalf("listenHost = %q, want ::1", s.hostGate.listenHost)
+	}
+	if s.hostGate.allowAny {
+		t.Fatal("::1 bind must not be treated as wildcard")
+	}
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	req.Host = "[::1]:8787"
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code == http.StatusMisdirectedRequest {
+		t.Fatal("loopback IPv6 listen host rejected")
+	}
+}

--- a/internal/serve/provider_setup_test.go
+++ b/internal/serve/provider_setup_test.go
@@ -281,6 +281,7 @@ func TestProviderSetupIsLoopbackOnlyAndAuthenticated(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/provider-setup", nil)
+	req.Host = "127.0.0.1"
 	rec := httptest.NewRecorder()
 	s.Handler().ServeHTTP(rec, req)
 	if rec.Code != http.StatusNotFound {
@@ -294,6 +295,7 @@ func TestProviderSetupIsLoopbackOnlyAndAuthenticated(t *testing.T) {
 	protected := New(s.ctl(), s.bc, config.ServeConfig{AuthMode: "token", Token: "serve-token"})
 	protected.EnableProviderSetupForListener("127.0.0.1:8787")
 	req = httptest.NewRequest(http.MethodGet, "/provider-setup", nil)
+	req.Host = "127.0.0.1"
 	req.Header.Set("Accept", "application/json")
 	rec = httptest.NewRecorder()
 	protected.Handler().ServeHTTP(rec, req)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -91,74 +91,7 @@ type Server struct {
 	detached      map[string]*detachedSession
 	tagsMu        sync.Mutex
 	tags          map[*control.Controller]*sessionTagSink
-	// hostGate is the Host-header allowlist state for hostGuard. Set from the
-	// listen address before Handler() is built (Run / RunGraceful /
-	// RunGracefulListener); the zero value restricts Host to loopback, the
-	// safe default for direct Handler() consumers.
-	hostGate hostGateState
-}
-
-// hostGateState captures which Host headers hostGuard accepts, derived from
-// the listen address. Wildcard and non-loopback binds deliberately expose the
-// server beyond this machine, so Host policing there adds nothing and is off.
-type hostGateState struct {
-	behindProxy bool
-	allowAny    bool
-	listenHost  string // specific, non-wildcard host the server is bound to
-}
-
-// setListenAddr derives hostGate from the address Run-style entry points will
-// listen on. It must be called before Handler(); a later call only affects
-// servers whose Handler is rebuilt.
-func (s *Server) setListenAddr(addr string) {
-	host := addr
-	if h, _, err := net.SplitHostPort(addr); err == nil {
-		host = h
-	}
-	host = strings.Trim(host, "[]")
-	s.hostGate = hostGateState{
-		behindProxy: s.auth != nil && s.auth.behindProxy,
-		listenHost:  strings.ToLower(host),
-		allowAny:    isUnspecifiedHost(host),
-	}
-}
-
-func isUnspecifiedHost(host string) bool {
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsUnspecified()
-}
-
-// hostGuard rejects requests whose Host header names neither a loopback
-// interface nor the address serve actually listens on.
-//
-// csrfGuard's application/json requirement only holds while an attacker's page
-// stays cross-origin: a DNS-rebinding page is served from evil.example, which
-// is then re-pointed at 127.0.0.1, making every subsequent fetch same-origin —
-// no preflight, any Content-Type, and full read access to responses. Such a
-// page can drive the unauthenticated agent endpoints (POST /bypass, /submit)
-// and read /history verbatim. Pinning Host to the interfaces we serve breaks
-// that: the rebound name never matches the allowlist.
-//
-// Exemptions: behind_proxy deployments send the reverse proxy's public
-// hostname and must instead run an authenticated mode; wildcard / non-loopback
-// binds (allowAny) intentionally expose the server. Requests with no Host at
-// all (raw HTTP/1.0 clients) pass — nothing to validate.
-func (s *Server) hostGuard(next http.Handler) http.Handler {
-	gate := s.hostGate
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		host := r.Host
-		if h, _, err := net.SplitHostPort(host); err == nil {
-			host = h
-		}
-		host = strings.ToLower(strings.Trim(host, "[]"))
-		if host == "" || gate.behindProxy || gate.allowAny ||
-			isLoopbackHost(host) || host == gate.listenHost {
-			next.ServeHTTP(w, r)
-			return
-		}
-		http.Error(w, "misdirected request: Host is not a serve listen address",
-			http.StatusMisdirectedRequest)
-	})
+	hostGate      hostGateState // hostGuard allowlist state; see hostguard.go
 }
 
 // SetControllerBuildOptions records the process-local options used to build
@@ -658,29 +591,6 @@ func (s *Server) reloadExtensionsHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
-}
-
-// csrfGuard rejects state-changing requests that don't carry a JSON content type.
-// The command endpoints have no auth and bind to localhost, so a page the user
-// visits could otherwise drive them with a simple cross-origin POST (text/plain,
-// no preflight) — submitting prompts or auto-approving tool calls. Requiring
-// application/json forces a CORS preflight the unauthenticated server never
-// answers, blocking cross-site requests; the same-origin frontend (which always
-// sends JSON) is unaffected.
-func csrfGuard(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
-			ct := r.Header.Get("Content-Type")
-			if i := strings.IndexByte(ct, ';'); i >= 0 {
-				ct = ct[:i]
-			}
-			if !strings.EqualFold(strings.TrimSpace(ct), "application/json") {
-				http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
-				return
-			}
-		}
-		next.ServeHTTP(w, r)
-	})
 }
 
 // Run serves until the process is killed. Interactive approval is enabled so

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -91,6 +91,74 @@ type Server struct {
 	detached      map[string]*detachedSession
 	tagsMu        sync.Mutex
 	tags          map[*control.Controller]*sessionTagSink
+	// hostGate is the Host-header allowlist state for hostGuard. Set from the
+	// listen address before Handler() is built (Run / RunGraceful /
+	// RunGracefulListener); the zero value restricts Host to loopback, the
+	// safe default for direct Handler() consumers.
+	hostGate hostGateState
+}
+
+// hostGateState captures which Host headers hostGuard accepts, derived from
+// the listen address. Wildcard and non-loopback binds deliberately expose the
+// server beyond this machine, so Host policing there adds nothing and is off.
+type hostGateState struct {
+	behindProxy bool
+	allowAny    bool
+	listenHost  string // specific, non-wildcard host the server is bound to
+}
+
+// setListenAddr derives hostGate from the address Run-style entry points will
+// listen on. It must be called before Handler(); a later call only affects
+// servers whose Handler is rebuilt.
+func (s *Server) setListenAddr(addr string) {
+	host := addr
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	s.hostGate = hostGateState{
+		behindProxy: s.auth != nil && s.auth.behindProxy,
+		listenHost:  strings.ToLower(host),
+		allowAny:    isUnspecifiedHost(host),
+	}
+}
+
+func isUnspecifiedHost(host string) bool {
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsUnspecified()
+}
+
+// hostGuard rejects requests whose Host header names neither a loopback
+// interface nor the address serve actually listens on.
+//
+// csrfGuard's application/json requirement only holds while an attacker's page
+// stays cross-origin: a DNS-rebinding page is served from evil.example, which
+// is then re-pointed at 127.0.0.1, making every subsequent fetch same-origin —
+// no preflight, any Content-Type, and full read access to responses. Such a
+// page can drive the unauthenticated agent endpoints (POST /bypass, /submit)
+// and read /history verbatim. Pinning Host to the interfaces we serve breaks
+// that: the rebound name never matches the allowlist.
+//
+// Exemptions: behind_proxy deployments send the reverse proxy's public
+// hostname and must instead run an authenticated mode; wildcard / non-loopback
+// binds (allowAny) intentionally expose the server. Requests with no Host at
+// all (raw HTTP/1.0 clients) pass — nothing to validate.
+func (s *Server) hostGuard(next http.Handler) http.Handler {
+	gate := s.hostGate
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host := r.Host
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
+		}
+		host = strings.ToLower(strings.Trim(host, "[]"))
+		if host == "" || gate.behindProxy || gate.allowAny ||
+			isLoopbackHost(host) || host == gate.listenHost {
+			next.ServeHTTP(w, r)
+			return
+		}
+		http.Error(w, "misdirected request: Host is not a serve listen address",
+			http.StatusMisdirectedRequest)
+	})
 }
 
 // SetControllerBuildOptions records the process-local options used to build
@@ -581,7 +649,7 @@ func (s *Server) handler() http.Handler {
 	mux.HandleFunc("GET /skills", s.skills)
 	mux.HandleFunc("GET /todos", s.todos)
 	mux.HandleFunc("POST /delete-session", s.deleteSession)
-	return logMiddleware(gzipMiddleware(s.auth.middleware(csrfGuard(mux))))
+	return logMiddleware(gzipMiddleware(s.auth.middleware(s.hostGuard(csrfGuard(mux)))))
 }
 
 func (s *Server) reloadExtensionsHTTP(w http.ResponseWriter, r *http.Request) {
@@ -619,6 +687,7 @@ func csrfGuard(next http.Handler) http.Handler {
 // "ask" decisions surface as approval_request events answered via POST /approve.
 func (s *Server) Run(addr string) error {
 	s.ctl().EnableInteractiveApproval()
+	s.setListenAddr(addr)
 	return http.ListenAndServe(addr, s.Handler())
 }
 
@@ -626,6 +695,7 @@ func (s *Server) Run(addr string) error {
 // the provided context and drains active connections for up to 10 seconds
 // before returning.
 func (s *Server) RunGraceful(ctx context.Context, addr string) error {
+	s.setListenAddr(addr)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return err
@@ -638,6 +708,7 @@ func (s *Server) RunGraceful(ctx context.Context, addr string) error {
 // listen first, record ln.Addr(), then hand the listener here.
 func (s *Server) RunGracefulListener(ctx context.Context, ln net.Listener) error {
 	s.ctl().EnableInteractiveApproval()
+	s.setListenAddr(ln.Addr().String())
 	srv := &http.Server{
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: 10 * time.Second,

--- a/internal/serve/serve_lock_test.go
+++ b/internal/serve/serve_lock_test.go
@@ -203,6 +203,7 @@ func TestForegroundMutationRejectsStaleSessionPath(t *testing.T) {
 	ctrl.SubmitHTTP("hi")
 	waitRunning(t, ctrl)
 	req := httptest.NewRequest(http.MethodPost, "/cancel", strings.NewReader(`{}`))
+	req.Host = "127.0.0.1"
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(expectedSessionPathHeader, stalePath)
 	rec := httptest.NewRecorder()
@@ -215,6 +216,7 @@ func TestForegroundMutationRejectsStaleSessionPath(t *testing.T) {
 	}
 
 	req = httptest.NewRequest(http.MethodPost, "/cancel", strings.NewReader(`{}`))
+	req.Host = "127.0.0.1"
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(expectedSessionPathHeader, currentPath)
 	rec = httptest.NewRecorder()

--- a/internal/shellsafe/shellsafe.go
+++ b/internal/shellsafe/shellsafe.go
@@ -71,7 +71,10 @@ var readOnlyPrefixes = map[string]map[string]bool{
 		"outdated": true, "audit": true,
 	},
 	"cargo": {
-		"check": true, "doc": true, "search": true,
+		// check/doc are deliberately absent: cargo runs the crate's build.rs
+		// (arbitrary code) even for them — classifyCargo already bills both as
+		// code-executing writers, and this legacy table must not disagree.
+		"search": true,
 	},
 	"docker": {
 		"ps": true, "images": true, "inspect": true, "logs": true,

--- a/internal/shellsafe/shellsafe_test.go
+++ b/internal/shellsafe/shellsafe_test.go
@@ -15,7 +15,7 @@ func TestCommandIsReadOnly(t *testing.T) {
 		`grep 'a|b' file`, `printf "%s\n" "a && b"`,
 		// tooling probes.
 		"go version", "go env", "go list ./...", "go doc fmt",
-		"npm view react version", "npm outdated", "cargo check",
+		"npm view react version", "npm outdated",
 		"docker ps", "docker images", "kubectl get pods",
 		"node -v", "node --version", "python --version", "python3 --version",
 		// PowerShell permission-safe inspection commands.
@@ -36,6 +36,9 @@ func TestCommandIsReadOnly(t *testing.T) {
 		"git reset --hard", "git branch -d feature", "git remote add o url",
 		"go build ./...", "go test ./...", "npm install", "docker rm x",
 		"kubectl apply -f x.yaml", "mv a b", "chmod 777 x",
+		// cargo runs build.rs (arbitrary code) even for its "checking" and
+		// doc-rendering subcommands; only the registry query is read-only.
+		"cargo check", "cargo doc",
 		// shell syntax can smuggle a write past a read-only base word.
 		"git status && rm -rf /", "cat a | tee b", "echo $(rm x)",
 		"git status > out.txt", "ls; rm x", "git log `whoami`", "echo $HOME",

--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -231,16 +231,13 @@ func confineWrite(ctx context.Context, roots []string, guard SessionDataGuard, m
 	return managed.approve(ctx, target)
 }
 
-// confinePreview mirrors confineWrite for ctx-less diff previews: they read the
-// target to render a diff but never write, so a managed config file passes
-// without the per-write approval — Execute still gates the actual write.
-func confinePreview(roots []string, guard SessionDataGuard, managed ManagedConfigPaths, target string) error {
-	confineErr := confine(roots, target)
-	if confineErr == nil {
-		return guard.Check(target)
-	}
-	if !managed.Match(target) {
-		return confineErr
+// confinePreview is stricter than confineWrite because Preview runs before the
+// permission gate and reads old content into the approval card and session.
+// Managed config files outside the roots therefore stay unreadable here; only
+// Execute may use their explicit, per-write approval escape hatch.
+func confinePreview(roots []string, guard SessionDataGuard, _ ManagedConfigPaths, target string) error {
+	if err := confine(roots, target); err != nil {
+		return err
 	}
 	return guard.Check(target)
 }

--- a/internal/tool/builtin/preview.go
+++ b/internal/tool/builtin/preview.go
@@ -19,6 +19,11 @@ import (
 // Execute would persist. That equality is asserted by TestPreviewMatchesExecute
 // in preview_test.go, which runs Execute against a temp file and compares; if
 // an Execute body ever drifts, that test fails rather than the preview lying.
+//
+// Every Preview also confines the path with confinePreview before reading:
+// a preview runs before the permission gate, so without it an absolute path
+// outside the write roots would be read (and its contents diffed into the
+// approval card and session log) even though Execute would refuse the write.
 
 // Preview computes the change write_file would make. A path that does not yet
 // exist is a Create; an existing one is a Modify.
@@ -34,6 +39,9 @@ func (w writeFile) Preview(ctx context.Context, args json.RawMessage) (diff.Chan
 		return diff.Change{}, fmt.Errorf("path is required")
 	}
 	p.Path = resolveIn(w.workDir, p.Path)
+	if err := confinePreview(effectiveWriteRoots(ctx, w.rootSet, w.roots), w.guard, w.managed, p.Path); err != nil {
+		return diff.Change{}, err
+	}
 
 	old, kind := "", diff.Create
 	if src, err := readEditSource(ctx, w.overlay, p.Path); err == nil {
@@ -63,6 +71,9 @@ func (e editFile) Preview(ctx context.Context, args json.RawMessage) (diff.Chang
 		return diff.Change{}, fmt.Errorf("old_string is required")
 	}
 	p.Path = resolveIn(e.workDir, p.Path)
+	if err := confinePreview(effectiveWriteRoots(ctx, e.rootSet, e.roots), e.guard, e.managed, p.Path); err != nil {
+		return diff.Change{}, err
+	}
 
 	src, err := readEditSource(ctx, e.overlay, p.Path)
 	if err != nil {
@@ -102,6 +113,9 @@ func (m multiEdit) Preview(ctx context.Context, args json.RawMessage) (diff.Chan
 		return diff.Change{}, fmt.Errorf("edits must not be empty")
 	}
 	p.Path = resolveIn(m.workDir, p.Path)
+	if err := confinePreview(effectiveWriteRoots(ctx, m.rootSet, m.roots), m.guard, m.managed, p.Path); err != nil {
+		return diff.Change{}, err
+	}
 
 	src, err := readEditSource(ctx, m.overlay, p.Path)
 	if err != nil {

--- a/internal/tool/builtin/preview.go
+++ b/internal/tool/builtin/preview.go
@@ -12,18 +12,13 @@ import (
 // preview.go gives the file-writing built-ins the optional tool.Previewer
 // capability: compute the change a call would make, reading the current file
 // but never writing. A front-end (e.g. a desktop approval card) calls Preview
-// before the permission gate runs Execute.
+// before the permission gate runs Execute, so every Preview confines its path
+// with confinePreview first: the read must be as bounded as the write.
 //
 // Each Preview mirrors its Execute's transformation exactly — same arg parsing,
 // same uniqueness / not-found rules — so the previewed NewText equals what
-// Execute would persist. That equality is asserted by TestPreviewMatchesExecute
-// in preview_test.go, which runs Execute against a temp file and compares; if
-// an Execute body ever drifts, that test fails rather than the preview lying.
-//
-// Every Preview also confines the path with confinePreview before reading:
-// a preview runs before the permission gate, so without it an absolute path
-// outside the write roots would be read (and its contents diffed into the
-// approval card and session log) even though Execute would refuse the write.
+// Execute would persist (asserted by TestPreviewMatchesExecute in
+// preview_test.go; drift fails the test rather than the preview lying).
 
 // Preview computes the change write_file would make. A path that does not yet
 // exist is a Create; an existing one is a Modify.

--- a/internal/tool/builtin/preview_confine_test.go
+++ b/internal/tool/builtin/preview_confine_test.go
@@ -1,0 +1,91 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/tool"
+)
+
+// Preview runs before the permission gate, so its read must be exactly as
+// confined as Execute's write: an absolute path outside the workspace roots
+// must error in Preview the way Execute would refuse it, instead of rendering
+// the secret file's contents into the approval card and session log.
+func TestPreviewRejectsPathsOutsideWriteRoots(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir() // a different tree: never inside the workspace
+	secret := filepath.Join(outside, "id_rsa")
+	if err := os.WriteFile(secret, []byte("SECRET MATERIAL\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	guard := NewSessionDataGuard(workspace, nil)
+	tools := ConfineWriters([]string{workspace}, guard, ManagedConfigPaths{})
+
+	previews := map[string]tool.Previewer{}
+	for _, tl := range tools {
+		if p, ok := tl.(tool.Previewer); ok {
+			previews[tl.Name()] = p
+		}
+	}
+
+	cases := map[string]map[string]any{
+		"write_file": {"path": secret, "content": "x"},
+		"edit_file":  {"path": secret, "old_string": "SECRET", "new_string": "PWNED"},
+		"multi_edit": {"path": secret, "edits": []map[string]any{{"old_string": "SECRET", "new_string": "PWNED"}}},
+	}
+	for name, args := range cases {
+		p, ok := previews[name]
+		if !ok {
+			t.Fatalf("%s does not implement tool.Previewer", name)
+		}
+		raw, err := json.Marshal(args)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := p.Preview(context.Background(), raw); err == nil {
+			t.Fatalf("%s previewed an out-of-roots path without error", name)
+		}
+	}
+}
+
+// The in-workspace happy path must keep working: Preview still renders a real
+// diff for a file the write roots cover.
+func TestPreviewAllowsInWorkspacePaths(t *testing.T) {
+	workspace := t.TempDir()
+	target := filepath.Join(workspace, "notes.txt")
+	if err := os.WriteFile(target, []byte("hello world\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	guard := NewSessionDataGuard(workspace, nil)
+	for _, tl := range ConfineWriters([]string{workspace}, guard, ManagedConfigPaths{}) {
+		p, ok := tl.(tool.Previewer)
+		if !ok {
+			continue
+		}
+		var args map[string]any
+		switch tl.Name() {
+		case "write_file":
+			args = map[string]any{"path": target, "content": "new\n"}
+		case "edit_file":
+			args = map[string]any{"path": target, "old_string": "world", "new_string": "reasonix"}
+		case "multi_edit":
+			args = map[string]any{"path": target, "edits": []map[string]any{{"old_string": "hello", "new_string": "hi"}}}
+		default:
+			continue
+		}
+		raw, err := json.Marshal(args)
+		if err != nil {
+			t.Fatal(err)
+		}
+		change, err := p.Preview(context.Background(), raw)
+		if err != nil {
+			t.Fatalf("%s preview inside workspace: %v", tl.Name(), err)
+		}
+		if change.Path == "" && change.NewText == "" && change.OldText == "" {
+			t.Fatalf("%s preview produced an empty change inside the workspace", tl.Name())
+		}
+	}
+}

--- a/internal/tool/builtin/preview_confine_test.go
+++ b/internal/tool/builtin/preview_confine_test.go
@@ -22,31 +22,35 @@ func TestPreviewRejectsPathsOutsideWriteRoots(t *testing.T) {
 		t.Fatal(err)
 	}
 	guard := NewSessionDataGuard(workspace, nil)
-	tools := ConfineWriters([]string{workspace}, guard, ManagedConfigPaths{})
-
-	previews := map[string]tool.Previewer{}
-	for _, tl := range tools {
-		if p, ok := tl.(tool.Previewer); ok {
-			previews[tl.Name()] = p
-		}
-	}
-
 	cases := map[string]map[string]any{
-		"write_file": {"path": secret, "content": "x"},
-		"edit_file":  {"path": secret, "old_string": "SECRET", "new_string": "PWNED"},
-		"multi_edit": {"path": secret, "edits": []map[string]any{{"old_string": "SECRET", "new_string": "PWNED"}}},
+		"write_file":    {"path": secret, "content": "x"},
+		"edit_file":     {"path": secret, "old_string": "SECRET", "new_string": "PWNED"},
+		"multi_edit":    {"path": secret, "edits": []map[string]any{{"old_string": "SECRET", "new_string": "PWNED"}}},
+		"delete_range":  {"path": secret, "start_anchor": "SECRET MATERIAL", "end_anchor": "SECRET MATERIAL"},
+		"delete_symbol": {"path": secret, "name": "secret"},
 	}
-	for name, args := range cases {
-		p, ok := previews[name]
-		if !ok {
-			t.Fatalf("%s does not implement tool.Previewer", name)
+	for _, managed := range []ManagedConfigPaths{
+		{},
+		NewManagedConfigPaths([]string{secret}),
+	} {
+		previews := map[string]tool.Previewer{}
+		for _, tl := range ConfineWriters([]string{workspace}, guard, managed) {
+			if p, ok := tl.(tool.Previewer); ok {
+				previews[tl.Name()] = p
+			}
 		}
-		raw, err := json.Marshal(args)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := p.Preview(context.Background(), raw); err == nil {
-			t.Fatalf("%s previewed an out-of-roots path without error", name)
+		for name, args := range cases {
+			p, ok := previews[name]
+			if !ok {
+				t.Fatalf("%s does not implement tool.Previewer", name)
+			}
+			raw, err := json.Marshal(args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := p.Preview(context.Background(), raw); err == nil {
+				t.Fatalf("%s previewed an out-of-roots path without error", name)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes six privately reported security-boundary gaps confirmed against `main-v2` (triage advisories GHSA-5gf8-hg54-m9q9 F1/F2, GHSA-grg2-7gc6-36m6, GHSA-pw6p-hp72-84q8, GHSA-5cvr-h8q4-47j4, and the cargo-check finding from GHSA-6qf8-c4r6-q4qq).

| # | Boundary gap | Fix |
|---|---|---|
| 1 | `reasonix serve` validated neither `Host` nor `Origin`; a DNS-rebinding page became same-origin with the unauthenticated loopback listener and drove `/bypass`, `/submit`, and read `/history` past the JSON CSRF guard | `hostGuard` middleware returns 421 unless `Host` is loopback or the actual listen address; listen address plumbed through `setListenAddr` from every Run entry point. `behind_proxy` deployments and wildcard/non-loopback binds are exempt (deliberate exposure). The non-loopback plaintext startup warning now also fires — loudest — for `auth = none` |
| 2 | `write_file`/`edit_file`/`multi_edit` `Preview()` read model-supplied absolute paths unconfined, leaking out-of-workspace file contents into approval cards and session logs while `Execute` would refuse the write | The three previews apply `confinePreview` after `resolveIn`, matching `delete_range`/`delete_symbol` |
| 3 | gitcmd diff invocations still executed repository-configured `filter.<driver>.clean` via `.gitattributes` — the residual the package's own doc comment names | Diff invocations neutralize every filter driver defined in the repository-local `.git/config` (`clean=` emptied, `required` forced off; linked-worktree `.git` followed). An emptied filter is an identity pass-through: the diff still renders the real working-tree change. Residuals documented: `include.path` chains, `core.sshCommand` |
| 4 | `install_source`'s SSRF dial guard validated only the proxy address when an HTTP/HTTPS proxy was configured; blocked IP-literal destinations were forwarded unchecked | `ssrfRequestGuard` RoundTripper rejects blocked IP literals (cloud metadata, RFC1918, link-local, CGNAT) before any proxy forwarding — the same boundary `web_fetch` enforces |
| 5 | The bash indirect-execution classifier missed `awk`/`gawk`/`mawk`/`nawk`, so `awk 'BEGIN{system("…")}'` fell into the reusable-approval class (auto-allowed under Allow mode / remembered prefix rules) | awk-family invocations with an inline program (not `-f`/`--file`) are classified as indirect execution like `python -c`: always human approval, never a reusable prefix |
| 6 | The legacy read-only prefix table still listed `cargo check`/`cargo doc` as permission readers although cargo executes the crate's `build.rs` for both | Both removed from `readOnlyPrefixes` (`cargo search` stays); the effect classifier already billed them as code-executing writers |

## Verification

- `go test ./internal/gitcmd ./internal/shellsafe ./internal/permission ./internal/installsource ./internal/tool/builtin ./internal/serve ./internal/cli` — all green on a clean `origin/main-v2` worktree.
- New regression tests reproduce each report end-to-end:
  - rebinding `Host` values (including IPv4-mapped forms) rejected with 421 before `csrfGuard`; loopback, listen-host, wildcard-bind, and `behind_proxy` behaviors pinned;
  - confined previews error on out-of-roots paths exactly like `Execute`, in-workspace previews still render;
  - a `filter.pwn` clean + `required=true` marker payload does **not** run during `gitcmd` diff (both the `-C`-in-args and dir-parameter shapes) while the diff output still shows the working-tree change — verified against real git;
  - a recording HTTP proxy receives zero blocked-destination forwards; loopback still passes through;
  - awk `system()` and `| getline` shapes require human approval; `awk -f script.awk` stays reusable;
  - `cargo check`/`cargo doc` asserted not read-only.

## Compatibility / cache impact

- No persisted-format, provider-visible prompt/tool-byte, or MCP registration changes → no cache impact.
- Behavior notes: awk inline programs now always prompt (like `python -c`); `cargo check`/`doc` now prompt under the legacy read-only path; LFS-filtered files degrade to whole-file diffs in the workspace-changes viewer (safe-by-default tradeoff, documented in the gitcmd package comment).

## Policy fields

Cache-impact: none - no provider-visible prompt, tool-schema, or serialization bytes change; installsource gains a request-level SSRF wrapper and builtin previews gain a confinement check before reading, both invisible to providers.
Cache-guard: scripts/cache-guard.sh passes on this branch (cachehit e2e cases all status=pass); no prompt or tool-schema surface is touched, so the existing guard remains the covering rationale.
Documentation-impact: none - internal security enforcement only; user-visible behavior notes are recorded in the CHANGELOG Unreleased section and no docs/*.md page describes these code paths.
