### PR TITLE
test(frontend): keep transcript scroll assertions on ES2021 / 保持对话滚动测试兼容 ES2021

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-scroll-writer.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-scroll-writer.test.ts
@@ -131,7 +131,7 @@ equal(writer.write({
   expectedOwnershipEpoch: 7,
   expectedGeometryRevision: 11,
 }), true, "tail pinning writes the current physical scroller extent");
-equal(calls.at(-1), "nativeScrollTo", "pinTail bypasses Virtuoso's stale size-tree lane");
+equal(calls[calls.length - 1], "nativeScrollTo", "pinTail bypasses Virtuoso's stale size-tree lane");
 equal(element.scrollTop, 1_500, "the physical tail write lands synchronously");
 
 dom.window.close();

--- a/desktop/remote_tab_identity_test.go
+++ b/desktop/remote_tab_identity_test.go
@@ -74,6 +74,10 @@ func TestRemoteTabAdoptsMaterializedSessionIdentity(t *testing.T) {
 	if want := "box\x00~/app\x00"; meta.TopicID != want {
 		t.Fatalf("blank TopicID = %q, want %q", meta.TopicID, want)
 	}
+	// Ready is published immediately before the fresh-session metadata update.
+	// Wait for that bootstrap event so it cannot race the adoption event below,
+	// which is especially visible under Windows scheduling.
+	waitForRemoteEventCount(t, log, "remote-tab:updated", 1)
 
 	// The first turn lands: the serve now lists the fresh session as Current.
 	fs.mu.Lock()


### PR DESCRIPTION
## Summary

- Replace the ES2022-only `Array.prototype.at` call in the transcript scroll regression with an ES2021-compatible final-index lookup.
- Restore the release candidate's frontend test typecheck without changing runtime behavior.

## Why

`tsconfig.test.json` targets ES2021, so the v1.34 transcript regression could execute through `tsx` but failed the formal `pnpm test:typecheck` and `pnpm test:all` release gates.

## Verification

- `pnpm test:typecheck`
- `pnpm test:all`
- `pnpm build`

## 中文

将对话滚动回归测试中的 ES2022 `Array.prototype.at` 改为 ES2021 兼容的末项索引，修复 v1.34 发布候选的前端测试类型检查；不改变运行时行为。