### PR TITLE
fix(sessioncatalog): unify filesystem path identity / 统一会话目录路径身份

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
         env:
           REASONIX_RELEASE_CACHE_GUARD: "1"
           WINDOWS_SANDBOX_WAIT_MS: "20000"
-        run: go test -p 4 -timeout=8m ./internal/agent/... ./internal/appidentity/... ./internal/boot/... ./internal/checkpoint/... ./internal/cli/... ./internal/desktoplauncher/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
+        run: go test -p 4 -timeout=8m ./internal/agent/... ./internal/appidentity/... ./internal/boot/... ./internal/checkpoint/... ./internal/cli/... ./internal/desktoplauncher/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sessioncatalog/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
 
       # The general Windows PR smoke list intentionally omits internal/tool.
       # Keep the session-temp portability contract covered without widening the

--- a/desktop/session_catalog_app_test.go
+++ b/desktop/session_catalog_app_test.go
@@ -435,7 +435,7 @@ func TestListProjectTopicsKeepsMetadataWhileFirstCatalogScanIsPending(t *testing
 		t.Fatal(err)
 	}
 	if len(page.Items) != 1 || page.Items[0].TopicID != "topic-keep" || page.Items[0].Label != "Previous chat" {
-		t.Fatalf("topics while v5 catalog is still empty = %#v, want the desktop-projects conversation", page.Items)
+		t.Fatalf("topics while v6 catalog is still empty = %#v, want the desktop-projects conversation", page.Items)
 	}
 }
 

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -486,7 +486,7 @@ func (a *App) listProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, 
 	}
 	availability := a.catalogWorkspaceAvailability(catalog, req.Scope, req.WorkspaceRoot)
 	if !availability.usable {
-		// A freshly opened v5 cache is live but empty until the first directory
+		// A freshly opened v6 cache is live but empty until the first directory
 		// scan. Treat that the same as "catalog unavailable" so upgrade does
 		// not blank the sidebar that desktop-projects.json still knows about.
 		page := a.metadataTopicPage(req)

--- a/desktop/session_catalog_targets.go
+++ b/desktop/session_catalog_targets.go
@@ -11,14 +11,8 @@ import (
 
 func (a *App) sessionCatalogTargets() []sessioncatalog.DirectoryTarget {
 	f := loadProjectsFile()
-	seen := map[string]bool{}
 	out := []sessioncatalog.DirectoryTarget{}
 	add := func(target sessioncatalog.DirectoryTarget) {
-		target.Path = filepath.Clean(strings.TrimSpace(target.Path))
-		if target.Path == "." || target.Path == "" || seen[target.Path] {
-			return
-		}
-		seen[target.Path] = true
 		out = append(out, target)
 	}
 	add(sessioncatalog.DirectoryTarget{Path: config.SessionDir(), Scope: "global"})
@@ -48,7 +42,7 @@ func (a *App) sessionCatalogTargets() []sessioncatalog.DirectoryTarget {
 		}
 		a.mu.RUnlock()
 	}
-	return out
+	return sessioncatalog.UniqueDirectoryTargets(out)
 }
 
 func (a *App) indexRestoredSessionPaths(ctx context.Context, catalog *sessioncatalog.Catalog) {

--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -42,7 +42,7 @@ non-destructively when `<Reasonix home>/.env` is missing them.
 | Memory | `<state root>/memory/` and `<state root>/projects/` |
 | Global Desktop topic metadata | `<state root>/desktop/topic-state-v1.sqlite` |
 | Project Desktop topic metadata | `<state root>/projects/<workspace slug>/desktop/topic-state-v1.sqlite` |
-| Disposable session catalog | `<cache root>/session-catalog/v5.sqlite` |
+| Disposable session catalog | `<cache root>/session-catalog/v6.sqlite` |
 | Disposable history search catalog | `<cache root>/history-search/v1.sqlite` |
 | Disposable usage catalog | `<cache root>/usage-catalog/v1.sqlite` |
 | Disposable task catalog | `<cache root>/task-catalog/v1.sqlite` |

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -35,7 +35,7 @@ Legacy 迁移、OS home 约定目录扫描以及其他 fallback 路径都会跳�
 | 记忆 | `<state root>/memory/` 与 `<state root>/projects/` |
 | 全局 Desktop Topic 元数据 | `<state root>/desktop/topic-state-v1.sqlite` |
 | 项目 Desktop Topic 元数据 | `<state root>/projects/<workspace slug>/desktop/topic-state-v1.sqlite` |
-| 可丢弃的会话 Catalog | `<cache root>/session-catalog/v5.sqlite` |
+| 可丢弃的会话 Catalog | `<cache root>/session-catalog/v6.sqlite` |
 | 可丢弃的 Task Catalog | `<cache root>/task-catalog/v1.sqlite` |
 
 `<state root>` 默认等于 `<Reasonix home>`；只有设置 `REASONIX_STATE_HOME`

--- a/docs/SESSION_CATALOG.md
+++ b/docs/SESSION_CATALOG.md
@@ -16,12 +16,14 @@ of the previous index.
 - Startup and project-tree requests never decode transcript JSONL, run legacy
   migration, or wait for a directory scan.
 - A successfully saved transcript is committed before its catalog update. The
-  non-blocking writer coalesces updates by filesystem path identity; background
-  reconciliation repairs updates dropped under queue pressure.
-- The original path spelling is retained for file access and display. A
-  separate identity key resolves aliases and folds case only where the
-  governing filesystem directory is case-insensitive; case-distinct files on
-  case-sensitive volumes remain separate sessions.
+  save observer performs only lexical queue staging and returns without
+  filesystem probes. Background workers resolve filesystem identity, SQLite
+  uniqueness is the final deduplication boundary, and reconciliation repairs
+  updates dropped under queue pressure.
+- Original session and workspace-root spellings are retained for file access
+  and display. Separate identity keys resolve aliases and fold case only where
+  the governing filesystem directory is case-insensitive; case-distinct files
+  and projects on case-sensitive volumes remain separate.
 - Missing legacy counts are represented as `unknown`. The session is visible
   immediately, then a single repair worker decodes it in the background.
 - A missing file is marked degraded on the first scan. It is removed from the
@@ -51,10 +53,11 @@ rebuild paths never remove authoritative files.
 The catalog stores only query projections:
 
 - directory signatures, scan generations, checkpoints, and errors;
-- project ordering, title, color, and pin state;
-- topic ordering, aggregate counts, activity, recovery, and health state; and
-- session access path plus path identity key, preview, counts, fingerprints,
-  recovery, and health state.
+- project ordering, title, color, pin state, and workspace-root identity key;
+- topic ordering, aggregate counts, activity, recovery, health state, and
+  workspace-root identity key; and
+- session access path plus path, directory, and workspace-root identity keys,
+  preview, counts, fingerprints, recovery, and health state.
 
 Topic pages use a `(pinned, last_activity_at, topic_id)` keyset cursor. The
 default page size is 50 and the maximum is 200. Directory reconciliation commits

--- a/docs/SESSION_CATALOG.md
+++ b/docs/SESSION_CATALOG.md
@@ -3,12 +3,12 @@
 Reasonix keeps session transcripts, event logs, metadata sidecars, and
 `desktop-projects.json` as the only authoritative session data. The desktop
 project tree reads a disposable SQLite projection from
-`<cache root>/session-catalog/v5.sqlite`; deleting that database never deletes
-or changes a conversation. The earlier `v1.sqlite` through `v4.sqlite` caches are
-left in place so a concurrent or downgraded process cannot cross-write the
-projection. v5 is the repair-release generation; it is rebuilt from
-authoritative files on first use while the old v4 file remains available for
-rollback. A manual rebuild of v5 also leaves a timestamped `.replaced-*` copy
+`<cache root>/session-catalog/v6.sqlite`; deleting that database never deletes
+or changes a conversation. The earlier `v1.sqlite` through `v5.sqlite` caches
+are left in place so a concurrent or downgraded process cannot cross-write the
+projection. v6 introduces filesystem-aware path identity and is rebuilt from
+authoritative files on first use while the old v5 file remains available for
+rollback. A manual rebuild of v6 also leaves a timestamped `.replaced-*` copy
 of the previous index.
 
 ## Invariants
@@ -16,8 +16,12 @@ of the previous index.
 - Startup and project-tree requests never decode transcript JSONL, run legacy
   migration, or wait for a directory scan.
 - A successfully saved transcript is committed before its catalog update. The
-  non-blocking writer coalesces updates by session path; background
+  non-blocking writer coalesces updates by filesystem path identity; background
   reconciliation repairs updates dropped under queue pressure.
+- The original path spelling is retained for file access and display. A
+  separate identity key resolves aliases and folds case only where the
+  governing filesystem directory is case-insensitive; case-distinct files on
+  case-sensitive volumes remain separate sessions.
 - Missing legacy counts are represented as `unknown`. The session is visible
   immediately, then a single repair worker decodes it in the background.
 - A missing file is marked degraded on the first scan. It is removed from the
@@ -49,7 +53,8 @@ The catalog stores only query projections:
 - directory signatures, scan generations, checkpoints, and errors;
 - project ordering, title, color, and pin state;
 - topic ordering, aggregate counts, activity, recovery, and health state; and
-- session path, preview, counts, fingerprints, recovery, and health state.
+- session access path plus path identity key, preview, counts, fingerprints,
+  recovery, and health state.
 
 Topic pages use a `(pinned, last_activity_at, topic_id)` keyset cursor. The
 default page size is 50 and the maximum is 200. Directory reconciliation commits

--- a/docs/SESSION_CATALOG.zh-CN.md
+++ b/docs/SESSION_CATALOG.zh-CN.md
@@ -2,17 +2,19 @@
 
 Reasonix 始终以会话 transcript、event log、metadata sidecar 和
 `desktop-projects.json` 作为唯一权威数据。桌面项目树读取位于
-`<缓存根目录>/session-catalog/v5.sqlite` 的一次性 SQLite 查询投影；删除该数据库
-不会删除或修改任何会话。早期的 `v1.sqlite` 至 `v4.sqlite` 缓存会保留，避免与仍在
-运行或降级后的旧版本进程交叉写同一投影。v5 是修复版本使用的独立索引代际，
-首次启动会从权威文件重新建立；旧 v4 文件保留用于回滚，不会被新版本写入。
-同一 v5 索引的手动重建也会留下带时间戳的 `.replaced-*` 旧文件。
+`<缓存根目录>/session-catalog/v6.sqlite` 的一次性 SQLite 查询投影；删除该数据库
+不会删除或修改任何会话。早期的 `v1.sqlite` 至 `v5.sqlite` 缓存会保留，避免与仍在
+运行或降级后的旧版本进程交叉写同一投影。v6 引入文件系统感知的路径身份，首次启动
+会从权威文件重新建立；旧 v5 文件保留用于回滚，不会被新版本写入。同一 v6 索引的
+手动重建也会留下带时间戳的 `.replaced-*` 旧文件。
 
 ## 不变量
 
 - 启动和项目树请求不会解码 transcript JSONL、执行旧版迁移或等待目录扫描。
-- transcript 成功落盘后才更新 catalog。非阻塞单写者队列按 session path 合并更新；
+- transcript 成功落盘后才更新 catalog。非阻塞单写者队列按文件系统路径身份合并更新；
   后台对账会修复队列拥塞时丢弃的更新。
+- 原始路径拼写继续用于文件访问和展示；独立的 identity key 会解析别名，并且只在
+  所属文件系统目录不区分大小写时折叠大小写。大小写敏感卷上的不同文件不会合并。
 - 缺少旧版计数时使用 `unknown` 状态。会话会立即可见，随后由单个 repair worker
   在后台解码修复。
 - 文件首次缺失时只标记为 degraded；只有连续第二次扫描仍缺失且超过宽限期后，
@@ -40,7 +42,7 @@ catalog 只保存查询投影：
 - 目录签名、扫描代次、检查点和错误；
 - 项目排序、标题、颜色和置顶状态；
 - topic 排序、聚合计数、活动时间、恢复和健康状态；
-- session path、preview、计数、指纹、恢复和健康状态。
+- session 访问路径及路径 identity key、preview、计数、指纹、恢复和健康状态。
 
 topic 分页使用 `(pinned, last_activity_at, topic_id)` keyset cursor。默认每页
 50 条，最多 200 条。目录对账每批最多提交 64 个 sidecar，并在让出调度前持久化

--- a/docs/SESSION_CATALOG.zh-CN.md
+++ b/docs/SESSION_CATALOG.zh-CN.md
@@ -11,10 +11,12 @@ Reasonix 始终以会话 transcript、event log、metadata sidecar 和
 ## 不变量
 
 - 启动和项目树请求不会解码 transcript JSONL、执行旧版迁移或等待目录扫描。
-- transcript 成功落盘后才更新 catalog。非阻塞单写者队列按文件系统路径身份合并更新；
-  后台对账会修复队列拥塞时丢弃的更新。
-- 原始路径拼写继续用于文件访问和展示；独立的 identity key 会解析别名，并且只在
-  所属文件系统目录不区分大小写时折叠大小写。大小写敏感卷上的不同文件不会合并。
+- transcript 成功落盘后才更新 catalog。保存观察器只做词法队列入队，不执行文件系统
+  探测；后台 worker 解析文件系统身份，SQLite 唯一约束作为最终去重边界，目录对账
+  会修复队列拥塞时丢弃的更新。
+- session 和 workspace root 的原始路径拼写继续用于文件访问和展示；独立的 identity
+  key 会解析别名，并且只在所属文件系统目录不区分大小写时折叠大小写。大小写敏感
+  卷上的不同文件和项目不会合并。
 - 缺少旧版计数时使用 `unknown` 状态。会话会立即可见，随后由单个 repair worker
   在后台解码修复。
 - 文件首次缺失时只标记为 degraded；只有连续第二次扫描仍缺失且超过宽限期后，
@@ -40,9 +42,10 @@ transcript 重建。隔离和重建都不会删除权威文件。
 catalog 只保存查询投影：
 
 - 目录签名、扫描代次、检查点和错误；
-- 项目排序、标题、颜色和置顶状态；
-- topic 排序、聚合计数、活动时间、恢复和健康状态；
-- session 访问路径及路径 identity key、preview、计数、指纹、恢复和健康状态。
+- 项目排序、标题、颜色、置顶状态及 workspace root identity key；
+- topic 排序、聚合计数、活动时间、恢复、健康状态及 workspace root identity key；
+- session 访问路径及路径、目录和 workspace root identity key、preview、计数、指纹、
+  恢复和健康状态。
 
 topic 分页使用 `(pinned, last_activity_at, topic_id)` keyset cursor。默认每页
 50 条，最多 200 条。目录对账每批最多提交 64 个 sidecar，并在让出调度前持久化

--- a/internal/cli/sessions_catalog.go
+++ b/internal/cli/sessions_catalog.go
@@ -57,15 +57,10 @@ func sessionsCommand(args []string) int {
 		return printSessionCatalogRebuild(status, *jsonOut)
 	}
 	targets := make([]sessioncatalog.DirectoryTarget, 0, len(dirs))
-	seen := map[string]bool{}
 	for _, dir := range dirs {
-		dir = filepath.Clean(strings.TrimSpace(dir))
-		if dir == "." || dir == "" || seen[dir] {
-			continue
-		}
-		seen[dir] = true
 		targets = append(targets, sessioncatalog.DirectoryTarget{Path: dir, Scope: "global"})
 	}
+	targets = sessioncatalog.UniqueDirectoryTargets(targets)
 	status, err := sessioncatalog.Rebuild(context.Background(), sessioncatalog.DefaultPath(), targets)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
@@ -117,6 +112,11 @@ func sessionsRecoveryCommand(args []string, cleanup bool) int {
 			dirs = append(dirs, target.Path)
 		}
 	}
+	targets := make([]sessioncatalog.DirectoryTarget, 0, len(dirs))
+	for _, dir := range dirs {
+		targets = append(targets, sessioncatalog.DirectoryTarget{Path: dir, Scope: "global"})
+	}
+	targets = sessioncatalog.UniqueDirectoryTargets(targets)
 	report := sessionRecoveryReport{Errors: []string{}, DryRun: !cleanup || !*apply}
 	persisted, persistedErr := sessioncatalog.Open(context.Background(), sessioncatalog.Options{
 		Path: sessioncatalog.DefaultPath(), DisableRepair: true,
@@ -126,13 +126,8 @@ func sessionsRecoveryCommand(args []string, cleanup bool) int {
 	} else {
 		defer persisted.Close(context.Background())
 	}
-	seen := map[string]bool{}
-	for _, rawDir := range dirs {
-		dir := filepath.Clean(strings.TrimSpace(rawDir))
-		if dir == "." || dir == "" || seen[dir] {
-			continue
-		}
-		seen[dir] = true
+	for _, target := range targets {
+		dir := target.Path
 		report.Directories++
 		inspectSessionRecoveryDirectory(context.Background(), dir, persisted, &report)
 	}
@@ -289,14 +284,8 @@ func defaultSessionCatalogTargets() []sessioncatalog.DirectoryTarget {
 	if data, err := os.ReadFile(filepath.Join(home, "desktop-projects.json")); err == nil {
 		_ = json.Unmarshal(data, &saved)
 	}
-	seen := map[string]bool{}
 	targets := make([]sessioncatalog.DirectoryTarget, 0, len(saved.Projects)+2)
 	add := func(target sessioncatalog.DirectoryTarget) {
-		target.Path = filepath.Clean(strings.TrimSpace(target.Path))
-		if target.Path == "." || target.Path == "" || seen[target.Path] {
-			return
-		}
-		seen[target.Path] = true
 		targets = append(targets, target)
 	}
 	add(sessioncatalog.DirectoryTarget{Path: config.SessionDir(), Scope: "global"})
@@ -313,5 +302,5 @@ func defaultSessionCatalogTargets() []sessioncatalog.DirectoryTarget {
 			Path: config.ProjectSessionDir(root), Scope: "project", WorkspaceRoot: root,
 		})
 	}
-	return targets
+	return sessioncatalog.UniqueDirectoryTargets(targets)
 }

--- a/internal/sessioncatalog/catalog.go
+++ b/internal/sessioncatalog/catalog.go
@@ -20,14 +20,15 @@ import (
 const defaultMissingGrace = 30 * time.Second
 
 type Catalog struct {
-	db          *sql.DB
-	opts        Options
-	revision    atomic.Uint64
-	statusMu    sync.RWMutex
-	status      Status
-	writeCh     chan string
-	writeMu     sync.Mutex
-	writeQueued map[string]SessionRecord
+	db           *sql.DB
+	opts         Options
+	pathIdentity func(string) string
+	revision     atomic.Uint64
+	statusMu     sync.RWMutex
+	status       Status
+	writeCh      chan string
+	writeMu      sync.Mutex
+	writeQueued  map[string]SessionRecord
 	// mutationMu is the process-local SQLite single-writer boundary. WAL permits
 	// concurrent readers, but repair, metadata, and reconcile mutations must not
 	// race into avoidable SQLITE_BUSY failures.
@@ -59,8 +60,9 @@ type Catalog struct {
 }
 
 type sessionPathRequest struct {
-	target DirectoryTarget
-	path   string
+	target  DirectoryTarget
+	path    string
+	pathKey string
 }
 
 type pageCursor struct {
@@ -98,6 +100,7 @@ func Open(ctx context.Context, opts Options) (*Catalog, error) {
 
 	c := &Catalog{
 		opts:           opts,
+		pathIdentity:   PathIdentityKey,
 		writeCh:        make(chan string, opts.QueueCapacity),
 		writeQueued:    map[string]SessionRecord{},
 		repairCh:       make(chan string, opts.QueueCapacity),
@@ -235,11 +238,11 @@ func normalizeScope(scope, root string) (string, string) {
 }
 
 func normalizeSessionRecord(record SessionRecord) SessionRecord {
-	record.Path = filepath.Clean(record.Path)
+	record.Path = cleanCatalogAccessPath(record.Path)
 	if record.Directory == "" {
 		record.Directory = filepath.Dir(record.Path)
 	}
-	record.Directory = filepath.Clean(record.Directory)
+	record.Directory = cleanCatalogAccessPath(record.Directory)
 	record.Scope, record.WorkspaceRoot = normalizeScope(record.Scope, record.WorkspaceRoot)
 	if record.TurnsState == "" {
 		record.TurnsState = TurnsUnknown
@@ -250,29 +253,40 @@ func normalizeSessionRecord(record SessionRecord) SessionRecord {
 	return record
 }
 
+func (c *Catalog) pathKey(path string) string {
+	if c != nil && c.pathIdentity != nil {
+		return c.pathIdentity(path)
+	}
+	return PathIdentityKey(path)
+}
+
 func (c *Catalog) EnqueueSession(record SessionRecord) bool {
 	if c == nil {
 		return false
 	}
 	record = normalizeSessionRecord(record)
-	c.removedPaths.Delete(record.Path)
+	key := c.pathKey(record.Path)
+	if key == "" {
+		return false
+	}
+	c.removedPaths.Delete(key)
 	c.writeMu.Lock()
-	if _, loaded := c.writeQueued[record.Path]; loaded {
-		c.writeQueued[record.Path] = record
+	if _, loaded := c.writeQueued[key]; loaded {
+		c.writeQueued[key] = record
 		c.writeMu.Unlock()
 		return true
 	}
-	c.writeQueued[record.Path] = record
+	c.writeQueued[key] = record
 	select {
 	case <-c.stop:
-		delete(c.writeQueued, record.Path)
+		delete(c.writeQueued, key)
 		c.writeMu.Unlock()
 		return false
-	case c.writeCh <- record.Path:
+	case c.writeCh <- key:
 		c.writeMu.Unlock()
 		return true
 	default:
-		delete(c.writeQueued, record.Path)
+		delete(c.writeQueued, key)
 		c.writeMu.Unlock()
 		return false
 	}
@@ -453,7 +467,7 @@ func (c *Catalog) listTopicSessions(ctx context.Context, key TopicKey) ([]Sessio
 			}
 			rawCount++
 			lastScanned = record
-			if c.pathRemoved(record.Path) {
+			if c.pathRemovedKey(record.pathKey, record.Path) {
 				continue
 			}
 			out = append(out, record)

--- a/internal/sessioncatalog/catalog.go
+++ b/internal/sessioncatalog/catalog.go
@@ -493,10 +493,6 @@ func mapKeys(values map[string]struct{}) []string {
 	}
 	return out
 }
-func (c *Catalog) listTopicSessions(ctx context.Context, key TopicKey) ([]SessionRecord, error) {
-	key.Scope, key.WorkspaceRoot = normalizeScope(key.Scope, key.WorkspaceRoot)
-	return c.listTopicSessionsByRootKey(ctx, key, c.workspaceRootKey(key.Scope, key.WorkspaceRoot))
-}
 
 func (c *Catalog) listTopicSessionsByRootKey(ctx context.Context, key TopicKey, rootKey string) ([]SessionRecord, error) {
 	out := []SessionRecord{}

--- a/internal/sessioncatalog/catalog.go
+++ b/internal/sessioncatalog/catalog.go
@@ -42,6 +42,7 @@ type Catalog struct {
 	reconcileDirtyMu sync.Mutex
 	reconcileDirty   map[string]DirectoryTarget
 	pathCh           chan sessionPathRequest
+	pathQueueMu      sync.Mutex
 	pathQueued       sync.Map
 	directoryLocksMu sync.Mutex
 	directoryLocks   map[string]*sync.Mutex
@@ -58,12 +59,16 @@ type Catalog struct {
 	// testRepairLockHook reports before and after repair acquires the directory
 	// lock. Production catalogs leave it nil.
 	testRepairLockHook func(acquired bool)
+	// testPathMutationLoadedHook pauses after reading a removal generation.
+	// Production catalogs leave it nil.
+	testPathMutationLoadedHook func(string)
 }
 
 type sessionPathRequest struct {
 	target   DirectoryTarget
 	path     string
 	queueKey string
+	sequence uint64
 }
 
 type pageCursor struct {
@@ -365,13 +370,19 @@ func (c *Catalog) writerLoop() {
 
 func (c *Catalog) recomputeTopic(ctx context.Context, tx *sql.Tx, key TopicKey) error {
 	key.Scope, key.WorkspaceRoot = normalizeScope(key.Scope, key.WorkspaceRoot)
-	rootKey := c.workspaceRootKey(key.Scope, key.WorkspaceRoot)
+	rootKey := key.workspaceKey
+	if key.Scope == "project" && rootKey == "" {
+		rootKey = c.workspaceRootKey(key.Scope, key.WorkspaceRoot)
+	}
 	var count int
 	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions WHERE scope=? AND workspace_root_key=? AND topic_id=?`, key.Scope, rootKey, key.TopicID).Scan(&count); err != nil {
 		return err
 	}
 	if count == 0 {
 		_, err := tx.ExecContext(ctx, `DELETE FROM catalog_topics WHERE scope=? AND workspace_root_key=? AND topic_id=?`, key.Scope, rootKey, key.TopicID)
+		return err
+	}
+	if err := removeRemappedTopicIdentity(ctx, tx, key, rootKey); err != nil {
 		return err
 	}
 	// Covered copies skip turn/health totals but still update recency. Adopted
@@ -441,8 +452,31 @@ func bumpRevision(ctx context.Context, tx *sql.Tx) (uint64, error) {
 func (c *Catalog) publishRevision(revision uint64, roots []string, reason string) {
 	c.rememberRevision(revision)
 	if c.opts.OnRevision != nil {
-		c.opts.OnRevision(revision, roots, reason)
+		c.opts.OnRevision(revision, c.registeredRevisionRoots(roots), reason)
 	}
+}
+
+func (c *Catalog) registeredRevisionRoots(roots []string) []string {
+	out := make([]string, 0, len(roots))
+	seen := make(map[string]struct{}, len(roots))
+	for _, root := range roots {
+		_, root = normalizeScope("project", root)
+		rootKey := c.workspaceRootKey("project", root)
+		if _, ok := seen[rootKey]; ok {
+			continue
+		}
+		seen[rootKey] = struct{}{}
+		registered := root
+		if rootKey != "" && c.db != nil {
+			var candidate string
+			if err := c.db.QueryRowContext(context.Background(), `SELECT workspace_root FROM catalog_projects
+				WHERE scope='project' AND workspace_root_key=?`, rootKey).Scan(&candidate); err == nil && candidate != "" {
+				registered = candidate
+			}
+		}
+		out = append(out, registered)
+	}
+	return out
 }
 
 func (c *Catalog) rememberRevision(revision uint64) {
@@ -461,7 +495,10 @@ func mapKeys(values map[string]struct{}) []string {
 }
 func (c *Catalog) listTopicSessions(ctx context.Context, key TopicKey) ([]SessionRecord, error) {
 	key.Scope, key.WorkspaceRoot = normalizeScope(key.Scope, key.WorkspaceRoot)
-	rootKey := c.workspaceRootKey(key.Scope, key.WorkspaceRoot)
+	return c.listTopicSessionsByRootKey(ctx, key, c.workspaceRootKey(key.Scope, key.WorkspaceRoot))
+}
+
+func (c *Catalog) listTopicSessionsByRootKey(ctx context.Context, key TopicKey, rootKey string) ([]SessionRecord, error) {
 	out := []SessionRecord{}
 	var cursor *sessionPageCursor
 	for len(out) < MaxLimit {
@@ -511,13 +548,14 @@ func (c *Catalog) listTopicSessions(ctx context.Context, key TopicKey) ([]Sessio
 func (c *Catalog) GetTopic(ctx context.Context, key TopicKey) (TopicRecord, bool, error) {
 	key.Scope, key.WorkspaceRoot = normalizeScope(key.Scope, key.WorkspaceRoot)
 	key.TopicID = strings.TrimSpace(key.TopicID)
+	rootKey := c.workspaceRootKey(key.Scope, key.WorkspaceRoot)
 	item := TopicRecord{Sessions: []SessionRecord{}}
 	err := c.db.QueryRowContext(ctx, `SELECT scope,workspace_root,topic_id,title,title_source,pinned,
 		CASE WHEN metadata_present=1 THEN sort_order ELSE -1 END,
-        turns,turns_state,created_at,last_activity_at,recovery_state,recovery_branch_count,
-        recovery_unresolved_count,recovery_cleanup_eligible_count,health
+		turns,turns_state,created_at,last_activity_at,recovery_state,recovery_branch_count,
+		recovery_unresolved_count,recovery_cleanup_eligible_count,health
 		FROM catalog_topics WHERE scope=? AND workspace_root_key=? AND topic_id=?`,
-		key.Scope, c.workspaceRootKey(key.Scope, key.WorkspaceRoot), key.TopicID).Scan(
+		key.Scope, rootKey, key.TopicID).Scan(
 		&item.Scope, &item.WorkspaceRoot, &item.TopicID, &item.Title, &item.TitleSource,
 		&item.Pinned, &item.SortOrder, &item.Turns, &item.TurnsState,
 		&item.CreatedAt, &item.LastActivityAt, &item.RecoveryState, &item.RecoveryBranchCount,
@@ -528,7 +566,7 @@ func (c *Catalog) GetTopic(ctx context.Context, key TopicKey) (TopicRecord, bool
 	if err != nil {
 		return item, false, err
 	}
-	item.Sessions, err = c.listTopicSessions(ctx, key)
+	item.Sessions, err = c.listTopicSessionsByRootKey(ctx, key, rootKey)
 	if err != nil {
 		return TopicRecord{Sessions: []SessionRecord{}}, false, err
 	}

--- a/internal/sessioncatalog/catalog.go
+++ b/internal/sessioncatalog/catalog.go
@@ -23,6 +23,7 @@ type Catalog struct {
 	db           *sql.DB
 	opts         Options
 	pathIdentity func(string) string
+	mutationSeq  atomic.Uint64
 	revision     atomic.Uint64
 	statusMu     sync.RWMutex
 	status       Status
@@ -60,9 +61,9 @@ type Catalog struct {
 }
 
 type sessionPathRequest struct {
-	target  DirectoryTarget
-	path    string
-	pathKey string
+	target   DirectoryTarget
+	path     string
+	queueKey string
 }
 
 type pageCursor struct {
@@ -260,16 +261,31 @@ func (c *Catalog) pathKey(path string) string {
 	return PathIdentityKey(path)
 }
 
+func (c *Catalog) workspaceRootKey(scope, root string) string {
+	scope, root = normalizeScope(scope, root)
+	if scope != "project" || root == "" {
+		return ""
+	}
+	return c.pathKey(root)
+}
+
+// queuePathKey is intentionally lexical. Save observers call the enqueue APIs
+// synchronously, so filesystem probes (EvalSymlinks/platform case detection)
+// belong to background workers and the SQLite uniqueness boundary.
+func queuePathKey(path string) string {
+	return cleanCatalogAccessPath(path)
+}
+
 func (c *Catalog) EnqueueSession(record SessionRecord) bool {
 	if c == nil {
 		return false
 	}
 	record = normalizeSessionRecord(record)
-	key := c.pathKey(record.Path)
+	record.enqueueSequence = c.mutationSeq.Add(1)
+	key := queuePathKey(record.Path)
 	if key == "" {
 		return false
 	}
-	c.removedPaths.Delete(key)
 	c.writeMu.Lock()
 	if _, loaded := c.writeQueued[key]; loaded {
 		c.writeQueued[key] = record
@@ -347,26 +363,28 @@ func (c *Catalog) writerLoop() {
 	}
 }
 
-func recomputeTopic(ctx context.Context, tx *sql.Tx, key TopicKey) error {
+func (c *Catalog) recomputeTopic(ctx context.Context, tx *sql.Tx, key TopicKey) error {
+	key.Scope, key.WorkspaceRoot = normalizeScope(key.Scope, key.WorkspaceRoot)
+	rootKey := c.workspaceRootKey(key.Scope, key.WorkspaceRoot)
 	var count int
-	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?`, key.Scope, key.WorkspaceRoot, key.TopicID).Scan(&count); err != nil {
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions WHERE scope=? AND workspace_root_key=? AND topic_id=?`, key.Scope, rootKey, key.TopicID).Scan(&count); err != nil {
 		return err
 	}
 	if count == 0 {
-		_, err := tx.ExecContext(ctx, `DELETE FROM catalog_topics WHERE scope=? AND workspace_root=? AND topic_id=?`, key.Scope, key.WorkspaceRoot, key.TopicID)
+		_, err := tx.ExecContext(ctx, `DELETE FROM catalog_topics WHERE scope=? AND workspace_root_key=? AND topic_id=?`, key.Scope, rootKey, key.TopicID)
 		return err
 	}
 	// Covered copies skip turn/health totals but still update recency. Adopted
 	// branches are alternate continuations, so preserve the pre-catalog contract:
 	// max(sum(normal turns), max(adopted recovery turns)).
 	_, err := tx.ExecContext(ctx, `INSERT INTO catalog_topics(
-        scope,workspace_root,topic_id,title,turns,turns_state,created_at,
-        last_activity_at,recovery_state,recovery_branch_count,
-        recovery_unresolved_count,recovery_cleanup_eligible_count,health
-    ) SELECT ?,?,?,
-        COALESCE(NULLIF((SELECT COALESCE(NULLIF(custom_title,''), NULLIF(topic_title,''), preview, '')
-            FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?
-            ORDER BY recovery_copy ASC, last_activity_at DESC, path ASC LIMIT 1),''), ?),
+		scope,workspace_root,workspace_root_key,topic_id,title,turns,turns_state,created_at,
+		last_activity_at,recovery_state,recovery_branch_count,
+		recovery_unresolved_count,recovery_cleanup_eligible_count,health
+	) SELECT ?,?,?,?,
+		COALESCE(NULLIF((SELECT COALESCE(NULLIF(custom_title,''), NULLIF(topic_title,''), preview, '')
+			FROM catalog_sessions WHERE scope=? AND workspace_root_key=? AND topic_id=?
+			ORDER BY recovery_copy ASC, last_activity_at DESC, path ASC LIMIT 1),''), ?),
 		MAX(
 			COALESCE(SUM(CASE WHEN recovery_copy=0 AND recovered=0 AND turns_state='valid' THEN turns ELSE 0 END),0),
 			COALESCE(MAX(CASE WHEN recovery_copy=0 AND recovered=1 AND turns_state='valid' THEN turns ELSE 0 END),0)
@@ -387,18 +405,18 @@ func recomputeTopic(ctx context.Context, tx *sql.Tx, key TopicKey) error {
         CASE WHEN SUM(CASE WHEN recovery_copy=0 AND health='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
              WHEN SUM(CASE WHEN recovery_copy=0 AND health='missing' THEN 1 ELSE 0 END)>0 THEN 'missing'
              ELSE 'ok' END
-      FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?
-    ON CONFLICT(scope,workspace_root,topic_id) DO UPDATE SET
-        title=excluded.title, turns=excluded.turns, turns_state=excluded.turns_state,
+	  FROM catalog_sessions WHERE scope=? AND workspace_root_key=? AND topic_id=?
+	ON CONFLICT(scope,workspace_root_key,topic_id) DO UPDATE SET
+		title=excluded.title, turns=excluded.turns, turns_state=excluded.turns_state,
         created_at=excluded.created_at, last_activity_at=excluded.last_activity_at,
         recovery_state=excluded.recovery_state,
         recovery_branch_count=excluded.recovery_branch_count,
         recovery_unresolved_count=excluded.recovery_unresolved_count,
         recovery_cleanup_eligible_count=excluded.recovery_cleanup_eligible_count,
         health=excluded.health`,
-		key.Scope, key.WorkspaceRoot, key.TopicID,
-		key.Scope, key.WorkspaceRoot, key.TopicID, key.TopicID,
-		key.Scope, key.WorkspaceRoot, key.TopicID)
+		key.Scope, key.WorkspaceRoot, rootKey, key.TopicID,
+		key.Scope, rootKey, key.TopicID, key.TopicID,
+		key.Scope, rootKey, key.TopicID)
 	return err
 }
 
@@ -442,11 +460,13 @@ func mapKeys(values map[string]struct{}) []string {
 	return out
 }
 func (c *Catalog) listTopicSessions(ctx context.Context, key TopicKey) ([]SessionRecord, error) {
+	key.Scope, key.WorkspaceRoot = normalizeScope(key.Scope, key.WorkspaceRoot)
+	rootKey := c.workspaceRootKey(key.Scope, key.WorkspaceRoot)
 	out := []SessionRecord{}
 	var cursor *sessionPageCursor
 	for len(out) < MaxLimit {
-		where := `scope=? AND workspace_root=? AND topic_id=?`
-		args := []any{key.Scope, key.WorkspaceRoot, key.TopicID}
+		where := `scope=? AND workspace_root_key=? AND topic_id=?`
+		args := []any{key.Scope, rootKey, key.TopicID}
 		if cursor != nil {
 			where += ` AND (last_activity_at<? OR (last_activity_at=? AND path>?))`
 			args = append(args, cursor.Activity, cursor.Activity, cursor.Path)
@@ -496,8 +516,8 @@ func (c *Catalog) GetTopic(ctx context.Context, key TopicKey) (TopicRecord, bool
 		CASE WHEN metadata_present=1 THEN sort_order ELSE -1 END,
         turns,turns_state,created_at,last_activity_at,recovery_state,recovery_branch_count,
         recovery_unresolved_count,recovery_cleanup_eligible_count,health
-        FROM catalog_topics WHERE scope=? AND workspace_root=? AND topic_id=?`,
-		key.Scope, key.WorkspaceRoot, key.TopicID).Scan(
+		FROM catalog_topics WHERE scope=? AND workspace_root_key=? AND topic_id=?`,
+		key.Scope, c.workspaceRootKey(key.Scope, key.WorkspaceRoot), key.TopicID).Scan(
 		&item.Scope, &item.WorkspaceRoot, &item.TopicID, &item.Title, &item.TitleSource,
 		&item.Pinned, &item.SortOrder, &item.Turns, &item.TurnsState,
 		&item.CreatedAt, &item.LastActivityAt, &item.RecoveryState, &item.RecoveryBranchCount,

--- a/internal/sessioncatalog/catalog_test.go
+++ b/internal/sessioncatalog/catalog_test.go
@@ -330,7 +330,7 @@ func TestSchemaMigrationLedgerRecordsEveryVersion(t *testing.T) {
 		}
 		versions = append(versions, version)
 	}
-	if fmt.Sprint(versions) != "[1 2 3 4 5 6 7 8 9]" {
+	if fmt.Sprint(versions) != "[1 2 3 4 5 6 7 8 9 10]" {
 		t.Fatalf("schema migration ledger = %v", versions)
 	}
 }

--- a/internal/sessioncatalog/catalog_test.go
+++ b/internal/sessioncatalog/catalog_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/projectiondb"
 )
 
 func TestReconcileMakesUnknownCountsVisibleWithoutReadingTranscript(t *testing.T) {
@@ -330,8 +331,48 @@ func TestSchemaMigrationLedgerRecordsEveryVersion(t *testing.T) {
 		}
 		versions = append(versions, version)
 	}
-	if fmt.Sprint(versions) != "[1 2 3 4 5 6 7 8]" {
+	if fmt.Sprint(versions) != "[1 2 3 4 5 6 7 8 9]" {
 		t.Fatalf("schema migration ledger = %v", versions)
+	}
+}
+
+func TestMigrationV9InvalidatesLegacyProjectionForAuthoritativeRebuild(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "catalog.sqlite")
+	handle, err := projectiondb.Open(ctx, projectiondb.OpenOptions{
+		Path: path, MemoryName: "session-catalog-v8-test", Migrations: sessionMigrations()[:8], RequireDisk: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`INSERT INTO catalog_directories(path,scope) VALUES('/Sessions','global')`,
+		`INSERT INTO catalog_sessions(path,directory,scope,topic_id) VALUES('/Sessions/Mixed.jsonl','/Sessions','global','topic')`,
+		`INSERT INTO catalog_topics(scope,topic_id) VALUES('global','topic')`,
+		`INSERT INTO catalog_folded_topics(scope,topic_id) VALUES('global','folded')`,
+	} {
+		if _, err := handle.DB.ExecContext(ctx, statement); err != nil {
+			_ = handle.DB.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := handle.DB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	catalog, err := Open(ctx, Options{Path: path, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	for _, table := range []string{"catalog_directories", "catalog_sessions", "catalog_topics", "catalog_folded_topics"} {
+		var rows int
+		if err := catalog.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&rows); err != nil {
+			t.Fatal(err)
+		}
+		if rows != 0 {
+			t.Fatalf("%s rows after v9 migration = %d, want clean disposable projection", table, rows)
+		}
 	}
 }
 

--- a/internal/sessioncatalog/catalog_test.go
+++ b/internal/sessioncatalog/catalog_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
-	"reasonix/internal/projectiondb"
 )
 
 func TestReconcileMakesUnknownCountsVisibleWithoutReadingTranscript(t *testing.T) {
@@ -333,46 +332,6 @@ func TestSchemaMigrationLedgerRecordsEveryVersion(t *testing.T) {
 	}
 	if fmt.Sprint(versions) != "[1 2 3 4 5 6 7 8 9]" {
 		t.Fatalf("schema migration ledger = %v", versions)
-	}
-}
-
-func TestMigrationV9InvalidatesLegacyProjectionForAuthoritativeRebuild(t *testing.T) {
-	ctx := context.Background()
-	path := filepath.Join(t.TempDir(), "catalog.sqlite")
-	handle, err := projectiondb.Open(ctx, projectiondb.OpenOptions{
-		Path: path, MemoryName: "session-catalog-v8-test", Migrations: sessionMigrations()[:8], RequireDisk: true,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, statement := range []string{
-		`INSERT INTO catalog_directories(path,scope) VALUES('/Sessions','global')`,
-		`INSERT INTO catalog_sessions(path,directory,scope,topic_id) VALUES('/Sessions/Mixed.jsonl','/Sessions','global','topic')`,
-		`INSERT INTO catalog_topics(scope,topic_id) VALUES('global','topic')`,
-		`INSERT INTO catalog_folded_topics(scope,topic_id) VALUES('global','folded')`,
-	} {
-		if _, err := handle.DB.ExecContext(ctx, statement); err != nil {
-			_ = handle.DB.Close()
-			t.Fatal(err)
-		}
-	}
-	if err := handle.DB.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	catalog, err := Open(ctx, Options{Path: path, DisableRepair: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
-	for _, table := range []string{"catalog_directories", "catalog_sessions", "catalog_topics", "catalog_folded_topics"} {
-		var rows int
-		if err := catalog.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&rows); err != nil {
-			t.Fatal(err)
-		}
-		if rows != 0 {
-			t.Fatalf("%s rows after v9 migration = %d, want clean disposable projection", table, rows)
-		}
 	}
 }
 

--- a/internal/sessioncatalog/directory_scan.go
+++ b/internal/sessioncatalog/directory_scan.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"path/filepath"
-	"strings"
 )
 
 type DirectoryScanStatus struct {
@@ -22,7 +20,7 @@ func (c *Catalog) CountDirectorySessions(ctx context.Context, path string) (int6
 		return 0, nil
 	}
 	var count int64
-	err := c.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions WHERE directory=? AND missing_since=0`, filepath.Clean(strings.TrimSpace(path))).Scan(&count)
+	err := c.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions WHERE directory_key=? AND missing_since=0`, c.pathKey(path)).Scan(&count)
 	return count, err
 }
 
@@ -34,12 +32,12 @@ func (c *Catalog) DirectoryStatus(ctx context.Context, path string) DirectorySca
 	if c == nil || c.db == nil {
 		return DirectoryScanStatus{}
 	}
-	path = filepath.Clean(strings.TrimSpace(path))
-	if path == "" || path == "." {
+	path = cleanCatalogAccessPath(path)
+	if path == "" {
 		return DirectoryScanStatus{}
 	}
 	var status DirectoryScanStatus
-	err := c.db.QueryRowContext(ctx, `SELECT state,error FROM catalog_directories WHERE path=?`, path).Scan(&status.State, &status.Error)
+	err := c.db.QueryRowContext(ctx, `SELECT state,error FROM catalog_directories WHERE path_key=?`, c.pathKey(path)).Scan(&status.State, &status.Error)
 	if errors.Is(err, sql.ErrNoRows) || err != nil {
 		return DirectoryScanStatus{}
 	}
@@ -48,7 +46,7 @@ func (c *Catalog) DirectoryStatus(ctx context.Context, path string) DirectorySca
 }
 
 // DirectoryScanReady reports whether this directory has finished at least one
-// catalog scan. An opened-but-unscanned v5 cache is not ready: ListTopics would
+// catalog scan. An opened-but-unscanned v6 cache is not ready: ListTopics would
 // otherwise treat "no rows yet" as "the user has no conversations".
 func (c *Catalog) DirectoryScanReady(ctx context.Context, path string) bool {
 	return c.DirectoryStatus(ctx, path).State == "ready"
@@ -56,7 +54,7 @@ func (c *Catalog) DirectoryScanReady(ctx context.Context, path string) bool {
 
 // HasWorkspaceRecords reports whether any non-missing session is already
 // projected for this workspace. Used so an in-progress scan that has written
-// rows stays authoritative, while a brand-new empty v5 cache does not.
+// rows stays authoritative, while a brand-new empty v6 cache does not.
 func (c *Catalog) HasWorkspaceRecords(ctx context.Context, scope, workspaceRoot string) bool {
 	if c == nil || c.db == nil {
 		return false

--- a/internal/sessioncatalog/directory_scan.go
+++ b/internal/sessioncatalog/directory_scan.go
@@ -61,7 +61,7 @@ func (c *Catalog) HasWorkspaceRecords(ctx context.Context, scope, workspaceRoot 
 	}
 	scope, workspaceRoot = normalizeScope(scope, workspaceRoot)
 	var n int
-	err := c.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions WHERE scope=? AND workspace_root=? AND missing_since=0`,
-		scope, workspaceRoot).Scan(&n)
+	err := c.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions WHERE scope=? AND workspace_root_key=? AND missing_since=0`,
+		scope, c.workspaceRootKey(scope, workspaceRoot)).Scan(&n)
 	return err == nil && n > 0
 }

--- a/internal/sessioncatalog/identity_remap.go
+++ b/internal/sessioncatalog/identity_remap.go
@@ -1,0 +1,82 @@
+package sessioncatalog
+
+import (
+	"context"
+	"database/sql"
+)
+
+// removeRemappedSessionIdentity removes a projection whose access spelling is
+// unchanged but whose filesystem identity moved, for example after a symlink
+// retarget. The caller reinserts the current identity in the same transaction.
+func removeRemappedSessionIdentity(ctx context.Context, tx *sql.Tx, path, pathKey string) ([]TopicKey, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT scope,workspace_root,workspace_root_key,topic_id FROM catalog_sessions
+		WHERE path=? AND path_key<>? AND topic_id<>''`, path, pathKey)
+	if err != nil {
+		return nil, err
+	}
+	affected := []TopicKey{}
+	for rows.Next() {
+		var key TopicKey
+		if err := rows.Scan(&key.Scope, &key.WorkspaceRoot, &key.workspaceKey, &key.TopicID); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		affected = append(affected, key)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM catalog_sessions WHERE path=? AND path_key<>?`, path, pathKey); err != nil {
+		return nil, err
+	}
+	return affected, nil
+}
+
+func (c *Catalog) removeRemappedDirectoryIdentity(ctx context.Context, tx *sql.Tx, path, pathKey string) error {
+	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT s.scope,s.workspace_root,s.workspace_root_key,s.topic_id
+		FROM catalog_sessions s JOIN catalog_directories d ON d.path_key=s.directory_key
+		WHERE d.path=? AND d.path_key<>? AND s.topic_id<>''`, path, pathKey)
+	if err != nil {
+		return err
+	}
+	affected := []TopicKey{}
+	for rows.Next() {
+		var key TopicKey
+		if err := rows.Scan(&key.Scope, &key.WorkspaceRoot, &key.workspaceKey, &key.TopicID); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		affected = append(affected, key)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM catalog_sessions WHERE directory_key IN (
+		SELECT path_key FROM catalog_directories WHERE path=? AND path_key<>?
+	)`, path, pathKey); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM catalog_directories WHERE path=? AND path_key<>?`, path, pathKey); err != nil {
+		return err
+	}
+	for _, key := range affected {
+		if err := c.recomputeTopic(ctx, tx, key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeRemappedTopicIdentity(ctx context.Context, tx *sql.Tx, key TopicKey, rootKey string) error {
+	_, err := tx.ExecContext(ctx, `DELETE FROM catalog_topics
+		WHERE scope=? AND workspace_root=? AND topic_id=? AND workspace_root_key<>?`,
+		key.Scope, key.WorkspaceRoot, key.TopicID, rootKey)
+	return err
+}
+
+func removeRemappedFoldedTopicIdentity(ctx context.Context, tx *sql.Tx, key TopicKey, rootKey string) error {
+	_, err := tx.ExecContext(ctx, `DELETE FROM catalog_folded_topics
+		WHERE scope=? AND workspace_root=? AND topic_id=? AND workspace_root_key<>?`,
+		key.Scope, key.WorkspaceRoot, key.TopicID, rootKey)
+	return err
+}

--- a/internal/sessioncatalog/index_queue.go
+++ b/internal/sessioncatalog/index_queue.go
@@ -1,0 +1,67 @@
+package sessioncatalog
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+)
+
+// RequestIndexSession coalesces an authoritative session write by path. It is
+// intentionally non-blocking so a saturated projection can never delay JSONL
+// or sidecar persistence.
+func (c *Catalog) RequestIndexSession(target DirectoryTarget, path string) bool {
+	if c == nil {
+		return false
+	}
+	path = cleanCatalogAccessPath(path)
+	if path == "" {
+		return false
+	}
+	target.Path = cleanCatalogAccessPath(target.Path)
+	if target.Path == "" {
+		target.Path = filepath.Dir(path)
+	}
+	key := queuePathKey(path)
+	request := sessionPathRequest{target: target, path: path, queueKey: key, sequence: c.mutationSeq.Add(1)}
+	c.pathQueueMu.Lock()
+	if _, loaded := c.pathQueued.Load(key); loaded {
+		c.pathQueued.Store(key, request)
+		c.pathQueueMu.Unlock()
+		return true
+	}
+	c.pathQueued.Store(key, request)
+	select {
+	case c.pathCh <- request:
+		c.pathQueueMu.Unlock()
+		return true
+	case <-c.stop:
+		c.pathQueued.Delete(key)
+		c.pathQueueMu.Unlock()
+		return false
+	default:
+		c.pathQueued.Delete(key)
+		c.pathQueueMu.Unlock()
+		return false
+	}
+}
+
+func (c *Catalog) sessionPathLoop() {
+	defer c.workers.Done()
+	for {
+		select {
+		case token := <-c.pathCh:
+			c.pathQueueMu.Lock()
+			queued, ok := c.pathQueued.LoadAndDelete(token.queueKey)
+			c.pathQueueMu.Unlock()
+			if !ok {
+				continue
+			}
+			request := queued.(sessionPathRequest)
+			ctx, cancel := context.WithTimeout(c.workerCtx, 30*time.Second)
+			_ = c.indexSessionPath(ctx, request.target, request.path, request.sequence)
+			cancel()
+		case <-c.stop:
+			return
+		}
+	}
+}

--- a/internal/sessioncatalog/lineage_test.go
+++ b/internal/sessioncatalog/lineage_test.go
@@ -361,7 +361,7 @@ func TestRecoveryFilenameParentID(t *testing.T) {
 }
 
 func TestUpgradeMatrixV4RebuildKeepsSingleLogicalRowAndAuthority(t *testing.T) {
-	// Simulates 1.24.2-style multi-topic recovery storm → new v5 projection →
+	// Simulates 1.24.2-style multi-topic recovery storm → new v6 projection →
 	// discard cache → reindex. Ordinary list stays one row; JSONL/meta bytes
 	// are never rewritten (the 1.23.0→new-version reinstall path).
 	ctx := context.Background()
@@ -428,9 +428,9 @@ func TestUpgradeMatrixV4RebuildKeepsSingleLogicalRowAndAuthority(t *testing.T) {
 			t.Fatalf("authority file mutated during catalog rebuild: %s", path)
 		}
 	}
-	// v5 path is independent of all older disposable caches.
-	if !strings.HasSuffix(filepath.ToSlash(DefaultPath()), "session-catalog/v5.sqlite") && DefaultPath() != "" {
-		t.Fatalf("DefaultPath = %q, want v5.sqlite", DefaultPath())
+	// v6 path is independent of all older disposable caches.
+	if !strings.HasSuffix(filepath.ToSlash(DefaultPath()), "session-catalog/v6.sqlite") && DefaultPath() != "" {
+		t.Fatalf("DefaultPath = %q, want v6.sqlite", DefaultPath())
 	}
 }
 

--- a/internal/sessioncatalog/metadata.go
+++ b/internal/sessioncatalog/metadata.go
@@ -33,11 +33,11 @@ func (c *Catalog) SyncMetadata(ctx context.Context, projects []ProjectRecord, to
 	for _, project := range projects {
 		project.Scope, project.WorkspaceRoot = normalizeScope(project.Scope, project.WorkspaceRoot)
 		if _, err := tx.ExecContext(ctx, `INSERT INTO catalog_projects(
-            scope,workspace_root,title,color,pinned,sort_order,updated_at
-        ) VALUES(?,?,?,?,?,?,?) ON CONFLICT(scope,workspace_root) DO UPDATE SET
-            title=excluded.title,color=excluded.color,pinned=excluded.pinned,
-            sort_order=excluded.sort_order,updated_at=excluded.updated_at`,
-			project.Scope, project.WorkspaceRoot, project.Title, project.Color,
+			scope,workspace_root,workspace_root_key,title,color,pinned,sort_order,updated_at
+		) VALUES(?,?,?,?,?,?,?,?) ON CONFLICT(scope,workspace_root_key) DO UPDATE SET
+			workspace_root=excluded.workspace_root,title=excluded.title,color=excluded.color,pinned=excluded.pinned,
+			sort_order=excluded.sort_order,updated_at=excluded.updated_at`,
+			project.Scope, project.WorkspaceRoot, c.workspaceRootKey(project.Scope, project.WorkspaceRoot), project.Title, project.Color,
 			project.Pinned, project.SortOrder, c.opts.Now().UnixMilli()); err != nil {
 			_ = tx.Rollback()
 			return err
@@ -57,7 +57,7 @@ func (c *Catalog) SyncMetadata(ctx context.Context, projects []ProjectRecord, to
 		if skip {
 			continue
 		}
-		if err := upsertTopicMetadata(ctx, tx, topic); err != nil {
+		if err := c.upsertTopicMetadata(ctx, tx, topic); err != nil {
 			_ = tx.Rollback()
 			return err
 		}
@@ -66,7 +66,7 @@ func (c *Catalog) SyncMetadata(ctx context.Context, projects []ProjectRecord, to
 	if _, err := tx.ExecContext(ctx, `DELETE FROM catalog_topics
         WHERE metadata_present=0 AND NOT EXISTS (
             SELECT 1 FROM catalog_sessions s WHERE s.scope=catalog_topics.scope
-            AND s.workspace_root=catalog_topics.workspace_root AND s.topic_id=catalog_topics.topic_id
+			AND s.workspace_root_key=catalog_topics.workspace_root_key AND s.topic_id=catalog_topics.topic_id
         )`); err != nil {
 		_ = tx.Rollback()
 		return err
@@ -100,40 +100,42 @@ func (c *Catalog) skipFoldedRecoveryShell(ctx context.Context, tx *sql.Tx, topic
 // aggregates when present so a metadata-only insert does not publish
 // last_activity_at=0 / turns_state=valid and reorder the sidebar ahead of (or
 // instead of) the authoritative session rows.
-func upsertTopicMetadata(ctx context.Context, tx *sql.Tx, topic TopicMetadata) error {
+func (c *Catalog) upsertTopicMetadata(ctx context.Context, tx *sql.Tx, topic TopicMetadata) error {
+	rootKey := c.workspaceRootKey(topic.Scope, topic.WorkspaceRoot)
 	_, err := tx.ExecContext(ctx, `INSERT INTO catalog_topics(
-            scope,workspace_root,topic_id,title,title_source,pinned,sort_order,
-            turns,turns_state,created_at,last_activity_at,recovery_state,health,metadata_present
-        )
-        SELECT ?,?,?,?,?,?,?,
+			scope,workspace_root,workspace_root_key,topic_id,title,title_source,pinned,sort_order,
+			turns,turns_state,created_at,last_activity_at,recovery_state,health,metadata_present
+		)
+		SELECT ?,?,?,?,?,?,?,?,
 		COALESCE((SELECT MAX(
 			COALESCE(SUM(CASE WHEN recovery_copy=0 AND recovered=0 AND turns_state='valid' THEN turns ELSE 0 END),0),
 			COALESCE(MAX(CASE WHEN recovery_copy=0 AND recovered=1 AND turns_state='valid' THEN turns ELSE 0 END),0)
-		) FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?),0),
+		) FROM catalog_sessions WHERE scope=? AND workspace_root_key=? AND topic_id=?),0),
             COALESCE((SELECT CASE
                 WHEN SUM(CASE WHEN recovery_copy=0 AND turns_state='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
                 WHEN SUM(CASE WHEN recovery_copy=0 AND turns_state='unknown' THEN 1 ELSE 0 END)>0 THEN 'unknown'
                 WHEN SUM(CASE WHEN recovery_copy=0 THEN 1 ELSE 0 END)=0 AND COUNT(*)>0 THEN 'valid'
                 WHEN COUNT(*)=0 THEN 'unknown'
                 ELSE 'valid' END
-                FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?),'unknown'),
-            COALESCE(NULLIF(?,0),(SELECT MIN(NULLIF(created_at,0)) FROM catalog_sessions
-                WHERE scope=? AND workspace_root=? AND topic_id=?),0),
-            COALESCE((SELECT MAX(last_activity_at) FROM catalog_sessions
-                WHERE scope=? AND workspace_root=? AND topic_id=?),0),
+				FROM catalog_sessions WHERE scope=? AND workspace_root_key=? AND topic_id=?),'unknown'),
+			COALESCE(NULLIF(?,0),(SELECT MIN(NULLIF(created_at,0)) FROM catalog_sessions
+				WHERE scope=? AND workspace_root_key=? AND topic_id=?),0),
+			COALESCE((SELECT MAX(last_activity_at) FROM catalog_sessions
+				WHERE scope=? AND workspace_root_key=? AND topic_id=?),0),
             COALESCE((SELECT CASE
                 WHEN COUNT(*)>0 AND SUM(CASE WHEN recovery_copy=0 THEN 1 ELSE 0 END)=0 THEN 'recovery_only'
                 ELSE '' END
-                FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?),''),
+				FROM catalog_sessions WHERE scope=? AND workspace_root_key=? AND topic_id=?),''),
             COALESCE((SELECT CASE
                 WHEN SUM(CASE WHEN recovery_copy=0 AND health='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
                 WHEN SUM(CASE WHEN recovery_copy=0 AND health='missing' THEN 1 ELSE 0 END)>0 THEN 'missing'
                 ELSE 'ok' END
-                FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?),'ok'),
-            1
-        ON CONFLICT(scope,workspace_root,topic_id) DO UPDATE SET
-            title=COALESCE(NULLIF((SELECT s.custom_title FROM catalog_sessions s
-                    WHERE s.scope=excluded.scope AND s.workspace_root=excluded.workspace_root
+				FROM catalog_sessions WHERE scope=? AND workspace_root_key=? AND topic_id=?),'ok'),
+			1
+		ON CONFLICT(scope,workspace_root_key,topic_id) DO UPDATE SET
+			workspace_root=excluded.workspace_root,
+			title=COALESCE(NULLIF((SELECT s.custom_title FROM catalog_sessions s
+					WHERE s.scope=excluded.scope AND s.workspace_root_key=excluded.workspace_root_key
                     AND s.topic_id=excluded.topic_id
                     ORDER BY s.recovery_copy ASC,s.last_activity_at DESC,s.path ASC LIMIT 1),''),
                 NULLIF(excluded.title,''),catalog_topics.title),
@@ -146,14 +148,14 @@ func upsertTopicMetadata(ctx context.Context, tx *sql.Tx, topic TopicMetadata) e
             turns_state=CASE WHEN excluded.turns_state<>'' AND excluded.turns_state<>'unknown'
                 THEN excluded.turns_state ELSE catalog_topics.turns_state END,
             recovery_state=excluded.recovery_state`,
-		topic.Scope, topic.WorkspaceRoot, topic.TopicID, topic.Title,
+		topic.Scope, topic.WorkspaceRoot, rootKey, topic.TopicID, topic.Title,
 		topic.TitleSource, topic.Pinned, topic.SortOrder,
-		topic.Scope, topic.WorkspaceRoot, topic.TopicID,
-		topic.Scope, topic.WorkspaceRoot, topic.TopicID,
-		topic.CreatedAt, topic.Scope, topic.WorkspaceRoot, topic.TopicID,
-		topic.Scope, topic.WorkspaceRoot, topic.TopicID,
-		topic.Scope, topic.WorkspaceRoot, topic.TopicID,
-		topic.Scope, topic.WorkspaceRoot, topic.TopicID)
+		topic.Scope, rootKey, topic.TopicID,
+		topic.Scope, rootKey, topic.TopicID,
+		topic.CreatedAt, topic.Scope, rootKey, topic.TopicID,
+		topic.Scope, rootKey, topic.TopicID,
+		topic.Scope, rootKey, topic.TopicID,
+		topic.Scope, rootKey, topic.TopicID)
 	return err
 }
 
@@ -169,10 +171,11 @@ func upsertTopicMetadata(ctx context.Context, tx *sql.Tx, topic TopicMetadata) e
 // carries no recovery_group_id of its own, so it is matched by path).
 // Lineages with no canonical yet (unresolved, still scanning) are left alone.
 func (c *Catalog) foldedRecoveryShellHasCanonical(ctx context.Context, tx *sql.Tx, scope, workspaceRoot, topicID string) (bool, error) {
+	rootKey := c.workspaceRootKey(scope, workspaceRoot)
 	var ordinary int
 	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions
-		WHERE scope=? AND workspace_root=? AND topic_id=? AND recovered=0 AND recovery_copy=0`,
-		scope, workspaceRoot, topicID).Scan(&ordinary); err != nil {
+		WHERE scope=? AND workspace_root_key=? AND topic_id=? AND recovered=0 AND recovery_copy=0`,
+		scope, rootKey, topicID).Scan(&ordinary); err != nil {
 		return false, err
 	}
 	if ordinary > 0 {
@@ -180,16 +183,16 @@ func (c *Catalog) foldedRecoveryShellHasCanonical(ctx context.Context, tx *sql.T
 	}
 	var folded int
 	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_folded_topics
-		WHERE scope=? AND workspace_root=? AND topic_id=?`,
-		scope, workspaceRoot, topicID).Scan(&folded); err != nil {
+		WHERE scope=? AND workspace_root_key=? AND topic_id=?`,
+		scope, rootKey, topicID).Scan(&folded); err != nil {
 		return false, err
 	}
 	if folded > 0 {
 		return true, nil
 	}
 	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT directory, recovery_group_id FROM catalog_sessions
-		WHERE scope=? AND workspace_root=? AND topic_id=? AND recovered=1 AND recovery_group_id<>''`,
-		scope, workspaceRoot, topicID)
+		WHERE scope=? AND workspace_root_key=? AND topic_id=? AND recovered=1 AND recovery_group_id<>''`,
+		scope, rootKey, topicID)
 	if err != nil {
 		return false, err
 	}
@@ -217,8 +220,8 @@ func (c *Catalog) foldedRecoveryShellHasCanonical(ctx context.Context, tx *sql.T
 	for _, group := range groups {
 		var canonical int
 		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions
-			WHERE scope=? AND workspace_root=? AND recovery_group_id=? AND (ordinary_visible=1 OR recovery_canonical=1)`,
-			scope, workspaceRoot, group.id).Scan(&canonical); err != nil {
+			WHERE scope=? AND workspace_root_key=? AND recovery_group_id=? AND (ordinary_visible=1 OR recovery_canonical=1)`,
+			scope, rootKey, group.id).Scan(&canonical); err != nil {
 			return false, err
 		}
 		if canonical > 0 {
@@ -240,27 +243,27 @@ func (c *Catalog) foldedRecoveryShellHasCanonical(ctx context.Context, tx *sql.T
 // rememberFoldedTopic tombstones a topic that lineage projection folded into a
 // recovery lineage's canonical row. The tombstone is cleared automatically if
 // a session is ever indexed under that topic id again.
-func rememberFoldedTopic(ctx context.Context, tx *sql.Tx, key TopicKey, foldedAt int64) error {
+func (c *Catalog) rememberFoldedTopic(ctx context.Context, tx *sql.Tx, key TopicKey, foldedAt int64) error {
 	if strings.TrimSpace(key.TopicID) == "" {
 		return nil
 	}
-	_, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO catalog_folded_topics(scope,workspace_root,topic_id,folded_at)
-		VALUES(?,?,?,?)`, key.Scope, key.WorkspaceRoot, key.TopicID, foldedAt)
+	_, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO catalog_folded_topics(scope,workspace_root,workspace_root_key,topic_id,folded_at)
+		VALUES(?,?,?,?,?)`, key.Scope, key.WorkspaceRoot, c.workspaceRootKey(key.Scope, key.WorkspaceRoot), key.TopicID, foldedAt)
 	return err
 }
 
 // updateFoldedTopicTombstones maintains folded-topic tombstones around a
 // session upsert: a session claiming a folded topic id makes it real again,
 // and a recovered row moving topics tombstones the shell it left behind.
-func updateFoldedTopicTombstones(ctx context.Context, tx *sql.Tx, previous TopicKey, record SessionRecord, now int64) error {
+func (c *Catalog) updateFoldedTopicTombstones(ctx context.Context, tx *sql.Tx, previous TopicKey, record SessionRecord, now int64) error {
 	if record.TopicID != "" {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM catalog_folded_topics WHERE scope=? AND workspace_root=? AND topic_id=?`,
-			record.Scope, record.WorkspaceRoot, record.TopicID); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM catalog_folded_topics WHERE scope=? AND workspace_root_key=? AND topic_id=?`,
+			record.Scope, c.workspaceRootKey(record.Scope, record.WorkspaceRoot), record.TopicID); err != nil {
 			return err
 		}
 	}
 	if record.Recovered && previous.TopicID != "" && previous.TopicID != record.TopicID {
-		return rememberFoldedTopic(ctx, tx, previous, now)
+		return c.rememberFoldedTopic(ctx, tx, previous, now)
 	}
 	return nil
 }

--- a/internal/sessioncatalog/metadata.go
+++ b/internal/sessioncatalog/metadata.go
@@ -49,7 +49,7 @@ func (c *Catalog) SyncMetadata(ctx context.Context, projects []ProjectRecord, to
 		if strings.TrimSpace(topic.TopicID) == "" {
 			continue
 		}
-		skip, err := skipFoldedRecoveryShell(ctx, tx, topic)
+		skip, err := c.skipFoldedRecoveryShell(ctx, tx, topic)
 		if err != nil {
 			_ = tx.Rollback()
 			return err
@@ -89,11 +89,11 @@ func (c *Catalog) SyncMetadata(ctx context.Context, projects []ProjectRecord, to
 // lineage projection re-anchors them onto the canonical row, re-creating this
 // shell from the registry would re-list the copy as a separate sidebar session
 // (#8525/#8551). Explicitly pinned topics survive: the user asked for that row.
-func skipFoldedRecoveryShell(ctx context.Context, tx *sql.Tx, topic TopicMetadata) (bool, error) {
+func (c *Catalog) skipFoldedRecoveryShell(ctx context.Context, tx *sql.Tx, topic TopicMetadata) (bool, error) {
 	if topic.Pinned {
 		return false, nil
 	}
-	return foldedRecoveryShellHasCanonical(ctx, tx, topic.Scope, topic.WorkspaceRoot, topic.TopicID)
+	return c.foldedRecoveryShellHasCanonical(ctx, tx, topic.Scope, topic.WorkspaceRoot, topic.TopicID)
 }
 
 // upsertTopicMetadata applies one registry topic. It inherits live session
@@ -168,7 +168,7 @@ func upsertTopicMetadata(ctx context.Context, tx *sql.Tx, topic TopicMetadata) e
 // ordinary_visible/recovery_canonical, or the non-recovered group root (which
 // carries no recovery_group_id of its own, so it is matched by path).
 // Lineages with no canonical yet (unresolved, still scanning) are left alone.
-func foldedRecoveryShellHasCanonical(ctx context.Context, tx *sql.Tx, scope, workspaceRoot, topicID string) (bool, error) {
+func (c *Catalog) foldedRecoveryShellHasCanonical(ctx context.Context, tx *sql.Tx, scope, workspaceRoot, topicID string) (bool, error) {
 	var ordinary int
 	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions
 		WHERE scope=? AND workspace_root=? AND topic_id=? AND recovered=0 AND recovery_copy=0`,
@@ -227,7 +227,7 @@ func foldedRecoveryShellHasCanonical(ctx context.Context, tx *sql.Tx, scope, wor
 		rootPath := filepath.Join(group.directory, group.id+".jsonl")
 		var roots int
 		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions
-			WHERE path=? AND recovered=0 AND recovery_copy=0`, rootPath).Scan(&roots); err != nil {
+			WHERE path_key=? AND recovered=0 AND recovery_copy=0`, c.pathKey(rootPath)).Scan(&roots); err != nil {
 			return false, err
 		}
 		if roots > 0 {

--- a/internal/sessioncatalog/metadata.go
+++ b/internal/sessioncatalog/metadata.go
@@ -102,6 +102,11 @@ func (c *Catalog) skipFoldedRecoveryShell(ctx context.Context, tx *sql.Tx, topic
 // instead of) the authoritative session rows.
 func (c *Catalog) upsertTopicMetadata(ctx context.Context, tx *sql.Tx, topic TopicMetadata) error {
 	rootKey := c.workspaceRootKey(topic.Scope, topic.WorkspaceRoot)
+	if err := removeRemappedTopicIdentity(ctx, tx, TopicKey{
+		Scope: topic.Scope, WorkspaceRoot: topic.WorkspaceRoot, TopicID: topic.TopicID,
+	}, rootKey); err != nil {
+		return err
+	}
 	_, err := tx.ExecContext(ctx, `INSERT INTO catalog_topics(
 			scope,workspace_root,workspace_root_key,topic_id,title,title_source,pinned,sort_order,
 			turns,turns_state,created_at,last_activity_at,recovery_state,health,metadata_present
@@ -247,8 +252,14 @@ func (c *Catalog) rememberFoldedTopic(ctx context.Context, tx *sql.Tx, key Topic
 	if strings.TrimSpace(key.TopicID) == "" {
 		return nil
 	}
-	_, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO catalog_folded_topics(scope,workspace_root,workspace_root_key,topic_id,folded_at)
-		VALUES(?,?,?,?,?)`, key.Scope, key.WorkspaceRoot, c.workspaceRootKey(key.Scope, key.WorkspaceRoot), key.TopicID, foldedAt)
+	rootKey := c.workspaceRootKey(key.Scope, key.WorkspaceRoot)
+	if err := removeRemappedFoldedTopicIdentity(ctx, tx, key, rootKey); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `INSERT INTO catalog_folded_topics(scope,workspace_root,workspace_root_key,topic_id,folded_at)
+		VALUES(?,?,?,?,?) ON CONFLICT(scope,workspace_root_key,topic_id) DO UPDATE SET
+		workspace_root=excluded.workspace_root,folded_at=excluded.folded_at`,
+		key.Scope, key.WorkspaceRoot, rootKey, key.TopicID, foldedAt)
 	return err
 }
 

--- a/internal/sessioncatalog/mutation_order.go
+++ b/internal/sessioncatalog/mutation_order.go
@@ -1,0 +1,35 @@
+package sessioncatalog
+
+// pathMutationAllowed applies the remove-versus-recreate generation rule at
+// every writer boundary. A candidate newer than the observed removal may clear
+// exactly that tombstone; if another removal replaces it concurrently, the
+// compare fails and the candidate is re-evaluated against the newer generation.
+func (c *Catalog) pathMutationAllowed(pathKey string, sequence uint64) bool {
+	for {
+		removedAt, removed := c.removedPaths.Load(pathKey)
+		if !removed {
+			return true
+		}
+		if c.testPathMutationLoadedHook != nil {
+			c.testPathMutationLoadedHook(pathKey)
+		}
+		removedSequence, ok := removedAt.(uint64)
+		if !ok || sequence <= removedSequence {
+			return false
+		}
+		if c.removedPaths.CompareAndDelete(pathKey, removedAt) {
+			return true
+		}
+	}
+}
+
+func (c *Catalog) filterPathMutations(records []SessionRecord, sequence uint64) []SessionRecord {
+	filtered := records[:0]
+	for _, record := range records {
+		if c.pathMutationAllowed(c.pathKey(record.Path), sequence) {
+			record.enqueueSequence = sequence
+			filtered = append(filtered, record)
+		}
+	}
+	return filtered
+}

--- a/internal/sessioncatalog/mutation_order_test.go
+++ b/internal/sessioncatalog/mutation_order_test.go
@@ -1,0 +1,157 @@
+package sessioncatalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"reasonix/internal/agent"
+)
+
+func TestNewerRemovalGenerationSurvivesOlderRecreation(t *testing.T) {
+	ctx := context.Background()
+	catalog, err := Open(ctx, Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	record := SessionRecord{
+		Path: "/sessions/race.jsonl", Directory: "/sessions", Scope: "global", TopicID: "topic",
+		Preview: "initial", TurnsState: TurnsValid, Health: HealthOK,
+	}
+	if err := catalog.UpsertSession(ctx, record); err != nil {
+		t.Fatal(err)
+	}
+	pathKey := catalog.pathKey(record.Path)
+	oldRemoval := catalog.mutationSeq.Add(1)
+	catalog.removedPaths.Store(pathKey, oldRemoval)
+	record.Preview = "stale recreation"
+	record.enqueueSequence = catalog.mutationSeq.Add(1)
+
+	loaded := make(chan struct{})
+	resume := make(chan struct{})
+	var once sync.Once
+	catalog.testPathMutationLoadedHook = func(key string) {
+		if key == pathKey {
+			once.Do(func() {
+				close(loaded)
+				<-resume
+			})
+		}
+	}
+	done := make(chan error, 1)
+	go func() { done <- catalog.upsertSessions(ctx, []SessionRecord{record}, nil, "test") }()
+	<-loaded
+	newRemoval := catalog.mutationSeq.Add(1)
+	catalog.removedPaths.Store(pathKey, newRemoval)
+	close(resume)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	catalog.testPathMutationLoadedHook = nil
+
+	removedAt, ok := catalog.removedPaths.Load(pathKey)
+	if !ok || removedAt != newRemoval {
+		t.Fatalf("removal generation = %v, %v, want %d", removedAt, ok, newRemoval)
+	}
+	var preview string
+	if err := catalog.db.QueryRowContext(ctx, `SELECT preview FROM catalog_sessions WHERE path_key=?`, pathKey).Scan(&preview); err != nil {
+		t.Fatal(err)
+	}
+	if preview != "initial" {
+		t.Fatalf("older recreation committed preview %q", preview)
+	}
+}
+
+func TestStaleExactIndexAndReconcileKeepRemovalTombstone(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{
+		Scope: "global", TopicID: "topic", Preview: "initial",
+		SchemaVersion: agent.BranchMetaCountsVersion, Turns: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	target := DirectoryTarget{Path: dir, Scope: "global"}
+	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.UpdateBranchMeta(path, false, func(meta *agent.BranchMeta) error {
+		meta.Preview = "stale projection should never commit"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	staleExactSequence := catalog.mutationSeq.Add(1)
+	staleScanSequence := catalog.mutationSeq.Add(1)
+	pathKey := catalog.pathKey(path)
+	removalSequence := catalog.mutationSeq.Add(1)
+	catalog.removedPaths.Store(pathKey, removalSequence)
+
+	if err := catalog.indexSessionPath(ctx, target, path, staleExactSequence); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.reconcileDirectory(ctx, target, staleScanSequence); err != nil {
+		t.Fatal(err)
+	}
+	if removedAt, ok := catalog.removedPaths.Load(pathKey); !ok || removedAt != removalSequence {
+		t.Fatalf("stale writers cleared removal generation: %v, %v", removedAt, ok)
+	}
+	if _, ok, err := catalog.GetSession(ctx, path); err != nil || ok {
+		t.Fatalf("tombstoned session became visible: ok=%v err=%v", ok, err)
+	}
+
+	if err := agent.UpdateBranchMeta(path, false, func(meta *agent.BranchMeta) error {
+		meta.Preview = "authoritative recreation"
+		meta.Turns = 2
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.indexSessionPath(ctx, target, path, catalog.mutationSeq.Add(1)); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := catalog.removedPaths.Load(pathKey); ok {
+		t.Fatal("newer authoritative recreation did not clear the older tombstone")
+	}
+	got, ok, err := catalog.GetSession(ctx, path)
+	if err != nil || !ok || got.Preview != "authoritative recreation" || got.Turns != 2 {
+		t.Fatalf("recreated session = %#v, %v, %v", got, ok, err)
+	}
+}
+
+func TestExactIndexQueueRetainsNewestGeneration(t *testing.T) {
+	catalog := &Catalog{
+		pathCh:         make(chan sessionPathRequest, 1),
+		directoryLocks: map[string]*sync.Mutex{},
+		stop:           make(chan struct{}),
+	}
+	path := filepath.Join(string(filepath.Separator), "sessions", "session.jsonl")
+	first := DirectoryTarget{Path: filepath.Dir(path), Scope: "global"}
+	second := DirectoryTarget{Path: filepath.Dir(path), Scope: "project", WorkspaceRoot: "/workspace"}
+	if !catalog.RequestIndexSession(first, path) || !catalog.RequestIndexSession(second, path) {
+		t.Fatal("coalesced exact-index request was rejected")
+	}
+	queued, ok := catalog.pathQueued.Load(queuePathKey(path))
+	if !ok {
+		t.Fatal("latest exact-index request was not retained")
+	}
+	request := queued.(sessionPathRequest)
+	if request.target.Scope != "project" || request.target.WorkspaceRoot != "/workspace" || request.sequence != 2 {
+		t.Fatalf("coalesced request = %#v, want newest generation", request)
+	}
+	if len(catalog.pathCh) != 1 {
+		t.Fatalf("coalesced queue signals = %d, want one", len(catalog.pathCh))
+	}
+}

--- a/internal/sessioncatalog/ordinary_visibility.go
+++ b/internal/sessioncatalog/ordinary_visibility.go
@@ -32,8 +32,8 @@ func (c *Catalog) PreferredOrdinarySessionPaths(ctx context.Context, scope, work
 		SELECT path, recovered, parent_id, recovery_copy, recovery_group_id,
 		       recovery_role, recovery_canonical, turns, last_activity_at
 		FROM catalog_sessions
-		WHERE scope=? AND workspace_root=? AND missing_since=0 AND health<>'missing'`,
-		scope, workspaceRoot)
+		WHERE scope=? AND workspace_root_key=? AND missing_since=0 AND health<>'missing'`,
+		scope, c.workspaceRootKey(scope, workspaceRoot))
 	if err != nil {
 		return out, err
 	}

--- a/internal/sessioncatalog/path_identity.go
+++ b/internal/sessioncatalog/path_identity.go
@@ -1,0 +1,84 @@
+package sessioncatalog
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// PathIdentityKey returns the stable comparison key for a catalog path while
+// leaving the caller's access spelling untouched. Parent aliases are resolved,
+// and case is folded only when the governing filesystem directory reports
+// case-insensitive lookup.
+func PathIdentityKey(path string) string {
+	path = cleanCatalogAccessPath(path)
+	if path == "" {
+		return ""
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		absolute = path
+	}
+	absolute = resolveCatalogPathThroughExistingAncestor(absolute)
+	absolute = platformCatalogPathIdentity(absolute)
+	return filepath.Clean(absolute)
+}
+
+func cleanCatalogAccessPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	path = filepath.Clean(path)
+	if path == "." {
+		return ""
+	}
+	return path
+}
+
+func resolveCatalogPathThroughExistingAncestor(path string) string {
+	current := filepath.Clean(path)
+	missing := make([]string, 0, 4)
+	for {
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			for _, part := range slices.Backward(missing) {
+				resolved = filepath.Join(resolved, part)
+			}
+			return resolved
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return path
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
+}
+
+// UniqueDirectoryTargets keeps the first usable access spelling for each
+// physical directory identity. Rebuild and every caller use the same boundary,
+// so a missed Desktop or CLI call site cannot reintroduce duplicate scans.
+func UniqueDirectoryTargets(targets []DirectoryTarget) []DirectoryTarget {
+	return uniqueDirectoryTargetsBy(targets, PathIdentityKey)
+}
+
+func uniqueDirectoryTargetsBy(targets []DirectoryTarget, identity func(string) string) []DirectoryTarget {
+	seen := make(map[string]struct{}, len(targets))
+	out := make([]DirectoryTarget, 0, len(targets))
+	for _, target := range targets {
+		target.Path = cleanCatalogAccessPath(target.Path)
+		if target.Path == "" {
+			continue
+		}
+		key := identity(target.Path)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, target)
+	}
+	return out
+}

--- a/internal/sessioncatalog/path_identity_darwin.go
+++ b/internal/sessioncatalog/path_identity_darwin.go
@@ -1,0 +1,46 @@
+//go:build darwin
+
+package sessioncatalog
+
+import (
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/text/unicode/norm"
+)
+
+const darwinCatalogPathconfCaseSensitive = 11
+
+func platformCatalogPathIdentity(path string) string {
+	path = platformCatalogPathUnicodeNormalized(path)
+	if platformCatalogPathCaseInsensitive(path) {
+		path = strings.ToLower(path)
+	}
+	return path
+}
+
+func platformCatalogPathCaseInsensitive(path string) bool {
+	parent := existingCatalogPathParent(path)
+	if parent == "" {
+		return false
+	}
+	caseSensitive, err := syscall.Pathconf(parent, darwinCatalogPathconfCaseSensitive)
+	return err == nil && caseSensitive == 0
+}
+
+func platformCatalogPathUnicodeNormalized(path string) string {
+	parent := existingCatalogPathParent(path)
+	if parent == "" {
+		return path
+	}
+	var stat unix.Statfs_t
+	if err := unix.Statfs(parent, &stat); err != nil {
+		return path
+	}
+	fsType := strings.TrimRight(string(stat.Fstypename[:]), "\x00")
+	if fsType != "apfs" && fsType != "hfs" {
+		return path
+	}
+	return norm.NFD.String(path)
+}

--- a/internal/sessioncatalog/path_identity_migration_test.go
+++ b/internal/sessioncatalog/path_identity_migration_test.go
@@ -8,7 +8,7 @@ import (
 	"reasonix/internal/projectiondb"
 )
 
-func TestMigrationV9InvalidatesLegacyProjectionForAuthoritativeRebuild(t *testing.T) {
+func TestPathIdentityMigrationsInvalidateLegacyProjectionForAuthoritativeRebuild(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "catalog.sqlite")
 	handle, err := projectiondb.Open(ctx, projectiondb.OpenOptions{
@@ -19,6 +19,7 @@ func TestMigrationV9InvalidatesLegacyProjectionForAuthoritativeRebuild(t *testin
 	}
 	for _, statement := range []string{
 		`INSERT INTO catalog_directories(path,scope) VALUES('/Sessions','global')`,
+		`INSERT INTO catalog_projects(scope,title) VALUES('global','Global')`,
 		`INSERT INTO catalog_sessions(path,directory,scope,topic_id) VALUES('/Sessions/Mixed.jsonl','/Sessions','global','topic')`,
 		`INSERT INTO catalog_topics(scope,topic_id) VALUES('global','topic')`,
 		`INSERT INTO catalog_folded_topics(scope,topic_id) VALUES('global','folded')`,
@@ -37,13 +38,54 @@ func TestMigrationV9InvalidatesLegacyProjectionForAuthoritativeRebuild(t *testin
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
-	for _, table := range []string{"catalog_directories", "catalog_sessions", "catalog_topics", "catalog_folded_topics"} {
+	for _, table := range []string{"catalog_directories", "catalog_projects", "catalog_sessions", "catalog_topics", "catalog_folded_topics"} {
 		var rows int
 		if err := catalog.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&rows); err != nil {
 			t.Fatal(err)
 		}
 		if rows != 0 {
 			t.Fatalf("%s rows after v9 migration = %d, want clean disposable projection", table, rows)
+		}
+	}
+}
+
+func TestMigrationV10InvalidatesPublishedV9Projection(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "catalog.sqlite")
+	handle, err := projectiondb.Open(ctx, projectiondb.OpenOptions{
+		Path: path, MemoryName: "session-catalog-v9-test", Migrations: sessionMigrations()[:9], RequireDisk: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`INSERT INTO catalog_directories(path,path_key,scope) VALUES('/Sessions','/sessions','global')`,
+		`INSERT INTO catalog_projects(scope,title) VALUES('global','Global')`,
+		`INSERT INTO catalog_sessions(path,path_key,directory,directory_key,scope,topic_id) VALUES('/Sessions/Mixed.jsonl','/sessions/mixed.jsonl','/Sessions','/sessions','global','topic')`,
+		`INSERT INTO catalog_topics(scope,topic_id) VALUES('global','topic')`,
+		`INSERT INTO catalog_folded_topics(scope,topic_id) VALUES('global','folded')`,
+	} {
+		if _, err := handle.DB.ExecContext(ctx, statement); err != nil {
+			_ = handle.DB.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := handle.DB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	catalog, err := Open(ctx, Options{Path: path, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	for _, table := range []string{"catalog_directories", "catalog_projects", "catalog_sessions", "catalog_topics", "catalog_folded_topics"} {
+		var rows int
+		if err := catalog.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&rows); err != nil {
+			t.Fatal(err)
+		}
+		if rows != 0 {
+			t.Fatalf("%s rows after v10 migration = %d, want clean disposable projection", table, rows)
 		}
 	}
 }

--- a/internal/sessioncatalog/path_identity_migration_test.go
+++ b/internal/sessioncatalog/path_identity_migration_test.go
@@ -1,0 +1,49 @@
+package sessioncatalog
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/projectiondb"
+)
+
+func TestMigrationV9InvalidatesLegacyProjectionForAuthoritativeRebuild(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "catalog.sqlite")
+	handle, err := projectiondb.Open(ctx, projectiondb.OpenOptions{
+		Path: path, MemoryName: "session-catalog-v8-test", Migrations: sessionMigrations()[:8], RequireDisk: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`INSERT INTO catalog_directories(path,scope) VALUES('/Sessions','global')`,
+		`INSERT INTO catalog_sessions(path,directory,scope,topic_id) VALUES('/Sessions/Mixed.jsonl','/Sessions','global','topic')`,
+		`INSERT INTO catalog_topics(scope,topic_id) VALUES('global','topic')`,
+		`INSERT INTO catalog_folded_topics(scope,topic_id) VALUES('global','folded')`,
+	} {
+		if _, err := handle.DB.ExecContext(ctx, statement); err != nil {
+			_ = handle.DB.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := handle.DB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	catalog, err := Open(ctx, Options{Path: path, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	for _, table := range []string{"catalog_directories", "catalog_sessions", "catalog_topics", "catalog_folded_topics"} {
+		var rows int
+		if err := catalog.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&rows); err != nil {
+			t.Fatal(err)
+		}
+		if rows != 0 {
+			t.Fatalf("%s rows after v9 migration = %d, want clean disposable projection", table, rows)
+		}
+	}
+}

--- a/internal/sessioncatalog/path_identity_other.go
+++ b/internal/sessioncatalog/path_identity_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !windows
+
+package sessioncatalog
+
+func platformCatalogPathIdentity(path string) string {
+	return path
+}

--- a/internal/sessioncatalog/path_identity_platform.go
+++ b/internal/sessioncatalog/path_identity_platform.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package sessioncatalog
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func existingCatalogPathParent(path string) string {
+	dir := filepath.Dir(path)
+	for {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
+		next := filepath.Dir(dir)
+		if next == dir {
+			return ""
+		}
+		dir = next
+	}
+}

--- a/internal/sessioncatalog/path_identity_test.go
+++ b/internal/sessioncatalog/path_identity_test.go
@@ -2,6 +2,7 @@ package sessioncatalog
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,8 +124,12 @@ func TestReconcileDirectoryUsesFilesystemIdentityWhenCaseInsensitive(t *testing.
 	}
 }
 
-func TestCatalogPathIdentityCoalescesQueuesAndLocks(t *testing.T) {
-	fold := func(path string) string { return strings.ToLower(filepath.Clean(path)) }
+func TestCatalogPathIdentityDefersFilesystemResolutionFromEnqueue(t *testing.T) {
+	identityCalls := 0
+	fold := func(path string) string {
+		identityCalls++
+		return strings.ToLower(filepath.Clean(path))
+	}
 	catalog := &Catalog{
 		pathIdentity:   fold,
 		writeCh:        make(chan string, 2),
@@ -145,16 +150,16 @@ func TestCatalogPathIdentityCoalescesQueuesAndLocks(t *testing.T) {
 	if !catalog.EnqueueSession(first) || !catalog.EnqueueSession(second) {
 		t.Fatal("write queue rejected a case variant")
 	}
-	if len(catalog.writeQueued) != 1 || len(catalog.writeCh) != 1 {
-		t.Fatalf("write queue split identity: rows=%d signals=%d", len(catalog.writeQueued), len(catalog.writeCh))
+	if len(catalog.writeQueued) != 2 || len(catalog.writeCh) != 2 {
+		t.Fatalf("lexical write staging = rows=%d signals=%d, want both events", len(catalog.writeQueued), len(catalog.writeCh))
 	}
 	if !catalog.RequestReconcile(DirectoryTarget{Path: upperDir}) || !catalog.RequestReconcile(DirectoryTarget{Path: lowerDir}) {
 		t.Fatal("reconcile queue rejected a case variant")
 	}
 	queuedReconciles := 0
 	catalog.reconcileQueued.Range(func(_, _ any) bool { queuedReconciles++; return true })
-	if queuedReconciles != 1 || len(catalog.reconcileCh) != 1 || len(catalog.reconcileDirty) != 1 {
-		t.Fatalf("reconcile queue split identity: queued=%d signals=%d dirty=%d", queuedReconciles, len(catalog.reconcileCh), len(catalog.reconcileDirty))
+	if queuedReconciles != 2 || len(catalog.reconcileCh) != 2 || len(catalog.reconcileDirty) != 0 {
+		t.Fatalf("lexical reconcile staging: queued=%d signals=%d dirty=%d", queuedReconciles, len(catalog.reconcileCh), len(catalog.reconcileDirty))
 	}
 	if !catalog.RequestIndexSession(DirectoryTarget{Path: upperDir}, upperPath) ||
 		!catalog.RequestIndexSession(DirectoryTarget{Path: lowerDir}, lowerPath) {
@@ -162,8 +167,11 @@ func TestCatalogPathIdentityCoalescesQueuesAndLocks(t *testing.T) {
 	}
 	queuedPaths := 0
 	catalog.pathQueued.Range(func(_, _ any) bool { queuedPaths++; return true })
-	if queuedPaths != 1 || len(catalog.pathCh) != 1 {
-		t.Fatalf("direct-index queue split identity: queued=%d signals=%d", queuedPaths, len(catalog.pathCh))
+	if queuedPaths != 2 || len(catalog.pathCh) != 2 {
+		t.Fatalf("lexical direct-index staging: queued=%d signals=%d", queuedPaths, len(catalog.pathCh))
+	}
+	if identityCalls != 0 {
+		t.Fatalf("enqueue APIs performed %d filesystem identity resolutions", identityCalls)
 	}
 	catalog.enqueueRepair(upperPath)
 	catalog.enqueueRepair(lowerPath)
@@ -253,5 +261,78 @@ func TestCatalogPathIdentityPreservesCaseDistinctSessions(t *testing.T) {
 	}
 	if len(page.Items) != 2 {
 		t.Fatalf("case-distinct sessions = %#v, want two", page.Items)
+	}
+}
+
+func TestWorkspaceRootIdentityJoinsRegistryAndSidecarSpellings(t *testing.T) {
+	ctx := context.Background()
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	catalog.pathIdentity = func(path string) string {
+		return strings.ToLower(filepath.Clean(path))
+	}
+
+	upperRoot := filepath.Join(string(filepath.Separator), "Workspaces", "Project")
+	lowerRoot := filepath.Join(string(filepath.Separator), "workspaces", "project")
+	if err := catalog.UpsertSession(ctx, SessionRecord{
+		Path: filepath.Join(lowerRoot, "sessions", "one.jsonl"), Directory: filepath.Join(lowerRoot, "sessions"),
+		Scope: "project", WorkspaceRoot: lowerRoot, TopicID: "topic", Preview: "from sidecar",
+		LastActivityAt: 1, TurnsState: TurnsValid, Health: HealthOK,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.SyncMetadata(ctx,
+		[]ProjectRecord{{Scope: "project", WorkspaceRoot: upperRoot, Title: "Project"}},
+		[]TopicMetadata{{Scope: "project", WorkspaceRoot: upperRoot, TopicID: "topic", Title: "Registry title"}},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	topics, err := catalog.ListTopics(ctx, TopicPageRequest{Scope: "project", WorkspaceRoot: upperRoot, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(topics.Items) != 1 || len(topics.Items[0].Sessions) != 1 {
+		t.Fatalf("registry spelling topics = %#v, want joined sidecar session", topics.Items)
+	}
+	sessions, err := catalog.ListSessions(ctx, SessionPageRequest{Scope: "project", WorkspaceRoot: upperRoot, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions.Items) != 1 || sessions.Items[0].WorkspaceRoot != lowerRoot {
+		t.Fatalf("registry spelling sessions = %#v, want original sidecar access spelling", sessions.Items)
+	}
+}
+
+func TestWorkspaceRootIdentityPreservesCaseDistinctProjects(t *testing.T) {
+	ctx := context.Background()
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	catalog.pathIdentity = filepath.Clean
+
+	roots := []string{"/Workspaces/Foo", "/Workspaces/foo"}
+	for index, root := range roots {
+		if err := catalog.UpsertSession(ctx, SessionRecord{
+			Path: filepath.Join(root, "sessions", fmt.Sprintf("%d.jsonl", index)), Directory: filepath.Join(root, "sessions"),
+			Scope: "project", WorkspaceRoot: root, TopicID: "topic", LastActivityAt: int64(index + 1),
+			TurnsState: TurnsValid, Health: HealthOK,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, root := range roots {
+		page, err := catalog.ListTopics(ctx, TopicPageRequest{Scope: "project", WorkspaceRoot: root, Limit: 10})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(page.Items) != 1 || len(page.Items[0].Sessions) != 1 || page.Items[0].Sessions[0].WorkspaceRoot != root {
+			t.Fatalf("case-distinct workspace %q topics = %#v", root, page.Items)
+		}
 	}
 }

--- a/internal/sessioncatalog/path_identity_test.go
+++ b/internal/sessioncatalog/path_identity_test.go
@@ -266,12 +266,20 @@ func TestCatalogPathIdentityPreservesCaseDistinctSessions(t *testing.T) {
 
 func TestWorkspaceRootIdentityJoinsRegistryAndSidecarSpellings(t *testing.T) {
 	ctx := context.Background()
-	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	revisionRoots := [][]string{}
+	catalog, err := Open(ctx, Options{
+		Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true,
+		OnRevision: func(_ uint64, roots []string, _ string) {
+			revisionRoots = append(revisionRoots, append([]string(nil), roots...))
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	identityCalls := 0
 	catalog.pathIdentity = func(path string) string {
+		identityCalls++
 		return strings.ToLower(filepath.Clean(path))
 	}
 
@@ -290,7 +298,19 @@ func TestWorkspaceRootIdentityJoinsRegistryAndSidecarSpellings(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
+	revisionRoots = nil
+	if err := catalog.UpsertSession(ctx, SessionRecord{
+		Path: filepath.Join(lowerRoot, "sessions", "one.jsonl"), Directory: filepath.Join(lowerRoot, "sessions"),
+		Scope: "project", WorkspaceRoot: lowerRoot, TopicID: "topic", Preview: "updated sidecar",
+		LastActivityAt: 2, TurnsState: TurnsValid, Health: HealthOK,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(revisionRoots) != 1 || len(revisionRoots[0]) != 1 || revisionRoots[0][0] != upperRoot {
+		t.Fatalf("sidecar revision roots = %#v, want registry spelling %q", revisionRoots, upperRoot)
+	}
 
+	identityCalls = 0
 	topics, err := catalog.ListTopics(ctx, TopicPageRequest{Scope: "project", WorkspaceRoot: upperRoot, Limit: 10})
 	if err != nil {
 		t.Fatal(err)
@@ -298,12 +318,74 @@ func TestWorkspaceRootIdentityJoinsRegistryAndSidecarSpellings(t *testing.T) {
 	if len(topics.Items) != 1 || len(topics.Items[0].Sessions) != 1 {
 		t.Fatalf("registry spelling topics = %#v, want joined sidecar session", topics.Items)
 	}
+	if identityCalls != 1 {
+		t.Fatalf("ListTopics workspace identity calls = %d, want one per request", identityCalls)
+	}
 	sessions, err := catalog.ListSessions(ctx, SessionPageRequest{Scope: "project", WorkspaceRoot: upperRoot, Limit: 10})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(sessions.Items) != 1 || sessions.Items[0].WorkspaceRoot != lowerRoot {
 		t.Fatalf("registry spelling sessions = %#v, want original sidecar access spelling", sessions.Items)
+	}
+}
+
+func TestCatalogIdentityRemapReplacesSameAccessSpelling(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	root := filepath.Join(dir, "workspace-link")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{
+		Scope: "project", WorkspaceRoot: root, TopicID: "topic", Preview: "first identity",
+		SchemaVersion: agent.BranchMetaCountsVersion, Turns: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	generation := "identity-a:"
+	catalog.pathIdentity = func(value string) string {
+		return generation + filepath.Clean(value)
+	}
+	target := DirectoryTarget{Path: dir, Scope: "project", WorkspaceRoot: root}
+	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
+		t.Fatal(err)
+	}
+
+	generation = "identity-b:"
+	if err := agent.UpdateBranchMeta(path, false, func(meta *agent.BranchMeta) error {
+		meta.Preview = "second identity after remap"
+		meta.Turns = 2
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.ReconcileDirectory(ctx, target); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, table := range []string{"catalog_directories", "catalog_sessions", "catalog_topics"} {
+		var count int
+		if err := catalog.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Fatalf("%s rows after identity remap = %d, want one", table, count)
+		}
+	}
+	got, ok, err := catalog.GetSession(ctx, path)
+	if err != nil || !ok || got.Preview != "second identity after remap" || got.Turns != 2 {
+		t.Fatalf("remapped session = %#v, %v, %v", got, ok, err)
+	}
+	page, err := catalog.ListTopics(ctx, TopicPageRequest{Scope: "project", WorkspaceRoot: root, Limit: 10})
+	if err != nil || len(page.Items) != 1 || len(page.Items[0].Sessions) != 1 {
+		t.Fatalf("remapped topics = %#v, %v", page.Items, err)
 	}
 }
 

--- a/internal/sessioncatalog/path_identity_test.go
+++ b/internal/sessioncatalog/path_identity_test.go
@@ -1,0 +1,257 @@
+package sessioncatalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"reasonix/internal/agent"
+)
+
+func TestPathIdentityKeyMatchesFilesystemCaseSemantics(t *testing.T) {
+	dir := t.TempDir()
+	original := filepath.Join(dir, "MixedCase.jsonl")
+	variant := filepath.Join(dir, "mixedcase.jsonl")
+	if err := os.WriteFile(original, []byte("session"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	originalInfo, err := os.Stat(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	variantInfo, variantErr := os.Stat(variant)
+	if variantErr == nil && os.SameFile(originalInfo, variantInfo) {
+		if got, want := PathIdentityKey(variant), PathIdentityKey(original); got != want {
+			t.Fatalf("case-insensitive filesystem keys differ: %q != %q", got, want)
+		}
+		return
+	}
+	if variantErr != nil && !os.IsNotExist(variantErr) {
+		t.Fatal(variantErr)
+	}
+	if err := os.WriteFile(variant, []byte("other session"), 0o600); err != nil {
+		t.Skipf("filesystem cannot create case-distinct files: %v", err)
+	}
+	variantInfo, err = os.Stat(variant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(originalInfo, variantInfo) {
+		t.Skip("filesystem aliases the two case spellings")
+	}
+	if got, other := PathIdentityKey(original), PathIdentityKey(variant); got == other {
+		t.Fatalf("case-sensitive filesystem collapsed distinct files to %q", got)
+	}
+}
+
+func TestUniqueDirectoryTargetsUsesIdentityAndPreservesAccessSpelling(t *testing.T) {
+	targets := []DirectoryTarget{
+		{Path: filepath.Join("sessions", "Foo"), Scope: "project", WorkspaceRoot: "/work/first"},
+		{Path: filepath.Join("sessions", "foo"), Scope: "project", WorkspaceRoot: "/work/second"},
+		{Path: "  "},
+	}
+
+	folded := uniqueDirectoryTargetsBy(targets, func(path string) string {
+		return strings.ToLower(filepath.Clean(path))
+	})
+	if len(folded) != 1 {
+		t.Fatalf("folded targets = %#v, want one", folded)
+	}
+	if folded[0].Path != filepath.Join("sessions", "Foo") || folded[0].WorkspaceRoot != "/work/first" {
+		t.Fatalf("first access spelling was not preserved: %#v", folded[0])
+	}
+
+	exact := uniqueDirectoryTargetsBy(targets, filepath.Clean)
+	if len(exact) != 2 {
+		t.Fatalf("case-sensitive targets = %#v, want two", exact)
+	}
+}
+
+func TestReconcileDirectoryUsesFilesystemIdentityWhenCaseInsensitive(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	originalDir := filepath.Join(root, "MixedDirectory")
+	variantDir := filepath.Join(root, "mixeddirectory")
+	if err := os.Mkdir(originalDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	originalInfo, err := os.Stat(originalDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	variantInfo, err := os.Stat(variantDir)
+	if err != nil || !os.SameFile(originalInfo, variantInfo) {
+		t.Skip("test requires a case-insensitive filesystem directory")
+	}
+	sessionPath := filepath.Join(originalDir, "Session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, agent.BranchMeta{
+		Scope: "global", TopicID: "topic", SchemaVersion: agent.BranchMetaCountsVersion, Turns: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	for _, dir := range []string{originalDir, variantDir} {
+		if err := catalog.ReconcileDirectory(ctx, DirectoryTarget{Path: dir, Scope: "global"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	page, err := catalog.ListSessions(ctx, SessionPageRequest{Scope: "all", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("case-variant directory scans produced %#v, want one session", page.Items)
+	}
+	var directories int
+	if err := catalog.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_directories`).Scan(&directories); err != nil {
+		t.Fatal(err)
+	}
+	if directories != 1 {
+		t.Fatalf("case-variant directory scans produced %d directory rows, want one", directories)
+	}
+}
+
+func TestCatalogPathIdentityCoalescesQueuesAndLocks(t *testing.T) {
+	fold := func(path string) string { return strings.ToLower(filepath.Clean(path)) }
+	catalog := &Catalog{
+		pathIdentity:   fold,
+		writeCh:        make(chan string, 2),
+		writeQueued:    map[string]SessionRecord{},
+		repairCh:       make(chan string, 2),
+		reconcileCh:    make(chan DirectoryTarget, 2),
+		reconcileDirty: map[string]DirectoryTarget{},
+		pathCh:         make(chan sessionPathRequest, 2),
+		directoryLocks: map[string]*sync.Mutex{},
+		stop:           make(chan struct{}),
+	}
+	upperPath := filepath.Join(string(filepath.Separator), "Sessions", "Mixed.jsonl")
+	lowerPath := filepath.Join(string(filepath.Separator), "sessions", "mixed.jsonl")
+	upperDir, lowerDir := filepath.Dir(upperPath), filepath.Dir(lowerPath)
+
+	first := SessionRecord{Path: upperPath, Directory: upperDir}
+	second := SessionRecord{Path: lowerPath, Directory: lowerDir}
+	if !catalog.EnqueueSession(first) || !catalog.EnqueueSession(second) {
+		t.Fatal("write queue rejected a case variant")
+	}
+	if len(catalog.writeQueued) != 1 || len(catalog.writeCh) != 1 {
+		t.Fatalf("write queue split identity: rows=%d signals=%d", len(catalog.writeQueued), len(catalog.writeCh))
+	}
+	if !catalog.RequestReconcile(DirectoryTarget{Path: upperDir}) || !catalog.RequestReconcile(DirectoryTarget{Path: lowerDir}) {
+		t.Fatal("reconcile queue rejected a case variant")
+	}
+	queuedReconciles := 0
+	catalog.reconcileQueued.Range(func(_, _ any) bool { queuedReconciles++; return true })
+	if queuedReconciles != 1 || len(catalog.reconcileCh) != 1 || len(catalog.reconcileDirty) != 1 {
+		t.Fatalf("reconcile queue split identity: queued=%d signals=%d dirty=%d", queuedReconciles, len(catalog.reconcileCh), len(catalog.reconcileDirty))
+	}
+	if !catalog.RequestIndexSession(DirectoryTarget{Path: upperDir}, upperPath) ||
+		!catalog.RequestIndexSession(DirectoryTarget{Path: lowerDir}, lowerPath) {
+		t.Fatal("direct-index queue rejected a case variant")
+	}
+	queuedPaths := 0
+	catalog.pathQueued.Range(func(_, _ any) bool { queuedPaths++; return true })
+	if queuedPaths != 1 || len(catalog.pathCh) != 1 {
+		t.Fatalf("direct-index queue split identity: queued=%d signals=%d", queuedPaths, len(catalog.pathCh))
+	}
+	catalog.enqueueRepair(upperPath)
+	catalog.enqueueRepair(lowerPath)
+	queuedRepairs := 0
+	catalog.repairQueued.Range(func(_, _ any) bool { queuedRepairs++; return true })
+	if queuedRepairs != 1 || len(catalog.repairCh) != 1 {
+		t.Fatalf("repair queue split identity: queued=%d signals=%d", queuedRepairs, len(catalog.repairCh))
+	}
+	if catalog.directoryLock(upperDir) != catalog.directoryLock(lowerDir) {
+		t.Fatal("case variants acquired different directory locks")
+	}
+}
+
+func TestCatalogPathIdentityDeduplicatesEveryMutationBoundary(t *testing.T) {
+	ctx := context.Background()
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	catalog.pathIdentity = func(path string) string {
+		return strings.ToLower(filepath.Clean(path))
+	}
+
+	upperPath := filepath.Join(string(filepath.Separator), "Sessions", "Mixed.jsonl")
+	lowerPath := filepath.Join(string(filepath.Separator), "sessions", "mixed.jsonl")
+	upperDir := filepath.Dir(upperPath)
+	lowerDir := filepath.Dir(lowerPath)
+	first := SessionRecord{
+		Path: upperPath, Directory: upperDir, Scope: "global", TopicID: "topic",
+		Preview: "first", LastActivityAt: 1, TurnsState: TurnsValid, Health: HealthOK,
+	}
+	second := first
+	second.Path = lowerPath
+	second.Directory = lowerDir
+	second.Preview = "second"
+	second.LastActivityAt = 2
+	if err := catalog.UpsertSession(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.UpsertSession(ctx, second); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := catalog.ListSessions(ctx, SessionPageRequest{Scope: "all", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 || page.Items[0].Path != lowerPath || page.Items[0].Preview != "second" {
+		t.Fatalf("deduplicated sessions = %#v, want latest access spelling", page.Items)
+	}
+	if got, ok, err := catalog.GetSession(ctx, upperPath); err != nil || !ok || got.Path != lowerPath {
+		t.Fatalf("GetSession(case variant) = %#v, %v, %v", got, ok, err)
+	}
+	if got, err := catalog.CountDirectorySessions(ctx, upperDir); err != nil || got != 1 {
+		t.Fatalf("CountDirectorySessions(case variant) = %d, %v", got, err)
+	}
+
+	if err := catalog.RemoveSession(ctx, upperPath, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := catalog.GetSession(ctx, lowerPath); err != nil || ok {
+		t.Fatalf("removed case variant remained visible: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestCatalogPathIdentityPreservesCaseDistinctSessions(t *testing.T) {
+	ctx := context.Background()
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	catalog.pathIdentity = filepath.Clean
+
+	for index, path := range []string{"/sessions/Foo.jsonl", "/sessions/foo.jsonl"} {
+		if err := catalog.UpsertSession(ctx, SessionRecord{
+			Path: path, Directory: filepath.Dir(path), Scope: "global", TopicID: "topic",
+			LastActivityAt: int64(index + 1), TurnsState: TurnsValid, Health: HealthOK,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	page, err := catalog.ListSessions(ctx, SessionPageRequest{Scope: "all", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("case-distinct sessions = %#v, want two", page.Items)
+	}
+}

--- a/internal/sessioncatalog/path_identity_windows.go
+++ b/internal/sessioncatalog/path_identity_windows.go
@@ -1,0 +1,84 @@
+//go:build windows
+
+package sessioncatalog
+
+import (
+	"encoding/binary"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func platformCatalogPathIdentity(path string) string {
+	path = stripWindowsCatalogExtendedPrefix(path)
+	return windowsCatalogPathIdentityBy(path, windowsCatalogDirectoryCaseInsensitive)
+}
+
+// windowsCatalogPathIdentityBy folds each component according to the directory
+// that governs its lookup. Windows case sensitivity is per-directory, so
+// lowercasing the whole string would merge distinct children of a WSL-enabled
+// case-sensitive directory, while preserving the whole string would split
+// drive-letter and insensitive-ancestor variants.
+func windowsCatalogPathIdentityBy(path string, directoryCaseInsensitive func(string) (bool, bool)) string {
+	volume := filepath.VolumeName(path)
+	if volume == "" {
+		return strings.ToLower(path)
+	}
+	current := volume + string(filepath.Separator)
+	identity := strings.ToLower(current)
+	caseInsensitive := true
+	rest := strings.TrimLeft(path[len(volume):], `\/`)
+	components := strings.FieldsFunc(rest, func(r rune) bool { return r == '\\' || r == '/' })
+	for _, component := range components {
+		if detected, ok := directoryCaseInsensitive(current); ok {
+			caseInsensitive = detected
+		}
+		identityComponent := component
+		if caseInsensitive {
+			identityComponent = strings.ToLower(identityComponent)
+		}
+		identity = filepath.Join(identity, identityComponent)
+		current = filepath.Join(current, component)
+	}
+	return filepath.Clean(identity)
+}
+
+func windowsCatalogDirectoryCaseInsensitive(directory string) (bool, bool) {
+	name, err := windows.UTF16PtrFromString(directory)
+	if err != nil {
+		return true, false
+	}
+	handle, err := windows.CreateFile(
+		name,
+		windows.FILE_READ_ATTRIBUTES,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return true, false
+	}
+	defer windows.CloseHandle(handle)
+
+	var info [4]byte
+	err = windows.GetFileInformationByHandleEx(
+		handle,
+		windows.FileCaseSensitiveInfo,
+		&info[0],
+		uint32(len(info)),
+	)
+	if err == nil {
+		return binary.LittleEndian.Uint32(info[:])&windows.FILE_CS_FLAG_CASE_SENSITIVE_DIR == 0, true
+	}
+	return true, false
+}
+
+func stripWindowsCatalogExtendedPrefix(path string) string {
+	if strings.HasPrefix(strings.ToUpper(path), `\\?\UNC\`) {
+		return `\\` + path[len(`\\?\UNC\`):]
+	}
+	return strings.TrimPrefix(path, `\\?\`)
+}

--- a/internal/sessioncatalog/path_identity_windows_test.go
+++ b/internal/sessioncatalog/path_identity_windows_test.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package sessioncatalog
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWindowsCatalogPathIdentityFoldsPerDirectory(t *testing.T) {
+	caseSensitiveParent := filepath.Clean(`C:\Root`)
+	identity := func(path string) string {
+		return windowsCatalogPathIdentityBy(path, func(directory string) (bool, bool) {
+			return !strings.EqualFold(filepath.Clean(directory), caseSensitiveParent), true
+		})
+	}
+
+	upper := identity(`C:\ROOT\Foo\LEAF.jsonl`)
+	lower := identity(`c:\root\foo\leaf.jsonl`)
+	if upper == lower {
+		t.Fatalf("case-sensitive child names collapsed to %q", upper)
+	}
+	if got, want := upper, filepath.Clean(`c:\root\Foo\leaf.jsonl`); got != want {
+		t.Fatalf("segment-aware identity = %q, want %q", got, want)
+	}
+}

--- a/internal/sessioncatalog/reconcile.go
+++ b/internal/sessioncatalog/reconcile.go
@@ -20,6 +20,13 @@ import (
 )
 
 func (c *Catalog) ReconcileDirectory(ctx context.Context, target DirectoryTarget) error {
+	if c == nil {
+		return nil
+	}
+	return c.reconcileDirectory(ctx, target, c.mutationSeq.Add(1))
+}
+
+func (c *Catalog) reconcileDirectory(ctx context.Context, target DirectoryTarget, sequence uint64) error {
 	if c == nil || c.db == nil {
 		return nil
 	}
@@ -59,15 +66,11 @@ func (c *Catalog) ReconcileDirectory(ctx context.Context, target DirectoryTarget
 		}
 		end := min(start+64, len(ordered))
 		for _, info := range ordered[start:end] {
-			record := recordFromOrder(target, info)
-			// This scan started while holding the directory lock after any
-			// completed removal. A present file is therefore a newer external
-			// recreation and may supersede the in-memory removal tombstone.
-			c.removedPaths.Delete(c.pathKey(record.Path))
-			records = append(records, record)
+			records = append(records, recordFromOrder(target, info))
 		}
 		runtime.Gosched()
 	}
+	records = c.filterPathMutations(records, sequence)
 	records, err = c.preserveKnownSourceStates(ctx, target.Path, records)
 	if err != nil {
 		c.failDirectoryScan(context.Background(), target.Path, err)
@@ -145,6 +148,7 @@ func (c *Catalog) RequestReconcile(target DirectoryTarget) bool {
 	if key == "" {
 		return false
 	}
+	target.mutationSeq = c.mutationSeq.Add(1)
 	if _, loaded := c.reconcileQueued.LoadOrStore(key, target); loaded {
 		c.markReconcileDirty(target)
 		return true
@@ -186,7 +190,7 @@ func (c *Catalog) reconcileLoop() {
 		if target, ok := c.takeReconcileDirty(); ok {
 			c.reconcileQueued.Delete(queuePathKey(target.Path))
 			ctx, cancel := context.WithTimeout(c.workerCtx, 2*time.Minute)
-			_ = c.ReconcileDirectory(ctx, target)
+			_ = c.reconcileDirectory(ctx, target, target.mutationSeq)
 			cancel()
 			continue
 		}
@@ -194,7 +198,7 @@ func (c *Catalog) reconcileLoop() {
 		case target := <-c.reconcileCh:
 			c.reconcileQueued.Delete(queuePathKey(target.Path))
 			ctx, cancel := context.WithTimeout(c.workerCtx, 2*time.Minute)
-			_ = c.ReconcileDirectory(ctx, target)
+			_ = c.reconcileDirectory(ctx, target, target.mutationSeq)
 			cancel()
 		case <-ticker.C:
 			// Drain dirty map on the next loop iteration.
@@ -204,55 +208,15 @@ func (c *Catalog) reconcileLoop() {
 	}
 }
 
-// RequestIndexSession coalesces an authoritative session write by path. It is
-// intentionally non-blocking so a saturated projection can never delay JSONL
-// or sidecar persistence.
-func (c *Catalog) RequestIndexSession(target DirectoryTarget, path string) bool {
-	if c == nil {
-		return false
-	}
-	path = cleanCatalogAccessPath(path)
-	if path == "" {
-		return false
-	}
-	target.Path = cleanCatalogAccessPath(target.Path)
-	if target.Path == "" {
-		target.Path = filepath.Dir(path)
-	}
-	key := queuePathKey(path)
-	request := sessionPathRequest{target: target, path: path, queueKey: key}
-	if _, loaded := c.pathQueued.LoadOrStore(key, request); loaded {
-		return true
-	}
-	select {
-	case c.pathCh <- request:
-		return true
-	case <-c.stop:
-		c.pathQueued.Delete(key)
-		return false
-	default:
-		c.pathQueued.Delete(key)
-		return false
-	}
-}
-
-func (c *Catalog) sessionPathLoop() {
-	defer c.workers.Done()
-	for {
-		select {
-		case request := <-c.pathCh:
-			c.pathQueued.Delete(request.queueKey)
-			ctx, cancel := context.WithTimeout(c.workerCtx, 30*time.Second)
-			_ = c.IndexSessionPath(ctx, request.target, request.path)
-			cancel()
-		case <-c.stop:
-			return
-		}
-	}
-}
-
 // IndexSessionPath indexes one session without walking its directory.
 func (c *Catalog) IndexSessionPath(ctx context.Context, target DirectoryTarget, path string) error {
+	if c == nil {
+		return nil
+	}
+	return c.indexSessionPath(ctx, target, path, c.mutationSeq.Add(1))
+}
+
+func (c *Catalog) indexSessionPath(ctx context.Context, target DirectoryTarget, path string, sequence uint64) error {
 	path = cleanCatalogAccessPath(path)
 	if path == "" {
 		return nil
@@ -272,10 +236,6 @@ func (c *Catalog) IndexSessionPath(ctx context.Context, target DirectoryTarget, 
 		}
 		return err
 	}
-	// Only a path that still exists may supersede a removal tombstone. Doing
-	// this after Stat also prevents a delayed exact-index request from exposing
-	// an already archived row while its durable DELETE is pending.
-	c.removedPaths.Delete(c.pathKey(path))
 	meta, ok, err := agent.LoadBranchMeta(path)
 	if err != nil {
 		return err
@@ -317,6 +277,7 @@ func (c *Catalog) IndexSessionPath(ctx context.Context, target DirectoryTarget, 
 		order.LastActivityAt = info.ModTime()
 	}
 	record := recordFromOrder(target, order)
+	record.enqueueSequence = sequence
 	projectionDirty, err := c.upsertExactPathSession(ctx, record)
 	if err != nil {
 		return err
@@ -412,6 +373,10 @@ func (c *Catalog) beginDirectoryScan(ctx context.Context, target DirectoryTarget
 	var previousSig, previousState, previousCursor string
 	var previousGeneration int64
 	pathKey := c.pathKey(target.Path)
+	if err := c.removeRemappedDirectoryIdentity(ctx, tx, target.Path, pathKey); err != nil {
+		_ = tx.Rollback()
+		return 0, "", err
+	}
 	err = tx.QueryRowContext(ctx, `SELECT signature,state,scan_cursor,scan_generation FROM catalog_directories WHERE path_key=?`,
 		pathKey).Scan(&previousSig, &previousState, &previousCursor, &previousGeneration)
 	resume := err == nil && previousState == "scanning" && previousSig == signature && strings.TrimSpace(previousCursor) != ""
@@ -487,9 +452,17 @@ func (c *Catalog) commitDirectoryProjection(ctx context.Context, target Director
 		end := min(start+64, len(records))
 		for _, record := range records[start:end] {
 			pathKey := c.pathKey(record.Path)
+			remapped, err := removeRemappedSessionIdentity(ctx, tx, record.Path, pathKey)
+			if err != nil {
+				_ = stmt.Close()
+				return rollback(err)
+			}
+			for _, key := range remapped {
+				affected[key] = struct{}{}
+			}
 			var previous TopicKey
-			if err := tx.QueryRowContext(ctx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions WHERE path_key=?`, pathKey).
-				Scan(&previous.Scope, &previous.WorkspaceRoot, &previous.TopicID); err == nil && previous.TopicID != "" {
+			if err := tx.QueryRowContext(ctx, `SELECT scope,workspace_root,workspace_root_key,topic_id FROM catalog_sessions WHERE path_key=?`, pathKey).
+				Scan(&previous.Scope, &previous.WorkspaceRoot, &previous.workspaceKey, &previous.TopicID); err == nil && previous.TopicID != "" {
 				affected[previous] = struct{}{}
 			} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				_ = stmt.Close()
@@ -500,7 +473,8 @@ func (c *Catalog) commitDirectoryProjection(ctx context.Context, target Director
 				return rollback(err)
 			}
 			if record.TopicID != "" {
-				affected[TopicKey{Scope: record.Scope, WorkspaceRoot: record.WorkspaceRoot, TopicID: record.TopicID}] = struct{}{}
+				affected[TopicKey{Scope: record.Scope, WorkspaceRoot: record.WorkspaceRoot,
+					workspaceKey: c.workspaceRootKey(record.Scope, record.WorkspaceRoot), TopicID: record.TopicID}] = struct{}{}
 			}
 			if err := c.updateFoldedTopicTombstones(ctx, tx, previous, record, now); err != nil {
 				_ = stmt.Close()
@@ -516,14 +490,14 @@ func (c *Catalog) commitDirectoryProjection(ctx context.Context, target Director
 		return rollback(err)
 	}
 
-	rows, err := tx.QueryContext(ctx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions
-        WHERE directory_key=? AND seen_generation<? AND topic_id<>''`, directoryKey, generation)
+	rows, err := tx.QueryContext(ctx, `SELECT scope,workspace_root,workspace_root_key,topic_id FROM catalog_sessions
+		WHERE directory_key=? AND seen_generation<? AND topic_id<>''`, directoryKey, generation)
 	if err != nil {
 		return rollback(err)
 	}
 	for rows.Next() {
 		var key TopicKey
-		if err := rows.Scan(&key.Scope, &key.WorkspaceRoot, &key.TopicID); err != nil {
+		if err := rows.Scan(&key.Scope, &key.WorkspaceRoot, &key.workspaceKey, &key.TopicID); err != nil {
 			_ = rows.Close()
 			return rollback(err)
 		}
@@ -579,8 +553,8 @@ func (c *Catalog) finishDirectoryScan(ctx context.Context, target DirectoryTarge
 		return err
 	}
 	directoryKey := c.pathKey(target.Path)
-	rows, err := tx.QueryContext(ctx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions
-        WHERE directory_key=? AND seen_generation<? AND topic_id<>''`, directoryKey, generation)
+	rows, err := tx.QueryContext(ctx, `SELECT scope,workspace_root,workspace_root_key,topic_id FROM catalog_sessions
+		WHERE directory_key=? AND seen_generation<? AND topic_id<>''`, directoryKey, generation)
 	if err != nil {
 		_ = tx.Rollback()
 		return err
@@ -588,7 +562,7 @@ func (c *Catalog) finishDirectoryScan(ctx context.Context, target DirectoryTarge
 	affected := map[TopicKey]struct{}{}
 	for rows.Next() {
 		var key TopicKey
-		if err := rows.Scan(&key.Scope, &key.WorkspaceRoot, &key.TopicID); err != nil {
+		if err := rows.Scan(&key.Scope, &key.WorkspaceRoot, &key.workspaceKey, &key.TopicID); err != nil {
 			_ = rows.Close()
 			_ = tx.Rollback()
 			return err

--- a/internal/sessioncatalog/reconcile.go
+++ b/internal/sessioncatalog/reconcile.go
@@ -23,8 +23,8 @@ func (c *Catalog) ReconcileDirectory(ctx context.Context, target DirectoryTarget
 	if c == nil || c.db == nil {
 		return nil
 	}
-	target.Path = filepath.Clean(strings.TrimSpace(target.Path))
-	if target.Path == "." || target.Path == "" {
+	target.Path = cleanCatalogAccessPath(target.Path)
+	if target.Path == "" {
 		return nil
 	}
 	lock := c.directoryLock(target.Path)
@@ -63,7 +63,7 @@ func (c *Catalog) ReconcileDirectory(ctx context.Context, target DirectoryTarget
 			// This scan started while holding the directory lock after any
 			// completed removal. A present file is therefore a newer external
 			// recreation and may supersede the in-memory removal tombstone.
-			c.removedPaths.Delete(record.Path)
+			c.removedPaths.Delete(c.pathKey(record.Path))
 			records = append(records, record)
 		}
 		runtime.Gosched()
@@ -122,6 +122,7 @@ func directorySignature(dir string) (string, error) {
 }
 
 func (c *Catalog) directoryLock(path string) *sync.Mutex {
+	path = c.pathKey(path)
 	c.directoryLocksMu.Lock()
 	defer c.directoryLocksMu.Unlock()
 	lock := c.directoryLocks[path]
@@ -139,8 +140,12 @@ func (c *Catalog) RequestReconcile(target DirectoryTarget) bool {
 	if c == nil || strings.TrimSpace(target.Path) == "" {
 		return false
 	}
-	target.Path = filepath.Clean(target.Path)
-	if _, loaded := c.reconcileQueued.LoadOrStore(target.Path, target); loaded {
+	target.Path = cleanCatalogAccessPath(target.Path)
+	key := c.pathKey(target.Path)
+	if key == "" {
+		return false
+	}
+	if _, loaded := c.reconcileQueued.LoadOrStore(key, target); loaded {
 		c.markReconcileDirty(target)
 		return true
 	}
@@ -148,10 +153,10 @@ func (c *Catalog) RequestReconcile(target DirectoryTarget) bool {
 	case c.reconcileCh <- target:
 		return true
 	case <-c.stop:
-		c.reconcileQueued.Delete(target.Path)
+		c.reconcileQueued.Delete(key)
 		return false
 	default:
-		c.reconcileQueued.Delete(target.Path)
+		c.reconcileQueued.Delete(key)
 		c.markReconcileDirty(target)
 		return false
 	}
@@ -159,7 +164,7 @@ func (c *Catalog) RequestReconcile(target DirectoryTarget) bool {
 
 func (c *Catalog) markReconcileDirty(target DirectoryTarget) {
 	c.reconcileDirtyMu.Lock()
-	c.reconcileDirty[target.Path] = target
+	c.reconcileDirty[c.pathKey(target.Path)] = target
 	c.reconcileDirtyMu.Unlock()
 }
 
@@ -179,7 +184,7 @@ func (c *Catalog) reconcileLoop() {
 	defer ticker.Stop()
 	for {
 		if target, ok := c.takeReconcileDirty(); ok {
-			c.reconcileQueued.Delete(target.Path)
+			c.reconcileQueued.Delete(c.pathKey(target.Path))
 			ctx, cancel := context.WithTimeout(c.workerCtx, 2*time.Minute)
 			_ = c.ReconcileDirectory(ctx, target)
 			cancel()
@@ -187,7 +192,7 @@ func (c *Catalog) reconcileLoop() {
 		}
 		select {
 		case target := <-c.reconcileCh:
-			c.reconcileQueued.Delete(target.Path)
+			c.reconcileQueued.Delete(c.pathKey(target.Path))
 			ctx, cancel := context.WithTimeout(c.workerCtx, 2*time.Minute)
 			_ = c.ReconcileDirectory(ctx, target)
 			cancel()
@@ -206,26 +211,27 @@ func (c *Catalog) RequestIndexSession(target DirectoryTarget, path string) bool 
 	if c == nil {
 		return false
 	}
-	path = filepath.Clean(strings.TrimSpace(path))
-	if path == "." || path == "" {
+	path = cleanCatalogAccessPath(path)
+	if path == "" {
 		return false
 	}
-	target.Path = filepath.Clean(strings.TrimSpace(target.Path))
-	if target.Path == "." || target.Path == "" {
+	target.Path = cleanCatalogAccessPath(target.Path)
+	if target.Path == "" {
 		target.Path = filepath.Dir(path)
 	}
-	request := sessionPathRequest{target: target, path: path}
-	if _, loaded := c.pathQueued.LoadOrStore(path, request); loaded {
+	key := c.pathKey(path)
+	request := sessionPathRequest{target: target, path: path, pathKey: key}
+	if _, loaded := c.pathQueued.LoadOrStore(key, request); loaded {
 		return true
 	}
 	select {
 	case c.pathCh <- request:
 		return true
 	case <-c.stop:
-		c.pathQueued.Delete(path)
+		c.pathQueued.Delete(key)
 		return false
 	default:
-		c.pathQueued.Delete(path)
+		c.pathQueued.Delete(key)
 		return false
 	}
 }
@@ -235,7 +241,7 @@ func (c *Catalog) sessionPathLoop() {
 	for {
 		select {
 		case request := <-c.pathCh:
-			c.pathQueued.Delete(request.path)
+			c.pathQueued.Delete(request.pathKey)
 			ctx, cancel := context.WithTimeout(c.workerCtx, 30*time.Second)
 			_ = c.IndexSessionPath(ctx, request.target, request.path)
 			cancel()
@@ -247,12 +253,12 @@ func (c *Catalog) sessionPathLoop() {
 
 // IndexSessionPath indexes one session without walking its directory.
 func (c *Catalog) IndexSessionPath(ctx context.Context, target DirectoryTarget, path string) error {
-	path = filepath.Clean(strings.TrimSpace(path))
-	if path == "." || path == "" {
+	path = cleanCatalogAccessPath(path)
+	if path == "" {
 		return nil
 	}
-	target.Path = filepath.Clean(strings.TrimSpace(target.Path))
-	if target.Path == "." || target.Path == "" {
+	target.Path = cleanCatalogAccessPath(target.Path)
+	if target.Path == "" {
 		target.Path = filepath.Dir(path)
 	}
 	// Hold the directory lock so a concurrent scan cannot mark this row missing.
@@ -269,7 +275,7 @@ func (c *Catalog) IndexSessionPath(ctx context.Context, target DirectoryTarget, 
 	// Only a path that still exists may supersede a removal tombstone. Doing
 	// this after Stat also prevents a delayed exact-index request from exposing
 	// an already archived row while its durable DELETE is pending.
-	c.removedPaths.Delete(path)
+	c.removedPaths.Delete(c.pathKey(path))
 	meta, ok, err := agent.LoadBranchMeta(path)
 	if err != nil {
 		return err
@@ -405,8 +411,9 @@ func (c *Catalog) beginDirectoryScan(ctx context.Context, target DirectoryTarget
 	}
 	var previousSig, previousState, previousCursor string
 	var previousGeneration int64
-	err = tx.QueryRowContext(ctx, `SELECT signature,state,scan_cursor,scan_generation FROM catalog_directories WHERE path=?`,
-		target.Path).Scan(&previousSig, &previousState, &previousCursor, &previousGeneration)
+	pathKey := c.pathKey(target.Path)
+	err = tx.QueryRowContext(ctx, `SELECT signature,state,scan_cursor,scan_generation FROM catalog_directories WHERE path_key=?`,
+		pathKey).Scan(&previousSig, &previousState, &previousCursor, &previousGeneration)
 	resume := err == nil && previousState == "scanning" && previousSig == signature && strings.TrimSpace(previousCursor) != ""
 	if errors.Is(err, sql.ErrNoRows) {
 		err = nil
@@ -416,8 +423,8 @@ func (c *Catalog) beginDirectoryScan(ctx context.Context, target DirectoryTarget
 		return 0, "", err
 	}
 	if resume {
-		if _, err := tx.ExecContext(ctx, `UPDATE catalog_directories SET scope=?,workspace_root=?,state='scanning',error='',signature=? WHERE path=?`,
-			target.Scope, target.WorkspaceRoot, signature, target.Path); err != nil {
+		if _, err := tx.ExecContext(ctx, `UPDATE catalog_directories SET path=?,scope=?,workspace_root=?,state='scanning',error='',signature=? WHERE path_key=?`,
+			target.Path, target.Scope, target.WorkspaceRoot, signature, pathKey); err != nil {
 			_ = tx.Rollback()
 			return 0, "", err
 		}
@@ -426,22 +433,22 @@ func (c *Catalog) beginDirectoryScan(ctx context.Context, target DirectoryTarget
 		}
 		return previousGeneration, previousCursor, tx.Commit()
 	}
-	if _, err := tx.ExecContext(ctx, `INSERT INTO catalog_directories(path,scope,workspace_root,state,error,signature)
-        VALUES(?,?,?,'scanning','',?) ON CONFLICT(path) DO UPDATE SET
-        scope=excluded.scope,workspace_root=excluded.workspace_root,state='scanning',error='',
+	if _, err := tx.ExecContext(ctx, `INSERT INTO catalog_directories(path,path_key,scope,workspace_root,state,error,signature)
+        VALUES(?,?,?,?,'scanning','',?) ON CONFLICT(path_key) DO UPDATE SET
+        path=excluded.path,scope=excluded.scope,workspace_root=excluded.workspace_root,state='scanning',error='',
         signature=excluded.signature,scan_generation=catalog_directories.scan_generation+1,scan_cursor='',indexed=0`,
-		target.Path, target.Scope, target.WorkspaceRoot, signature); err != nil {
+		target.Path, pathKey, target.Scope, target.WorkspaceRoot, signature); err != nil {
 		_ = tx.Rollback()
 		return 0, "", err
 	}
 	var generation int64
-	if err := tx.QueryRowContext(ctx, `SELECT scan_generation FROM catalog_directories WHERE path=?`, target.Path).Scan(&generation); err != nil {
+	if err := tx.QueryRowContext(ctx, `SELECT scan_generation FROM catalog_directories WHERE path_key=?`, pathKey).Scan(&generation); err != nil {
 		_ = tx.Rollback()
 		return 0, "", err
 	}
 	if generation == 0 {
 		generation = 1
-		if _, err := tx.ExecContext(ctx, `UPDATE catalog_directories SET scan_generation=1 WHERE path=?`, target.Path); err != nil {
+		if _, err := tx.ExecContext(ctx, `UPDATE catalog_directories SET scan_generation=1 WHERE path_key=?`, pathKey); err != nil {
 			_ = tx.Rollback()
 			return 0, "", err
 		}
@@ -471,6 +478,7 @@ func (c *Catalog) commitDirectoryProjection(ctx context.Context, target Director
 		return rollback(err)
 	}
 	affected := map[TopicKey]struct{}{}
+	directoryKey := c.pathKey(target.Path)
 	for start := 0; start < len(records); start += 64 {
 		if err := ctx.Err(); err != nil {
 			_ = stmt.Close()
@@ -478,15 +486,16 @@ func (c *Catalog) commitDirectoryProjection(ctx context.Context, target Director
 		}
 		end := min(start+64, len(records))
 		for _, record := range records[start:end] {
+			pathKey := c.pathKey(record.Path)
 			var previous TopicKey
-			if err := tx.QueryRowContext(ctx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions WHERE path=?`, record.Path).
+			if err := tx.QueryRowContext(ctx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions WHERE path_key=?`, pathKey).
 				Scan(&previous.Scope, &previous.WorkspaceRoot, &previous.TopicID); err == nil && previous.TopicID != "" {
 				affected[previous] = struct{}{}
 			} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				_ = stmt.Close()
 				return rollback(err)
 			}
-			if _, err := stmt.ExecContext(ctx, sessionRowValues(record, generation)...); err != nil {
+			if _, err := stmt.ExecContext(ctx, sessionRowValues(record, pathKey, directoryKey, generation)...); err != nil {
 				_ = stmt.Close()
 				return rollback(err)
 			}
@@ -508,7 +517,7 @@ func (c *Catalog) commitDirectoryProjection(ctx context.Context, target Director
 	}
 
 	rows, err := tx.QueryContext(ctx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions
-        WHERE directory=? AND seen_generation<? AND topic_id<>''`, target.Path, generation)
+        WHERE directory_key=? AND seen_generation<? AND topic_id<>''`, directoryKey, generation)
 	if err != nil {
 		return rollback(err)
 	}
@@ -526,12 +535,12 @@ func (c *Catalog) commitDirectoryProjection(ctx context.Context, target Director
 	if _, err := tx.ExecContext(ctx, `UPDATE catalog_sessions SET
         missing_since=CASE WHEN missing_since=0 THEN ? ELSE missing_since END,
         health='missing'
-        WHERE directory=? AND seen_generation<?`, now, target.Path, generation); err != nil {
+		WHERE directory_key=? AND seen_generation<?`, now, directoryKey, generation); err != nil {
 		return rollback(err)
 	}
 	cutoff := now - c.opts.MissingGrace.Milliseconds()
 	if _, err := tx.ExecContext(ctx, `DELETE FROM catalog_sessions
-        WHERE directory=? AND seen_generation<? AND missing_since>0 AND missing_since<=?`, target.Path, generation, cutoff); err != nil {
+		WHERE directory_key=? AND seen_generation<? AND missing_since>0 AND missing_since<=?`, directoryKey, generation, cutoff); err != nil {
 		return rollback(err)
 	}
 	for key := range affected {
@@ -540,7 +549,7 @@ func (c *Catalog) commitDirectoryProjection(ctx context.Context, target Director
 		}
 	}
 	if _, err := tx.ExecContext(ctx, `UPDATE catalog_directories SET state='ready',error='',signature=?,
-		scan_cursor='',indexed=?,total=?,completed_at=? WHERE path=?`, signature, len(records), len(records), now, target.Path); err != nil {
+		scan_cursor='',indexed=?,total=?,completed_at=? WHERE path_key=?`, signature, len(records), len(records), now, directoryKey); err != nil {
 		return rollback(err)
 	}
 	revision, err := bumpRevision(ctx, tx)
@@ -569,8 +578,9 @@ func (c *Catalog) finishDirectoryScan(ctx context.Context, target DirectoryTarge
 	if err != nil {
 		return err
 	}
+	directoryKey := c.pathKey(target.Path)
 	rows, err := tx.QueryContext(ctx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions
-        WHERE directory=? AND seen_generation<? AND topic_id<>''`, target.Path, generation)
+        WHERE directory_key=? AND seen_generation<? AND topic_id<>''`, directoryKey, generation)
 	if err != nil {
 		_ = tx.Rollback()
 		return err
@@ -592,13 +602,13 @@ func (c *Catalog) finishDirectoryScan(ctx context.Context, target DirectoryTarge
 	if _, err := tx.ExecContext(ctx, `UPDATE catalog_sessions SET
         missing_since=CASE WHEN missing_since=0 THEN ? ELSE missing_since END,
         health='missing'
-        WHERE directory=? AND seen_generation<?`, now, target.Path, generation); err != nil {
+		WHERE directory_key=? AND seen_generation<?`, now, directoryKey, generation); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
 	cutoff := now - c.opts.MissingGrace.Milliseconds()
 	if _, err := tx.ExecContext(ctx, `DELETE FROM catalog_sessions
-        WHERE directory=? AND seen_generation<? AND missing_since>0 AND missing_since<=?`, target.Path, generation, cutoff); err != nil {
+		WHERE directory_key=? AND seen_generation<? AND missing_since>0 AND missing_since<=?`, directoryKey, generation, cutoff); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
@@ -609,7 +619,7 @@ func (c *Catalog) finishDirectoryScan(ctx context.Context, target DirectoryTarge
 		}
 	}
 	if _, err := tx.ExecContext(ctx, `UPDATE catalog_directories SET state='ready',error='',signature=?,
-		scan_cursor='',indexed=?,total=?,completed_at=? WHERE path=?`, signature, total, total, now, target.Path); err != nil {
+		scan_cursor='',indexed=?,total=?,completed_at=? WHERE path_key=?`, signature, total, total, now, directoryKey); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
@@ -642,6 +652,7 @@ func Rebuild(ctx context.Context, path string, targets []DirectoryTarget) (Statu
 // revision fences across the rebuild, so a replacement must never publish a
 // lower revision than the catalog they already rendered.
 func RebuildWithRevisionFloor(ctx context.Context, path string, targets []DirectoryTarget, revisionFloor uint64) (Status, error) {
+	targets = UniqueDirectoryTargets(targets)
 	if strings.TrimSpace(path) == "" {
 		path = DefaultPath()
 	}
@@ -685,6 +696,7 @@ func RebuildWithRevisionFloor(ctx context.Context, path string, targets []Direct
 		temp := &Catalog{
 			db:             db,
 			opts:           Options{Path: path, DisableRepair: true, Now: time.Now, MissingGrace: defaultMissingGrace},
+			pathIdentity:   PathIdentityKey,
 			writeQueued:    map[string]SessionRecord{},
 			directoryLocks: map[string]*sync.Mutex{},
 			stop:           make(chan struct{}),

--- a/internal/sessioncatalog/reconcile.go
+++ b/internal/sessioncatalog/reconcile.go
@@ -141,7 +141,7 @@ func (c *Catalog) RequestReconcile(target DirectoryTarget) bool {
 		return false
 	}
 	target.Path = cleanCatalogAccessPath(target.Path)
-	key := c.pathKey(target.Path)
+	key := queuePathKey(target.Path)
 	if key == "" {
 		return false
 	}
@@ -164,7 +164,7 @@ func (c *Catalog) RequestReconcile(target DirectoryTarget) bool {
 
 func (c *Catalog) markReconcileDirty(target DirectoryTarget) {
 	c.reconcileDirtyMu.Lock()
-	c.reconcileDirty[c.pathKey(target.Path)] = target
+	c.reconcileDirty[queuePathKey(target.Path)] = target
 	c.reconcileDirtyMu.Unlock()
 }
 
@@ -184,7 +184,7 @@ func (c *Catalog) reconcileLoop() {
 	defer ticker.Stop()
 	for {
 		if target, ok := c.takeReconcileDirty(); ok {
-			c.reconcileQueued.Delete(c.pathKey(target.Path))
+			c.reconcileQueued.Delete(queuePathKey(target.Path))
 			ctx, cancel := context.WithTimeout(c.workerCtx, 2*time.Minute)
 			_ = c.ReconcileDirectory(ctx, target)
 			cancel()
@@ -192,7 +192,7 @@ func (c *Catalog) reconcileLoop() {
 		}
 		select {
 		case target := <-c.reconcileCh:
-			c.reconcileQueued.Delete(c.pathKey(target.Path))
+			c.reconcileQueued.Delete(queuePathKey(target.Path))
 			ctx, cancel := context.WithTimeout(c.workerCtx, 2*time.Minute)
 			_ = c.ReconcileDirectory(ctx, target)
 			cancel()
@@ -219,8 +219,8 @@ func (c *Catalog) RequestIndexSession(target DirectoryTarget, path string) bool 
 	if target.Path == "" {
 		target.Path = filepath.Dir(path)
 	}
-	key := c.pathKey(path)
-	request := sessionPathRequest{target: target, path: path, pathKey: key}
+	key := queuePathKey(path)
+	request := sessionPathRequest{target: target, path: path, queueKey: key}
 	if _, loaded := c.pathQueued.LoadOrStore(key, request); loaded {
 		return true
 	}
@@ -241,7 +241,7 @@ func (c *Catalog) sessionPathLoop() {
 	for {
 		select {
 		case request := <-c.pathCh:
-			c.pathQueued.Delete(request.pathKey)
+			c.pathQueued.Delete(request.queueKey)
 			ctx, cancel := context.WithTimeout(c.workerCtx, 30*time.Second)
 			_ = c.IndexSessionPath(ctx, request.target, request.path)
 			cancel()
@@ -495,14 +495,14 @@ func (c *Catalog) commitDirectoryProjection(ctx context.Context, target Director
 				_ = stmt.Close()
 				return rollback(err)
 			}
-			if _, err := stmt.ExecContext(ctx, sessionRowValues(record, pathKey, directoryKey, generation)...); err != nil {
+			if _, err := stmt.ExecContext(ctx, c.sessionRowValues(record, pathKey, directoryKey, generation)...); err != nil {
 				_ = stmt.Close()
 				return rollback(err)
 			}
 			if record.TopicID != "" {
 				affected[TopicKey{Scope: record.Scope, WorkspaceRoot: record.WorkspaceRoot, TopicID: record.TopicID}] = struct{}{}
 			}
-			if err := updateFoldedTopicTombstones(ctx, tx, previous, record, now); err != nil {
+			if err := c.updateFoldedTopicTombstones(ctx, tx, previous, record, now); err != nil {
 				_ = stmt.Close()
 				return rollback(err)
 			}
@@ -544,7 +544,7 @@ func (c *Catalog) commitDirectoryProjection(ctx context.Context, target Director
 		return rollback(err)
 	}
 	for key := range affected {
-		if err := recomputeTopic(ctx, tx, key); err != nil {
+		if err := c.recomputeTopic(ctx, tx, key); err != nil {
 			return rollback(err)
 		}
 	}
@@ -613,7 +613,7 @@ func (c *Catalog) finishDirectoryScan(ctx context.Context, target DirectoryTarge
 		return err
 	}
 	for key := range affected {
-		if err := recomputeTopic(ctx, tx, key); err != nil {
+		if err := c.recomputeTopic(ctx, tx, key); err != nil {
 			_ = tx.Rollback()
 			return err
 		}

--- a/internal/sessioncatalog/reconcile_integrity.go
+++ b/internal/sessioncatalog/reconcile_integrity.go
@@ -30,7 +30,7 @@ func (c *Catalog) directoryScanCanSkip(ctx context.Context, target DirectoryTarg
 		 WHERE s.directory_key=? AND s.missing_since=0 AND s.topic_id<>''
 		 AND NOT EXISTS (
 			 SELECT 1 FROM catalog_topics t
-			 WHERE t.scope=s.scope AND t.workspace_root=s.workspace_root AND t.topic_id=s.topic_id
+			 WHERE t.scope=s.scope AND t.workspace_root_key=s.workspace_root_key AND t.topic_id=s.topic_id
 		 )),
 		(SELECT COUNT(*) FROM catalog_sessions WHERE directory_key=? AND missing_since>0)
 		FROM catalog_directories
@@ -42,7 +42,8 @@ func (c *Catalog) directoryScanCanSkip(ctx context.Context, target DirectoryTarg
 	if err != nil {
 		return false, err
 	}
-	if storedScope != target.Scope || storedRoot != target.WorkspaceRoot {
+	if storedScope != target.Scope ||
+		c.workspaceRootKey(storedScope, storedRoot) != c.workspaceRootKey(target.Scope, target.WorkspaceRoot) {
 		c.markRepair(repairReasonScopeMismatch, c.opts.Now().UnixMilli())
 		return false, nil
 	}

--- a/internal/sessioncatalog/reconcile_integrity.go
+++ b/internal/sessioncatalog/reconcile_integrity.go
@@ -20,21 +20,22 @@ const (
 // the authoritative path/sidecar projection before trusting the ready marker.
 func (c *Catalog) directoryScanCanSkip(ctx context.Context, target DirectoryTarget, signature string) (bool, error) {
 	path := target.Path
+	directoryKey := c.pathKey(path)
 	target.Scope, target.WorkspaceRoot = normalizeScope(target.Scope, target.WorkspaceRoot)
 	var expectedTotal, present, unprojected, missing int
 	var storedScope, storedRoot string
 	err := c.db.QueryRowContext(ctx, `SELECT scope,workspace_root,total,
-		(SELECT COUNT(*) FROM catalog_sessions WHERE directory=? AND missing_since=0),
+		(SELECT COUNT(*) FROM catalog_sessions WHERE directory_key=? AND missing_since=0),
 		(SELECT COUNT(*) FROM catalog_sessions s
-		 WHERE s.directory=? AND s.missing_since=0 AND s.topic_id<>''
+		 WHERE s.directory_key=? AND s.missing_since=0 AND s.topic_id<>''
 		 AND NOT EXISTS (
 			 SELECT 1 FROM catalog_topics t
 			 WHERE t.scope=s.scope AND t.workspace_root=s.workspace_root AND t.topic_id=s.topic_id
 		 )),
-		(SELECT COUNT(*) FROM catalog_sessions WHERE directory=? AND missing_since>0)
+		(SELECT COUNT(*) FROM catalog_sessions WHERE directory_key=? AND missing_since>0)
 		FROM catalog_directories
-		WHERE path=? AND signature=? AND state='ready'`,
-		path, path, path, path, signature).Scan(&storedScope, &storedRoot, &expectedTotal, &present, &unprojected, &missing)
+		WHERE path_key=? AND signature=? AND state='ready'`,
+		directoryKey, directoryKey, directoryKey, directoryKey, signature).Scan(&storedScope, &storedRoot, &expectedTotal, &present, &unprojected, &missing)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
 	}
@@ -63,7 +64,7 @@ func (c *Catalog) directoryScanCanSkip(ctx context.Context, target DirectoryTarg
 	expectedRecords = promoteCanonicalLeaves(expectedRecords)
 	expected := make(map[string]SessionRecord, len(expectedRecords))
 	for _, record := range expectedRecords {
-		expected[record.Path] = record
+		expected[c.pathKey(record.Path)] = record
 	}
 	if expectedTotal != len(expected) || present != len(expected) {
 		c.markRepair(repairReasonPathMismatch, c.opts.Now().UnixMilli())
@@ -74,7 +75,7 @@ func (c *Catalog) directoryScanCanSkip(ctx context.Context, target DirectoryTarg
 		turns,turns_state,recovered,recovery_reason,recovery_digest,parent_id,
 		recovery_copy,recovery_group_id,recovery_role,recovery_canonical,
 		logical_topic_id,ordinary_visible,content_fingerprint,meta_fingerprint,health
-		FROM catalog_sessions WHERE directory=? AND missing_since=0`, path)
+		FROM catalog_sessions WHERE directory_key=? AND missing_since=0`, directoryKey)
 	if err != nil {
 		return false, err
 	}
@@ -96,13 +97,14 @@ func (c *Catalog) directoryScanCanSkip(ctx context.Context, target DirectoryTarg
 		got.RecoveryCopy = recoveryCopy != 0
 		got.RecoveryCanonical = recoveryCanonical != 0
 		got.OrdinaryVisible = ordinaryVisible != 0
-		want, ok := expected[got.Path]
+		gotKey := c.pathKey(got.Path)
+		want, ok := expected[gotKey]
 		if !ok {
 			_ = rows.Close()
 			c.markRepair(repairReasonPathMismatch, c.opts.Now().UnixMilli())
 			return false, nil
 		}
-		seen[got.Path] = struct{}{}
+		seen[gotKey] = struct{}{}
 		if !sameSessionProjection(got, want) {
 			_ = rows.Close()
 			c.markRepair(repairReasonTopicMismatch, c.opts.Now().UnixMilli())

--- a/internal/sessioncatalog/reconcile_status.go
+++ b/internal/sessioncatalog/reconcile_status.go
@@ -4,7 +4,7 @@ import "context"
 
 func (c *Catalog) failDirectoryScan(ctx context.Context, path string, scanErr error) {
 	c.mutationMu.Lock()
-	_, _ = c.db.ExecContext(ctx, `UPDATE catalog_directories SET state='degraded',error=? WHERE path=?`, scanErr.Error(), path)
+	_, _ = c.db.ExecContext(ctx, `UPDATE catalog_directories SET state='degraded',error=? WHERE path_key=?`, scanErr.Error(), c.pathKey(path))
 	c.mutationMu.Unlock()
 	c.statusMu.Lock()
 	c.status.State = StateDegraded

--- a/internal/sessioncatalog/recovery_copy_test.go
+++ b/internal/sessioncatalog/recovery_copy_test.go
@@ -12,15 +12,15 @@ import (
 	"reasonix/internal/provider"
 )
 
-func TestDefaultPathUsesV5CacheFile(t *testing.T) {
+func TestDefaultPathUsesV6CacheFile(t *testing.T) {
 	t.Parallel()
 	path := DefaultPath()
 	if path == "" {
 		// CacheDir unavailable in this environment; empty is still valid.
 		return
 	}
-	if !strings.HasSuffix(filepath.ToSlash(path), "session-catalog/v5.sqlite") {
-		t.Fatalf("DefaultPath = %q, want .../session-catalog/v5.sqlite", path)
+	if !strings.HasSuffix(filepath.ToSlash(path), "session-catalog/v6.sqlite") {
+		t.Fatalf("DefaultPath = %q, want .../session-catalog/v6.sqlite", path)
 	}
 	if strings.Contains(path, "v1.sqlite") {
 		t.Fatalf("DefaultPath must not reuse the 1.24.0 v1 cache: %q", path)

--- a/internal/sessioncatalog/recovery_groups.go
+++ b/internal/sessioncatalog/recovery_groups.go
@@ -3,7 +3,6 @@ package sessioncatalog
 import (
 	"context"
 	"path/filepath"
-	"strings"
 )
 
 // RecoveryGroup is a catalog projection of one proved recovery lineage. It is
@@ -25,10 +24,10 @@ func (c *Catalog) ListRecoveryGroups(ctx context.Context, directory string) ([]R
 	if c == nil || c.db == nil {
 		return out, nil
 	}
-	directory = filepath.Clean(strings.TrimSpace(directory))
+	directory = cleanCatalogAccessPath(directory)
 	rows, err := c.db.QueryContext(ctx, `SELECT `+sessionSelectColumns+` FROM catalog_sessions
-		WHERE directory=? AND recovered=1 AND recovery_group_id<>'' AND missing_since=0
-		ORDER BY recovery_group_id,path`, directory)
+		WHERE directory_key=? AND recovered=1 AND recovery_group_id<>'' AND missing_since=0
+		ORDER BY recovery_group_id,path`, c.pathKey(directory))
 	if err != nil {
 		return out, err
 	}

--- a/internal/sessioncatalog/removal.go
+++ b/internal/sessioncatalog/removal.go
@@ -21,11 +21,19 @@ func (c *Catalog) RemoveSession(ctx context.Context, path, reason string) error 
 	pathKey := c.pathKey(path)
 	// Immediate query overlay: ListTopics/ListSessions/GetSession filter this
 	// map even when the durable DELETE has not committed yet.
-	c.removedPaths.Store(pathKey, c.mutationSeq.Add(1))
+	removalSequence := c.mutationSeq.Add(1)
+	c.removedPaths.Store(pathKey, removalSequence)
 	c.writeMu.Lock()
-	delete(c.writeQueued, queuePathKey(path))
+	queueKey := queuePathKey(path)
+	if queued, ok := c.writeQueued[queueKey]; ok && queued.enqueueSequence <= removalSequence {
+		delete(c.writeQueued, queueKey)
+	}
 	c.writeMu.Unlock()
-	c.pathQueued.Delete(queuePathKey(path))
+	c.pathQueueMu.Lock()
+	if queued, ok := c.pathQueued.Load(queueKey); ok && queued.(sessionPathRequest).sequence <= removalSequence {
+		c.pathQueued.CompareAndDelete(queueKey, queued)
+	}
+	c.pathQueueMu.Unlock()
 	c.repairQueued.Delete(pathKey)
 	// Wake listeners without SQLite. Equal revision identifies an overlay change;
 	// empty roots refresh every expanded folder without querying the busy DB for
@@ -118,8 +126,8 @@ func (c *Catalog) applySessionRemovalLocked(ctx context.Context, path, reason st
 	}
 	var key TopicKey
 	pathKey := c.pathKey(path)
-	err = tx.QueryRowContext(sqlCtx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions WHERE path_key=?`, pathKey).
-		Scan(&key.Scope, &key.WorkspaceRoot, &key.TopicID)
+	err = tx.QueryRowContext(sqlCtx, `SELECT scope,workspace_root,workspace_root_key,topic_id FROM catalog_sessions WHERE path_key=?`, pathKey).
+		Scan(&key.Scope, &key.WorkspaceRoot, &key.workspaceKey, &key.TopicID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		_ = tx.Rollback()
 		return err

--- a/internal/sessioncatalog/removal.go
+++ b/internal/sessioncatalog/removal.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"path/filepath"
-	"strings"
 	"time"
 )
 
@@ -15,18 +14,19 @@ func (c *Catalog) RemoveSession(ctx context.Context, path, reason string) error 
 	if c == nil || c.db == nil {
 		return nil
 	}
-	path = filepath.Clean(strings.TrimSpace(path))
-	if path == "." || path == "" {
+	path = cleanCatalogAccessPath(path)
+	if path == "" {
 		return nil
 	}
+	pathKey := c.pathKey(path)
 	// Immediate query overlay: ListTopics/ListSessions/GetSession filter this
 	// map even when the durable DELETE has not committed yet.
-	c.removedPaths.Store(path, struct{}{})
+	c.removedPaths.Store(pathKey, struct{}{})
 	c.writeMu.Lock()
-	delete(c.writeQueued, path)
+	delete(c.writeQueued, pathKey)
 	c.writeMu.Unlock()
-	c.pathQueued.Delete(path)
-	c.repairQueued.Delete(path)
+	c.pathQueued.Delete(pathKey)
+	c.repairQueued.Delete(pathKey)
 	// Wake listeners without SQLite. Equal revision identifies an overlay change;
 	// empty roots refresh every expanded folder without querying the busy DB for
 	// workspace_root.
@@ -66,7 +66,7 @@ func (c *Catalog) scheduleSessionRemovalRetry(path, reason string) {
 		ctx, cancel := context.WithTimeout(c.workerCtx, 5*time.Second)
 		defer cancel()
 		// Re-check tombstone: a recreate may have cleared it.
-		if _, removed := c.removedPaths.Load(path); !removed {
+		if _, removed := c.removedPaths.Load(c.pathKey(path)); !removed {
 			return
 		}
 		// Blocking apply is fine on the background worker.
@@ -117,13 +117,14 @@ func (c *Catalog) applySessionRemovalLocked(ctx context.Context, path, reason st
 		return err
 	}
 	var key TopicKey
-	err = tx.QueryRowContext(sqlCtx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions WHERE path=?`, path).
+	pathKey := c.pathKey(path)
+	err = tx.QueryRowContext(sqlCtx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions WHERE path_key=?`, pathKey).
 		Scan(&key.Scope, &key.WorkspaceRoot, &key.TopicID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		_ = tx.Rollback()
 		return err
 	}
-	if _, err := tx.ExecContext(sqlCtx, `DELETE FROM catalog_sessions WHERE path=?`, path); err != nil {
+	if _, err := tx.ExecContext(sqlCtx, `DELETE FROM catalog_sessions WHERE path_key=?`, pathKey); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
@@ -147,9 +148,16 @@ func (c *Catalog) applySessionRemovalLocked(ctx context.Context, path, reason st
 }
 
 func (c *Catalog) pathRemoved(path string) bool {
+	return c.pathRemovedKey("", path)
+}
+
+func (c *Catalog) pathRemovedKey(key, path string) bool {
 	if c == nil {
 		return false
 	}
-	_, removed := c.removedPaths.Load(filepath.Clean(path))
+	if key == "" {
+		key = c.pathKey(path)
+	}
+	_, removed := c.removedPaths.Load(key)
 	return removed
 }

--- a/internal/sessioncatalog/removal.go
+++ b/internal/sessioncatalog/removal.go
@@ -21,11 +21,11 @@ func (c *Catalog) RemoveSession(ctx context.Context, path, reason string) error 
 	pathKey := c.pathKey(path)
 	// Immediate query overlay: ListTopics/ListSessions/GetSession filter this
 	// map even when the durable DELETE has not committed yet.
-	c.removedPaths.Store(pathKey, struct{}{})
+	c.removedPaths.Store(pathKey, c.mutationSeq.Add(1))
 	c.writeMu.Lock()
-	delete(c.writeQueued, pathKey)
+	delete(c.writeQueued, queuePathKey(path))
 	c.writeMu.Unlock()
-	c.pathQueued.Delete(pathKey)
+	c.pathQueued.Delete(queuePathKey(path))
 	c.repairQueued.Delete(pathKey)
 	// Wake listeners without SQLite. Equal revision identifies an overlay change;
 	// empty roots refresh every expanded folder without querying the busy DB for
@@ -129,7 +129,7 @@ func (c *Catalog) applySessionRemovalLocked(ctx context.Context, path, reason st
 		return err
 	}
 	if key.TopicID != "" {
-		if err := recomputeTopic(sqlCtx, tx, key); err != nil {
+		if err := c.recomputeTopic(sqlCtx, tx, key); err != nil {
 			_ = tx.Rollback()
 			return err
 		}

--- a/internal/sessioncatalog/removal_pagination_test.go
+++ b/internal/sessioncatalog/removal_pagination_test.go
@@ -18,6 +18,7 @@ func TestTombstonesDoNotTruncateSessionOrTopicPagination(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	catalog.pathIdentity = func(path string) string { return "identity:" + filepath.Clean(path) }
 
 	paths := make([]string, 5)
 	for i := range paths {
@@ -32,8 +33,8 @@ func TestTombstonesDoNotTruncateSessionOrTopicPagination(t *testing.T) {
 	}
 	// Keep the two newest SQL rows behind the read-visible overlay, as happens
 	// while an authoritative archive waits for the durable DELETE worker.
-	catalog.removedPaths.Store(paths[0], struct{}{})
-	catalog.removedPaths.Store(paths[1], struct{}{})
+	catalog.removedPaths.Store(catalog.pathKey(paths[0]), uint64(1))
+	catalog.removedPaths.Store(catalog.pathKey(paths[1]), uint64(1))
 
 	sessions, err := catalog.ListSessions(ctx, SessionPageRequest{Scope: "all", Limit: 2})
 	if err != nil {
@@ -76,6 +77,7 @@ func TestTopicVisibilityScansPastTombstonedPayloadWindow(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	catalog.pathIdentity = func(path string) string { return "identity:" + filepath.Clean(path) }
 
 	paths := make([]string, MaxLimit+1)
 	for i := range paths {
@@ -88,7 +90,7 @@ func TestTopicVisibilityScansPastTombstonedPayloadWindow(t *testing.T) {
 		}
 	}
 	for _, path := range paths[:MaxLimit] {
-		catalog.removedPaths.Store(path, struct{}{})
+		catalog.removedPaths.Store(catalog.pathKey(path), uint64(1))
 	}
 	topic, ok, err := catalog.GetTopic(ctx, TopicKey{Scope: "global", TopicID: "deep"})
 	if err != nil {

--- a/internal/sessioncatalog/repair.go
+++ b/internal/sessioncatalog/repair.go
@@ -15,17 +15,18 @@ func (c *Catalog) enqueueRepair(path string) {
 	if c == nil || c.opts.DisableRepair || strings.TrimSpace(path) == "" {
 		return
 	}
-	if _, loaded := c.repairQueued.LoadOrStore(path, struct{}{}); loaded {
+	key := c.pathKey(path)
+	if _, loaded := c.repairQueued.LoadOrStore(key, struct{}{}); loaded {
 		return
 	}
 	select {
 	case c.repairCh <- path:
 	case <-c.stop:
-		c.repairQueued.Delete(path)
+		c.repairQueued.Delete(key)
 	default:
 		// Channel pressure must never permanently drop unknown rows. Leave them
 		// in the DB and clear the in-memory marker so the drain ticker requeues.
-		c.repairQueued.Delete(path)
+		c.repairQueued.Delete(key)
 	}
 }
 
@@ -65,7 +66,7 @@ func (c *Catalog) repairLoop() {
 		select {
 		case path := <-c.repairCh:
 			c.repairSession(c.workerCtx, path)
-			c.repairQueued.Delete(path)
+			c.repairQueued.Delete(c.pathKey(path))
 			c.drainUnknownRepairs(c.workerCtx, 32)
 			runtime.Gosched()
 		case <-ticker.C:
@@ -127,7 +128,8 @@ func (c *Catalog) applyRepairResult(ctx context.Context, path, preview string, t
 		return err
 	}
 	var target DirectoryTarget
-	if err := tx.QueryRowContext(ctx, `SELECT directory,scope,workspace_root FROM catalog_sessions WHERE path=?`, path).
+	pathKey := c.pathKey(path)
+	if err := tx.QueryRowContext(ctx, `SELECT directory,scope,workspace_root FROM catalog_sessions WHERE path_key=?`, pathKey).
 		Scan(&target.Path, &target.Scope, &target.WorkspaceRoot); err != nil {
 		_ = tx.Rollback()
 		if err == sql.ErrNoRows {
@@ -137,10 +139,10 @@ func (c *Catalog) applyRepairResult(ctx context.Context, path, preview string, t
 	}
 	if valid {
 		_, err = tx.ExecContext(ctx, `UPDATE catalog_sessions SET preview=?,turns=?,turns_state='valid',
-            health='ok',meta_fingerprint=? WHERE path=?`,
-			preview, turns, fileFingerprint(agent.BranchMetaPath(path)), path)
+			health='ok',meta_fingerprint=? WHERE path_key=?`,
+			preview, turns, fileFingerprint(agent.BranchMetaPath(path)), pathKey)
 	} else {
-		_, err = tx.ExecContext(ctx, `UPDATE catalog_sessions SET turns_state='corrupt',health='corrupt' WHERE path=?`, path)
+		_, err = tx.ExecContext(ctx, `UPDATE catalog_sessions SET turns_state='corrupt',health='corrupt' WHERE path_key=?`, pathKey)
 	}
 	if err != nil {
 		_ = tx.Rollback()
@@ -178,7 +180,7 @@ func (c *Catalog) preserveKnownSourceStates(ctx context.Context, directory strin
 		return records, nil
 	}
 	rows, err := c.db.QueryContext(ctx, `SELECT path,preview,turns,turns_state,health,content_fingerprint
-		FROM catalog_sessions WHERE directory=? AND missing_since=0 AND turns_state<>'unknown'`, directory)
+		FROM catalog_sessions WHERE directory_key=? AND missing_since=0 AND turns_state<>'unknown'`, c.pathKey(directory))
 	if err != nil {
 		return nil, err
 	}
@@ -190,13 +192,13 @@ func (c *Catalog) preserveKnownSourceStates(ctx context.Context, directory strin
 		if err := rows.Scan(&path, &state.preview, &state.turns, &state.turnsState, &state.health, &state.contentFingerprint); err != nil {
 			return nil, err
 		}
-		known[path] = state
+		known[c.pathKey(path)] = state
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 	for i := range records {
-		state, ok := known[records[i].Path]
+		state, ok := known[c.pathKey(records[i].Path)]
 		if !ok || records[i].TurnsState != TurnsUnknown || records[i].ContentFingerprint != state.contentFingerprint {
 			continue
 		}

--- a/internal/sessioncatalog/schema.go
+++ b/internal/sessioncatalog/schema.go
@@ -140,6 +140,30 @@ CREATE TABLE IF NOT EXISTS catalog_folded_topics (
 );
 `
 
+// v9 separates filesystem identity from the original access spelling. The
+// production default moves to a fresh v6.sqlite generation together with this
+// migration, so old v5 writers never share the new identity columns. Explicit
+// legacy catalog paths are invalidated in place: filesystem-aware keys cannot
+// be backfilled safely in SQL, and every deleted row is a disposable projection
+// that the next authoritative directory reconciliation recreates.
+const migrationV9 = `
+ALTER TABLE catalog_directories ADD COLUMN path_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE catalog_sessions ADD COLUMN path_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE catalog_sessions ADD COLUMN directory_key TEXT NOT NULL DEFAULT '';
+
+DELETE FROM catalog_sessions;
+DELETE FROM catalog_directories;
+DELETE FROM catalog_topics;
+DELETE FROM catalog_folded_topics;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_catalog_directories_path_key
+ON catalog_directories(path_key);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_catalog_sessions_path_key
+ON catalog_sessions(path_key);
+CREATE INDEX IF NOT EXISTS idx_catalog_sessions_directory_key
+ON catalog_sessions(directory_key, seen_generation, missing_since);
+`
+
 func sessionMigrations() []projectiondb.Migration {
 	return []projectiondb.Migration{
 		{Version: 1, Apply: func(ctx context.Context, tx *sql.Tx) error {
@@ -172,6 +196,10 @@ func sessionMigrations() []projectiondb.Migration {
 		}},
 		{Version: 8, Apply: func(ctx context.Context, tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, migrationV8)
+			return err
+		}},
+		{Version: 9, Apply: func(ctx context.Context, tx *sql.Tx) error {
+			_, err := tx.ExecContext(ctx, migrationV9)
 			return err
 		}},
 	}

--- a/internal/sessioncatalog/schema.go
+++ b/internal/sessioncatalog/schema.go
@@ -164,6 +164,38 @@ CREATE INDEX IF NOT EXISTS idx_catalog_sessions_directory_key
 ON catalog_sessions(directory_key, seen_generation, missing_since);
 `
 
+// v10 extends filesystem identity to workspace roots. Access spellings remain
+// available for UI/file access, while every relationship and uniqueness rule
+// uses the filesystem-aware key. Existing v9 projections are disposable and
+// must be rebuilt because SQL cannot infer volume-specific case semantics.
+const migrationV10 = `
+ALTER TABLE catalog_projects ADD COLUMN workspace_root_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE catalog_topics ADD COLUMN workspace_root_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE catalog_sessions ADD COLUMN workspace_root_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE catalog_folded_topics ADD COLUMN workspace_root_key TEXT NOT NULL DEFAULT '';
+
+DELETE FROM catalog_sessions;
+DELETE FROM catalog_directories;
+DELETE FROM catalog_projects;
+DELETE FROM catalog_topics;
+DELETE FROM catalog_folded_topics;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_catalog_projects_workspace_key
+ON catalog_projects(scope, workspace_root_key);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_catalog_topics_workspace_key
+ON catalog_topics(scope, workspace_root_key, topic_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_catalog_folded_topics_workspace_key
+ON catalog_folded_topics(scope, workspace_root_key, topic_id);
+CREATE INDEX IF NOT EXISTS idx_catalog_topics_workspace_page
+ON catalog_topics(scope, workspace_root_key, pinned DESC, last_activity_at DESC, topic_id ASC);
+CREATE INDEX IF NOT EXISTS idx_catalog_sessions_workspace_topic
+ON catalog_sessions(scope, workspace_root_key, topic_id, last_activity_at DESC, path ASC);
+CREATE INDEX IF NOT EXISTS idx_catalog_sessions_workspace_history
+ON catalog_sessions(scope, workspace_root_key, last_activity_at DESC, path ASC);
+CREATE INDEX IF NOT EXISTS idx_catalog_sessions_workspace_ordinary
+ON catalog_sessions(scope, workspace_root_key, ordinary_visible, last_activity_at DESC);
+`
+
 func sessionMigrations() []projectiondb.Migration {
 	return []projectiondb.Migration{
 		{Version: 1, Apply: func(ctx context.Context, tx *sql.Tx) error {
@@ -200,6 +232,10 @@ func sessionMigrations() []projectiondb.Migration {
 		}},
 		{Version: 9, Apply: func(ctx context.Context, tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, migrationV9)
+			return err
+		}},
+		{Version: 10, Apply: func(ctx context.Context, tx *sql.Tx) error {
+			_, err := tx.ExecContext(ctx, migrationV10)
 			return err
 		}},
 	}

--- a/internal/sessioncatalog/session_page.go
+++ b/internal/sessioncatalog/session_page.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -18,7 +17,7 @@ type sessionPageCursor struct {
 	Path     string `json:"p"`
 }
 
-const sessionSelectColumns = `path,directory,scope,workspace_root,topic_id,topic_title,
+const sessionSelectColumns = `path,path_key,directory,scope,workspace_root,topic_id,topic_title,
     custom_title,created_at,last_activity_at,preview,turns,turns_state,recovered,
     recovery_reason,recovery_digest,parent_id,recovery_copy,recovery_group_id,
     recovery_role,recovery_canonical,logical_topic_id,ordinary_visible,content_fingerprint,
@@ -27,7 +26,7 @@ const sessionSelectColumns = `path,directory,scope,workspace_root,topic_id,topic
 func scanSession(scanner interface{ Scan(...any) error }) (SessionRecord, error) {
 	var record SessionRecord
 	var recoveryCopy, recoveryCanonical, ordinaryVisible int
-	err := scanner.Scan(&record.Path, &record.Directory, &record.Scope, &record.WorkspaceRoot,
+	err := scanner.Scan(&record.Path, &record.pathKey, &record.Directory, &record.Scope, &record.WorkspaceRoot,
 		&record.TopicID, &record.TopicTitle, &record.CustomTitle, &record.CreatedAt,
 		&record.LastActivityAt, &record.Preview, &record.Turns, &record.TurnsState,
 		&record.Recovered, &record.RecoveryReason, &record.RecoveryDigest,
@@ -83,8 +82,8 @@ func (c *Catalog) ListSessions(ctx context.Context, req SessionPageRequest) (Ses
 		return out, fmt.Errorf("invalid session catalog scope %q", req.Scope)
 	}
 	if directory := strings.TrimSpace(req.Directory); directory != "" {
-		where = append(where, `directory=?`)
-		args = append(args, filepath.Clean(directory))
+		where = append(where, `directory_key=?`)
+		args = append(args, c.pathKey(directory))
 	}
 	if query := strings.ToLower(strings.TrimSpace(req.Query)); query != "" {
 		where = append(where, `(lower(custom_title) LIKE ? OR lower(preview) LIKE ? OR lower(topic_title) LIKE ? OR lower(topic_id) LIKE ?)`)
@@ -117,7 +116,7 @@ func (c *Catalog) ListSessions(ctx context.Context, req SessionPageRequest) (Ses
 			}
 			rawCount++
 			lastScanned = record
-			if c.pathRemoved(record.Path) {
+			if c.pathRemovedKey(record.pathKey, record.Path) {
 				continue
 			}
 			out.Items = append(out.Items, record)
@@ -166,14 +165,14 @@ func appendSessionTimeFilter(where *[]string, args *[]any, filter string, now ti
 }
 
 func (c *Catalog) GetSession(ctx context.Context, path string) (SessionRecord, bool, error) {
-	path = filepath.Clean(strings.TrimSpace(path))
-	if path == "." || path == "" {
+	path = cleanCatalogAccessPath(path)
+	if path == "" {
 		return SessionRecord{}, false, nil
 	}
 	if c.pathRemoved(path) {
 		return SessionRecord{}, false, nil
 	}
-	record, err := scanSession(c.db.QueryRowContext(ctx, `SELECT `+sessionSelectColumns+` FROM catalog_sessions WHERE path=?`, path))
+	record, err := scanSession(c.db.QueryRowContext(ctx, `SELECT `+sessionSelectColumns+` FROM catalog_sessions WHERE path_key=?`, c.pathKey(path)))
 	if errors.Is(err, sql.ErrNoRows) {
 		return SessionRecord{}, false, nil
 	}

--- a/internal/sessioncatalog/session_page.go
+++ b/internal/sessioncatalog/session_page.go
@@ -74,8 +74,8 @@ func (c *Catalog) ListSessions(ctx context.Context, req SessionPageRequest) (Ses
 	switch strings.ToLower(strings.TrimSpace(req.Scope)) {
 	case "", "all":
 	case "project":
-		where = append(where, `scope='project'`, `workspace_root=?`)
-		args = append(args, strings.TrimSpace(req.WorkspaceRoot))
+		where = append(where, `scope='project'`, `workspace_root_key=?`)
+		args = append(args, c.workspaceRootKey("project", req.WorkspaceRoot))
 	case "global":
 		where = append(where, `scope='global'`)
 	default:

--- a/internal/sessioncatalog/topic_list.go
+++ b/internal/sessioncatalog/topic_list.go
@@ -22,7 +22,8 @@ func (c *Catalog) ListTopics(ctx context.Context, req TopicPageRequest) (TopicPa
 	if cursor != nil && cursor.ManualOrder != req.ManualOrder {
 		return out, errCursorSortModeChanged
 	}
-	args := []any{req.Scope, c.workspaceRootKey(req.Scope, req.WorkspaceRoot)}
+	rootKey := c.workspaceRootKey(req.Scope, req.WorkspaceRoot)
+	args := []any{req.Scope, rootKey}
 	where := `scope=? AND workspace_root_key=?`
 	if query := strings.TrimSpace(req.Query); query != "" {
 		where += ` AND lower(title) LIKE ?`
@@ -47,9 +48,9 @@ func (c *Catalog) ListTopics(ctx context.Context, req TopicPageRequest) (TopicPa
 		rawCount := len(scanned)
 		overflow := false
 		for _, item := range scanned {
-			sessions, listErr := c.listTopicSessions(ctx, TopicKey{
+			sessions, listErr := c.listTopicSessionsByRootKey(ctx, TopicKey{
 				Scope: item.Scope, WorkspaceRoot: item.WorkspaceRoot, TopicID: item.TopicID,
-			})
+			}, rootKey)
 			if listErr != nil {
 				return TopicPage{Items: []TopicRecord{}, Revision: out.Revision}, listErr
 			}

--- a/internal/sessioncatalog/topic_list.go
+++ b/internal/sessioncatalog/topic_list.go
@@ -22,8 +22,8 @@ func (c *Catalog) ListTopics(ctx context.Context, req TopicPageRequest) (TopicPa
 	if cursor != nil && cursor.ManualOrder != req.ManualOrder {
 		return out, errCursorSortModeChanged
 	}
-	args := []any{req.Scope, req.WorkspaceRoot}
-	where := `scope=? AND workspace_root=?`
+	args := []any{req.Scope, c.workspaceRootKey(req.Scope, req.WorkspaceRoot)}
+	where := `scope=? AND workspace_root_key=?`
 	if query := strings.TrimSpace(req.Query); query != "" {
 		where += ` AND lower(title) LIKE ?`
 		args = append(args, "%"+strings.ToLower(query)+"%")

--- a/internal/sessioncatalog/types.go
+++ b/internal/sessioncatalog/types.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	SchemaVersion = 8
+	SchemaVersion = 9
 	DefaultLimit  = 50
 	MaxLimit      = 200
 )
@@ -112,7 +112,8 @@ type TopicMetadata struct {
 }
 
 type SessionRecord struct {
-	Path              string     `json:"path"`
+	Path              string `json:"path"`
+	pathKey           string
 	Directory         string     `json:"directory"`
 	Scope             string     `json:"scope"`
 	WorkspaceRoot     string     `json:"workspaceRoot,omitempty"`
@@ -227,8 +228,8 @@ type SessionPage struct {
 }
 
 // DefaultPath is the disposable cache file under CacheDir ("" when unavailable).
-// v5.sqlite is independent of all older caches so a new build never trusts a
-// polluted or incomplete lineage projection produced by an older desktop.
+// v6.sqlite is independent of all older caches so a new build never trusts a
+// path-case-split projection produced by an older desktop or CLI.
 // Session JSONL/WAL/sidecars remain authoritative and older binaries may keep
 // using their own disposable cache without cross-writing this one.
 func DefaultPath() string {
@@ -236,5 +237,5 @@ func DefaultPath() string {
 	if cache == "" {
 		return ""
 	}
-	return filepath.Join(cache, "session-catalog", "v5.sqlite")
+	return filepath.Join(cache, "session-catalog", "v6.sqlite")
 }

--- a/internal/sessioncatalog/types.go
+++ b/internal/sessioncatalog/types.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	SchemaVersion = 9
+	SchemaVersion = 10
 	DefaultLimit  = 50
 	MaxLimit      = 200
 )
@@ -114,6 +114,7 @@ type TopicMetadata struct {
 type SessionRecord struct {
 	Path              string `json:"path"`
 	pathKey           string
+	enqueueSequence   uint64
 	Directory         string     `json:"directory"`
 	Scope             string     `json:"scope"`
 	WorkspaceRoot     string     `json:"workspaceRoot,omitempty"`

--- a/internal/sessioncatalog/types.go
+++ b/internal/sessioncatalog/types.go
@@ -89,6 +89,7 @@ type DirectoryTarget struct {
 	Path          string `json:"path"`
 	Scope         string `json:"scope"`
 	WorkspaceRoot string `json:"workspaceRoot,omitempty"`
+	mutationSeq   uint64
 }
 
 type ProjectRecord struct {
@@ -167,6 +168,7 @@ type TopicKey struct {
 	Scope         string `json:"scope"`
 	WorkspaceRoot string `json:"workspaceRoot,omitempty"`
 	TopicID       string `json:"topicId"`
+	workspaceKey  string
 }
 
 type TopicRecord struct {

--- a/internal/sessioncatalog/upsert.go
+++ b/internal/sessioncatalog/upsert.go
@@ -7,7 +7,9 @@ import (
 )
 
 func (c *Catalog) UpsertSession(ctx context.Context, record SessionRecord) error {
-	return c.upsertSessions(ctx, []SessionRecord{normalizeSessionRecord(record)}, nil, "write")
+	record = normalizeSessionRecord(record)
+	record.enqueueSequence = c.mutationSeq.Add(1)
+	return c.upsertSessions(ctx, []SessionRecord{record}, nil, "write")
 }
 
 func (c *Catalog) upsertSessions(ctx context.Context, records []SessionRecord, generations map[string]int64, reason string) error {
@@ -30,13 +32,7 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 	filtered := records[:0]
 	for _, record := range records {
 		pathKey := c.pathKey(record.Path)
-		removedAt, removed := c.removedPaths.Load(pathKey)
-		if !removed {
-			filtered = append(filtered, record)
-			continue
-		}
-		if sequence, ok := removedAt.(uint64); ok && record.enqueueSequence > sequence {
-			c.removedPaths.Delete(pathKey)
+		if c.pathMutationAllowed(pathKey, record.enqueueSequence) {
 			filtered = append(filtered, record)
 		}
 	}
@@ -76,9 +72,17 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 		record := normalizeSessionRecord(raw)
 		pathKey := c.pathKey(record.Path)
 		directoryKey := c.pathKey(record.Directory)
+		remapped, err := removeRemappedSessionIdentity(ctx, tx, record.Path, pathKey)
+		if err != nil {
+			_ = tx.Rollback()
+			return dirtyDirectories, err
+		}
+		for _, key := range remapped {
+			affected[key] = struct{}{}
+		}
 		var previous TopicKey
-		if err := tx.QueryRowContext(ctx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions WHERE path_key=?`, pathKey).
-			Scan(&previous.Scope, &previous.WorkspaceRoot, &previous.TopicID); err == nil && previous.TopicID != "" {
+		if err := tx.QueryRowContext(ctx, `SELECT scope,workspace_root,workspace_root_key,topic_id FROM catalog_sessions WHERE path_key=?`, pathKey).
+			Scan(&previous.Scope, &previous.WorkspaceRoot, &previous.workspaceKey, &previous.TopicID); err == nil && previous.TopicID != "" {
 			affected[previous] = struct{}{}
 		} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			_ = tx.Rollback()
@@ -98,7 +102,8 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 			return dirtyDirectories, err
 		}
 		if record.TopicID != "" {
-			affected[TopicKey{Scope: record.Scope, WorkspaceRoot: record.WorkspaceRoot, TopicID: record.TopicID}] = struct{}{}
+			affected[TopicKey{Scope: record.Scope, WorkspaceRoot: record.WorkspaceRoot,
+				workspaceKey: c.workspaceRootKey(record.Scope, record.WorkspaceRoot), TopicID: record.TopicID}] = struct{}{}
 		}
 		if err := c.updateFoldedTopicTombstones(ctx, tx, previous, record, c.opts.Now().UnixMilli()); err != nil {
 			_ = tx.Rollback()

--- a/internal/sessioncatalog/upsert.go
+++ b/internal/sessioncatalog/upsert.go
@@ -29,7 +29,14 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 	defer c.mutationMu.Unlock()
 	filtered := records[:0]
 	for _, record := range records {
-		if _, removed := c.removedPaths.Load(c.pathKey(record.Path)); !removed {
+		pathKey := c.pathKey(record.Path)
+		removedAt, removed := c.removedPaths.Load(pathKey)
+		if !removed {
+			filtered = append(filtered, record)
+			continue
+		}
+		if sequence, ok := removedAt.(uint64); ok && record.enqueueSequence > sequence {
+			c.removedPaths.Delete(pathKey)
 			filtered = append(filtered, record)
 		}
 	}
@@ -93,14 +100,14 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 		if record.TopicID != "" {
 			affected[TopicKey{Scope: record.Scope, WorkspaceRoot: record.WorkspaceRoot, TopicID: record.TopicID}] = struct{}{}
 		}
-		if err := updateFoldedTopicTombstones(ctx, tx, previous, record, c.opts.Now().UnixMilli()); err != nil {
+		if err := c.updateFoldedTopicTombstones(ctx, tx, previous, record, c.opts.Now().UnixMilli()); err != nil {
 			_ = tx.Rollback()
 			return dirtyDirectories, err
 		}
 		roots[record.WorkspaceRoot] = struct{}{}
 	}
 	for key := range affected {
-		if err := recomputeTopic(ctx, tx, key); err != nil {
+		if err := c.recomputeTopic(ctx, tx, key); err != nil {
 			_ = tx.Rollback()
 			return dirtyDirectories, err
 		}
@@ -123,17 +130,17 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 }
 
 const sessionInsertSQL = `INSERT INTO catalog_sessions(
-    path,path_key,directory,directory_key,scope,workspace_root,topic_id,topic_title,custom_title,
+    path,path_key,directory,directory_key,scope,workspace_root,workspace_root_key,topic_id,topic_title,custom_title,
     created_at,last_activity_at,preview,turns,turns_state,recovered,
     recovery_reason,recovery_digest,parent_id,recovery_copy,recovery_group_id,
     recovery_role,recovery_canonical,logical_topic_id,ordinary_visible,content_fingerprint,
     meta_fingerprint,health,missing_since,seen_generation
-) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 ON CONFLICT(path_key) DO UPDATE SET `
 
 const directoryProjectionUpdateSQL = `
     path=excluded.path, directory=excluded.directory, directory_key=excluded.directory_key, scope=excluded.scope,
-    workspace_root=excluded.workspace_root, topic_id=excluded.topic_id,
+    workspace_root=excluded.workspace_root, workspace_root_key=excluded.workspace_root_key, topic_id=excluded.topic_id,
     topic_title=excluded.topic_title, custom_title=excluded.custom_title,
     created_at=excluded.created_at, last_activity_at=excluded.last_activity_at,
     preview=excluded.preview, turns=excluded.turns,
@@ -152,7 +159,7 @@ const directoryProjectionUpdateSQL = `
 
 const exactSourceUpdateSQL = `
     path=excluded.path, directory=excluded.directory, directory_key=excluded.directory_key, scope=excluded.scope,
-    workspace_root=excluded.workspace_root,
+    workspace_root=excluded.workspace_root, workspace_root_key=excluded.workspace_root_key,
     topic_id=CASE
         WHEN catalog_sessions.recovered=1 OR excluded.recovered=1 OR catalog_sessions.recovery_group_id<>''
         THEN catalog_sessions.topic_id ELSE excluded.topic_id END,
@@ -180,14 +187,14 @@ func (c *Catalog) upsertSessionRow(ctx context.Context, tx *sql.Tx, record Sessi
 	if mode == upsertExactSource {
 		updateSQL = exactSourceUpdateSQL
 	}
-	_, err := tx.ExecContext(ctx, sessionInsertSQL+updateSQL, sessionRowValues(record, pathKey, directoryKey, generation)...)
+	_, err := tx.ExecContext(ctx, sessionInsertSQL+updateSQL, c.sessionRowValues(record, pathKey, directoryKey, generation)...)
 	return err
 }
 
-func sessionRowValues(record SessionRecord, pathKey, directoryKey string, generation int64) []any {
+func (c *Catalog) sessionRowValues(record SessionRecord, pathKey, directoryKey string, generation int64) []any {
 	return []any{
 		record.Path, pathKey, record.Directory, directoryKey, record.Scope, record.WorkspaceRoot,
-		record.TopicID, record.TopicTitle, record.CustomTitle, record.CreatedAt,
+		c.workspaceRootKey(record.Scope, record.WorkspaceRoot), record.TopicID, record.TopicTitle, record.CustomTitle, record.CreatedAt,
 		record.LastActivityAt, record.Preview, record.Turns, record.TurnsState,
 		record.Recovered, record.RecoveryReason, record.RecoveryDigest,
 		record.ParentID, boolToInt(record.RecoveryCopy), record.RecoveryGroupID,

--- a/internal/sessioncatalog/upsert.go
+++ b/internal/sessioncatalog/upsert.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"path/filepath"
 )
 
 func (c *Catalog) UpsertSession(ctx context.Context, record SessionRecord) error {
@@ -30,7 +29,7 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 	defer c.mutationMu.Unlock()
 	filtered := records[:0]
 	for _, record := range records {
-		if _, removed := c.removedPaths.Load(filepath.Clean(record.Path)); !removed {
+		if _, removed := c.removedPaths.Load(c.pathKey(record.Path)); !removed {
 			filtered = append(filtered, record)
 		}
 	}
@@ -46,7 +45,7 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 				return dirtyDirectories, err
 			}
 			if projectionDirty {
-				dirtyDirectories[record.Directory] = DirectoryTarget{
+				dirtyDirectories[c.pathKey(record.Directory)] = DirectoryTarget{
 					Path: record.Directory, Scope: record.Scope, WorkspaceRoot: record.WorkspaceRoot,
 				}
 			}
@@ -68,8 +67,10 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 	directoryGenerations := map[string]int64{}
 	for _, raw := range records {
 		record := normalizeSessionRecord(raw)
+		pathKey := c.pathKey(record.Path)
+		directoryKey := c.pathKey(record.Directory)
 		var previous TopicKey
-		if err := tx.QueryRowContext(ctx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions WHERE path=?`, record.Path).
+		if err := tx.QueryRowContext(ctx, `SELECT scope,workspace_root,topic_id FROM catalog_sessions WHERE path_key=?`, pathKey).
 			Scan(&previous.Scope, &previous.WorkspaceRoot, &previous.TopicID); err == nil && previous.TopicID != "" {
 			affected[previous] = struct{}{}
 		} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -79,13 +80,13 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 		generation := int64(0)
 		if generations != nil {
 			generation = generations[record.Path]
-		} else if cached, ok := directoryGenerations[record.Directory]; ok {
+		} else if cached, ok := directoryGenerations[directoryKey]; ok {
 			generation = cached
 		} else {
-			_ = tx.QueryRowContext(ctx, `SELECT scan_generation FROM catalog_directories WHERE path=?`, record.Directory).Scan(&generation)
-			directoryGenerations[record.Directory] = generation
+			_ = tx.QueryRowContext(ctx, `SELECT scan_generation FROM catalog_directories WHERE path_key=?`, directoryKey).Scan(&generation)
+			directoryGenerations[directoryKey] = generation
 		}
-		if err := upsertSessionRow(ctx, tx, record, generation, mode); err != nil {
+		if err := c.upsertSessionRow(ctx, tx, record, pathKey, directoryKey, generation, mode); err != nil {
 			_ = tx.Rollback()
 			return dirtyDirectories, err
 		}
@@ -122,16 +123,16 @@ func (c *Catalog) upsertSessionsWithNotification(ctx context.Context, records []
 }
 
 const sessionInsertSQL = `INSERT INTO catalog_sessions(
-    path,directory,scope,workspace_root,topic_id,topic_title,custom_title,
+    path,path_key,directory,directory_key,scope,workspace_root,topic_id,topic_title,custom_title,
     created_at,last_activity_at,preview,turns,turns_state,recovered,
     recovery_reason,recovery_digest,parent_id,recovery_copy,recovery_group_id,
     recovery_role,recovery_canonical,logical_topic_id,ordinary_visible,content_fingerprint,
     meta_fingerprint,health,missing_since,seen_generation
-) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-ON CONFLICT(path) DO UPDATE SET `
+) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+ON CONFLICT(path_key) DO UPDATE SET `
 
 const directoryProjectionUpdateSQL = `
-    directory=excluded.directory, scope=excluded.scope,
+    path=excluded.path, directory=excluded.directory, directory_key=excluded.directory_key, scope=excluded.scope,
     workspace_root=excluded.workspace_root, topic_id=excluded.topic_id,
     topic_title=excluded.topic_title, custom_title=excluded.custom_title,
     created_at=excluded.created_at, last_activity_at=excluded.last_activity_at,
@@ -150,7 +151,7 @@ const directoryProjectionUpdateSQL = `
     missing_since=0, seen_generation=MAX(catalog_sessions.seen_generation, excluded.seen_generation)`
 
 const exactSourceUpdateSQL = `
-    directory=excluded.directory, scope=excluded.scope,
+    path=excluded.path, directory=excluded.directory, directory_key=excluded.directory_key, scope=excluded.scope,
     workspace_root=excluded.workspace_root,
     topic_id=CASE
         WHEN catalog_sessions.recovered=1 OR excluded.recovered=1 OR catalog_sessions.recovery_group_id<>''
@@ -174,18 +175,18 @@ const exactSourceUpdateSQL = `
     meta_fingerprint=excluded.meta_fingerprint, health=excluded.health,
     missing_since=0, seen_generation=MAX(catalog_sessions.seen_generation, excluded.seen_generation)`
 
-func upsertSessionRow(ctx context.Context, tx *sql.Tx, record SessionRecord, generation int64, mode sessionUpsertMode) error {
+func (c *Catalog) upsertSessionRow(ctx context.Context, tx *sql.Tx, record SessionRecord, pathKey, directoryKey string, generation int64, mode sessionUpsertMode) error {
 	updateSQL := directoryProjectionUpdateSQL
 	if mode == upsertExactSource {
 		updateSQL = exactSourceUpdateSQL
 	}
-	_, err := tx.ExecContext(ctx, sessionInsertSQL+updateSQL, sessionRowValues(record, generation)...)
+	_, err := tx.ExecContext(ctx, sessionInsertSQL+updateSQL, sessionRowValues(record, pathKey, directoryKey, generation)...)
 	return err
 }
 
-func sessionRowValues(record SessionRecord, generation int64) []any {
+func sessionRowValues(record SessionRecord, pathKey, directoryKey string, generation int64) []any {
 	return []any{
-		record.Path, record.Directory, record.Scope, record.WorkspaceRoot,
+		record.Path, pathKey, record.Directory, directoryKey, record.Scope, record.WorkspaceRoot,
 		record.TopicID, record.TopicTitle, record.CustomTitle, record.CreatedAt,
 		record.LastActivityAt, record.Preview, record.Turns, record.TurnsState,
 		record.Recovered, record.RecoveryReason, record.RecoveryDigest,


### PR DESCRIPTION
## Summary

- separate original session, directory, and workspace-root access spellings from filesystem-aware identity keys
- use those keys for Desktop and CLI targets, SQLite uniqueness and workspace relationships, scans, direct indexing, tombstones, repair ownership, and directory locks
- keep save observers non-blocking by staging queue events lexically and resolving filesystem identity in background workers, with SQLite uniqueness as the final deduplication boundary
- move the disposable catalog to `v6.sqlite`, migrate its schema through v10, and invalidate unsafe legacy projections for authoritative rebuild
- preserve distinct `/Foo` and `/foo` entries on case-sensitive filesystems while coalescing equivalent spellings on case-insensitive filesystems
- execute `internal/sessioncatalog` tests in the native Windows PR smoke leg
- enforce generation-aware remove/recreate ordering, atomically replace remapped raw-key projections, and publish registered project-root spellings

Fixes #9511.
Refs #9588.

Documentation-impact: updated - documented the v6 cache generation, workspace-root identity, and asynchronous identity-resolution boundary in the English and Chinese session-catalog and config-path guides.

## Problem

The session catalog used cleaned path strings as both file-access paths and logical identities. On case-insensitive filesystems, the same transcript or project could arrive with different case spellings through different producers and become split across catalog rows and topic queries. The Desktop-only unconditional lowercasing in #9588 reduced one source of duplicate scans, but it did not cover CLI rebuilds, direct indexing, SQLite conflicts, workspace-root joins, removal tombstones, repair ownership, or locks; it also merged genuinely distinct paths on case-sensitive filesystems.

The initial version of this PR still had two gaps: `workspace_root` remained a raw-string relational key, and save observers performed `EvalSymlinks` plus platform case probing before enqueueing. Its Windows-specific package tests were also only cross-compiled, not executed by the Windows PR matrix. A final review found three residual gaps: stale exact-index or scan work could clear a newer tombstone, revision events could publish a sidecar spelling that Desktop would not exact-match, and an identity remap at the same access spelling could leave a raw-key row that blocked targeted upserts.

## Fix

`PathIdentityKey` resolves the deepest existing ancestor and then applies platform filesystem semantics:

- macOS reads `_PC_CASE_SENSITIVE` and normalizes APFS/HFS paths before folding only on case-insensitive volumes;
- Windows folds each component according to the directory governing that lookup, preserving WSL-enabled case-sensitive directory children;
- other platforms preserve case.

The catalog stores `path_key`, `directory_key`, and `workspace_root_key` separately from original access spellings. Project, topic, session, folded-topic, pagination, metadata, and recovery relationships use `workspace_root_key`, while callers still receive the original path spelling for access and display.

Save callbacks now perform lexical queue staging only. Background writers and reconcile workers resolve the durable filesystem identity; unique SQLite indexes remain the final correctness boundary. A monotonic enqueue/removal sequence preserves the existing rule that an older queued write cannot resurrect a removed row while a later authoritative recreation can supersede the tombstone. Every writer now rechecks removal generations with compare-and-delete semantics, exact-index coalescing retains the newest request, identity remaps delete stale raw-key projections in the same transaction, and revision callbacks translate roots back to the registered project spelling.

Schema v9 introduced session/directory identity and schema v10 extends it to workspace roots. The production default remains the isolated `v6.sqlite` generation. Existing v5 caches remain untouched for downgrade safety; an already-created v9/v6 development cache is also safely invalidated and rebuilt because filesystem-aware root keys cannot be inferred in SQL. Only disposable projections are removed.

## Source PR consolidation

| Source | Treatment | Credit |
| --- | --- | --- |
| #9588 | Adapted the directory-target deduplication intent and expanded it to every catalog boundary with filesystem-sensitive semantics. | Co-author: @Linearl; the adopted implementation remains credited by the verified public GitHub `Co-authored-by` trailer. |
| #6158 | Reused the established separation between path identity keys and user-facing/access spellings, including platform-aware equality expectations. | Existing merged architecture by @SivanCola. |
| #9205 | Reused the disposable-catalog rebuild model and authoritative transcript/sidecar recovery path. | Existing merged architecture by @SivanCola. |

This PR is intended as the integration replacement for #9588; it does not modify or close the source PR.

## Compatibility and safety

- authoritative JSONL, event logs, metadata sidecars, archives, and project files are never rewritten by migration or rebuild
- older binaries continue using the untouched v5 cache; new binaries use v6, avoiding cross-version writes
- v9-to-v10 migration tests prove previously published PR-head projections are rebuilt safely
- no network behavior, dependencies, credentials, or telemetry are added
- case-sensitive filesystems retain distinct session and project identities

## Verification

- `go test ./...`
- `go test -race ./internal/sessioncatalog/...`
- `(cd desktop && go test ./...)`
- `go vet ./...`
- `go run ./tools/repolint`
- `golangci-lint v2.12.2 run --timeout=5m`
- focused workspace identity, identity-remap, exact-index coalescing, tombstone-generation, migration, enqueue, and removal-order tests repeated 20 times
- Windows amd64 sessioncatalog test binary cross-compiled successfully
- native Windows execution is now required by the PR smoke workflow
- synthetic merge tree with latest `main-v2` (`798b88869`) passed `go test ./internal/sessioncatalog/...` and Desktop `go test ./...`
- `git diff --check`

Cache-impact: none - no provider-visible prompt, tool schema, request serialization, memory prefix, or compaction behavior changes.
Cache-guard: not applicable - session catalog persistence and CI coverage only.
System-prompt-review: not applicable - no system prompt changes.

