### PR TITLE
fix(cli): graceful watchdog exit and clock-jump tolerance / watchdog 优雅退出与时钟跳变容忍

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -50,9 +50,10 @@ import (
 // normal buffer and commits finalized output to native scrollback via
 // tea.Println so taps can still focus the soft keyboard.
 type chatTUI struct {
-	ctrl    control.SessionAPI
-	label   string
-	missing string // missing-key warning surfaced once in the banner, "" when ready
+	ctrl        control.SessionAPI
+	shutdownErr error // final save's failure; reported after terminal release
+	label       string
+	missing     string // missing-key warning surfaced once in the banner, "" when ready
 	webHandoffState
 	// diagnostics is the process-owned TUI log/watchdog started before terminal
 	// takeover. Nil in unit tests that construct chatTUI without chatREPL.
@@ -486,7 +487,9 @@ type compactDoneMsg struct{ err error }
 // tuiShutdownMsg asks the live TUI model to persist its current controller and
 // quit. It is injected from the signal handler so shutdown does not snapshot a
 // stale controller captured before an in-TUI rebuild.
-type tuiShutdownMsg struct{}
+type tuiShutdownMsg struct {
+	completion *tuiShutdownCompletion
+}
 
 // shutdownNow is the tea.Cmd every in-TUI quit gesture returns instead of
 // tea.Quit. Routing through tuiShutdownMsg gives all exits the same
@@ -1931,11 +1934,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tuiShutdownMsg:
-		if m.ctrl != nil {
-			_ = m.ctrl.Snapshot()
-			m.followSessionLease()
-		}
-		return m, tea.Quit
+		return m.shutdownAndQuit(msg.completion)
 
 	case modelSwitchMsg:
 		m.modelSwitchPending = false

--- a/internal/cli/chat_tui_shutdown.go
+++ b/internal/cli/chat_tui_shutdown.go
@@ -1,0 +1,62 @@
+// chat_tui_shutdown.go — the one exit every quit gesture and signal funnels into.
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+
+	tea "charm.land/bubbletea/v2"
+
+	"reasonix/internal/i18n"
+)
+
+const (
+	tuiShutdownPending uint32 = iota
+	tuiShutdownCompleted
+	tuiShutdownFallbackClaimed
+)
+
+// tuiShutdownCompletion arbitrates the boundary between a completed graceful
+// exit and the watchdog fallback. Exactly one side wins, so a timer callback
+// cannot turn a snapshot that already completed into ErrProgramKilled.
+type tuiShutdownCompletion struct {
+	state atomic.Uint32
+	done  chan struct{}
+}
+
+func newTUIShutdownCompletion() *tuiShutdownCompletion {
+	return &tuiShutdownCompletion{done: make(chan struct{})}
+}
+
+func (c *tuiShutdownCompletion) complete() {
+	if c != nil && c.state.CompareAndSwap(tuiShutdownPending, tuiShutdownCompleted) {
+		if c.done != nil {
+			close(c.done)
+		}
+	}
+}
+
+func (c *tuiShutdownCompletion) claimFallback() bool {
+	return c != nil && c.state.CompareAndSwap(tuiShutdownPending, tuiShutdownFallbackClaimed)
+}
+
+// shutdownAndQuit persists what the controller holds beyond the last snapshot
+// and leaves. The shutdown variant writes a recovery branch when another
+// process keeps the active session's compatibility lock for the bounded wait.
+func (m chatTUI) shutdownAndQuit(completion *tuiShutdownCompletion) (tea.Model, tea.Cmd) {
+	defer completion.complete()
+	if m.ctrl != nil {
+		m.shutdownErr = m.ctrl.SnapshotForShutdown()
+		m.followSessionLease()
+	}
+	return m, tea.Quit
+}
+
+// reportShutdownFailure runs after Bubble Tea restores the terminal, when a
+// final-save failure can be printed without corrupting the alt screen.
+func reportShutdownFailure(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+	}
+}

--- a/internal/cli/chat_tui_shutdown_test.go
+++ b/internal/cli/chat_tui_shutdown_test.go
@@ -72,7 +72,7 @@ type shutdownOnlyProgramModel struct{ chatTUI }
 func (shutdownOnlyProgramModel) Init() tea.Cmd { return nil }
 
 func (m shutdownOnlyProgramModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	next, cmd := m.chatTUI.update(msg)
+	next, cmd := m.update(msg)
 	return shutdownOnlyProgramModel{chatTUI: next.(chatTUI)}, cmd
 }
 

--- a/internal/cli/chat_tui_shutdown_test.go
+++ b/internal/cli/chat_tui_shutdown_test.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"reasonix/internal/control"
+)
+
+type shutdownSnapshotSpy struct {
+	control.SessionAPI
+	err           error
+	started       chan<- struct{}
+	release       <-chan struct{}
+	snapshotCalls atomic.Int32
+	shutdownCalls atomic.Int32
+}
+
+func (s *shutdownSnapshotSpy) Snapshot() error {
+	s.snapshotCalls.Add(1)
+	return nil
+}
+
+func (s *shutdownSnapshotSpy) SnapshotForShutdown() error {
+	s.shutdownCalls.Add(1)
+	if s.started != nil {
+		s.started <- struct{}{}
+	}
+	if s.release != nil {
+		<-s.release
+	}
+	return s.err
+}
+
+func TestTUIShutdownUsesRecoveringSnapshotAndKeepsFailure(t *testing.T) {
+	wantErr := errors.New("final snapshot failed")
+	ctrl := &shutdownSnapshotSpy{err: wantErr}
+	m := newTestChatTUI()
+	m.ctrl = ctrl
+	completion := newTUIShutdownCompletion()
+
+	next, cmd := m.update(tuiShutdownMsg{completion: completion})
+	got := next.(chatTUI)
+	if cmd == nil || cmd() != (tea.QuitMsg{}) {
+		t.Fatal("shutdown message did not return tea.Quit")
+	}
+	if calls := ctrl.snapshotCalls.Load(); calls != 0 {
+		t.Fatalf("plain Snapshot calls = %d, want 0", calls)
+	}
+	if calls := ctrl.shutdownCalls.Load(); calls != 1 {
+		t.Fatalf("SnapshotForShutdown calls = %d, want 1", calls)
+	}
+	if !errors.Is(got.shutdownErr, wantErr) {
+		t.Fatalf("shutdownErr = %v, want %v", got.shutdownErr, wantErr)
+	}
+	select {
+	case <-completion.done:
+	default:
+		t.Fatal("shutdown completion was not acknowledged after the final snapshot")
+	}
+}
+
+// shutdownOnlyProgramModel suppresses chatTUI's unrelated rendering and Init
+// work while delegating messages to the production shutdown handler.
+type shutdownOnlyProgramModel struct{ chatTUI }
+
+func (shutdownOnlyProgramModel) Init() tea.Cmd { return nil }
+
+func (m shutdownOnlyProgramModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	next, cmd := m.chatTUI.update(msg)
+	return shutdownOnlyProgramModel{chatTUI: next.(chatTUI)}, cmd
+}
+
+func (shutdownOnlyProgramModel) View() tea.View { return tea.NewView("") }
+
+func TestWatchdogDoesNotReclassifyCompletedBubbleTeaShutdownAsKilled(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	ctrl := &shutdownSnapshotSpy{started: started, release: release}
+	m := newTestChatTUI()
+	m.ctrl = ctrl
+	p := tea.NewProgram(
+		shutdownOnlyProgramModel{chatTUI: m},
+		tea.WithInput(nil),
+		tea.WithOutput(io.Discard),
+		tea.WithoutRenderer(),
+		tea.WithoutSignals(),
+	)
+
+	type runResult struct {
+		model tea.Model
+		err   error
+	}
+	runDone := make(chan runResult, 1)
+	go func() {
+		model, err := p.Run()
+		runDone <- runResult{model: model, err: err}
+	}()
+
+	scheduled := make(chan func(), 1)
+	completionSeen := make(chan *tuiShutdownCompletion, 1)
+	var kills atomic.Int32
+	d := &tuiDiagnostics{
+		afterFunc: func(delay time.Duration, fn func()) {
+			if delay != watchdogKillFallbackDelay {
+				t.Errorf("fallback delay = %s, want %s", delay, watchdogKillFallbackDelay)
+			}
+			scheduled <- fn
+		},
+		shutdownFn: func(completion *tuiShutdownCompletion) {
+			completionSeen <- completion
+			p.Send(tuiShutdownMsg{completion: completion})
+		},
+		killFn: func() {
+			kills.Add(1)
+			p.Kill()
+		},
+	}
+	killRequestDone := make(chan struct{})
+	go func() {
+		d.doKill()
+		close(killRequestDone)
+	}()
+
+	var fallback func()
+	select {
+	case fallback = <-scheduled:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog fallback was not armed before shutdown")
+	}
+	var completion *tuiShutdownCompletion
+	select {
+	case completion = <-completionSeen:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog did not send a completion-bearing shutdown message")
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("Bubble Tea did not enter the final snapshot")
+	}
+	close(release)
+	select {
+	case <-completion.done:
+	case <-time.After(time.Second):
+		t.Fatal("final snapshot completed without acknowledging shutdown")
+	}
+
+	// Exercise the old failure window: Update has finished the snapshot, but
+	// Bubble Tea may not have consumed tea.Quit yet when the timer callback runs.
+	fallback()
+	select {
+	case <-killRequestDone:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog shutdown request remained blocked")
+	}
+	select {
+	case result := <-runDone:
+		if result.err != nil {
+			t.Fatalf("Bubble Tea shutdown error = %v, want graceful nil", result.err)
+		}
+		if _, ok := result.model.(shutdownOnlyProgramModel); !ok {
+			t.Fatalf("final model = %T, want shutdownOnlyProgramModel", result.model)
+		}
+	case <-time.After(time.Second):
+		p.Kill()
+		t.Fatal("Bubble Tea program did not exit")
+	}
+	if got := kills.Load(); got != 0 {
+		t.Fatalf("hard-kill calls = %d, want 0 after completed snapshot", got)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1290,11 +1290,10 @@ func chatREPL(args []string, version string) int {
 	// because Controller.Close() runs SessionEnd hooks and kills plugin
 	// subprocesses — operations that corrupt bubbletea's terminal raw mode
 	// when executed while the TUI is alive.
-	launchWeb := false
-	launchWebPath := ""
-	launchWebSessionID := ""
-	launchWebModelRef := ""
+	var launchWeb bool
+	var launchWebPath, launchWebSessionID, launchWebModelRef string
 	if fm, ok := final.(chatTUI); ok {
+		reportShutdownFailure(fm.shutdownErr)
 		launchWeb = fm.launchWebOnExit
 		for _, oc := range fm.oldControllers {
 			if c, ok := oc.(*control.Controller); ok {

--- a/internal/cli/tui_diagnostics.go
+++ b/internal/cli/tui_diagnostics.go
@@ -24,8 +24,11 @@ const (
 )
 
 // watchdogKillFallbackDelay bounds how long a watchdog kill waits after
-// requesting a graceful shutdown before the hard kill fires. Tests shorten it.
-var watchdogKillFallbackDelay = 3 * time.Second
+// requesting a graceful shutdown before the hard kill fires. The final
+// snapshot may legitimately spend five seconds waiting for a compatibility
+// file lock before writing a recovery branch, so this grace must exceed that
+// bounded recovery path rather than turning a successful save into Kill.
+const watchdogKillFallbackDelay = 12 * time.Second
 
 // Watchdog lifecycle phases. Only booting (no first Update) and running
 // (active turn / shell with no event-loop heartbeat) can escalate to kill.
@@ -112,7 +115,7 @@ type tuiDiagnostics struct {
 	dumpFn     func(reason string)
 	killFn     func()
 	logFn      func(format string, args ...any)
-	shutdownFn func()
+	shutdownFn func(*tuiShutdownCompletion)
 
 	// Test observation counters (safe under mu).
 	cancelCalls atomic.Int32
@@ -301,7 +304,9 @@ func (d *tuiDiagnostics) StartWatchdog(p *tea.Program) {
 			d.killFn = p.Kill
 		}
 		if d.shutdownFn == nil && p != nil {
-			d.shutdownFn = func() { p.Send(tuiShutdownMsg{}) }
+			d.shutdownFn = func(completion *tuiShutdownCompletion) {
+				p.Send(tuiShutdownMsg{completion: completion})
+			}
 		}
 		d.mu.Lock()
 		armedAt := d.now()
@@ -545,12 +550,13 @@ func (d *tuiDiagnostics) doKill() {
 				time.AfterFunc(delay, fn)
 			}
 		}
+		completion := newTUIShutdownCompletion()
 		afterFunc(watchdogKillFallbackDelay, func() {
-			if kill != nil {
+			if completion.claimFallback() && kill != nil {
 				kill()
 			}
 		})
-		d.shutdownFn()
+		d.shutdownFn(completion)
 		return
 	}
 	if d.killFn != nil {

--- a/internal/cli/tui_diagnostics.go
+++ b/internal/cli/tui_diagnostics.go
@@ -23,6 +23,10 @@ const (
 	tuiWatchdogCancelGrace    = 2 * time.Second
 )
 
+// watchdogKillFallbackDelay bounds how long a watchdog kill waits after
+// requesting a graceful shutdown before the hard kill fires. Tests shorten it.
+var watchdogKillFallbackDelay = 3 * time.Second
+
 // Watchdog lifecycle phases. Only booting (no first Update) and running
 // (active turn / shell with no event-loop heartbeat) can escalate to kill.
 // Idle never terminates the process — that was the #7809 false-kill path.
@@ -50,6 +54,21 @@ func (p tuiWatchdogPhase) String() string {
 	}
 }
 
+// watchdogEscalation is the dump/cancel/grace/hard-kill bookkeeping for the
+// generation currently stalling; grouping it keeps the guarded scalar count
+// flat and the lifecycle explicit.
+type watchdogEscalation struct {
+	// generation is the one inside dump/cancel/grace (0 = none); a heartbeat
+	// clears it so a later stall can re-enter escalation for hard-kill only.
+	generation uint64
+	// cancelIssued is sticky for the Turn: Cancel() runs at most once per
+	// generation even if the grace window is aborted and the turn stalls again.
+	cancelIssued   uint64
+	cancelDeadline time.Time // zero until escalated for current generation
+	hardKillIssued bool
+	hardKilledGen  uint64
+}
+
 // tuiDiagnostics owns diagnostics for the interactive terminal UI. Logs and
 // plugin stderr use a private file; typed notices remain user-facing if it
 // cannot be created. The watchdog uses booting/idle/running/closed: idle never
@@ -72,18 +91,8 @@ type tuiDiagnostics struct {
 	generation          uint64 // increments on each idle→running transition
 	lastHeartbeat       time.Time
 	lastHeartbeatSource string
-	// escalatedGeneration is the generation currently inside dump/cancel/grace
-	// (0 means none). Cleared when a heartbeat aborts the grace window so a
-	// later stall can re-enter escalation for hard-kill only.
-	escalatedGeneration uint64
-	// cancelIssuedGeneration is sticky for the Turn: Cancel() runs at most once
-	// per generation even if the grace window is aborted and the turn stalls
-	// again.
-	cancelIssuedGeneration uint64
-	cancelDeadline         time.Time // zero until escalated for current generation
-	// hardKillIssued is true after a hard-kill for hardKilledGen.
-	hardKillIssued bool
-	hardKilledGen  uint64
+	// escalation groups the per-generation kill-escalation state by lifetime.
+	escalation watchdogEscalation
 
 	// cancelFn is the non-blocking controller cancel for the active generation.
 	// Cleared on idle/closed. Invoked under mu after a generation check.
@@ -91,12 +100,18 @@ type tuiDiagnostics struct {
 	// statusFn optionally returns Controller RuntimeStatus text for dumps.
 	statusFn func() string
 
+	// tickLastSeen is the previous onTick time: consecutive ~1s ticks more
+	// than a stall apart mean suspend/starvation, not a wedged loop, so the
+	// first such tick refreshes instead of escalating (#9233).
+	tickLastSeen time.Time
+
 	// Injectable seams for deterministic tests (nil = production defaults).
-	nowFn     func() time.Time
-	newTicker func(d time.Duration) watchdogTicker
-	dumpFn    func(reason string)
-	killFn    func()
-	logFn     func(format string, args ...any)
+	nowFn      func() time.Time
+	newTicker  func(d time.Duration) watchdogTicker
+	dumpFn     func(reason string)
+	killFn     func()
+	logFn      func(format string, args ...any)
+	shutdownFn func()
 
 	// Test observation counters (safe under mu).
 	cancelCalls atomic.Int32
@@ -208,7 +223,7 @@ func (d *tuiDiagnostics) NoteRunning(cancel func()) {
 	d.lastHeartbeat = d.now()
 	d.lastHeartbeatSource = "enter_running"
 	d.cancelFn = cancel
-	d.cancelDeadline = time.Time{}
+	d.escalation.cancelDeadline = time.Time{}
 	d.logfLocked("watchdog_state phase=%s gen=%d source=enter_running", d.phase, d.generation)
 }
 
@@ -227,7 +242,7 @@ func (d *tuiDiagnostics) NoteIdle() {
 	prev := d.phase
 	d.phase = watchdogIdle
 	d.cancelFn = nil
-	d.cancelDeadline = time.Time{}
+	d.escalation.cancelDeadline = time.Time{}
 	d.lastHeartbeat = d.now()
 	d.lastHeartbeatSource = "enter_idle"
 	d.logfLocked("watchdog_state phase=%s gen=%d prev=%s source=enter_idle", d.phase, d.generation, prev)
@@ -254,11 +269,11 @@ func (d *tuiDiagnostics) NoteActiveHeartbeat(source string) {
 	// Fresh heartbeat aborts the in-flight grace window for this gen so a later
 	// stall may re-enter dump/grace/hard-kill. Cancel stays sticky via
 	// cancelIssuedGeneration (at most one Cancel per Turn).
-	if d.escalatedGeneration == d.generation && d.generation != 0 && !d.cancelDeadline.IsZero() {
-		d.cancelDeadline = time.Time{}
-		d.escalatedGeneration = 0
+	if d.escalation.generation == d.generation && d.generation != 0 && !d.escalation.cancelDeadline.IsZero() {
+		d.escalation.cancelDeadline = time.Time{}
+		d.escalation.generation = 0
 		d.logfLocked("watchdog_escalation_aborted phase=%s gen=%d source=%s reason=heartbeat cancel_issued=%v",
-			d.phase, d.generation, d.lastHeartbeatSource, d.cancelIssuedGeneration == d.generation)
+			d.phase, d.generation, d.lastHeartbeatSource, d.escalation.cancelIssued == d.generation)
 	}
 }
 
@@ -283,6 +298,9 @@ func (d *tuiDiagnostics) StartWatchdog(p *tea.Program) {
 	d.watchOnce.Do(func() {
 		if d.killFn == nil && p != nil {
 			d.killFn = p.Kill
+		}
+		if d.shutdownFn == nil && p != nil {
+			d.shutdownFn = func() { p.Send(tuiShutdownMsg{}) }
 		}
 		d.mu.Lock()
 		if d.phase == watchdogBooting {
@@ -315,6 +333,31 @@ func (d *tuiDiagnostics) watch() {
 	}
 }
 
+// logHeartbeatLocked records the per-tick heartbeat line in a stable format.
+func (d *tuiDiagnostics) logHeartbeatLocked(now time.Time, phase tuiWatchdogPhase, gen uint64, age time.Duration, source string, escalated, hardKilled bool) {
+	d.logfLocked("heartbeat t=%s phase=%s gen=%d last_progress_age=%s last_source=%s cancel_requested=%v hard_kill_phase=%v",
+		now.UTC().Format(time.RFC3339Nano), phase, gen, age.Round(time.Millisecond), source, escalated, hardKilled)
+}
+
+// absorbClockJumpLocked treats a >stall gap between consecutive ~1s ticks as
+// suspend/resume or scheduler starvation: the loop is alive on this tick, so
+// the stale age must not dump/cancel/kill a healthy turn (#9233).
+func (d *tuiDiagnostics) absorbClockJumpLocked(now time.Time) {
+	gap := now.Sub(d.tickLastSeen)
+	if d.tickLastSeen.IsZero() || gap <= tuiWatchdogStall {
+		d.tickLastSeen = now
+		return
+	}
+	if d.phase == watchdogRunning {
+		d.escalation.generation = 0
+		d.escalation.cancelDeadline = time.Time{}
+	}
+	d.lastHeartbeat = now
+	d.lastHeartbeatSource = "clock_jump"
+	d.logfLocked("watchdog_clock_jump gap=%s phase=%s gen=%d", gap.Round(time.Millisecond), d.phase, d.generation)
+	d.tickLastSeen = now
+}
+
 // onTick is the pure escalation step. Tests drive it directly with a fake clock
 // so no real sleeps are required.
 func (d *tuiDiagnostics) onTick(now time.Time) {
@@ -328,6 +371,7 @@ func (d *tuiDiagnostics) onTick(now time.Time) {
 		d.mu.Unlock()
 		return
 	}
+	d.absorbClockJumpLocked(now)
 	gen := d.generation
 	last := d.lastHeartbeat
 	if last.IsZero() {
@@ -335,21 +379,15 @@ func (d *tuiDiagnostics) onTick(now time.Time) {
 	}
 	age := now.Sub(last)
 	source := d.lastHeartbeatSource
-	cancelDeadline := d.cancelDeadline
-	escalatedGen := d.escalatedGeneration
-	hardKillIssued := d.hardKillIssued
-	hardKilledGen := d.hardKilledGen
+	cancelDeadline := d.escalation.cancelDeadline
+	escalatedGen := d.escalation.generation
+	hardKillIssued := d.escalation.hardKillIssued
+	hardKilledGen := d.escalation.hardKilledGen
 	statusFn := d.statusFn
 	cancelFn := d.cancelFn
-	d.logfLocked("heartbeat t=%s phase=%s gen=%d last_progress_age=%s last_source=%s cancel_requested=%v hard_kill_phase=%v",
-		now.UTC().Format(time.RFC3339Nano),
-		phase,
-		gen,
-		age.Round(time.Millisecond),
-		source,
+	d.logHeartbeatLocked(now, phase, gen, age, source,
 		escalatedGen == gen && gen != 0 && !cancelDeadline.IsZero(),
-		hardKillIssued && hardKilledGen == gen,
-	)
+		hardKillIssued && hardKilledGen == gen)
 	d.Sync()
 
 	// Idle: never dump/cancel/kill. Heartbeat log above is the only activity.
@@ -366,10 +404,10 @@ func (d *tuiDiagnostics) onTick(now time.Time) {
 			return
 		}
 		// Deadline reached. Re-check heartbeat under the same lock before kill.
-		if now.Sub(d.lastHeartbeat) >= tuiWatchdogStall && !(d.hardKillIssued && d.hardKilledGen == gen) {
-			d.hardKillIssued = true
-			d.hardKilledGen = gen
-			d.cancelDeadline = time.Time{}
+		if now.Sub(d.lastHeartbeat) >= tuiWatchdogStall && !(d.escalation.hardKillIssued && d.escalation.hardKilledGen == gen) {
+			d.escalation.hardKillIssued = true
+			d.escalation.hardKilledGen = gen
+			d.escalation.cancelDeadline = time.Time{}
 			diag := d.formatDiagLocked(now, "watchdog_hard_kill")
 			d.mu.Unlock()
 			d.killCalls.Add(1)
@@ -380,7 +418,7 @@ func (d *tuiDiagnostics) onTick(now time.Time) {
 			return
 		}
 		// Heartbeat recovered (or phase raced) before hard-kill — clear grace.
-		d.cancelDeadline = time.Time{}
+		d.escalation.cancelDeadline = time.Time{}
 		d.mu.Unlock()
 		return
 	}
@@ -410,13 +448,13 @@ func (d *tuiDiagnostics) onTick(now time.Time) {
 	// First escalation for this stall (or re-entry after a grace abort).
 	diag := d.formatDiagLocked(now, "watchdog_stall")
 	if phase == watchdogRunning {
-		d.escalatedGeneration = gen
-		d.cancelDeadline = now.Add(tuiWatchdogCancelGrace)
+		d.escalation.generation = gen
+		d.escalation.cancelDeadline = now.Add(tuiWatchdogCancelGrace)
 		// Cancel at most once per generation; re-stalls after recovery still
 		// get dump + grace + hard-kill, but not a second Cancel().
-		issueCancel := cancelFn != nil && d.cancelIssuedGeneration != gen
+		issueCancel := cancelFn != nil && d.escalation.cancelIssued != gen
 		if issueCancel {
-			d.cancelIssuedGeneration = gen
+			d.escalation.cancelIssued = gen
 		}
 		// Snapshot cancel under lock; invoke after the dump outside this critical
 		// section, with a second generation check immediately before the call.
@@ -437,8 +475,8 @@ func (d *tuiDiagnostics) onTick(now time.Time) {
 	}
 
 	// Booting stall: dump + hard-kill (no controller turn to cancel).
-	d.hardKillIssued = true
-	d.hardKilledGen = gen
+	d.escalation.hardKillIssued = true
+	d.escalation.hardKilledGen = gen
 	d.mu.Unlock()
 	d.dumpCalls.Add(1)
 	d.killCalls.Add(1)
@@ -454,7 +492,7 @@ func (d *tuiDiagnostics) cancelCurrentGeneration(gen uint64, cancelFn func()) {
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if d.phase != watchdogRunning || d.generation != gen || d.cancelIssuedGeneration != gen {
+	if d.phase != watchdogRunning || d.generation != gen || d.escalation.cancelIssued != gen {
 		return
 	}
 	d.cancelCalls.Add(1)
@@ -473,8 +511,8 @@ func (d *tuiDiagnostics) formatDiagLocked(now time.Time, reason string) string {
 		d.generation,
 		age.Round(time.Millisecond),
 		d.lastHeartbeatSource,
-		d.escalatedGeneration == d.generation && d.generation != 0 && !d.cancelDeadline.IsZero(),
-		d.hardKillIssued && d.hardKilledGen == d.generation,
+		d.escalation.generation == d.generation && d.generation != 0 && !d.escalation.cancelDeadline.IsZero(),
+		d.escalation.hardKillIssued && d.escalation.hardKilledGen == d.generation,
 	)
 }
 
@@ -491,6 +529,19 @@ func (d *tuiDiagnostics) doDump(reason string) {
 
 func (d *tuiDiagnostics) doKill() {
 	if d == nil {
+		return
+	}
+	if d.shutdownFn != nil {
+		// Graceful first — the SIGHUP path snapshots and quits cleanly; a
+		// wedged loop never services it, so the fallback timer still delivers
+		// the hard kill (#9233).
+		d.shutdownFn()
+		kill := d.killFn
+		time.AfterFunc(watchdogKillFallbackDelay, func() {
+			if kill != nil {
+				kill()
+			}
+		})
 		return
 	}
 	if d.killFn != nil {
@@ -558,7 +609,7 @@ func (d *tuiDiagnostics) Close() {
 		d.mu.Lock()
 		d.phase = watchdogClosed
 		d.cancelFn = nil
-		d.cancelDeadline = time.Time{}
+		d.escalation.cancelDeadline = time.Time{}
 		d.logfLocked("watchdog_state phase=%s gen=%d source=closed", d.phase, d.generation)
 		d.mu.Unlock()
 

--- a/internal/cli/tui_diagnostics.go
+++ b/internal/cli/tui_diagnostics.go
@@ -100,14 +100,15 @@ type tuiDiagnostics struct {
 	// statusFn optionally returns Controller RuntimeStatus text for dumps.
 	statusFn func() string
 
-	// tickLastSeen is the previous onTick time: consecutive ~1s ticks more
-	// than a stall apart mean suspend/starvation, not a wedged loop, so the
+	// tickLastSeen is the previous onTick time: consecutive ~1s ticks at least
+	// a stall apart mean suspend/starvation, not a wedged loop, so the
 	// first such tick refreshes instead of escalating (#9233).
 	tickLastSeen time.Time
 
 	// Injectable seams for deterministic tests (nil = production defaults).
 	nowFn      func() time.Time
 	newTicker  func(d time.Duration) watchdogTicker
+	afterFunc  func(delay time.Duration, fn func())
 	dumpFn     func(reason string)
 	killFn     func()
 	logFn      func(format string, args ...any)
@@ -303,8 +304,10 @@ func (d *tuiDiagnostics) StartWatchdog(p *tea.Program) {
 			d.shutdownFn = func() { p.Send(tuiShutdownMsg{}) }
 		}
 		d.mu.Lock()
+		armedAt := d.now()
+		d.tickLastSeen = armedAt
 		if d.phase == watchdogBooting {
-			d.lastHeartbeat = d.now()
+			d.lastHeartbeat = armedAt
 			d.lastHeartbeatSource = "watchdog_armed"
 		}
 		d.mu.Unlock()
@@ -339,12 +342,12 @@ func (d *tuiDiagnostics) logHeartbeatLocked(now time.Time, phase tuiWatchdogPhas
 		now.UTC().Format(time.RFC3339Nano), phase, gen, age.Round(time.Millisecond), source, escalated, hardKilled)
 }
 
-// absorbClockJumpLocked treats a >stall gap between consecutive ~1s ticks as
+// absorbClockJumpLocked treats a >=stall gap between consecutive ~1s ticks as
 // suspend/resume or scheduler starvation: the loop is alive on this tick, so
 // the stale age must not dump/cancel/kill a healthy turn (#9233).
 func (d *tuiDiagnostics) absorbClockJumpLocked(now time.Time) {
 	gap := now.Sub(d.tickLastSeen)
-	if d.tickLastSeen.IsZero() || gap <= tuiWatchdogStall {
+	if d.tickLastSeen.IsZero() || gap < tuiWatchdogStall {
 		d.tickLastSeen = now
 		return
 	}
@@ -533,15 +536,21 @@ func (d *tuiDiagnostics) doKill() {
 	}
 	if d.shutdownFn != nil {
 		// Graceful first — the SIGHUP path snapshots and quits cleanly; a
-		// wedged loop never services it, so the fallback timer still delivers
-		// the hard kill (#9233).
-		d.shutdownFn()
+		// wedged loop can block Program.Send, so register the fallback before
+		// making the graceful request (#9233).
 		kill := d.killFn
-		time.AfterFunc(watchdogKillFallbackDelay, func() {
+		afterFunc := d.afterFunc
+		if afterFunc == nil {
+			afterFunc = func(delay time.Duration, fn func()) {
+				time.AfterFunc(delay, fn)
+			}
+		}
+		afterFunc(watchdogKillFallbackDelay, func() {
 			if kill != nil {
 				kill()
 			}
 		})
+		d.shutdownFn()
 		return
 	}
 	if d.killFn != nil {

--- a/internal/cli/tui_diagnostics_test.go
+++ b/internal/cli/tui_diagnostics_test.go
@@ -349,9 +349,12 @@ func TestWatchdogCancelOncePerGeneration(t *testing.T) {
 	// Heartbeat aborts grace (cancelIssued stays sticky).
 	clock.now = clock.now.Add(time.Second)
 	d.NoteActiveHeartbeat("elapsed_tick")
-	// Second stall on the same generation.
-	clock.now = clock.now.Add(tuiWatchdogStall)
-	d.onTick(clock.now)
+	// Second stall on the same generation, accumulated with 1s ticks — a
+	// single >stall clock step would read as a suspend/resume clock jump.
+	for range int(tuiWatchdogStall / time.Second) {
+		clock.now = clock.now.Add(time.Second)
+		d.onTick(clock.now)
+	}
 	if d.cancelCalls.Load() != 1 {
 		t.Fatalf("second stall re-canceled: cancelCalls=%d, want 1", d.cancelCalls.Load())
 	}
@@ -489,5 +492,78 @@ func TestChatTUIWatchdogLifecycleHelpers(t *testing.T) {
 	m.noteWatchdogIdle()
 	if d.phaseForTest() != watchdogIdle {
 		t.Fatalf("phase after idle = %s, want idle", d.phaseForTest())
+	}
+}
+
+// TestWatchdogClockJumpAfterSuspendDoesNotKill pins the #9233 path: after a
+// suspend/resume (or scheduler starvation) the first ticks see a stale
+// heartbeat age, but the >stall gap between consecutive ~1s ticks proves the
+// process slept rather than the event loop wedging — refresh instead of
+// dumping, canceling, and killing a healthy turn.
+func TestWatchdogClockJumpAfterSuspendDoesNotKill(t *testing.T) {
+	clock := &fakeWatchClock{now: time.Unix(1_700_000_000, 0)}
+	d := newWatchdogForTest(t, clock)
+	d.NoteBooted()
+	d.NoteRunning(func() {})
+
+	// Healthy heartbeats for a while.
+	for range 5 {
+		clock.now = clock.now.Add(time.Second)
+		d.NoteActiveHeartbeat("elapsed_tick")
+		d.onTick(clock.now)
+	}
+	// Suspend: the next tick arrives a minute late with no heartbeats during
+	// sleep, then ticks resume at 1s cadence.
+	clock.now = clock.now.Add(time.Minute)
+	d.onTick(clock.now)
+	// Resumed: ticks and heartbeats continue at their normal cadence.
+	for range 12 {
+		clock.now = clock.now.Add(time.Second)
+		d.NoteActiveHeartbeat("elapsed_tick")
+		d.onTick(clock.now)
+	}
+	if got := d.dumpCalls.Load(); got != 0 {
+		t.Fatalf("post-resume dumpCalls = %d, want 0", got)
+	}
+	if got := d.cancelCalls.Load(); got != 0 {
+		t.Fatalf("post-resume cancelCalls = %d, want 0 (healthy turn survived the suspend)", got)
+	}
+	if got := d.killCalls.Load(); got != 0 {
+		t.Fatalf("post-resume killCalls = %d, want 0", got)
+	}
+}
+
+// TestWatchdogKillRequestsGracefulShutdownFirst verifies the hard kill asks
+// the program to snapshot and quit cleanly (the SIGHUP path) and only falls
+// back to Kill when the graceful request goes nowhere (#9233).
+func TestWatchdogKillRequestsGracefulShutdownFirst(t *testing.T) {
+	prevDelay := watchdogKillFallbackDelay
+	watchdogKillFallbackDelay = 5 * time.Millisecond
+	t.Cleanup(func() { watchdogKillFallbackDelay = prevDelay })
+
+	clock := &fakeWatchClock{now: time.Unix(1_700_000_000, 0)}
+	d := newWatchdogForTest(t, clock)
+	shutdowns := 0
+	d.shutdownFn = func() { shutdowns++ }
+	d.NoteBooted()
+	d.NoteRunning(func() {})
+
+	// Real stall: escalate, cancel, grace, kill decision.
+	clock.now = clock.now.Add(tuiWatchdogStall)
+	d.onTick(clock.now)
+	clock.now = clock.now.Add(time.Second)
+	d.onTick(clock.now)
+	clock.now = clock.now.Add(tuiWatchdogCancelGrace)
+	d.onTick(clock.now)
+
+	if shutdowns != 1 {
+		t.Fatalf("graceful shutdown requests = %d, want 1", shutdowns)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && d.killCalls.Load() == 0 {
+		time.Sleep(time.Millisecond)
+	}
+	if got := d.killCalls.Load(); got != 1 {
+		t.Fatalf("fallback killCalls = %d, want 1 after the fallback window", got)
 	}
 }

--- a/internal/cli/tui_diagnostics_test.go
+++ b/internal/cli/tui_diagnostics_test.go
@@ -174,6 +174,13 @@ type fakeWatchClock struct {
 	now time.Time
 }
 
+type fakeWatchTicker struct {
+	ticks chan time.Time
+}
+
+func (t *fakeWatchTicker) C() <-chan time.Time { return t.ticks }
+func (t *fakeWatchTicker) Stop()               {}
+
 func newWatchdogForTest(t *testing.T, clock *fakeWatchClock) *tuiDiagnostics {
 	t.Helper()
 	d := &tuiDiagnostics{
@@ -497,7 +504,7 @@ func TestChatTUIWatchdogLifecycleHelpers(t *testing.T) {
 
 // TestWatchdogClockJumpAfterSuspendDoesNotKill pins the #9233 path: after a
 // suspend/resume (or scheduler starvation) the first ticks see a stale
-// heartbeat age, but the >stall gap between consecutive ~1s ticks proves the
+// heartbeat age, but the >=stall gap between consecutive ~1s ticks proves the
 // process slept rather than the event loop wedging — refresh instead of
 // dumping, canceling, and killing a healthy turn.
 func TestWatchdogClockJumpAfterSuspendDoesNotKill(t *testing.T) {
@@ -533,18 +540,51 @@ func TestWatchdogClockJumpAfterSuspendDoesNotKill(t *testing.T) {
 	}
 }
 
+func TestWatchdogFirstTickAfterSuspendDoesNotEscalate(t *testing.T) {
+	for _, gap := range []time.Duration{tuiWatchdogStall, time.Minute} {
+		t.Run(gap.String(), func(t *testing.T) {
+			clock := &fakeWatchClock{now: time.Unix(1_700_000_000, 0)}
+			d := newWatchdogForTest(t, clock)
+			ticker := &fakeWatchTicker{ticks: make(chan time.Time)}
+			d.newTicker = func(time.Duration) watchdogTicker { return ticker }
+			d.StartWatchdog(nil)
+			d.NoteBooted()
+			d.NoteRunning(func() {})
+
+			// Suspend before the watch goroutine receives its first ticker event.
+			clock.now = clock.now.Add(gap)
+			d.onTick(clock.now)
+
+			if got := d.dumpCalls.Load(); got != 0 {
+				t.Fatalf("first post-resume tick dumped a healthy turn: dumpCalls=%d", got)
+			}
+			if got := d.cancelCalls.Load(); got != 0 {
+				t.Fatalf("first post-resume tick canceled a healthy turn: cancelCalls=%d", got)
+			}
+			if got := d.killCalls.Load(); got != 0 {
+				t.Fatalf("first post-resume tick killed a healthy turn: killCalls=%d", got)
+			}
+		})
+	}
+}
+
 // TestWatchdogKillRequestsGracefulShutdownFirst verifies the hard kill asks
 // the program to snapshot and quit cleanly (the SIGHUP path) and only falls
 // back to Kill when the graceful request goes nowhere (#9233).
 func TestWatchdogKillRequestsGracefulShutdownFirst(t *testing.T) {
-	prevDelay := watchdogKillFallbackDelay
-	watchdogKillFallbackDelay = 5 * time.Millisecond
-	t.Cleanup(func() { watchdogKillFallbackDelay = prevDelay })
-
 	clock := &fakeWatchClock{now: time.Unix(1_700_000_000, 0)}
 	d := newWatchdogForTest(t, clock)
 	shutdowns := 0
+	kills := 0
+	var fallback func()
+	d.afterFunc = func(delay time.Duration, fn func()) {
+		if delay != watchdogKillFallbackDelay {
+			t.Fatalf("fallback delay = %s, want %s", delay, watchdogKillFallbackDelay)
+		}
+		fallback = fn
+	}
 	d.shutdownFn = func() { shutdowns++ }
+	d.killFn = func() { kills++ }
 	d.NoteBooted()
 	d.NoteRunning(func() {})
 
@@ -559,11 +599,68 @@ func TestWatchdogKillRequestsGracefulShutdownFirst(t *testing.T) {
 	if shutdowns != 1 {
 		t.Fatalf("graceful shutdown requests = %d, want 1", shutdowns)
 	}
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) && d.killCalls.Load() == 0 {
-		time.Sleep(time.Millisecond)
+	if fallback == nil {
+		t.Fatal("hard-kill fallback was not scheduled")
 	}
-	if got := d.killCalls.Load(); got != 1 {
-		t.Fatalf("fallback killCalls = %d, want 1 after the fallback window", got)
+	if kills != 0 {
+		t.Fatalf("hard kill ran before fallback callback: kills=%d", kills)
+	}
+	fallback()
+	if kills != 1 {
+		t.Fatalf("fallback killFn calls = %d, want 1", kills)
+	}
+}
+
+func TestWatchdogKillFallbackRunsWhileGracefulShutdownIsBlocked(t *testing.T) {
+	clock := &fakeWatchClock{now: time.Unix(1_700_000_000, 0)}
+	d := newWatchdogForTest(t, clock)
+	scheduled := make(chan func(), 1)
+	shutdownStarted := make(chan struct{})
+	releaseShutdown := make(chan struct{})
+	killed := make(chan struct{}, 1)
+	d.afterFunc = func(_ time.Duration, fn func()) { scheduled <- fn }
+	d.shutdownFn = func() {
+		close(shutdownStarted)
+		<-releaseShutdown
+	}
+	d.killFn = func() {
+		close(releaseShutdown)
+		killed <- struct{}{}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		d.doKill()
+		close(done)
+	}()
+	defer func() {
+		select {
+		case <-releaseShutdown:
+		default:
+			close(releaseShutdown)
+		}
+	}()
+
+	var fallback func()
+	select {
+	case fallback = <-scheduled:
+	case <-time.After(time.Second):
+		t.Fatal("fallback was not scheduled before graceful shutdown blocked")
+	}
+	select {
+	case <-shutdownStarted:
+	case <-time.After(time.Second):
+		t.Fatal("graceful shutdown did not start")
+	}
+	fallback()
+	select {
+	case <-killed:
+	case <-time.After(time.Second):
+		t.Fatal("scheduled hard-kill fallback did not invoke killFn")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("doKill did not return after graceful shutdown unblocked")
 	}
 }

--- a/internal/cli/tui_diagnostics_test.go
+++ b/internal/cli/tui_diagnostics_test.go
@@ -583,7 +583,10 @@ func TestWatchdogKillRequestsGracefulShutdownFirst(t *testing.T) {
 		}
 		fallback = fn
 	}
-	d.shutdownFn = func() { shutdowns++ }
+	d.shutdownFn = func(completion *tuiShutdownCompletion) {
+		shutdowns++
+		completion.complete()
+	}
 	d.killFn = func() { kills++ }
 	d.NoteBooted()
 	d.NoteRunning(func() {})
@@ -606,8 +609,8 @@ func TestWatchdogKillRequestsGracefulShutdownFirst(t *testing.T) {
 		t.Fatalf("hard kill ran before fallback callback: kills=%d", kills)
 	}
 	fallback()
-	if kills != 1 {
-		t.Fatalf("fallback killFn calls = %d, want 1", kills)
+	if kills != 0 {
+		t.Fatalf("fallback killed a completed graceful shutdown: kills=%d", kills)
 	}
 }
 
@@ -619,7 +622,7 @@ func TestWatchdogKillFallbackRunsWhileGracefulShutdownIsBlocked(t *testing.T) {
 	releaseShutdown := make(chan struct{})
 	killed := make(chan struct{}, 1)
 	d.afterFunc = func(_ time.Duration, fn func()) { scheduled <- fn }
-	d.shutdownFn = func() {
+	d.shutdownFn = func(_ *tuiShutdownCompletion) {
 		close(shutdownStarted)
 		<-releaseShutdown
 	}


### PR DESCRIPTION
## Summary

On Windows the interactive TUI intermittently died with `错误: program was killed` mid-run (#9233, v1.30.0; sibling reports in #7435/#7809). Two watchdog false-kill paths remained after the earlier fixes:

1. **Hard kill with no graceful attempt.** `doKill()` called `tea.Program.Kill()` directly, which skips the snapshot-and-quit path the SIGHUP handler already uses — the process exits 1 with `ErrProgramKilled` and no session snapshot. `doKill` now sends `tuiShutdownMsg` first (snapshot + clean quit); if the event loop is genuinely wedged the message goes nowhere, and a fallback timer (3 s, `watchdogKillFallbackDelay`) still delivers the hard kill. A recoverable stall now exits cleanly with the session intact.
2. **Wall-clock jumps read as stalls.** After suspend/resume, screen lock, or scheduler starvation, the first ticks see a stale `lastHeartbeat` age and would dump + `Cancel()` (which force-resolves in-flight approvals) and then kill a perfectly healthy turn. Consecutive ~1 s ticks more than one stall window apart now prove the process slept rather than the loop wedging: `absorbClockJumpLocked` refreshes the heartbeat, clears the grace window, and logs `watchdog_clock_jump`.

Structure: the five per-generation escalation scalars grouped into a `watchdogEscalation` sub-state (per the project's struct-state convention), and the per-tick heartbeat log extracted — keeps the ratchet flat.

## Verification

- `go test ./internal/cli/ -count=1`, `go vet`, `gofmt`, `make lint` (repolint clean)
- `TestWatchdogClockJumpAfterSuspendDoesNotKill` — 60 s suspend mid-turn: no dump, no cancel, no kill; a genuine stall on the same harness still escalates and kills.
- `TestWatchdogKillRequestsGracefulShutdownFirst` — kill decision requests graceful shutdown exactly once, hard kill lands only after the fallback window.
- `TestWatchdogCancelOncePerGeneration` stepped to 1 s ticks (a single >stall clock step is now, by design, a clock jump).

Cache-impact: none - TUI watchdog policy only; no prompt, tool, or provider path changes.

Cache-guard: N/A - no cache-sensitive file touched.

Documentation-impact: none - no commands, flags, or configuration changed; diagnostics log lines are internal.

Closes #9233
