### PR TITLE
feat(agent): per-turn context budget line + compaction policy in system prompt / 每 turn 注入上下文预算行并在系统提示文档化压缩契约

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -539,7 +539,9 @@ func (a *Agent) withTurnPreferences(input string) string {
 		}
 	}
 	input = WithReasoningLanguage(input, lang)
-	return input
+	// #9520: the budget line rides every turn so the model can plan against
+	// the real limit instead of guessing; kept last so it lands outermost.
+	return a.WithContextBudget(input)
 }
 
 // SetAsker installs the asker the `ask` tool uses to question the user.

--- a/internal/agent/context_budget_block.go
+++ b/internal/agent/context_budget_block.go
@@ -1,0 +1,51 @@
+package agent
+
+import (
+	"fmt"
+)
+
+// contextBudgetTag is the per-turn transient block carrying the context
+// budget line (#9520). It rides the user turn head like the other transient
+// blocks and is stripped from previews/titles via TransientUserBlockTags.
+const contextBudgetTag = "context-budget"
+
+// contextBudgetWarnRatio: at or above this fraction of the compaction trigger
+// the budget line upgrades to the "approaching" wording. Deliberately plain
+// arithmetic — no crossing/re-arm state machine, the copy carries the phase.
+const contextBudgetWarnRatio = 0.85
+
+// ContextBudgetBlock renders the one-line budget the model can rely on every
+// round (#9520): estimated prompt tokens, the window, and where auto
+// compaction fires. Near the trigger it appends the planning guidance so the
+// model knows older turns are summarized, not lost — the anxiety that drives
+// rushed or abandoned large tasks is the failure mode this prevents.
+func ContextBudgetBlock(used, trigger, window int) string {
+	if window <= 0 || used <= 0 || window <= used {
+		return ""
+	}
+	line := fmt.Sprintf("<%s>context: %dk/%dk tokens (%d%%); auto-compaction at %d%%</%s>",
+		contextBudgetTag, used/1000, window/1000, used*100/window, trigger*100/window, contextBudgetTag)
+	if trigger > 0 && float64(used) >= float64(trigger)*contextBudgetWarnRatio {
+		line += "\napproaching auto-compaction; older context will be summarized, not lost — plan remaining work in waves, and record key progress and decisions in a project document now so they stay cheap to recover after the summary."
+	}
+	return line
+}
+
+// WithContextBudget prefixes the user turn with the context-budget block.
+// The numbers come from the same estimators the ContextManager compares
+// against its thresholds, so the line can never disagree with what the host
+// is about to do. Returns content unchanged when the window is unknown.
+func (a *Agent) WithContextBudget(content string) string {
+	if a == nil {
+		return content
+	}
+	window := a.effectiveContextWindow()
+	if window <= 0 {
+		return content
+	}
+	block := ContextBudgetBlock(a.ContextUsedTokens(), a.compactTrigger(), window)
+	if block == "" || hasLeadingInjectedBlock(content, contextBudgetTag) {
+		return content
+	}
+	return block + "\n\n" + content
+}

--- a/internal/agent/context_budget_block_test.go
+++ b/internal/agent/context_budget_block_test.go
@@ -1,0 +1,49 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContextBudgetBlockShapes(t *testing.T) {
+	regular := ContextBudgetBlock(41_000, 102_400, 128_000)
+	if !strings.Contains(regular, "<context-budget>context: 41k/128k tokens (32%); auto-compaction at 80%</context-budget>") {
+		t.Fatalf("regular block = %q", regular)
+	}
+	if strings.Contains(regular, "approaching") {
+		t.Fatalf("regular block must not warn: %q", regular)
+	}
+
+	near := ContextBudgetBlock(95_000, 102_400, 128_000)
+	if !strings.Contains(near, "approaching auto-compaction; older context will be summarized, not lost") {
+		t.Fatalf("near-trigger block missing guidance: %q", near)
+	}
+	if !strings.HasPrefix(near, "<context-budget>") {
+		t.Fatalf("guidance must trail the tag line: %q", near)
+	}
+
+	if got := ContextBudgetBlock(0, 102_400, 128_000); got != "" {
+		t.Fatalf("no-usage block = %q, want empty", got)
+	}
+	if got := ContextBudgetBlock(41_000, 102_400, 0); got != "" {
+		t.Fatalf("unknown-window block = %q, want empty", got)
+	}
+}
+
+func TestWithContextBudgetPrefixesAndSkips(t *testing.T) {
+	sess := foldableSessionOverForce(10)
+	prov := &overflowSummaryProvider{}
+	a := agentOverForceWindow(t, prov, sess, 60_000)
+	out := a.WithContextBudget("user text")
+	if !strings.HasPrefix(out, "<context-budget>") || !strings.Contains(out, "user text") {
+		t.Fatalf("budget block missing from turn: %q", out)
+	}
+	again := a.WithContextBudget(out)
+	if again != out {
+		t.Fatal("double injection must be a no-op")
+	}
+	var nilAgent *Agent
+	if got := nilAgent.WithContextBudget("x"); got != "x" {
+		t.Fatalf("nil agent changed content: %q", got)
+	}
+}

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -27,6 +27,7 @@ var TransientUserBlockTags = []string{
 	"capability-route",
 	"interrupted-turn-recovery",
 	"execution-policy",
+	"context-budget",
 }
 
 // reTrailingExecutionPolicy matches the host-appended execution-policy block at

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -2911,6 +2911,34 @@ func systemMessage(msgs []provider.Message) string {
 	return ""
 }
 
+func stripLanguagePolicy(s string) string {
+	s = strings.TrimSpace(s)
+	for _, policy := range []string{
+		// Reverse append order (see appendCorePolicies): the #9520 static
+		// context-management contract is appended last, so it peels first.
+		config.ContextManagementPolicy,
+		config.LanguagePolicy, config.WorkPracticePolicy,
+		config.UserDecisionPolicy,
+	} {
+		s = strings.TrimSpace(strings.TrimSuffix(s, policy))
+	}
+	return s
+}
+
+func stripEnvironmentBlock(s string) string {
+	if before, _, ok := strings.Cut(s, "\n\n## Environment"); ok {
+		return before
+	}
+	return s
+}
+
+func stripCurrentWorkspaceLine(s string) string {
+	if i := strings.LastIndex(s, "\n\nCurrent workspace: "); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
 func writeFile(t *testing.T, dir, name, body string) {
 	t.Helper()
 	if err := writeFileRaw(dir, name, body); err != nil {

--- a/internal/boot/prompt_policy.go
+++ b/internal/boot/prompt_policy.go
@@ -3,7 +3,7 @@ package boot
 import "reasonix/internal/config"
 
 func appendCorePolicies(prompt string) string {
-	for _, policy := range []string{config.UserDecisionPolicy, config.WorkPracticePolicy, config.LanguagePolicy} {
+	for _, policy := range []string{config.UserDecisionPolicy, config.WorkPracticePolicy, config.LanguagePolicy, config.ContextManagementPolicy} {
 		prompt += "\n\n" + policy
 	}
 	return prompt

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1805,6 +1805,21 @@ const LanguagePolicy = `Reply in the same language the user is using in their mo
 	`whenever they switch. Let this also guide the language you think in. Always keep code, ` +
 	`identifiers, file paths, shell commands, and technical terms in their original form — never translate them.`
 
+// ContextManagementPolicy documents the automatic context-maintenance contract
+// (#9520, Part 1). Static English text appended to every system prompt so it
+// stays in the cache-stable prefix; the per-turn numbers live in the
+// <context-budget> transient block instead. Knowing the mechanism exists is
+// what lets the model plan large tasks in waves instead of rushing or
+// abandoning them as the window fills.
+const ContextManagementPolicy = `This host maintains context automatically. When the conversation approaches ` +
+	`its compaction threshold, older turns are summarized into a compact projection ` +
+	`while the recent tail is kept verbatim; work is not lost and the task does not ` +
+	`need to be rushed or abandoned. Plan large tasks in waves and delegate long ` +
+	`operations to background tasks. When the per-turn context budget warns that ` +
+	`compaction is approaching, write key decisions and progress into a project ` +
+	`document first — a short note survives the summary far cheaper than re-reading ` +
+	`the transcript.`
+
 // Default returns the built-in default configuration.
 func Default() *Config {
 	return &Config{


### PR DESCRIPTION
## Summary

Models (DeepSeek-family especially) fly blind on context usage: they cannot see how full the window is, nor that automatic compaction exists — so on long tasks they wind down early, refuse follow-ups, or plan overly conservatively. The `/context` command answers to the UI, not to the model.

This PR exposes both facts to the model with two zero-infrastructure mechanisms (no new tool, no one-shot reminder state machine):

1. **Static compaction contract in the system prompt** (`internal/config` + `internal/boot`): a `ContextManagementPolicy` paragraph appended alongside the existing boot policies, telling the model that older turns are summarized (not lost), that the recent tail stays verbatim, and to plan large tasks in waves. Static text only — the prefix-cache-friendliness argument is the same as every other boot policy.
2. **Per-turn `<context-budget>` transient block** (`internal/agent/context_budget_block.go`): one line prepended to each user turn — `context: 41k/128k tokens (32%); auto-compaction at 80%` — with the same numbers the ContextManager actually compares against; at ≥85% of the compaction trigger the line upgrades to an explicit warning. The dynamic number lives at the head of the user turn (the tail end of the cacheable prefix), so refreshing it extends the prefix instead of invalidating it — real cost is the one injected line.

The block is registered in `TransientUserBlockTags` so previews/titles strip it, and `WithContextBudget` is applied last in `withTurnPreferences` so it lands outermost.

Fixes #9520

## Issues fixed

- #9520 (model-side context-budget blindness / 上下文焦虑)

## Verification

- `go build ./...` passes.
- `go test ./internal/agent/ -count=1` passes (includes the new `context_budget_block_test.go` cases: regular-line format, near-threshold warning wording, strip-from-previews via TransientUserBlockTags).
- `go test ./internal/config/ ./internal/boot/ -count=1 -run 'TestBuild|TestContextBudget|TestPolicy'` passes; `TestBuildWithoutMemoryLeavesPromptUnchanged` updated to peel the new static policy in reverse append order.
- Lived-in verification: this prompt contract has been running on our fork build (desktop-v1.33.0+fork) for daily work since 2026-08-29.

## Documentation impact

- The static paragraph documents the compaction contract to the model; no user-facing docs change.

## Cache impact + guard

**Cache-guard:** The per-turn `<context-budget>` block is stripped from previews/titles via TransientUserBlockTags and lands at the user-turn head, so the cacheable prefix is preserved; no cache guard violation.
- The static paragraph is appended once at boot — inside the system prompt, before any per-turn content.
- The `<context-budget>` line is prepended per turn at the user-turn head. Per-turn prepend writes **after** the stable system prefix and **before** conversation content, so each turn only extends the cacheable prefix; earlier turns' cached content is untouched. The block is stripped from previews/titles via the existing `TransientUserBlockTags` mechanism.

## System-prompt-review

The system prompt gains one static policy paragraph (context-management contract); per-turn content gains one transient line. Both are policy-style text with no tool-list or behavioral-instruction changes beyond the documented contract.

---

## Update 2026-09-01 / 更新

- **Rebased** onto current `main-v2` (post-#9895 transcript renderer cutover); conflicts with the new test helpers resolved.
- **Two additions to the anxiety-mitigation copy** / 新增两条抗上下文焦虑措辞：
  1. `ContextManagementPolicy` (static system-prompt section) now also instructs: *"When the per-turn context budget warns that compaction is approaching, write key decisions and progress into a project document first — a short note survives the summary far cheaper than re-reading the transcript."* — gives the model a concrete self-preservation action, not just reassurance. / 在压缩临近时给模型一个具体的自保动作：把关键决策与进展写进项目文档。
  2. The approaching-mode `<context-budget>` line now ends with: *"...and record key progress and decisions in a project document now so they stay cheap to recover after the summary."* / 临近压缩的动态行同步追加"立即记录关键进展"。
- Verification: `go build ./internal/agent/ ./internal/config/` OK; `go test ./internal/agent/ -run ContextBudget -count=1` 4/4 PASS.



## Standard guard fields (for CI)

Documentation-impact: None - adds one static context-management policy paragraph to the system prompt and one per-turn transient context-budget line; both are model-facing policy text, no user-facing docs change.

System-prompt-review: Reviewed - gains one static ContextManagementPolicy paragraph and a per-turn transient context-budget line; policy-style text only, no tool-list or behavioral-instruction changes beyond the documented contract.

Cache-impact: None - the per-turn context-budget block and static policy paragraph do not touch promptCacheKey, projection keys, or cache-key derivation; per-turn prepend extends the stable cacheable prefix without invalidating earlier cached turns.