### PR TITLE
fix(cli): negotiate clipboard image types and stop silent paste failure / 修复 Wayland 图片粘贴协商与静默失败

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -2028,11 +2028,11 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// pasting again would duplicate the text.
 				pending := pendingClipboardTextPastes(requests, m.clipboardImageTerminalPasteSeq, m.terminalPasteSeq)
 				if pending > 0 {
-					cmds = append(cmds, pasteClipboardTextGuarded(m.terminalPasteSeq, pending))
+					cmds = append(cmds, pasteClipboardTextGuarded(m.terminalPasteSeq, pending, msg.err))
 				}
 				break
 			}
-			m.notice(fmt.Sprintf(i18n.M.ClipboardImagePasteFailedFmt, msg.err))
+			m.notice(fmt.Sprintf(i18n.M.ClipboardImagePasteFailedFmt, sanitizeExternalDisplayText(msg.err.Error())))
 			break
 		}
 		imageBefore := m.input.Value()
@@ -2042,25 +2042,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case clipboardTextPasteMsg:
-		if msg.remote {
-			m.notice(i18n.M.ClipboardTextPasteRemoteHint)
-			break
-		}
-		if msg.err != nil {
-			m.notice(fmt.Sprintf(i18n.M.ClipboardTextPasteFailedFmt, msg.err))
-			break
-		}
-		if msg.text == "" {
-			break
-		}
-		count := 1
-		if msg.pending > 0 {
-			count = pendingClipboardTextPastes(msg.pending, msg.terminalPasteSeq, m.terminalPasteSeq)
-			if count == 0 {
-				break
-			}
-		}
-		return m.applyComposerPasteCount(tea.PasteMsg{Content: msg.text}, false, count)
+		return m.handleClipboardTextPaste(msg)
 
 	case clipboardCopyMsg:
 		if msg.statusHint && msg.seq != m.copyNoticeSeq {

--- a/internal/cli/chat_tui_clipboard_fallback_test.go
+++ b/internal/cli/chat_tui_clipboard_fallback_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"runtime"
 	"strings"
 	"testing"
@@ -9,17 +10,22 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"reasonix/internal/control"
+	"reasonix/internal/i18n"
 )
 
-func stubEmptyImageClipboard(t *testing.T, text string) {
+func stubEmptyImageClipboard(t *testing.T, text string, imageErrs ...error) {
 	t.Helper()
+	imageErr := control.ErrNoClipboardImage
+	if len(imageErrs) > 0 {
+		imageErr = imageErrs[0]
+	}
 	prevImage := readClipboardImage
 	prevText := readNativeClipboardText
 	t.Cleanup(func() {
 		readClipboardImage = prevImage
 		readNativeClipboardText = prevText
 	})
-	readClipboardImage = func() (string, error) { return "", control.ErrNoClipboardImage }
+	readClipboardImage = func() (string, error) { return "", imageErr }
 	readNativeClipboardText = func() (string, error) { return text, nil }
 }
 
@@ -30,9 +36,10 @@ func imagePasteKey() tea.KeyPressMsg {
 	return tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl}
 }
 
-func TestCtrlVPastesTextWhenClipboardHasNoImage(t *testing.T) {
+func TestCtrlVUnsupportedImageFallsBackToText(t *testing.T) {
 	setLocalClipboardSession(t)
-	stubEmptyImageClipboard(t, "https://example.com/x")
+	imageErr := fmt.Errorf("read clipboard image: unsupported image/bmp: %w", errors.Join(control.ErrNoClipboardImage, control.ErrUnsupportedClipboardImage))
+	stubEmptyImageClipboard(t, "https://example.com/x", imageErr)
 
 	m := newComposerMouseTestTUI(t, 60, 16)
 	m.input.SetValue("before ")
@@ -54,6 +61,9 @@ func TestCtrlVPastesTextWhenClipboardHasNoImage(t *testing.T) {
 
 	if got, want := m.input.Value(), "before https://example.com/x"; got != want {
 		t.Fatalf("clipboard text fallback produced %q, want %q", got, want)
+	}
+	if got := strings.Join(m.transcript, "\n"); strings.Contains(got, "image/bmp") {
+		t.Fatalf("successful text fallback surfaced an image error:\n%s", got)
 	}
 }
 
@@ -194,28 +204,35 @@ func TestOverlappingCtrlVStillAttachesImageOnce(t *testing.T) {
 }
 
 func TestLateTerminalPasteCancelsScheduledTextFallback(t *testing.T) {
-	setLocalClipboardSession(t)
-	stubEmptyImageClipboard(t, "term text")
+	for _, nativeText := range []string{"term text", ""} {
+		t.Run(fmt.Sprintf("native_text_%q", nativeText), func(t *testing.T) {
+			setLocalClipboardSession(t)
+			stubEmptyImageClipboard(t, nativeText)
 
-	m := newComposerMouseTestTUI(t, 60, 16)
-	next, imageProbe := m.Update(imagePasteKey())
-	m = next.(chatTUI)
-	next, textFallback := m.Update(imageProbe())
-	m = next.(chatTUI)
-	if textFallback == nil {
-		t.Fatal("empty image clipboard did not schedule a text fallback")
-	}
+			m := newComposerMouseTestTUI(t, 60, 16)
+			next, imageProbe := m.Update(imagePasteKey())
+			m = next.(chatTUI)
+			next, textFallback := m.Update(imageProbe())
+			m = next.(chatTUI)
+			if textFallback == nil {
+				t.Fatal("empty image clipboard did not schedule a text fallback")
+			}
 
-	// The terminal paste arrives after the image result but before the native
-	// text read completes. It still owns this paste and must cancel the fallback.
-	next, _ = m.Update(tea.PasteMsg{Content: "term text"})
-	m = next.(chatTUI)
-	result := clipboardTextPasteResultFromCmd(t, textFallback)
-	next, _ = m.Update(result)
-	m = next.(chatTUI)
+			// The terminal paste arrives after the image result but before the native
+			// text read completes. It owns this paste and must cancel every fallback result.
+			next, _ = m.Update(tea.PasteMsg{Content: "term text"})
+			m = next.(chatTUI)
+			result := clipboardTextPasteResultFromCmd(t, textFallback)
+			next, _ = m.Update(result)
+			m = next.(chatTUI)
 
-	if got, want := m.input.Value(), "term text"; got != want {
-		t.Fatalf("late terminal paste was duplicated: %q, want %q", got, want)
+			if got, want := m.input.Value(), "term text"; got != want {
+				t.Fatalf("late terminal paste was duplicated: %q, want %q", got, want)
+			}
+			if got := strings.Join(m.transcript, "\n"); strings.Contains(got, i18n.M.ClipboardPasteEmptyNotice) {
+				t.Fatalf("terminal-owned paste surfaced a stale empty notice:\n%s", got)
+			}
+		})
 	}
 }
 
@@ -224,7 +241,7 @@ func TestClipboardImagePasteKeepsNoticeForRealFailures(t *testing.T) {
 	m := newComposerMouseTestTUI(t, 60, 16)
 	m.input.SetValue("before ")
 
-	next, cmd := m.Update(clipboardImageMsg{err: errors.New("clipboard image paste needs wl-paste (Wayland) or xclip (X11)")})
+	next, cmd := m.Update(clipboardImageMsg{err: errors.New("clipboard image paste needs wl-paste \x1b]52;c;owned\a (Wayland) or xclip (X11)")})
 	m = next.(chatTUI)
 
 	if cmd != nil {
@@ -232,8 +249,40 @@ func TestClipboardImagePasteKeepsNoticeForRealFailures(t *testing.T) {
 	}
 	if got := strings.Join(m.transcript, "\n"); !strings.Contains(got, "wl-paste") {
 		t.Fatalf("a real clipboard failure lost its notice:\n%s", got)
+	} else if strings.ContainsAny(got, "\x1b\a") {
+		t.Fatalf("a real clipboard failure rendered terminal controls: %q", got)
 	}
 	if got := m.input.Value(); got != "before " {
 		t.Fatalf("a real clipboard failure changed the composer: %q", got)
+	}
+}
+
+func TestCtrlVEmptyImageProbeWithNoTextSurfacesNotice(t *testing.T) {
+	cases := []struct {
+		name     string
+		imageErr error
+		want     string
+	}{
+		{name: "no image", imageErr: control.ErrNoClipboardImage, want: i18n.M.ClipboardPasteEmptyNotice},
+		{name: "unsupported image", imageErr: fmt.Errorf("unsupported image/bmp: %w", errors.Join(control.ErrNoClipboardImage, control.ErrUnsupportedClipboardImage)), want: "image/bmp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setLocalClipboardSession(t)
+			stubEmptyImageClipboard(t, "", tc.imageErr)
+
+			m := newComposerMouseTestTUI(t, 60, 16)
+			next, cmd := m.Update(imagePasteKey())
+			m = next.(chatTUI)
+			next, cmd = m.Update(cmd())
+			m = next.(chatTUI)
+
+			result := clipboardTextPasteResultFromCmd(t, cmd)
+			next, _ = m.Update(result)
+			m = next.(chatTUI)
+			if got := strings.Join(m.transcript, "\n"); !strings.Contains(got, tc.want) {
+				t.Fatalf("empty image probe notice = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/cli/chat_tui_paste.go
+++ b/internal/cli/chat_tui_paste.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"github.com/atotto/clipboard"
 
 	"reasonix/internal/control"
+	"reasonix/internal/i18n"
 	"reasonix/internal/provider"
 	"reasonix/internal/secrets"
 	"reasonix/internal/shellparse"
@@ -383,9 +385,43 @@ func pasteClipboardImage() tea.Cmd {
 type clipboardTextPasteMsg struct {
 	text             string
 	err              error
+	imageErr         error
 	remote           bool
 	terminalPasteSeq uint64
 	pending          int
+}
+
+// handleClipboardTextPaste applies the guarded native text read that backs a
+// keyboard paste on terminals without bracketed-paste delivery, including the
+// image-probe fallback. A fallback that reads neither text nor a supported
+// image surfaces a notice instead of failing silently (#8377).
+func (m chatTUI) handleClipboardTextPaste(msg clipboardTextPasteMsg) (tea.Model, tea.Cmd) {
+	count := 1
+	if msg.pending > 0 {
+		count = pendingClipboardTextPastes(msg.pending, msg.terminalPasteSeq, m.terminalPasteSeq)
+		if count == 0 {
+			return m, nil
+		}
+	}
+	if msg.remote {
+		m.notice(i18n.M.ClipboardTextPasteRemoteHint)
+		return m, nil
+	}
+	if msg.err != nil {
+		m.notice(fmt.Sprintf(i18n.M.ClipboardTextPasteFailedFmt, sanitizeExternalDisplayText(msg.err.Error())))
+		return m, nil
+	}
+	if msg.text == "" {
+		if msg.pending > 0 {
+			if errors.Is(msg.imageErr, control.ErrUnsupportedClipboardImage) {
+				m.notice(fmt.Sprintf(i18n.M.ClipboardImagePasteFailedFmt, sanitizeExternalDisplayText(msg.imageErr.Error())))
+			} else {
+				m.notice(i18n.M.ClipboardPasteEmptyNotice)
+			}
+		}
+		return m, nil
+	}
+	return m.applyComposerPasteCount(tea.PasteMsg{Content: msg.text}, false, count)
 }
 
 var readNativeClipboardText = clipboard.ReadAll
@@ -394,12 +430,12 @@ var readNativeClipboardText = clipboard.ReadAll
 // paste still arrives from the terminal as a bracketed tea.PasteMsg; this read
 // is deliberately text-only so right-click never probes for an image first.
 func pasteClipboardText() tea.Cmd {
-	return pasteClipboardTextGuarded(0, 0)
+	return pasteClipboardTextGuarded(0, 0, nil)
 }
 
-func pasteClipboardTextGuarded(terminalPasteSeq uint64, pending int) tea.Cmd {
+func pasteClipboardTextGuarded(terminalPasteSeq uint64, pending int, imageErr error) tea.Cmd {
 	return func() tea.Msg {
-		msg := clipboardTextPasteMsg{terminalPasteSeq: terminalPasteSeq, pending: pending}
+		msg := clipboardTextPasteMsg{imageErr: imageErr, terminalPasteSeq: terminalPasteSeq, pending: pending}
 		if remoteClipboardSession() {
 			msg.remote = true
 			return msg

--- a/internal/control/attachments.go
+++ b/internal/control/attachments.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -25,10 +27,30 @@ const maxFileAttachmentBytes = 25 * 1024 * 1024
 const maxAttachmentCreateAttempts = 1000
 
 // ErrNoClipboardImage reports that the clipboard was read successfully but holds
-// no image. It is distinct from a missing clipboard tool: callers offering an
-// image-first paste shortcut use it to fall back to text instead of surfacing a
-// failure the user cannot act on.
+// no supported image. It is distinct from a missing clipboard tool: callers
+// offering an image-first paste shortcut use it to fall back to text before
+// surfacing an image-specific diagnostic.
 var ErrNoClipboardImage = errors.New("clipboard does not contain an image")
+
+// ErrUnsupportedClipboardImage marks the more specific no-pasteable-image case
+// where the clipboard advertised only image formats Reasonix cannot save.
+var ErrUnsupportedClipboardImage = errors.New("clipboard image type is not supported")
+
+type unsupportedClipboardImageError struct {
+	tool  string
+	types []string
+}
+
+func (e unsupportedClipboardImageError) Error() string {
+	return fmt.Sprintf("%s offers unsupported image types: %s", e.tool, strings.Join(e.types, ", "))
+}
+
+// Unsupported image formats still mean there is no image Reasonix can paste.
+// Wrapping the sentinel lets image-first shortcuts try their normal text
+// fallback before surfacing the more specific diagnostic.
+func (e unsupportedClipboardImageError) Unwrap() []error {
+	return []error{ErrNoClipboardImage, ErrUnsupportedClipboardImage}
+}
 
 var (
 	lookClipboardTool = exec.LookPath
@@ -283,15 +305,25 @@ $img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
 	return SaveImageBytes("", raw)
 }
 
+// clipboardImageTypes lists the image mimes we can save, most preferred
+// first; Wayland compositors and screenshot apps offer any of these.
+var clipboardImageTypes = []string{"image/png", "image/jpeg", "image/gif", "image/webp"}
+
+func clipboardImageReadArgs(tool, mime string) []string {
+	if tool == "wl-paste" {
+		return []string{"--type", mime, "--no-newline"}
+	}
+	return []string{"-selection", "clipboard", "-t", mime, "-o"}
+}
+
 func saveLinuxClipboardImage() (string, error) {
 	type clipboardTool struct {
 		name      string
 		typesArgs []string
-		imageArgs []string
 	}
 	tools := []clipboardTool{
-		{name: "wl-paste", typesArgs: []string{"--list-types"}, imageArgs: []string{"--type", "image/png", "--no-newline"}},
-		{name: "xclip", typesArgs: []string{"-selection", "clipboard", "-t", "TARGETS", "-o"}, imageArgs: []string{"-selection", "clipboard", "-t", "image/png", "-o"}},
+		{name: "wl-paste", typesArgs: []string{"--list-types"}},
+		{name: "xclip", typesArgs: []string{"-selection", "clipboard", "-t", "TARGETS", "-o"}},
 	}
 	foundTool := false
 	confirmedNoImage := false
@@ -311,11 +343,22 @@ func saveLinuxClipboardImage() (string, error) {
 			probeFailures = append(probeFailures, fmt.Errorf("probe %s clipboard types: %w", tool.name, err))
 			continue
 		}
-		if !clipboardTypeListed(types, "image/png") {
+		mime := ""
+		for _, want := range clipboardImageTypes {
+			if clipboardTypeListed(types, want) {
+				mime = want
+				break
+			}
+		}
+		if mime == "" {
+			if offered := offeredImageTypes(types); len(offered) > 0 {
+				readFailures = append(readFailures, unsupportedClipboardImageError{tool: tool.name, types: offered})
+				continue
+			}
 			confirmedNoImage = true
 			continue
 		}
-		out, _, err := runClipboardTool(path, tool.imageArgs...)
+		out, _, err := runClipboardTool(path, clipboardImageReadArgs(tool.name, mime)...)
 		if err != nil {
 			readFailures = append(readFailures, fmt.Errorf("read clipboard image with %s: %w", tool.name, err))
 			continue
@@ -350,6 +393,20 @@ func clipboardTypeListed(raw []byte, want string) bool {
 		}
 	}
 	return false
+}
+
+// offeredImageTypes returns safely quoted image/* MIME names that Reasonix
+// cannot save. Clipboard owners control these strings, so errors must never
+// contain their terminal control sequences verbatim.
+func offeredImageTypes(raw []byte) []string {
+	var offered []string
+	for field := range strings.FieldsSeq(string(raw)) {
+		lower := strings.ToLower(field)
+		if strings.HasPrefix(lower, "image/") && !slices.Contains(clipboardImageTypes, lower) {
+			offered = append(offered, strconv.QuoteToASCII(field))
+		}
+	}
+	return offered
 }
 
 func clipboardProbeMeansNoImage(tool string, stderr []byte) bool {

--- a/internal/control/attachments_test.go
+++ b/internal/control/attachments_test.go
@@ -401,3 +401,64 @@ func TestClassifyDarwinClipboardResultDistinguishesMissingTypeFromFailure(t *tes
 		t.Fatalf("darwin operational failure = %v, want wrapped %v", err, want)
 	}
 }
+
+func TestSaveLinuxClipboardImageNegotiatesSupportedImageType(t *testing.T) {
+	t.Chdir(t.TempDir())
+	png, err := base64.StdEncoding.DecodeString(tinyPNG)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var readArgs []string
+	stubClipboardTools(t,
+		func(name string) (string, error) {
+			if name == "wl-paste" {
+				return name, nil
+			}
+			return "", exec.ErrNotFound
+		},
+		func(_ string, args ...string) ([]byte, []byte, error) {
+			if len(args) == 1 && args[0] == "--list-types" {
+				return []byte("text/plain\nimage/jpeg\n"), nil, nil
+			}
+			readArgs = args
+			return png, nil, nil
+		},
+	)
+	if _, err := saveLinuxClipboardImage(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Join(readArgs, " "), "--type image/jpeg --no-newline"; got != want {
+		t.Fatalf("read args = %q, want %q", got, want)
+	}
+}
+
+func TestSaveLinuxClipboardImageNamesUnsupportedImageTypes(t *testing.T) {
+	stubClipboardTools(t,
+		func(name string) (string, error) {
+			if name == "wl-paste" {
+				return name, nil
+			}
+			return "", exec.ErrNotFound
+		},
+		func(_ string, args ...string) ([]byte, []byte, error) {
+			if len(args) == 1 && args[0] == "--list-types" {
+				return []byte("text/plain\nimage/bmp\nimage/\x1b]52;c;owned\a\n"), nil, nil
+			}
+			t.Fatalf("unsupported image types must not be read: %v", args)
+			return nil, nil, nil
+		},
+	)
+	_, err := saveLinuxClipboardImage()
+	if !errors.Is(err, ErrNoClipboardImage) {
+		t.Fatalf("unsupported image error = %v, want ErrNoClipboardImage fallback", err)
+	}
+	if !errors.Is(err, ErrUnsupportedClipboardImage) {
+		t.Fatalf("unsupported image error lost its diagnostic type: %v", err)
+	}
+	if !strings.Contains(err.Error(), "image/bmp") || !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("error should name the unsupported image type: %v", err)
+	}
+	if strings.ContainsAny(err.Error(), "\x1b\a") {
+		t.Fatalf("error contains clipboard-provided terminal controls: %q", err)
+	}
+}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -231,6 +231,7 @@ type Messages struct {
 	ClipboardTextPasteRemoteHint string // mouse paste cannot read the user's local clipboard/PRIMARY selection over SSH
 	ClipboardTextPasteFailedFmt  string // text clipboard read failed, one %v
 	ClipboardImagePastingHint    string // shown while an image is being read from the system clipboard
+	ClipboardPasteEmptyNotice    string
 	ClipboardImagePasteFailedFmt string // image clipboard read failed, one %v
 	MouseCaptureOnHint           string // "/mouse" turned in-app mouse handling back on
 	MouseCaptureOffHint          string // "/mouse" released mouse capture to the terminal

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -250,6 +250,7 @@ var English = Messages{
 	ClipboardTextPasteFailedFmt:  "paste text failed: %v",
 	ClipboardImagePastingHint:    "Pasting image…",
 	ClipboardImagePasteFailedFmt: "paste image failed: %v",
+	ClipboardPasteEmptyNotice:    "clipboard holds no pasteable text or supported image (PNG/JPEG/GIF/WebP)",
 	MouseCaptureOnHint:           "mouse capture on — in-app drag-select/scrollbar/wheel active",
 	MouseCaptureOffHint:          "mouse capture off — your terminal now handles selection and right-click",
 	MouseCaptureTag:              "native mouse",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -251,6 +251,7 @@ var Chinese = Messages{
 	ClipboardTextPasteFailedFmt:  "粘贴文本失败：%v",
 	ClipboardImagePastingHint:    "正在粘贴图片…",
 	ClipboardImagePasteFailedFmt: "粘贴图片失败：%v",
+	ClipboardPasteEmptyNotice:    "剪贴板中没有可粘贴的文本或受支持的图片（PNG/JPEG/GIF/WebP）",
 	MouseCaptureOnHint:           "鼠标接管已开启 — 应用内拖拽选中/滚动条/滚轮生效",
 	MouseCaptureOffHint:          "鼠标接管已关闭 — 由终端原生处理选中和右键菜单",
 	MouseCaptureTag:              "终端原生鼠标",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -241,6 +241,7 @@ var ChineseTraditional = Messages{
 	ClipboardTextPasteFailedFmt:  "貼上文字失敗：%v",
 	ClipboardImagePastingHint:    "正在貼上圖片…",
 	ClipboardImagePasteFailedFmt: "貼上圖片失敗：%v",
+	ClipboardPasteEmptyNotice:    "剪貼簿中沒有可粘貼的文字或受支援的圖片（PNG/JPEG/GIF/WebP）",
 	MouseCaptureOnHint:           "滑鼠接管已開啟 — 應用內拖拽選取/捲軸/滾輪生效",
 	MouseCaptureOffHint:          "滑鼠接管已關閉 — 由終端原生處理選取與右鍵選單",
 	MouseCaptureTag:              "終端原生滑鼠",


### PR DESCRIPTION
## Summary

On Wayland (and X11 applications that offer non-PNG images), Ctrl+V image paste could do nothing and show no feedback (#8377). This PR fixes the clipboard target negotiation and the image-first text fallback together:

1. **Negotiate supported image MIME types** (`internal/control/attachments.go`): the Linux clipboard path now selects the first supported target advertised by `wl-paste --list-types` or `xclip TARGETS`. The preference order is PNG → JPEG → GIF → WebP, matching the existing `SaveImageBytes` content-sniffing allowlist.
2. **Preserve normal text paste**: an advertised but unsupported image format remains a typed “no supported image” result, so Ctrl+V first tries the existing native text fallback. If text is available, it is pasted without an image error; if text is also empty, the TUI reports the specific unsupported image type.
3. **Make empty fallback feedback race-safe** (`internal/cli/chat_tui_paste.go`): guarded text completions validate their terminal-paste generation before displaying remote, read-error, or empty-result notices. A bracketed paste that arrives while the native read is in flight therefore suppresses the stale fallback result.
4. **Treat clipboard metadata as untrusted**: unsupported MIME names are quoted before entering errors, clipboard failures are sanitized before TUI rendering, and unsupported-target collection is linear instead of repeatedly rescanning the full target list.

## Verification

- `go test ./... -count=1`
- `go test -race ./internal/cli ./internal/control -count=1`
- `go vet ./...`
- `make lint` (golangci-lint, repolint, and Wails pin checks pass)
- `TestSaveLinuxClipboardImageNegotiatesSupportedImageType`: a JPEG-only clipboard is read with `--type image/jpeg`
- `TestSaveLinuxClipboardImageNamesUnsupportedImageTypes`: unsupported targets retain both fallback and diagnostic classifications, and terminal controls are escaped
- `TestCtrlVUnsupportedImageFallsBackToText`: valid text is pasted even when an unsupported image target is advertised
- `TestLateTerminalPasteCancelsScheduledTextFallback`: late bracketed paste suppresses both non-empty and empty native fallback results
- `TestCtrlVEmptyImageProbeWithNoTextSurfacesNotice`: empty and unsupported-image fallbacks produce the appropriate visible notice

Cache-impact: none - clipboard probing and TUI paste handling only; no prompt, tool, or provider path changes.

Cache-guard: N/A - no cache-sensitive file touched.

Documentation-impact: none - no commands, flags, or configuration changed; existing image-paste documentation remains accurate.

Closes #8377
