### PR TITLE
fix(sessioncatalog): back off failed repairs

### DIFF
--- a/internal/sessioncatalog/catalog.go
+++ b/internal/sessioncatalog/catalog.go
@@ -37,6 +37,7 @@ type Catalog struct {
 	removedPaths     sync.Map
 	repairCh         chan string
 	repairQueued     sync.Map
+	repairRetry      sync.Map
 	reconcileCh      chan DirectoryTarget
 	reconcileQueued  sync.Map
 	reconcileDirtyMu sync.Mutex

--- a/internal/sessioncatalog/removal.go
+++ b/internal/sessioncatalog/removal.go
@@ -35,6 +35,7 @@ func (c *Catalog) RemoveSession(ctx context.Context, path, reason string) error 
 	}
 	c.pathQueueMu.Unlock()
 	c.repairQueued.Delete(pathKey)
+	c.repairRetry.Delete(pathKey)
 	// Wake listeners without SQLite. Equal revision identifies an overlay change;
 	// empty roots refresh every expanded folder without querying the busy DB for
 	// workspace_root.

--- a/internal/sessioncatalog/repair.go
+++ b/internal/sessioncatalog/repair.go
@@ -11,32 +11,129 @@ import (
 	"reasonix/internal/agent"
 )
 
-func (c *Catalog) enqueueRepair(path string) {
+const (
+	repairRetryInitial = 30 * time.Second
+	repairRetryMaximum = 30 * time.Minute
+	repairRetryReset   = 2 * repairRetryMaximum
+)
+
+type repairRetryState struct {
+	failures          int
+	failedAt          time.Time
+	retryAt           time.Time
+	sourceFingerprint string
+}
+
+func (c *Catalog) enqueueRepair(path string) bool {
 	if c == nil || c.opts.DisableRepair || strings.TrimSpace(path) == "" {
-		return
+		return false
 	}
 	key := c.pathKey(path)
+	if !c.repairReady(path) {
+		return false
+	}
 	if _, loaded := c.repairQueued.LoadOrStore(key, struct{}{}); loaded {
-		return
+		return false
 	}
 	select {
 	case c.repairCh <- path:
+		return true
 	case <-c.stop:
 		c.repairQueued.Delete(key)
+		return false
 	default:
 		// Channel pressure must never permanently drop unknown rows. Leave them
 		// in the DB and clear the in-memory marker so the drain ticker requeues.
 		c.repairQueued.Delete(key)
+		return false
 	}
+}
+
+func (c *Catalog) repairNow() time.Time {
+	if c != nil && c.opts.Now != nil {
+		return c.opts.Now()
+	}
+	return time.Now()
+}
+
+func (c *Catalog) repairReadyKey(key string) bool {
+	value, ok := c.repairRetry.Load(key)
+	if !ok {
+		return true
+	}
+	state := value.(repairRetryState)
+	return !c.repairNow().Before(state.retryAt)
+}
+
+func (c *Catalog) repairReady(path string) bool {
+	key := c.pathKey(path)
+	for {
+		value, ok := c.repairRetry.Load(key)
+		if !ok {
+			return true
+		}
+		state := value.(repairRetryState)
+		if fileFingerprint(path) == state.sourceFingerprint {
+			return !c.repairNow().Before(state.retryAt)
+		}
+		if c.repairRetry.CompareAndDelete(key, value) {
+			return true
+		}
+	}
+}
+
+func (c *Catalog) recordRepairFailure(path string) {
+	key := c.pathKey(path)
+	now := c.repairNow()
+	failures := 1
+	if value, ok := c.repairRetry.Load(key); ok {
+		state := value.(repairRetryState)
+		elapsed := now.Sub(state.failedAt)
+		if !state.failedAt.IsZero() && elapsed >= 0 && elapsed <= repairRetryReset {
+			failures = state.failures + 1
+		}
+	}
+	delay := repairRetryInitial
+	for attempt := 1; attempt < failures && delay < repairRetryMaximum; attempt++ {
+		delay *= 2
+		if delay > repairRetryMaximum {
+			delay = repairRetryMaximum
+		}
+	}
+	c.repairRetry.Store(key, repairRetryState{
+		failures:          failures,
+		failedAt:          now,
+		retryAt:           now.Add(delay),
+		sourceFingerprint: fileFingerprint(path),
+	})
+}
+
+func (c *Catalog) clearRepairFailure(path string) {
+	c.repairRetry.Delete(c.pathKey(path))
+}
+
+func (c *Catalog) repairScanLimit(limit int) int {
+	scanLimit := limit
+	c.repairRetry.Range(func(key, _ any) bool {
+		if !c.repairReadyKey(key.(string)) {
+			scanLimit++
+		}
+		return true
+	})
+	c.repairQueued.Range(func(_, _ any) bool {
+		scanLimit++
+		return true
+	})
+	return scanLimit
 }
 
 func (c *Catalog) enqueuePersistedRepairs(ctx context.Context) {
 	c.drainUnknownRepairs(ctx, c.opts.QueueCapacity)
 }
 
-// drainUnknownRepairs pulls the next batch of turns_state=unknown paths from the
-// durable projection. Combined with the repair ticker this gives eventual
-// completeness even when more than QueueCapacity sessions need repair.
+// drainUnknownRepairs pulls the next eligible turns_state=unknown paths from
+// the durable projection. It scans past backed-off or already queued rows so
+// they cannot consume the batch limit and starve later repairs.
 func (c *Catalog) drainUnknownRepairs(ctx context.Context, limit int) {
 	if c == nil || c.db == nil || c.opts.DisableRepair || limit <= 0 {
 		return
@@ -44,16 +141,28 @@ func (c *Catalog) drainUnknownRepairs(ctx context.Context, limit int) {
 	if err := ctx.Err(); err != nil {
 		return
 	}
+	queuedSignals := len(c.repairCh)
+	if queuedSignals >= limit || (cap(c.repairCh) > 0 && queuedSignals >= cap(c.repairCh)) {
+		return
+	}
+	scanLimit := c.repairScanLimit(limit)
 	rows, err := c.db.QueryContext(ctx, `SELECT path FROM catalog_sessions
-        WHERE turns_state='unknown' ORDER BY last_activity_at DESC LIMIT ?`, limit)
+		WHERE turns_state='unknown' ORDER BY last_activity_at DESC,path_key ASC LIMIT ?`, scanLimit)
 	if err != nil {
 		return
 	}
 	defer rows.Close()
+	queued := 0
 	for rows.Next() {
 		var path string
-		if rows.Scan(&path) == nil {
-			c.enqueueRepair(path)
+		if rows.Scan(&path) != nil {
+			continue
+		}
+		if c.enqueueRepair(path) {
+			queued++
+		}
+		if queued >= limit || (cap(c.repairCh) > 0 && len(c.repairCh) >= cap(c.repairCh)) {
+			return
 		}
 	}
 }
@@ -65,7 +174,12 @@ func (c *Catalog) repairLoop() {
 	for {
 		select {
 		case path := <-c.repairCh:
-			c.repairSession(c.workerCtx, path)
+			repaired := c.repairSession(c.workerCtx, path)
+			if repaired {
+				c.clearRepairFailure(path)
+			} else if c.workerCtx.Err() == nil {
+				c.recordRepairFailure(path)
+			}
 			c.repairQueued.Delete(c.pathKey(path))
 			c.drainUnknownRepairs(c.workerCtx, 32)
 			runtime.Gosched()
@@ -77,9 +191,9 @@ func (c *Catalog) repairLoop() {
 	}
 }
 
-func (c *Catalog) repairSession(workerCtx context.Context, path string) {
+func (c *Catalog) repairSession(workerCtx context.Context, path string) bool {
 	if workerCtx.Err() != nil {
-		return
+		return false
 	}
 	// Repair writes a source snapshot that the next directory projection will
 	// consume. Share the directory lock with exact indexing and reconcile so a
@@ -99,21 +213,20 @@ func (c *Catalog) repairSession(workerCtx context.Context, path string) {
 	// LoadSessionDisplayMessages is not yet context-aware; check before/after.
 	msgs, state, _, err := agent.LoadSessionDisplayMessages(path)
 	if ctx.Err() != nil || workerCtx.Err() != nil {
-		return
+		return false
 	}
 	if err != nil {
-		_ = c.applyRepairResult(ctx, path, "", 0, false)
-		return
+		return c.applyRepairResult(ctx, path, "", 0, false) == nil
 	}
 	preview, turns := agent.SessionPreviewFromMessages(msgs)
 	applied, err := agent.UpdateSessionListingProjectionIfCurrent(path, "", preview, turns, false, state)
 	if err != nil || !applied {
-		return
+		return false
 	}
 	if ctx.Err() != nil || workerCtx.Err() != nil {
-		return
+		return false
 	}
-	_ = c.applyRepairResult(ctx, path, preview, turns, true)
+	return c.applyRepairResult(ctx, path, preview, turns, true) == nil
 }
 
 // applyRepairResult updates only fields proven by parsing one transcript. Topic

--- a/internal/sessioncatalog/repair_test.go
+++ b/internal/sessioncatalog/repair_test.go
@@ -2,12 +2,173 @@ package sessioncatalog
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"reasonix/internal/agent"
 )
+
+func TestRepairFailureBacksOffSubsequentEnqueue(t *testing.T) {
+	now := time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+	catalog := &Catalog{
+		opts:         Options{Now: func() time.Time { return now }},
+		pathIdentity: func(path string) string { return path },
+		repairCh:     make(chan string, 1),
+		stop:         make(chan struct{}),
+	}
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+
+	catalog.recordRepairFailure(path)
+	if catalog.enqueueRepair(path) {
+		t.Fatal("failed repair was immediately requeued")
+	}
+	now = now.Add(29 * time.Second)
+	if catalog.enqueueRepair(path) {
+		t.Fatal("failed repair was requeued before the first backoff elapsed")
+	}
+	now = now.Add(time.Second)
+	if !catalog.enqueueRepair(path) {
+		t.Fatal("failed repair was not requeued after the first backoff elapsed")
+	}
+	<-catalog.repairCh
+	catalog.repairQueued.Delete(catalog.pathKey(path))
+
+	catalog.recordRepairFailure(path)
+	now = now.Add(59 * time.Second)
+	if catalog.enqueueRepair(path) {
+		t.Fatal("second repair failure was requeued before exponential backoff elapsed")
+	}
+	now = now.Add(time.Second)
+	if !catalog.enqueueRepair(path) {
+		t.Fatal("second repair failure was not requeued after exponential backoff elapsed")
+	}
+	<-catalog.repairCh
+	catalog.repairQueued.Delete(catalog.pathKey(path))
+
+	catalog.clearRepairFailure(path)
+	if !catalog.enqueueRepair(path) {
+		t.Fatal("successful repair did not clear the retry backoff")
+	}
+}
+
+func TestRepairBackoffIsCapped(t *testing.T) {
+	now := time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+	catalog := &Catalog{
+		opts:         Options{Now: func() time.Time { return now }},
+		pathIdentity: func(path string) string { return path },
+	}
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	for range 10 {
+		catalog.recordRepairFailure(path)
+	}
+	now = now.Add(repairRetryMaximum - time.Second)
+	if catalog.repairReadyKey(catalog.pathKey(path)) {
+		t.Fatal("repair retry became eligible before the maximum backoff elapsed")
+	}
+	now = now.Add(time.Second)
+	if !catalog.repairReadyKey(catalog.pathKey(path)) {
+		t.Fatal("repair retry remained blocked beyond the maximum backoff")
+	}
+}
+
+func TestRepairBackoffResetsAfterStaleFailureGeneration(t *testing.T) {
+	now := time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+	catalog := &Catalog{
+		opts:         Options{Now: func() time.Time { return now }},
+		pathIdentity: func(path string) string { return path },
+	}
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	for range 6 {
+		catalog.recordRepairFailure(path)
+	}
+
+	now = now.Add(repairRetryReset + time.Second)
+	catalog.recordRepairFailure(path)
+	value, ok := catalog.repairRetry.Load(catalog.pathKey(path))
+	if !ok {
+		t.Fatal("stale repair failure generation was not replaced")
+	}
+	state := value.(repairRetryState)
+	if state.failures != 1 {
+		t.Fatalf("stale repair failure generation retained %d failures, want 1", state.failures)
+	}
+	if want := now.Add(repairRetryInitial); !state.retryAt.Equal(want) {
+		t.Fatalf("retryAt = %v, want reset initial retry %v", state.retryAt, want)
+	}
+}
+
+func TestRepairBackoffClearsWhenSourceGenerationChanges(t *testing.T) {
+	now := time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+	catalog := &Catalog{
+		opts:         Options{Now: func() time.Time { return now }},
+		pathIdentity: func(path string) string { return path },
+		repairCh:     make(chan string, 1),
+		stop:         make(chan struct{}),
+	}
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(path, []byte("first generation"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	catalog.recordRepairFailure(path)
+	if catalog.enqueueRepair(path) {
+		t.Fatal("unchanged failed source was immediately requeued")
+	}
+
+	if err := os.WriteFile(path, []byte("second generation with a different size"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !catalog.enqueueRepair(path) {
+		t.Fatal("changed source generation retained stale repair backoff")
+	}
+}
+
+func TestDrainUnknownRepairsScansPastBackedOffRows(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+	catalog, err := Open(ctx, Options{
+		InMemory:      true,
+		DisableRepair: true,
+		QueueCapacity: 1,
+		Now:           func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	catalog.opts.DisableRepair = false
+
+	dir := t.TempDir()
+	delayed := filepath.Join(dir, "delayed.jsonl")
+	ready := filepath.Join(dir, "ready.jsonl")
+	for _, row := range []struct {
+		path     string
+		activity int64
+	}{
+		{path: delayed, activity: 2},
+		{path: ready, activity: 1},
+	} {
+		_, err := catalog.db.ExecContext(ctx, `INSERT INTO catalog_sessions(
+			path,path_key,directory,directory_key,scope,last_activity_at,turns_state
+		) VALUES(?,?,?,?,?,?,?)`, row.path, catalog.pathKey(row.path), dir, catalog.pathKey(dir), "global", row.activity, TurnsUnknown)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	catalog.recordRepairFailure(delayed)
+	catalog.drainUnknownRepairs(ctx, 1)
+	select {
+	case got := <-catalog.repairCh:
+		if got != ready {
+			t.Fatalf("drain queued %q, want eligible path %q", got, ready)
+		}
+	default:
+		t.Fatal("backed-off row exhausted the drain limit and starved an eligible row")
+	}
+}
 
 func TestRepairResultPreservesDirectoryProjectionUntilReconcile(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- back off failed session catalog repairs from 30 seconds up to 30 minutes
- clear stale retry state when the transcript fingerprint changes or a repair succeeds
- scan past delayed and already queued rows so later eligible repairs are not starved

## Issues

Fixes #9533

## Verification

- `go test -p 4 -timeout=8m ./...`
- `go test -race ./internal/sessioncatalog -count=1`
- `go vet ./...`

## Documentation impact

Documentation-impact: none - this only changes internal session catalog repair scheduling.

## Cache impact

Cache-impact: low - retry metadata is process-local and is not persisted.
Cache-guard: `go test ./internal/sessioncatalog -count=1`
System-prompt-review: N/A
