### PR TITLE
fix(mcp): harden Streamable HTTP compatibility / 修复 Streamable HTTP 兼容性

### DIFF
--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mattn/go-pointer v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.27 // indirect
-	github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect
+	github.com/modelcontextprotocol/go-sdk v1.7.1-0.20260825122737-c68ad9a4e6e1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -93,8 +93,8 @@ github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o
 github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=
 github.com/mattn/go-runewidth v0.0.27 h1:Feg/Oou5zI/wnpgDF6omIU0OokC9GxLC/WRknhVlIR0=
 github.com/mattn/go-runewidth v0.0.27/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0IGEXZ9jeHp/8=
-github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
-github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
+github.com/modelcontextprotocol/go-sdk v1.7.1-0.20260825122737-c68ad9a4e6e1 h1:rTPZySmS2UtXGKUvbjh2JaiLxKcFtPUHzrsiExDtOrI=
+github.com/modelcontextprotocol/go-sdk v1.7.1-0.20260825122737-c68ad9a4e6e1/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/kevinburke/ssh_config v1.6.0
 	github.com/larksuite/oapi-sdk-go/v3 v3.9.9
 	github.com/mattn/go-runewidth v0.0.27
-	github.com/modelcontextprotocol/go-sdk v1.7.0
+	github.com/modelcontextprotocol/go-sdk v1.7.1-0.20260825122737-c68ad9a4e6e1
 	github.com/pkg/sftp v1.13.11
 	github.com/rivo/uniseg v0.4.7
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o
 github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=
 github.com/mattn/go-runewidth v0.0.27 h1:Feg/Oou5zI/wnpgDF6omIU0OokC9GxLC/WRknhVlIR0=
 github.com/mattn/go-runewidth v0.0.27/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0IGEXZ9jeHp/8=
-github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
-github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
+github.com/modelcontextprotocol/go-sdk v1.7.1-0.20260825122737-c68ad9a4e6e1 h1:rTPZySmS2UtXGKUvbjh2JaiLxKcFtPUHzrsiExDtOrI=
+github.com/modelcontextprotocol/go-sdk v1.7.1-0.20260825122737-c68ad9a4e6e1/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=

--- a/internal/plugin/sdk_errors.go
+++ b/internal/plugin/sdk_errors.go
@@ -67,6 +67,9 @@ func hasMCPTransportRejection(err error) bool {
 	return found
 }
 
+// visitMCPRPCErrors walks every concrete error-tree node because errors.As
+// returns only the first matching RPC error and would hide transport evidence.
+//nolint:errorlint // Direct inspection distinguishes server errors from the SDK transport sentinel.
 func visitMCPRPCErrors(err error, visit func(*mcpjsonrpc.Error)) {
 	if err == nil {
 		return

--- a/internal/plugin/sdk_errors.go
+++ b/internal/plugin/sdk_errors.go
@@ -14,23 +14,25 @@ func isExplicitMCPSessionMissing(err error) bool {
 	if errors.Is(err, mcpsdk.ErrSessionMissing) {
 		return true
 	}
-	var rpcErr *mcpjsonrpc.Error
-	if !errors.As(err, &rpcErr) || rpcErr == nil {
+	if !isMCPHTTPNotFound(err) || !hasMCPTransportRejection(err) {
 		return false
 	}
-	message := strings.ToLower(strings.TrimSpace(rpcErr.Message))
-	for _, marker := range []string{
-		"session not found",
-		"session missing",
-		"session expired",
-		"invalid session",
-		"unknown session",
-	} {
-		if strings.Contains(message, marker) {
-			return true
+	found := false
+	visitMCPRPCErrors(err, func(rpcErr *mcpjsonrpc.Error) {
+		message := strings.ToLower(strings.TrimSpace(rpcErr.Message))
+		for _, marker := range []string{
+			"session not found",
+			"session missing",
+			"session expired",
+			"invalid session",
+			"unknown session",
+		} {
+			if strings.Contains(message, marker) {
+				found = true
+			}
 		}
-	}
-	return false
+	})
+	return found
 }
 
 // isMCPHTTPNotFound recognizes the status-only error emitted by newer Go MCP
@@ -41,11 +43,49 @@ func isMCPHTTPNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
+	hasRPCError := false
+	visitMCPRPCErrors(err, func(*mcpjsonrpc.Error) {
+		hasRPCError = true
+	})
+	if hasRPCError && !hasMCPTransportRejection(err) {
+		return false
+	}
 	message := strings.ToLower(strings.TrimSpace(err.Error()))
 	return message == "not found" ||
 		strings.HasSuffix(message, ": not found") ||
 		strings.Contains(message, "http 404") ||
 		strings.Contains(message, "status 404")
+}
+
+func hasMCPTransportRejection(err error) bool {
+	found := false
+	visitMCPRPCErrors(err, func(rpcErr *mcpjsonrpc.Error) {
+		if rpcErr.Code == -32005 && strings.EqualFold(strings.TrimSpace(rpcErr.Message), "rejected by transport") {
+			found = true
+		}
+	})
+	return found
+}
+
+func visitMCPRPCErrors(err error, visit func(*mcpjsonrpc.Error)) {
+	if err == nil {
+		return
+	}
+	if rpcErr, ok := err.(*mcpjsonrpc.Error); ok && rpcErr != nil {
+		visit(rpcErr)
+	}
+	switch wrapped := err.(type) {
+	case interface{ Unwrap() []error }:
+		for _, child := range wrapped.Unwrap() {
+			visitMCPRPCErrors(child, visit)
+		}
+	case interface{ Unwrap() error }:
+		visitMCPRPCErrors(wrapped.Unwrap(), visit)
+	}
+}
+
+func (t *sdkSessionTransport) isStreamableHTTPNotFound(err error) bool {
+	return canonicalMCPRuntimeTransport(t.spec.Type) == "streamable-http" && isMCPHTTPNotFound(err)
 }
 
 func isTerminalSDKError(err error) bool {

--- a/internal/plugin/sdk_errors.go
+++ b/internal/plugin/sdk_errors.go
@@ -69,6 +69,7 @@ func hasMCPTransportRejection(err error) bool {
 
 // visitMCPRPCErrors walks every concrete error-tree node because errors.As
 // returns only the first matching RPC error and would hide transport evidence.
+//
 //nolint:errorlint // Direct inspection distinguishes server errors from the SDK transport sentinel.
 func visitMCPRPCErrors(err error, visit func(*mcpjsonrpc.Error)) {
 	if err == nil {

--- a/internal/plugin/sdk_errors.go
+++ b/internal/plugin/sdk_errors.go
@@ -6,8 +6,47 @@ import (
 	"io"
 	"strings"
 
+	mcpjsonrpc "github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+func isExplicitMCPSessionMissing(err error) bool {
+	if errors.Is(err, mcpsdk.ErrSessionMissing) {
+		return true
+	}
+	var rpcErr *mcpjsonrpc.Error
+	if !errors.As(err, &rpcErr) || rpcErr == nil {
+		return false
+	}
+	message := strings.ToLower(strings.TrimSpace(rpcErr.Message))
+	for _, marker := range []string{
+		"session not found",
+		"session missing",
+		"session expired",
+		"invalid session",
+		"unknown session",
+	} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// isMCPHTTPNotFound recognizes the status-only error emitted by newer Go MCP
+// SDKs for a plain HTTP 404 when no session ID exists. It intentionally does
+// not match arbitrary "not found" prose so a tool-level domain error cannot be
+// mistaken for an endpoint or protocol mismatch.
+func isMCPHTTPNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(strings.TrimSpace(err.Error()))
+	return message == "not found" ||
+		strings.HasSuffix(message, ": not found") ||
+		strings.Contains(message, "http 404") ||
+		strings.Contains(message, "status 404")
+}
 
 func isTerminalSDKError(err error) bool {
 	return errors.Is(err, mcpsdk.ErrConnectionClosed) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
@@ -31,7 +70,7 @@ func classifySessionError(err error) SessionErrorKind {
 		return SessionErrorNone
 	}
 	switch {
-	case errors.Is(err, mcpsdk.ErrSessionMissing):
+	case isExplicitMCPSessionMissing(err):
 		return SessionErrorSessionMissing
 	case errors.Is(err, context.DeadlineExceeded):
 		return SessionErrorTimeout

--- a/internal/plugin/sdk_session.go
+++ b/internal/plugin/sdk_session.go
@@ -192,67 +192,6 @@ func hasExplicitMCPAuth(s Spec) bool {
 	return mcpdiag.HasAuthConfig(s.Headers, s.Env, s.URL)
 }
 
-func (t *sdkSessionTransport) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
-	managed, err := t.acquire(ctx)
-	if err != nil {
-		return nil, t.sanitizeError(err, nil)
-	}
-	result, err := t.invokeManaged(ctx, managed, method, params)
-	if err == nil {
-		t.clearRuntimeError(managed)
-		return result, nil
-	}
-
-	if errors.Is(err, mcpsdk.ErrSessionMissing) {
-		if managed.session.ID() == "" {
-			endpointErr := fmt.Errorf("MCP endpoint returned HTTP 404 without an established session: %w", err)
-			t.noteRuntimeError(managed, SessionErrorProtocol, endpointErr)
-			return nil, t.sanitizeError(endpointErr, managed)
-		}
-		t.noteRuntimeError(managed, SessionErrorSessionMissing, err)
-		t.invalidate(managed)
-		replacement, rebuildErr := t.acquire(ctx)
-		if rebuildErr != nil {
-			return nil, t.sanitizeError(fmt.Errorf("MCP session expired; rebuild failed: %w", rebuildErr), managed)
-		}
-		result, err = t.invokeManaged(ctx, replacement, method, params)
-		if err == nil {
-			t.clearRuntimeError(replacement)
-			return result, nil
-		}
-		return nil, t.sanitizeError(err, replacement)
-	}
-
-	if isTerminalSDKError(err) || isAmbiguousTransportError(err) || errors.Is(err, context.DeadlineExceeded) {
-		kind := SessionErrorStreamClosed
-		if errors.Is(err, context.DeadlineExceeded) {
-			kind = SessionErrorTimeout
-		} else if !isTerminalSDKError(err) {
-			kind = SessionErrorTransport
-		}
-		t.noteRuntimeError(managed, kind, err)
-		t.invalidate(managed)
-		if safeToReplayMCPMethod(method) {
-			replacement, rebuildErr := t.acquire(ctx)
-			if rebuildErr != nil {
-				return nil, t.sanitizeError(fmt.Errorf("MCP connection closed; rebuild failed: %w", rebuildErr), managed)
-			}
-			result, err = t.invokeManaged(ctx, replacement, method, params)
-			if err == nil {
-				t.clearRuntimeError(replacement)
-				return result, nil
-			}
-			return nil, t.sanitizeError(err, replacement)
-		}
-		t.startAutoReconnect()
-		return nil, t.sanitizeError(fmt.Errorf("MCP tool connection closed after dispatch; execution result is unknown and the call was not retried: %w", err), managed)
-	}
-
-	kind := classifySessionError(err)
-	t.noteRuntimeError(managed, kind, err)
-	return nil, t.sanitizeError(err, managed)
-}
-
 func (t *sdkSessionTransport) registerProgress(token string, sink tool.ProgressFunc) func() {
 	unregister := t.progress.registerProgress(token, sink)
 	var once sync.Once
@@ -413,6 +352,9 @@ func (t *sdkSessionTransport) build(ctx context.Context, generation uint64) (*ma
 			t.dispatchSDKProgress(generation, req.Params)
 		},
 	})
+	if canonicalMCPRuntimeTransport(t.spec.Type) == "streamable-http" {
+		client.AddSendingMiddleware(asyncStreamableHTTPSubscriptions)
+	}
 	for _, root := range mcpRoots(t.spec.WorkspaceRoot) {
 		//nolint:staticcheck // Preserve the existing workspace-root contract for legacy MCP servers.
 		client.AddRoots(&mcpsdk.Root{URI: root.URI, Name: root.Name})
@@ -560,7 +502,7 @@ func (t *sdkSessionTransport) handleSessionEnd(managed *managedMCPSession, err e
 		return
 	}
 	t.current = nil
-	if errors.Is(err, mcpsdk.ErrSessionMissing) && managed.session.ID() == "" {
+	if managed.session.ID() == "" && (errors.Is(err, mcpsdk.ErrSessionMissing) || isMCPHTTPNotFound(err)) {
 		t.state = SessionStateFailed
 		t.lastErrorKind = SessionErrorProtocol
 		t.lastError = t.safeErrorText(fmt.Errorf("MCP endpoint returned HTTP 404 without an established session: %w", err), "")

--- a/internal/plugin/sdk_session.go
+++ b/internal/plugin/sdk_session.go
@@ -502,7 +502,7 @@ func (t *sdkSessionTransport) handleSessionEnd(managed *managedMCPSession, err e
 		return
 	}
 	t.current = nil
-	if managed.session.ID() == "" && (errors.Is(err, mcpsdk.ErrSessionMissing) || isMCPHTTPNotFound(err)) {
+	if managed.session.ID() == "" && (errors.Is(err, mcpsdk.ErrSessionMissing) || t.isStreamableHTTPNotFound(err)) {
 		t.state = SessionStateFailed
 		t.lastErrorKind = SessionErrorProtocol
 		t.lastError = t.safeErrorText(fmt.Errorf("MCP endpoint returned HTTP 404 without an established session: %w", err), "")

--- a/internal/plugin/sdk_session_call.go
+++ b/internal/plugin/sdk_session_call.go
@@ -1,0 +1,69 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+func (t *sdkSessionTransport) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	managed, err := t.acquire(ctx)
+	if err != nil {
+		return nil, t.sanitizeError(err, nil)
+	}
+	result, err := t.invokeManaged(ctx, managed, method, params)
+	if err == nil {
+		t.clearRuntimeError(managed)
+		return result, nil
+	}
+
+	if isExplicitMCPSessionMissing(err) || managed.session.ID() == "" && isMCPHTTPNotFound(err) {
+		if managed.session.ID() == "" {
+			endpointErr := fmt.Errorf("MCP endpoint returned HTTP 404 without an established session: %w", err)
+			t.noteRuntimeError(managed, SessionErrorProtocol, endpointErr)
+			return nil, t.sanitizeError(endpointErr, managed)
+		}
+		t.noteRuntimeError(managed, SessionErrorSessionMissing, err)
+		t.invalidate(managed)
+		replacement, rebuildErr := t.acquire(ctx)
+		if rebuildErr != nil {
+			return nil, t.sanitizeError(fmt.Errorf("MCP session expired; rebuild failed: %w", rebuildErr), managed)
+		}
+		result, err = t.invokeManaged(ctx, replacement, method, params)
+		if err == nil {
+			t.clearRuntimeError(replacement)
+			return result, nil
+		}
+		return nil, t.sanitizeError(err, replacement)
+	}
+
+	if isTerminalSDKError(err) || isAmbiguousTransportError(err) || errors.Is(err, context.DeadlineExceeded) {
+		kind := SessionErrorStreamClosed
+		if errors.Is(err, context.DeadlineExceeded) {
+			kind = SessionErrorTimeout
+		} else if !isTerminalSDKError(err) {
+			kind = SessionErrorTransport
+		}
+		t.noteRuntimeError(managed, kind, err)
+		t.invalidate(managed)
+		if safeToReplayMCPMethod(method) {
+			replacement, rebuildErr := t.acquire(ctx)
+			if rebuildErr != nil {
+				return nil, t.sanitizeError(fmt.Errorf("MCP connection closed; rebuild failed: %w", rebuildErr), managed)
+			}
+			result, err = t.invokeManaged(ctx, replacement, method, params)
+			if err == nil {
+				t.clearRuntimeError(replacement)
+				return result, nil
+			}
+			return nil, t.sanitizeError(err, replacement)
+		}
+		t.startAutoReconnect()
+		return nil, t.sanitizeError(fmt.Errorf("MCP tool connection closed after dispatch; execution result is unknown and the call was not retried: %w", err), managed)
+	}
+
+	kind := classifySessionError(err)
+	t.noteRuntimeError(managed, kind, err)
+	return nil, t.sanitizeError(err, managed)
+}

--- a/internal/plugin/sdk_session_call.go
+++ b/internal/plugin/sdk_session_call.go
@@ -18,7 +18,7 @@ func (t *sdkSessionTransport) call(ctx context.Context, method string, params an
 		return result, nil
 	}
 
-	if isExplicitMCPSessionMissing(err) || managed.session.ID() == "" && isMCPHTTPNotFound(err) {
+	if isExplicitMCPSessionMissing(err) || managed.session.ID() == "" && t.isStreamableHTTPNotFound(err) {
 		if managed.session.ID() == "" {
 			endpointErr := fmt.Errorf("MCP endpoint returned HTTP 404 without an established session: %w", err)
 			t.noteRuntimeError(managed, SessionErrorProtocol, endpointErr)

--- a/internal/plugin/sdk_session_error_test.go
+++ b/internal/plugin/sdk_session_error_test.go
@@ -1,0 +1,104 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	mcpjsonrpc "github.com/modelcontextprotocol/go-sdk/jsonrpc"
+)
+
+func TestApplicationJSONRPCSessionErrorsAreNotTransportLoss(t *testing.T) {
+	for _, message := range []string{
+		"session not found",
+		"session missing",
+		"session expired",
+		"invalid session",
+		"unknown session",
+	} {
+		err := fmt.Errorf("calling tool: %w", &mcpjsonrpc.Error{Code: -32042, Message: message})
+		if isExplicitMCPSessionMissing(err) {
+			t.Errorf("isExplicitMCPSessionMissing(%q) = true, want false without transport rejection", message)
+		}
+	}
+
+	err := fmt.Errorf("calling tool: %w", &mcpjsonrpc.Error{Code: -32042, Message: "not found"})
+	if isMCPHTTPNotFound(err) {
+		t.Fatal("application JSON-RPC not-found error was classified as HTTP 404")
+	}
+}
+
+func TestStructuredHTTP404SessionErrorIsTransportLoss(t *testing.T) {
+	sessionErr := &mcpjsonrpc.Error{Code: -32042, Message: "Session not found"}
+	rejectedErr := &mcpjsonrpc.Error{Code: -32005, Message: "rejected by transport"}
+	err := fmt.Errorf("sending tools/call: %w: %w: Not Found", sessionErr, rejectedErr)
+	if !isExplicitMCPSessionMissing(err) {
+		t.Fatal("structured HTTP 404 session error was not classified as transport session loss")
+	}
+}
+
+func TestHTTPTransportApplicationSessionErrorDoesNotReplayToolCall(t *testing.T) {
+	var initializeCount atomic.Int32
+	var toolCallCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+
+		switch req.Method {
+		case "server/discover":
+			writeRawHTTPRPCError(w, req.ID, -32601, "method not found")
+		case "initialize":
+			initializeCount.Add(1)
+			w.Header().Set("Mcp-Session-Id", "application-session")
+			writeRawHTTPRPCResult(w, req.ID, map[string]any{
+				"protocolVersion": testLegacyProtocolVersion,
+				"serverInfo":      map[string]any{"name": "application-error", "version": "1"},
+				"capabilities":    map[string]any{"tools": map[string]any{}},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			writeRawHTTPRPCResult(w, req.ID, map[string]any{"tools": []any{}})
+		case "tools/call":
+			toolCallCount.Add(1)
+			writeRawHTTPRPCError(w, req.ID, -32042, "invalid session")
+		default:
+			http.Error(w, "unknown method", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	transport, err := newHTTPTransport(Spec{Name: "application-error", Type: "http", URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transport.close()
+	if _, err := transport.call(t.Context(), "tools/list", map[string]any{}); err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	if _, err := transport.call(t.Context(), "tools/call", map[string]any{
+		"name": "write", "arguments": map[string]any{},
+	}); err == nil || !strings.Contains(err.Error(), "invalid session") {
+		t.Fatalf("tools/call error = %v, want application error", err)
+	}
+	if got := initializeCount.Load(); got != 1 {
+		t.Fatalf("initialize count = %d, want no session rebuild", got)
+	}
+	if got := toolCallCount.Load(); got != 1 {
+		t.Fatalf("tools/call count = %d, want no replay", got)
+	}
+}

--- a/internal/plugin/transport_http.go
+++ b/internal/plugin/transport_http.go
@@ -15,6 +15,32 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+const mcpSubscriptionsListenMethod = "subscriptions/listen"
+
+// asyncStreamableHTTPSubscriptions keeps the optional SEP-2575 notification
+// stream from becoming part of the mandatory startup critical path. Some MCP
+// HTTP bridges buffer a streaming Web Response before writing HTTP response
+// headers, so the SDK's synchronous transport write would otherwise block
+// Client.Connect even though server/discover already completed successfully.
+//
+// The underlying call still uses the SDK-owned connection and context. A
+// compliant server therefore keeps delivering notifications normally, while a
+// buffering server is cancelled with the session without blocking tools/list.
+func asyncStreamableHTTPSubscriptions(next mcpsdk.MethodHandler) mcpsdk.MethodHandler {
+	return func(ctx context.Context, method string, req mcpsdk.Request) (mcpsdk.Result, error) {
+		if method != mcpSubscriptionsListenMethod {
+			return next(ctx, method, req)
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		go func() {
+			_, _ = next(ctx, method, req)
+		}()
+		return &mcpsdk.SubscriptionsListenResult{}, nil
+	}
+}
+
 func newHTTPTransport(s Spec) (*sdkSessionTransport, error) {
 	if strings.TrimSpace(s.Type) == "" {
 		s.Type = "http"

--- a/internal/plugin/transport_http_compat_test.go
+++ b/internal/plugin/transport_http_compat_test.go
@@ -1,0 +1,455 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestHTTPTransportBufferedSubscriptionDoesNotBlockStartup(t *testing.T) {
+	listenStarted := make(chan struct{})
+	listenStopped := make(chan struct{})
+	var started atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     *int   `json:"id"`
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+
+		switch req.Method {
+		case "server/discover":
+			writeHTTPRPCResult(w, req.ID, map[string]any{
+				"supportedVersions": []string{"2026-07-28"},
+				"capabilities": map[string]any{
+					"tools":     map[string]any{"listChanged": true},
+					"resources": map[string]any{"listChanged": true},
+				},
+				"_meta": map[string]any{
+					"io.modelcontextprotocol/serverInfo": map[string]any{"name": "qmd-like", "version": "1"},
+				},
+			})
+		case "subscriptions/listen":
+			if started.CompareAndSwap(false, true) {
+				close(listenStarted)
+			}
+			// qmd 2.8.3 converts the infinite Web Response to an arrayBuffer
+			// before writing Node's response headers. Model that observable wire
+			// behavior: the request arrived, but no headers are ever flushed.
+			<-r.Context().Done()
+			close(listenStopped)
+		case "tools/list":
+			writeHTTPRPCResult(w, req.ID, map[string]any{"tools": []map[string]any{{
+				"name":        "query",
+				"description": "Search local markdown.",
+				"inputSchema": map[string]any{"type": "object"},
+			}}})
+		default:
+			http.Error(w, "unknown method", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	host, tools, err := StartAll(ctx, []Spec{{
+		Name: "qmd-like", Type: "http", URL: srv.URL, StartupTimeout: 750 * time.Millisecond,
+	}})
+	if err != nil {
+		t.Fatalf("StartAll: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name() != "mcp__qmd-like__query" {
+		host.Close()
+		t.Fatalf("tools = %v, want [mcp__qmd-like__query]", names(tools))
+	}
+	select {
+	case <-listenStarted:
+	case <-time.After(time.Second):
+		host.Close()
+		t.Fatal("subscriptions/listen was not attempted")
+	}
+
+	host.Close()
+	select {
+	case <-listenStopped:
+	case <-time.After(time.Second):
+		t.Fatal("buffered subscriptions/listen request survived host close")
+	}
+}
+
+func TestHTTPTransportAsyncSubscriptionStillRoutesNotifications(t *testing.T) {
+	notificationSent := make(chan struct{})
+	var sent atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+
+		switch req.Method {
+		case "server/discover":
+			writeRawHTTPRPCResult(w, req.ID, map[string]any{
+				"supportedVersions": []string{"2026-07-28"},
+				"capabilities": map[string]any{
+					"tools": map[string]any{"listChanged": true},
+				},
+				"_meta": map[string]any{
+					"io.modelcontextprotocol/serverInfo": map[string]any{"name": "streaming", "version": "1"},
+				},
+			})
+		case "subscriptions/listen":
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			ack, _ := json.Marshal(map[string]any{
+				"jsonrpc": "2.0", "method": "notifications/subscriptions/acknowledged",
+				"params": map[string]any{
+					"notifications": map[string]any{"toolsListChanged": true},
+					"_meta":         map[string]any{"io.modelcontextprotocol/subscriptionId": json.RawMessage(req.ID)},
+				},
+			})
+			changed, _ := json.Marshal(map[string]any{
+				"jsonrpc": "2.0", "method": "notifications/tools/list_changed",
+				"params": map[string]any{
+					"_meta": map[string]any{"io.modelcontextprotocol/subscriptionId": json.RawMessage(req.ID)},
+				},
+			})
+			fmt.Fprintf(w, "event: message\ndata: %s\n\nevent: message\ndata: %s\n\n", ack, changed)
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			if sent.CompareAndSwap(false, true) {
+				close(notificationSent)
+			}
+			<-r.Context().Done()
+		case "tools/list":
+			writeRawHTTPRPCResult(w, req.ID, map[string]any{"tools": []map[string]any{{
+				"name": "query", "inputSchema": map[string]any{"type": "object"},
+			}}})
+		default:
+			http.Error(w, "unknown method", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	transport, err := newHTTPTransport(Spec{Name: "streaming", Type: "http", URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transport.close()
+	notificationReceived := make(chan json.RawMessage, 1)
+	unregister := transport.registerNotification("notifications/tools/list_changed", func(params json.RawMessage) {
+		notificationReceived <- params
+	})
+	defer unregister()
+
+	if _, err := transport.call(t.Context(), "tools/list", map[string]any{}); err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	select {
+	case <-notificationSent:
+	case <-time.After(time.Second):
+		t.Fatal("server did not flush the subscription notification")
+	}
+	select {
+	case params := <-notificationReceived:
+		if !strings.Contains(string(params), "subscriptionId") {
+			t.Fatalf("notification params = %s, want subscription metadata", params)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("streamed tools/list_changed notification was not routed")
+	}
+}
+
+func TestHTTPTransportStatelessSubscription404KeepsSessionUsable(t *testing.T) {
+	listenServed := make(chan struct{})
+	var discoverCount atomic.Int32
+	var listCount atomic.Int32
+	var listenReported atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+
+		switch req.Method {
+		case "server/discover":
+			discoverCount.Add(1)
+			writeRawHTTPRPCResult(w, req.ID, map[string]any{
+				"supportedVersions": []string{"2026-07-28"},
+				"capabilities": map[string]any{
+					"tools": map[string]any{"listChanged": true},
+				},
+				"_meta": map[string]any{
+					"io.modelcontextprotocol/serverInfo": map[string]any{"name": "stateless-404", "version": "1"},
+				},
+			})
+		case "subscriptions/listen":
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("404 Not Found"))
+			if listenReported.CompareAndSwap(false, true) {
+				close(listenServed)
+			}
+		case "tools/list":
+			listCount.Add(1)
+			writeRawHTTPRPCResult(w, req.ID, map[string]any{"tools": []any{}})
+		default:
+			http.Error(w, "unknown method", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	transport, err := newHTTPTransport(Spec{Name: "stateless-404", Type: "http", URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transport.close()
+	if _, err := transport.call(t.Context(), "tools/list", map[string]any{}); err != nil {
+		t.Fatalf("first tools/list: %v", err)
+	}
+	select {
+	case <-listenServed:
+	case <-time.After(time.Second):
+		t.Fatal("subscriptions/listen was not rejected")
+	}
+	if _, err := transport.call(t.Context(), "tools/list", map[string]any{}); err != nil {
+		t.Fatalf("tools/list after subscriptions/listen 404: %v", err)
+	}
+	if got := discoverCount.Load(); got != 1 {
+		t.Fatalf("server/discover count = %d, want one surviving stateless session", got)
+	}
+	if got := listCount.Load(); got != 2 {
+		t.Fatalf("tools/list count = %d, want 2", got)
+	}
+	transport.mu.Lock()
+	generations := transport.nextGeneration
+	transport.mu.Unlock()
+	if generations != 1 {
+		t.Fatalf("supervisor generations = %d, want no rebuild after optional subscription 404", generations)
+	}
+}
+
+func TestHTTPTransportPerCallJSONRPC4xxKeepsSession(t *testing.T) {
+	var discoverCount atomic.Int32
+	var toolCallCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+
+		switch req.Method {
+		case "server/discover":
+			discoverCount.Add(1)
+			writeRawHTTPRPCResult(w, req.ID, map[string]any{
+				"supportedVersions": []string{"2026-07-28"},
+				"capabilities":      map[string]any{"tools": map[string]any{}},
+				"_meta": map[string]any{
+					"io.modelcontextprotocol/serverInfo": map[string]any{"name": "request-error", "version": "1"},
+				},
+			})
+		case "tools/list":
+			writeRawHTTPRPCResult(w, req.ID, map[string]any{"tools": []any{}})
+		case "subscriptions/listen":
+			// Keep the optional SEP-2575 listener out of this test's failure
+			// path so the HTTP 400 below is attributable to tools/call.
+			writeRawHTTPRPCResult(w, req.ID, map[string]any{})
+		case "tools/call":
+			toolCallCount.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"error": map[string]any{
+					"code": -32021, "message": "missing required client capability",
+				},
+			})
+		default:
+			http.Error(w, "unknown method", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	transport, err := newHTTPTransport(Spec{Name: "request-error", Type: "http", URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transport.close()
+	if _, err := transport.call(t.Context(), "tools/list", map[string]any{}); err != nil {
+		t.Fatalf("initial tools/list: %v", err)
+	}
+	if _, err := transport.call(t.Context(), "tools/call", map[string]any{
+		"name": "requires-capability", "arguments": map[string]any{},
+	}); err == nil || !strings.Contains(err.Error(), "missing required client capability") {
+		t.Fatalf("tools/call error = %v, want the server's per-call JSON-RPC error", err)
+	}
+	if _, err := transport.call(t.Context(), "tools/list", map[string]any{}); err != nil {
+		t.Fatalf("tools/list after per-call HTTP 400: %v", err)
+	}
+	if got := discoverCount.Load(); got != 1 {
+		t.Fatalf("server/discover count = %d, want the original session to survive", got)
+	}
+	if got := toolCallCount.Load(); got != 1 {
+		t.Fatalf("tools/call count = %d, want no replay of a rejected writer", got)
+	}
+	transport.mu.Lock()
+	generations := transport.nextGeneration
+	transport.mu.Unlock()
+	if generations != 1 {
+		t.Fatalf("supervisor generations = %d, want no rebuild for a per-call rejection", generations)
+	}
+}
+
+func TestHTTPTransportUnsupportedProtocolClosesNegotiatedSession(t *testing.T) {
+	deleteReceived := make(chan struct{})
+	var deleteReported atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			if got := r.Header.Get("Mcp-Session-Id"); got != "unsupported-session" {
+				t.Errorf("DELETE session ID = %q, want unsupported-session", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			if deleteReported.CompareAndSwap(false, true) {
+				close(deleteReceived)
+			}
+			return
+		}
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+
+		switch req.Method {
+		case "server/discover":
+			writeRawHTTPRPCError(w, req.ID, -32601, "method not found")
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "unsupported-session")
+			writeRawHTTPRPCResult(w, req.ID, map[string]any{
+				"protocolVersion": "2099-01-01",
+				"serverInfo":      map[string]any{"name": "unsupported", "version": "1"},
+				"capabilities":    map[string]any{},
+			})
+		default:
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	transport, err := newHTTPTransport(Spec{Name: "unsupported", Type: "http", URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transport.close()
+	if _, err := transport.call(t.Context(), "tools/list", map[string]any{}); err == nil || !strings.Contains(err.Error(), "unsupported protocol version") {
+		t.Fatalf("tools/list error = %v, want unsupported protocol version", err)
+	}
+	select {
+	case <-deleteReceived:
+	case <-time.After(time.Second):
+		t.Fatal("failed protocol negotiation did not terminate the allocated server session")
+	}
+}
+
+func TestHTTPTransportLegacySessionlessJSONPostOnly(t *testing.T) {
+	var discoverCount atomic.Int32
+	var initializeCount atomic.Int32
+	var getCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			getCount.Add(1)
+			w.Header().Set("Allow", http.MethodPost)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+
+		switch req.Method {
+		case "server/discover":
+			discoverCount.Add(1)
+			writeRawHTTPRPCError(w, req.ID, -32601, "method not found")
+		case "initialize":
+			initializeCount.Add(1)
+			writeRawHTTPRPCResult(w, req.ID, map[string]any{
+				"protocolVersion": "2025-11-25",
+				"serverInfo":      map[string]any{"name": "legacy-post", "version": "1"},
+				"capabilities":    map[string]any{"tools": map[string]any{}},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			writeRawHTTPRPCResult(w, req.ID, map[string]any{"tools": []map[string]any{{
+				"name": "legacy_tool", "inputSchema": map[string]any{"type": "object"},
+			}}})
+		default:
+			http.Error(w, "unknown method", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	host, tools, err := StartAll(t.Context(), []Spec{{Name: "legacy-post", Type: "http", URL: srv.URL}})
+	if err != nil {
+		t.Fatalf("StartAll: %v", err)
+	}
+	defer host.Close()
+	if got := names(tools); len(got) != 1 || got[0] != "mcp__legacy-post__legacy_tool" {
+		t.Fatalf("tools = %v, want [mcp__legacy-post__legacy_tool]", got)
+	}
+	if got := discoverCount.Load(); got != 1 {
+		t.Fatalf("server/discover count = %d, want one bounded modern probe", got)
+	}
+	if got := initializeCount.Load(); got != 1 {
+		t.Fatalf("initialize count = %d, want one legacy fallback", got)
+	}
+	if got := getCount.Load(); got != 1 {
+		t.Fatalf("standalone GET count = %d, want one optional probe accepted as HTTP 405", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Keep optional SEP-2575 `subscriptions/listen` outside the mandatory startup path so qmd-style stateless Streamable HTTP bridges cannot block an otherwise successful connection. Compliant streaming servers continue to route list-change notifications.
- Pin the official Go MCP SDK commit containing upstream request-rejection, stateless subscription 404, and failed-negotiation cleanup fixes; preserve Reasonix session recovery for explicit structured session-loss errors.
- Add deterministic coverage for buffered and live subscription streams, stateless subscription 404, per-call JSON-RPC 4xx responses, protocol-negotiation cleanup, and legacy sessionless JSON POST-only servers.

## Issues

Fixes #9600

Follow-up to #9547 after that PR merged. This PR contains only the transport compatibility work discovered during its post-merge MCP interoperability validation.

## Compatibility and risk

- The ordinary path remains zero-configuration: existing `http` MCP entries gain the compatibility behavior automatically.
- Legacy sessionless JSON POST servers and optional GET 405 behavior remain supported. The separate legacy `sse` transport contract is unchanged.
- Provider-visible MCP tool names, schemas, ordering, rich-result projection, and host-profile cache identity are unchanged.
- qmd startup and tool calls no longer depend on its buffered notification bridge. Dynamic list-change delivery still requires the server to flush that long-lived response.
- The SDK is pinned to exact official upstream commit `c68ad9a4e6e1` until the fixes are available in a tagged release.

## Verification

- `go test ./internal/plugin -count=1`
- focused HTTP compatibility tests repeated 30 times
- focused `go test -race` repeated 5 times
- `go test ./... -count=1`
- `go vet ./internal/plugin`
- `go run ./tools/repolint`
- `./scripts/cache-guard.sh`
- `go mod tidy -diff`
- `git diff --check`
- old-SDK control: the three upstream regression cases fail on v1.7.0 and pass on the pinned commit; the legacy POST-only baseline passes on both

## Documentation impact

Documentation-impact: none - the documented `http` transport remains the correct configuration; this fixes internal interoperability without adding settings or changing the user workflow.

## Cache impact

Cache-impact: none - provider-visible MCP tool names, schemas, ordering, result projection, and host-profile cache identity are unchanged.
Cache-guard: `./scripts/cache-guard.sh` plus the complete plugin and root Go suites.
System-prompt-review: N/A