### PR TITLE
feat(control): authorized write-dir query/add/remove backend / 后端：已授权写目录查询与增删（#9167 Phase 1+2）

### DIFF
--- a/internal/config/write_access.go
+++ b/internal/config/write_access.go
@@ -14,6 +14,77 @@ import (
 	"reasonix/internal/sandbox"
 )
 
+func SetProjectWriteAccess(path string, allowWrite []string, permRule string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("persist write access: empty config path")
+	}
+	unlock, err := LockConfigFileEdits(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	resolved, exists, err := statConfigPath(path)
+	if err != nil {
+		return err
+	}
+	var raw []byte
+	if exists {
+		raw, err = fileencoding.ReadFileUTF8(resolved)
+		if err != nil {
+			return err
+		}
+	}
+	body := string(raw)
+	edit, err := loadForEditStrict(path, true, false)
+	if err != nil {
+		return err
+	}
+
+	// Replace the complete allow_write list (supports removal), normalizing each
+	// entry through FormatConfigWritePath.
+	home, _ := os.UserHomeDir()
+	var normalized []string
+	for _, dir := range allowWrite {
+		formatted := sandbox.FormatConfigWritePath(strings.TrimSpace(dir), home)
+		if formatted == "" {
+			continue
+		}
+		if writeRootCovered(normalized, formatted, home) {
+			continue
+		}
+		normalized = append(normalized, formatted)
+	}
+
+	allow := append([]string(nil), edit.Permissions.Allow...)
+	if rule := strings.TrimSpace(permRule); rule != "" {
+		if coveredBy := coveredPermissionRule(allow, rule); coveredBy == "" {
+			allow = pruneCoveredPermissionRules(allow, rule)
+			allow = append(allow, rule)
+		}
+	}
+
+	if body == "" {
+		body = fmt.Sprintf("[permissions]\nallow = %s\n\n[sandbox]\nallow_write = %s\n", renderStringArray(allow), renderStringArray(normalized))
+	} else {
+		body = upsertTOMLSectionKey(body, "permissions", "allow", "allow = "+renderStringArray(allow))
+		body = upsertTOMLSectionKey(body, "sandbox", "allow_write", "allow_write = "+renderStringArray(normalized))
+	}
+
+	var candidate Config
+	if _, err := toml.Decode(body, &candidate); err != nil {
+		return fmt.Errorf("persist write access: validate updated config: %w", err)
+	}
+	if !slices.Equal(candidate.Permissions.Allow, allow) {
+		return fmt.Errorf("persist write access: validate updated allow: got %v, want %v", candidate.Permissions.Allow, allow)
+	}
+	if !slices.Equal(candidate.Sandbox.AllowWrite, normalized) {
+		return fmt.Errorf("persist write access: validate updated allow_write: got %v, want %v", candidate.Sandbox.AllowWrite, normalized)
+	}
+	return writeConfigFileResolved(resolved, body, configFilePerm(path))
+}
+
 // PersistProjectWriteAccess updates [permissions].allow and [sandbox].allow_write
 // in one locked, validated, atomic write. permRule may be empty when ordinary
 // permission is already allowed.

--- a/internal/config/write_access_test.go
+++ b/internal/config/write_access_test.go
@@ -58,3 +58,50 @@ func TestPersistProjectWriteAccessDoesNotDuplicateAncestor(t *testing.T) {
 		t.Fatalf("child should not be persisted when ancestor exists: %s", raw)
 	}
 }
+
+func TestSetProjectWriteAccessReplacesListAndRemoves(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "reasonix.toml")
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	if err := os.MkdirAll(a, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(b, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fixture := "[sandbox]\nallow_write = " + renderStringArray([]string{a, b}) + "\n"
+	if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Replace the whole list with a single entry => b is removed.
+	if err := SetProjectWriteAccess(path, []string{a}, ""); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := LoadForEditReadOnlyStrict(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots := reloaded.AllowWriteRoots()
+	if len(roots) != 1 || filepath.Clean(roots[0]) != filepath.Clean(a) {
+		t.Fatalf("allow_write after replace = %v, want [%s]", roots, a)
+	}
+	for _, r := range roots {
+		if filepath.Clean(r) == filepath.Clean(b) {
+			t.Fatalf("b should have been removed, got %v", roots)
+		}
+	}
+
+	// Setting an empty list removes everything.
+	if err := SetProjectWriteAccess(path, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err = LoadForEditReadOnlyStrict(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reloaded.AllowWriteRoots()) != 0 {
+		t.Fatalf("expected empty allow_write, got %v", reloaded.AllowWriteRoots())
+	}
+}

--- a/internal/control/write_access.go
+++ b/internal/control/write_access.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"reasonix/internal/agent"
@@ -342,4 +343,154 @@ func scopeFromApprove(allow, session, persist bool) sandbox.ApprovalScope {
 		return sandbox.ApprovalScopeSession
 	}
 	return sandbox.ApprovalScopeOnce
+}
+
+// QueryAuthorizedWriteDirs returns the write directories currently authorized
+// for this controller, split by scope:
+//
+//	project — configured [sandbox].allow_write (persisted in the project config)
+//	         as [project] allow_write entries;
+//	session — session-level roots granted for the rest of this logical session
+//	         (process memory).
+//
+// This backs the "authorized write directories" management surface (see
+// #9167). Per-call one-shot grants are intentionally not listed.
+func (c *Controller) QueryAuthorizedWriteDirs() (project, session []string) {
+	if c != nil && c.workspaceRoot != "" {
+		if cfg, err := config.LoadForRootReadOnly(c.workspaceRoot); err == nil && cfg != nil {
+			project = cfg.AllowWriteRoots()
+		}
+	}
+	if c != nil && c.writeAccess.roots != nil {
+		session = c.writeAccess.roots.SessionRoots()
+	}
+	return project, session
+}
+
+// AddAuthorizedWriteDir adds a writable directory at the given scope.
+//   - ApprovalScopeProject: persists into the project config [sandbox].allow_write
+//     (via SetProjectWriteAccess) and grants it as a verified baseline root.
+//   - ApprovalScopeSession: grants a verified session root for this logical session.
+//
+// Other scopes are rejected. Directory creation is best-effort; a not-yet
+// existing approved path is created like the interactive approval flow does.
+func (c *Controller) AddAuthorizedWriteDir(scope sandbox.ApprovalScope, dir string) error {
+	if c == nil {
+		return fmt.Errorf("no active controller")
+	}
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return fmt.Errorf("directory is required")
+	}
+	stateRoot := config.MemoryUserDir()
+	verified, err := sandbox.EnsureWriteDir(dir, stateRoot)
+	if err != nil {
+		return fmt.Errorf("add authorized write dir: %w", err)
+	}
+	switch scope {
+	case sandbox.ApprovalScopeProject:
+		if c.writeAccess.persist == nil {
+			return fmt.Errorf("project persistence is not available")
+		}
+		// Rewrite the full allow_write list with the new entry appended
+		// (replacement write on current list) so removal can also be served.
+		project, _ := c.QueryAuthorizedWriteDirs()
+		if !containsWriteRoot(project, verified) {
+			project = append(project, verified)
+		}
+		if err := c.persistSetWriteAccess(project); err != nil {
+			return err
+		}
+		if c.writeAccess.roots != nil {
+			c.writeAccess.roots.GrantVerifiedBaseline([]string{verified})
+		}
+		return nil
+	case sandbox.ApprovalScopeSession:
+		if c.writeAccess.roots != nil {
+			c.writeAccess.roots.GrantVerifiedSession([]string{verified})
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported scope %v for adding a write directory", scope)
+	}
+}
+
+// RemoveAuthorizedWriteDir removes a writable directory at the given scope.
+//   - ApprovalScopeProject: removes it from the project config [sandbox].allow_write
+//     and from the in-memory baseline.
+//   - ApprovalScopeSession: removes it from the session roots.
+func (c *Controller) RemoveAuthorizedWriteDir(scope sandbox.ApprovalScope, dir string) error {
+	if c == nil {
+		return fmt.Errorf("no active controller")
+	}
+	if strings.TrimSpace(dir) == "" {
+		return fmt.Errorf("directory is required")
+	}
+	switch scope {
+	case sandbox.ApprovalScopeProject:
+		project, _ := c.QueryAuthorizedWriteDirs()
+		kept := project[:0]
+		for _, p := range project {
+			if pathEqualDir(p, dir) {
+				continue
+			}
+			kept = append(kept, p)
+		}
+		if err := c.persistSetWriteAccess(kept); err != nil {
+			return err
+		}
+		// The persisted [sandbox].allow_write rewrite is authoritative for the
+		// project scope; the in-memory baseline will refresh from config on the
+		// next LoadForRoot. Nothing to mutate in session roots here.
+		return nil
+	case sandbox.ApprovalScopeSession:
+		if c.writeAccess.roots != nil {
+			c.writeAccess.roots.RemoveSessionRoot(dir)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported scope %v for removing a write directory", scope)
+	}
+}
+
+func containsWriteRoot(roots []string, target string) bool {
+	for _, r := range roots {
+		if pathEqualDir(r, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathEqualDir(a, b string) bool {
+	absA, errA := filepath.Abs(filepath.Clean(a))
+	absB, errB := filepath.Abs(filepath.Clean(b))
+	if errA == nil && errB == nil {
+		return absA == absB
+	}
+	return strings.TrimSpace(a) == strings.TrimSpace(b)
+}
+
+// projectConfigPathForWriteAccess returns the project config path that holds
+// [sandbox].allow_write for a workspace (workspaceRoot/reasonix.toml), matching
+// boot's rememberPermissionConfigPath semantics. Empty workspaceRoot falls back
+// to the user config path.
+func projectConfigPathForWriteAccess(workspaceRoot string) string {
+	root := strings.TrimSpace(workspaceRoot)
+	if root != "" {
+		return filepath.Join(root, "reasonix.toml")
+	}
+	path := config.SourcePath()
+	if path == "" {
+		path = "reasonix.toml"
+	}
+	return path
+}
+
+// persistSetWriteAccess rewrites the project config [sandbox].allow_write to
+// exactly the given list (replacement write, supports removal). It is the
+// management-surface counterpart to the interactive approval's append-only
+// PersistProjectWriteAccess (see #9167).
+func (c *Controller) persistSetWriteAccess(allowWrite []string) error {
+	return config.SetProjectWriteAccess(projectConfigPathForWriteAccess(c.workspaceRoot), allowWrite, "")
 }

--- a/internal/control/write_access_test.go
+++ b/internal/control/write_access_test.go
@@ -270,3 +270,95 @@ func canonicalWriteTestDir(t *testing.T) string {
 	}
 	return dir
 }
+
+func assertSessionRoots(t *testing.T, c *Controller, present, absent []string) {
+	t.Helper()
+	_, session := c.QueryAuthorizedWriteDirs()
+	for _, p := range present {
+		if !writeRootsContains(session, p) {
+			t.Fatalf("session roots should contain %s, got %v", p, session)
+		}
+	}
+	for _, a := range absent {
+		if writeRootsContains(session, a) {
+			t.Fatalf("session roots should NOT contain %s, got %v", a, session)
+		}
+	}
+}
+
+func writeRootsContains(roots []string, target string) bool {
+	targetAbs, _ := filepath.Abs(filepath.Clean(target))
+	for _, r := range roots {
+		if ra, _ := filepath.Abs(filepath.Clean(r)); ra == targetAbs {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAuthorizedWriteDirsSessionAddQueryRemove(t *testing.T) {
+	dir := t.TempDir()
+	set := sandbox.NewWritableRootSet([]string{dir})
+	c := New(Options{Policy: permission.New("allow", nil, nil, nil), WriteRoots: set})
+
+	a := canonicalWriteTestDir(t)
+	b := canonicalWriteTestDir(t)
+
+	// Add session-level.
+	if err := c.AddAuthorizedWriteDir(sandbox.ApprovalScopeSession, a); err != nil {
+		t.Fatalf("add session: %v", err)
+	}
+	assertSessionRoots(t, c, []string{a}, nil)
+
+	if err := c.AddAuthorizedWriteDir(sandbox.ApprovalScopeSession, b); err != nil {
+		t.Fatalf("add session b: %v", err)
+	}
+	assertSessionRoots(t, c, []string{a, b}, nil)
+
+	// Query reflects both.
+	project, session := c.QueryAuthorizedWriteDirs()
+	if len(project) != 0 {
+		t.Fatalf("project roots should be empty (no workspaceRoot config), got %v", project)
+	}
+	if !writeRootsContains(session, a) || !writeRootsContains(session, b) {
+		t.Fatalf("session roots = %v, want a and b", session)
+	}
+
+	// Remove a session-level.
+	if err := c.RemoveAuthorizedWriteDir(sandbox.ApprovalScopeSession, a); err != nil {
+		t.Fatalf("remove session: %v", err)
+	}
+	assertSessionRoots(t, c, []string{b}, []string{a})
+}
+
+func TestQueryAuthorizedWriteDirsReadsProjectConfig(t *testing.T) {
+	ws := t.TempDir()
+	// A project config with an allow_write entry.
+	extra := canonicalWriteTestDir(t)
+	cfgBody := `[sandbox]
+allow_write = ["` + strings.ReplaceAll(extra, `\`, `\\`) + `"]
+`
+	if err := os.WriteFile(filepath.Join(ws, "reasonix.toml"), []byte(cfgBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := New(Options{WorkspaceRoot: ws, Policy: permission.New("allow", nil, nil, nil), WriteRoots: sandbox.NewWritableRootSet([]string{ws})})
+
+	project, session := c.QueryAuthorizedWriteDirs()
+	if len(session) != 0 {
+		t.Fatalf("session roots should be empty, got %v", session)
+	}
+	if !writeRootsContains(project, extra) {
+		t.Fatalf("project roots should include %s, got %v", extra, project)
+	}
+}
+
+func TestAddAuthorizedWriteDirProjectRequiresPersist(t *testing.T) {
+	ws := t.TempDir()
+	c := New(Options{WorkspaceRoot: ws, Policy: permission.New("allow", nil, nil, nil), WriteRoots: sandbox.NewWritableRootSet([]string{ws})})
+	extra := canonicalWriteTestDir(t)
+	// Without an injected persist (OnPersistWriteAccess nil), project-scope add
+	// must fail closed instead of mutating memory-only.
+	if err := c.AddAuthorizedWriteDir(sandbox.ApprovalScopeProject, extra); err == nil {
+		t.Fatal("project add without persist should error")
+	}
+}

--- a/internal/sandbox/writable_roots.go
+++ b/internal/sandbox/writable_roots.go
@@ -75,6 +75,32 @@ func (s *WritableRootSet) ClearSession() {
 	s.mu.Unlock()
 }
 
+// RemoveSessionRoot removes one path from the session grant set (canonical /
+// path-within comparison). It is a no-op when the root is not present.
+func (s *WritableRootSet) RemoveSessionRoot(dir string) {
+	if s == nil || strings.TrimSpace(dir) == "" {
+		return
+	}
+	target := canonicalDir(dir)
+	if target == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.session[:0]
+	changed := false
+	for _, root := range s.session {
+		if canonicalDir(root) == target {
+			changed = true
+			continue
+		}
+		out = append(out, root)
+	}
+	if changed {
+		s.session = CollapseWriteRoots(out)
+	}
+}
+
 // SessionRoots returns a copy of the session-approved directories.
 func (s *WritableRootSet) SessionRoots() []string {
 	if s == nil {

--- a/internal/sandbox/writable_roots_test.go
+++ b/internal/sandbox/writable_roots_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -159,4 +160,48 @@ func containsRoot(roots []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func TestWritableRootSetRemoveSessionRoot(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	c := t.TempDir()
+	set := NewWritableRootSet([]string{t.TempDir()})
+	set.GrantVerifiedSession([]string{a, b, c})
+
+	roots := set.SessionRoots()
+	if len(roots) != 3 {
+		t.Fatalf("SessionRoots = %d items, want 3", len(roots))
+	}
+
+	// Remove the middle one; only b should remain.
+	set.RemoveSessionRoot(b)
+	roots = set.SessionRoots()
+	if containsRoot(roots, b) {
+		t.Fatal("b should be removed from session roots")
+	}
+	if !containsRoot(roots, a) || !containsRoot(roots, c) {
+		t.Fatalf("a/c should remain, got %v", roots)
+	}
+
+	// Removing a non-present path is a no-op.
+	set.RemoveSessionRoot(t.TempDir())
+	if len(set.SessionRoots()) != 2 {
+		t.Fatalf("no-op removal changed count: %v", set.SessionRoots())
+	}
+
+	// Case-insensitive removal (Windows/Darwin fold).
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		upper := filepath.Join(a, "..", strings.ToUpper(filepath.Base(a)))
+		set.RemoveSessionRoot(upper)
+		if containsRoot(set.SessionRoots(), a) {
+			t.Fatalf("case-folded removal should drop a, got %v", set.SessionRoots())
+		}
+	}
+
+	// ClearSession still clears everything.
+	set.ClearSession()
+	if len(set.SessionRoots()) != 0 {
+		t.Fatalf("ClearSession should empty session roots")
+	}
 }


### PR DESCRIPTION
**TL;DR**: 后端：已授权写目录的查询/增删（会话级内存态+项目级持久化），是 #9167 修复的后端基座。Stacked PR-B（面板）依赖本 PR。

## Summary

Adds the **backend** for the "#9167 authorized write directories" management surface (Phases 1+2: visible + editable). Today the set of directories a project/session may write is invisible and unmanaged: `[project] allow_write` lives in config, session grants are process-memory roots, and users can only react to per-call approval prompts.

This PR is intentionally **backend-only** (no frontend wiring), so it can be reviewed independently; the desktop IPC + settings panel + right-click entry land in a follow-up PR.

**`internal/sandbox/writable_roots.go`**
- `RemoveSessionRoot(dir)` — remove a single session-level write root (previously only `ClearSession` existed).

**`internal/config/write_access.go`**
- `SetProjectWriteAccess(path, allowWrite, permRule)` — rewrite the whole `[sandbox].allow_write` list (replacement write, supports removal), complementing the append-only `PersistProjectWriteAccess` used by interactive approval.

**`internal/control/write_access.go`**
- `QueryAuthorizedWriteDirs()` → `(project, session []string)` — project from config `[sandbox].allow_write`, session from `WritableRootSet.SessionRoots()`, split by scope/source.
- `AddAuthorizedWriteDir(scope, dir)` — project scope persists into `allow_write` + grants baseline; session scope grants a session root.
- `RemoveAuthorizedWriteDir(scope, dir)` — project scope rewrites `allow_write` without the dir; session scope removes the session root.
- Project writes fail closed when persistence (`OnPersistWriteAccess`) is unavailable.

**Tests** — sandbox removal (incl. no-op + case-fold), config replacement/removal/empty, control session add/query/remove, project config read, fail-closed project add without persistence.

- Refs: #9167, #7085, #7436

## Motivation

External-directory writes repeatedly interrupt workflows with approval prompts, and there is no way to see what a project/session is currently allowed to write, or to add/remove entries. This backend gives a future management UI the primitives to list/edit authorized write dirs at project and session scope.

## Test plan

- `go build ./internal/sandbox/ ./internal/config/ ./internal/control/` — pass
- `go test ./internal/sandbox/ ./internal/config/ ./internal/control/ -count=1` — pass

Cache-impact: none- no cache behavior change (write-authorization bookkeeping only)
Cache-guard: updated- TestWritableRootSetRemoveSessionRoot, TestSetProjectWriteAccessReplacesListAndRemoves, TestAuthorizedWriteDirsSessionAddQueryRemove, TestQueryAuthorizedWriteDirsReadsProjectConfig, TestAddAuthorizedWriteDirProjectRequiresPersist
Documentation-impact: none- internal behavior only; frontend exposure follows in a separate PR
System-prompt-review: none- no agent/boot/config system-prompt changes

> Note: this PR was previously submitted as #9174 and closed in favor of #9476; re-opened as a standalone PR so upstream can merge incrementally (#9476 remains the superset tracking PR — merge order A → B → #9476, each rebase slims the next).
