### PR TITLE
test(desktop): keep failed session history discoverable / 保证失败会话历史可发现

### DIFF
--- a/desktop/tab_startup_history_test.go
+++ b/desktop/tab_startup_history_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+)
+
+func TestTerminalStartupFailureRemainsInProjectHistoryAfterRestart(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	topicID := "topic_failed_startup_history"
+	topicTitle := "Failed startup history"
+	if err := addProject(projectRoot, "Failed startup project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	if err := setTopicTitle(projectRoot, topicID, topicTitle); err != nil {
+		t.Fatalf("set topic title: %v", err)
+	}
+	sessionDir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session directory: %v", err)
+	}
+	sessionPath := writeTopicSession(t, sessionDir, "failed-startup.jsonl", topicID, topicTitle, projectRoot)
+
+	app := NewApp()
+	failed := &WorkspaceTab{
+		ID: "failed", Scope: "project", WorkspaceRoot: projectRoot,
+		TopicID: topicID, TopicTitle: topicTitle, SessionPath: sessionPath,
+		Ready: true, disabledMCP: map[string]ServerView{},
+	}
+	app.tabs[failed.ID] = failed
+	app.tabOrder = []string{failed.ID}
+	app.activeTabID = failed.ID
+	app.mu.Lock()
+	app.newSessionRuntimeLocked(failed, sessionRuntimeKey(sessionPath))
+	leaseHeld, save := app.markTabStartupFailureLocked(failed, agent.ErrSessionWriteAuthorityMissing, suppressStartupRestore)
+	app.mu.Unlock()
+	if leaseHeld || save == nil {
+		t.Fatalf("terminal failure result: leaseHeld=%v save=%#v", leaseHeld, save)
+	}
+	app.writeTabsSaveRequest(save)
+
+	persisted := loadTabsFile()
+	if len(persisted.Tabs) != 0 || persisted.ActiveTab != "" {
+		t.Fatalf("persisted tabs = %#v active=%q, want failed tab omitted", persisted.Tabs, persisted.ActiveTab)
+	}
+	if _, err := os.Stat(sessionPath); err != nil {
+		t.Fatalf("terminal startup failure removed session history: %v", err)
+	}
+
+	restarted := NewApp()
+	targetFound := false
+	for _, target := range restarted.sessionCatalogTargets() {
+		if sameDesktopPath(target.Path, sessionDir) && target.Scope == "project" && sameProjectRoot(target.WorkspaceRoot, projectRoot) {
+			targetFound = true
+			break
+		}
+	}
+	if !targetFound {
+		t.Fatalf("restart catalog targets = %#v, want project session directory %q", restarted.sessionCatalogTargets(), sessionDir)
+	}
+	restarted.startSessionCatalog()
+	t.Cleanup(func() { restarted.stopSessionCatalog(time.Second) })
+	waitForCatalogTreeCondition(t, restarted, "failed session history after restart", func(nodes []ProjectNode) bool {
+		for _, project := range nodes {
+			if project.Kind != "project" || !sameProjectRoot(project.Root, projectRoot) {
+				continue
+			}
+			for _, topic := range project.Children {
+				if topic.TopicID == topicID && sameDesktopPath(topic.SessionPath, sessionPath) {
+					return true
+				}
+			}
+		}
+		return false
+	})
+}


### PR DESCRIPTION
## Summary

- Add a project-scoped regression for the terminal restore failure fixed in #9591.
- Prove the failed tab leaves `desktop-tabs.json` while its transcript remains on disk.
- Simulate a restart with a fresh `App`, discover the session directory from persisted project registration, rebuild the catalog, and require the project tree to return the exact session path.

This is a test-only follow-up to #9591 by @Linearl and the user report in #9393. It does not alter production behavior.

## Verification

- `cd desktop && go test . -run ^TestTerminalStartupFailureRemainsInProjectHistoryAfterRestart$ -count=10`
- `cd desktop && go test -race . -run ^TestTerminalStartupFailureRemainsInProjectHistoryAfterRestart$ -count=1`
- `cd desktop && go test ./...`
- `cd desktop && go vet ./...`
- `go run ./tools/repolint`
- `git diff --check`

## Compatibility and risk

The change adds one Go test file. It does not change runtime code, persisted data, cross-process files, Wails payloads, dependencies, network access, or security boundaries.

Documentation-impact: none; test-only coverage for an existing contract.
Cache-impact: none; no provider-visible bytes or cache-sensitive paths change.
Cache-guard: not applicable; no cache behavior changes.
System-prompt-review: not applicable; no prompt or tool schema changes.