### PR TITLE
fix(control): strip interleaved compose prefixes and record raw prompts / 修复回滚选择器只显示注入通知的问题

### DIFF
--- a/internal/control/checkpoint_prompt_test.go
+++ b/internal/control/checkpoint_prompt_test.go
@@ -69,3 +69,33 @@ func TestHeadlessRunOpensCheckpoint(t *testing.T) {
 		t.Fatalf("headless checkpoints = %+v, want one checkpoint for the submitted turn", checkpoints)
 	}
 }
+
+func TestHeadlessRunStoresRawCheckpointPrompt(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	runner := &fakeTurnRunner{}
+	c := New(Options{
+		Runner:            runner,
+		Executor:          exec,
+		SessionDir:        dir,
+		SessionPath:       filepath.Join(dir, "headless-raw.jsonl"),
+		Label:             "test",
+		ReasoningLanguage: "zh",
+	})
+
+	const typed = "inspect the auth flow"
+	if err := c.Run(context.Background(), typed); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.inputs) != 1 || !strings.Contains(runner.inputs[0], "<reasoning-language>") {
+		t.Fatalf("runner inputs = %q, want one composed prompt", runner.inputs)
+	}
+	checkpoints := c.checkpoints.list()
+	if len(checkpoints) != 1 || checkpoints[0].Prompt != typed {
+		t.Fatalf("stored checkpoints = %+v, want raw prompt %q", checkpoints, typed)
+	}
+	if strings.Contains(checkpoints[0].Prompt, "<reasoning-language>") {
+		t.Fatalf("stored checkpoint contains composed prefix: %q", checkpoints[0].Prompt)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2039,7 +2039,7 @@ func (c *Controller) runReady(ctx context.Context, input string) (err error) {
 	startMessages := c.messageCount()
 	var marker agent.InFlightTurnMeta
 	defer func() { c.finishInFlightTurn(startMessages, marker) }()
-	c.beginCheckpoint(ctx, input)
+	c.beginCheckpoint(ctx, rawInput)
 	if c.guardianSess != nil {
 		c.guardianSess.ResetTurn()
 	}

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -63,11 +63,19 @@ const (
 // sidecar recording exists (e.g. sessions created before the display-recording
 // feature, or synthetic user messages injected by the controller).
 func StripComposePrefixes(content string) string {
-	s := agent.StripTransientUserBlocks(content)
-	s = stripComposeMarker(s, PlanModeMarker)
-	s = stripComposeMarker(s, legacyPlanModeMarker)
-	s = strings.TrimSpace(s)
-	return s
+	// The plan marker is prepended after the transient blocks, so a block can
+	// become leading only after the marker strips: iterate to a fixpoint.
+	s := content
+	for range 4 {
+		next := agent.StripTransientUserBlocks(s)
+		next = stripComposeMarker(next, PlanModeMarker)
+		next = stripComposeMarker(next, legacyPlanModeMarker)
+		if next == s {
+			break
+		}
+		s = next
+	}
+	return strings.TrimSpace(s)
 }
 
 func stripComposeMarker(s, marker string) string {

--- a/internal/control/input_strip_order_test.go
+++ b/internal/control/input_strip_order_test.go
@@ -1,0 +1,33 @@
+package control
+
+import "testing"
+
+// TestStripComposePrefixesOrdering pins the #7804 regression: the plan marker
+// is prepended after the transient blocks, so blocks only become leading once
+// the marker strips — a single pass left the whole notice chain in the rewind
+// picker's turn label.
+func TestStripComposePrefixesOrdering(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "marker before transient blocks strips both",
+			input: PlanModeMarker + "\n\n<reasoning-language>zh</reasoning-language>\n\n<memory-update>\nsaved\n</memory-update>\n\nfix login",
+			want:  "fix login",
+		},
+		{
+			name:  "marker between transient blocks strips all",
+			input: "<background-jobs>\n1 running\n</background-jobs>\n\n" + PlanModeMarker + "\n\n<active-goal>ship it</active-goal>\n\nkeep going",
+			want:  "keep going",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripComposePrefixes(tt.input); got != tt.want {
+				t.Fatalf("StripComposePrefixes() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The rewind picker (「回滚 → 选择一轮」) showed every turn's label as the injected notice chain — `<reasoning-language>… <memory-update>… <background-jobs>…` — instead of the user's own words, so users could not tell which turn to roll back to (#7804).

Two causes, both fixed:

1. **`StripComposePrefixes` was single-pass and mis-ordered** (`internal/control/input.go`). `Compose` prepends the plan-mode marker *after* the goal/language/memory/jobs blocks, so whenever the marker (or another preamble) sat in front, the `^`-anchored transient-block strip never matched and the whole chain survived into `Checkpoint.Meta.Prompt` → `Controller.Checkpoints()` → the picker label. The strip now iterates block-strip → marker-strip to a fixpoint (bounded at 4 passes), so interleaved marker/block shapes fully strip. Already-persisted checkpoints clean up on read.
2. **The headless run path recorded the *composed* input** (`controller.go` called `beginCheckpoint(ctx, input)` after `input = c.Compose(input)`). It now records `rawInput`, mirroring the orchestrated turn path (`turn_orchestrator.go`).

## Verification

- `go test ./internal/control/ -count=1`, `go vet`, `gofmt`, `make lint` (repolint clean)
- `TestStripComposePrefixesOrdering` (new): marker-before-blocks and marker-between-blocks both fully strip.
- Existing `TestStripComposePrefixes` and `TestHeadlessRunOpensCheckpoint` stay green (raw recording still yields the submitted text).

Cache-impact: none - checkpoint prompt recording and display stripping only; the provider-visible prompt prefix and tool paths are untouched.

Cache-guard: N/A - no cache-sensitive file touched.

Documentation-impact: none - no commands, flags, or configuration changed; the rewind picker now matches its documented behavior.

Closes #7804
