### PR TITLE
fix: bound transcript prepend commit / 修复持续滚动时尾部交接

### DIFF
--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -1577,10 +1577,16 @@ try {
   const stormApproach = await stormTranscript.evaluate((element) => ({
     writes: window.__stormProbe?.writes.length ?? null,
     mode: element.dataset.scrollMode,
+    readerIntent: element.dataset.transcriptReaderIntent,
+    historyPrependPending: element.dataset.transcriptHistoryPrependPending,
     top: Math.round(element.scrollTop),
     height: Math.round(element.scrollHeight),
     clientHeight: element.clientHeight,
     distance: Math.round(element.scrollHeight - element.scrollTop - element.clientHeight),
+    lastRowMounted: Boolean(element.querySelector('[data-transcript-last-row="true"]')),
+    diagnostics: element.dataset.scrollMode === "tail-follow"
+      ? undefined
+      : window.__stormProbe?.diagnostics.slice(-24) ?? [],
   }));
   stormApproach.gestures = stormAttempts;
   assert(

--- a/desktop/frontend/src/__tests__/transcript-history-prepend-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-history-prepend-race.test.tsx
@@ -162,6 +162,43 @@ const prependWrites = scrollWrites.filter((write) => write.owner === "reader-sta
 check(arbiter?.historyPrependLease.pendingRef.current === false, "full stable coverage releases within the wall-clock budget");
 check(prependWrites.length === 1 && prependWrites[0].kind === "scrollBy", "the stable key gets exactly one final correction");
 
+// Continuous reader input may keep extending the reader transaction, but it
+// cannot extend a covered prepend's independent wall-clock commit bound. The
+// old shared deadline left physical-bottom readers permanently manual: every
+// wheel postponed the geometry commit that tail handoff was waiting for.
+await act(async () => arbiter?.reset());
+scrollExtent = 46_235;
+scrollElement.scrollTop = 45_000;
+rowElement.getBoundingClientRect = () => rectAt(0);
+rowElement.dataset.transcriptLastRow = "true";
+await act(async () => arbiter?.deliverScroll());
+await act(async () => arbiter?.setMode("manual", "test-continuous-reader-prepend"));
+await act(async () => arbiter?.onWheelIntent({
+  ctrlKey: false, deltaX: 0, deltaY: 640, target: scrollElement,
+} as React.WheelEvent<HTMLElement>));
+const continuousGeneration = arbiter!.historyPrependLease.begin(2);
+await act(async () => root.render(
+  <Probe rows={pageTwo} deliveredCount={pageTwo.length} historyMutation={{ seq: 3, kind: "prepend" }} />,
+));
+for (let gesture = 0; gesture < 10; gesture += 1) {
+  await advanceClock(120);
+  await act(async () => arbiter?.onWheelIntent({
+    ctrlKey: false, deltaX: 0, deltaY: 640, target: scrollElement,
+  } as React.WheelEvent<HTMLElement>));
+  scrollElement.scrollTop = Math.min(scrollExtent - scrollElement.clientHeight, scrollElement.scrollTop + 120);
+  await act(async () => arbiter?.deliverScroll());
+}
+check(arbiter?.historyPrependLease.pendingRef.current, "continuous wheels retain the prepend until a stable reader interval");
+await advanceClock(181);
+for (let frame = 0; frame < 10; frame += 1) await flushFrames();
+check(arbiter?.historyPrependLease.pendingRef.current === false,
+  "continuous wheels cannot postpone a covered prepend past its wall-clock bound");
+check(arbiter?.historyPrependLease.generationRef.current === continuousGeneration,
+  "the bounded commit completes the same prepend generation");
+check(String(arbiter?.modeRef.current) === "tail-follow",
+  "the physical-bottom reader hands ownership to the tail after the bounded commit");
+delete rowElement.dataset.transcriptLastRow;
+
 const competingOwners: [string, () => void][] = [
   ["selection", () => arbiter!.setMode("selection")],
   ["user resize", () => arbiter!.setMode("user-resize")],

--- a/desktop/frontend/src/lib/useTranscriptReaderExtentStability.ts
+++ b/desktop/frontend/src/lib/useTranscriptReaderExtentStability.ts
@@ -48,6 +48,9 @@ type ActiveReaderTransaction = TranscriptReaderTransaction & {
   transient: boolean;
   visualOffset: number;
   postCorrectionSettleDeadline: number;
+  /** Wall-clock bound for a history-prepend geometry commit. Reader input may
+   *  extend its own settle window, but must not postpone the prepend forever. */
+  commitAt: number;
   /** Last tick's native height: a rebound correction spends its budget only
    *  after one unchanged-height interval with mounted viewport coverage. */
   correctionHeightSample: number;
@@ -511,7 +514,7 @@ export function useTranscriptReaderExtentStability({
 
       if (transaction.stableFrames >= STABLE_FRAMES_REQUIRED) {
         if (geometryCommitBlockedRef.current) {
-          if (now >= transaction.settleDeadline && !geometryCommitReadyRef.current) {
+          if (now >= transaction.commitAt && !geometryCommitReadyRef.current) {
             geometryCommitReadyRef.current = true;
             callbacksRef.current.onGeometryCommitReady();
           }
@@ -547,7 +550,7 @@ export function useTranscriptReaderExtentStability({
       }
       if (now >= transaction.settleDeadline) {
         if (geometryCommitBlockedRef.current) {
-          if (now >= transaction.settleDeadline + 620 && !geometryCommitReadyRef.current) {
+          if (now >= transaction.commitAt + 620 && !geometryCommitReadyRef.current) {
             geometryCommitReadyRef.current = true;
             callbacksRef.current.onGeometryCommitReady();
           }
@@ -579,6 +582,10 @@ export function useTranscriptReaderExtentStability({
     if (captureAnchor) transaction.anchor = captureLogicalAnchor(transaction.element) ?? transaction.anchor;
     transaction.settleDeadline = Math.max(
       transaction.settleDeadline,
+      now + TRANSCRIPT_READER_IDLE_MS + TRANSCRIPT_READER_SETTLE_MS,
+    );
+    transaction.commitAt = Math.max(
+      transaction.commitAt,
       now + TRANSCRIPT_READER_IDLE_MS + TRANSCRIPT_READER_SETTLE_MS,
     );
     transaction.stableFrames = 0;
@@ -668,6 +675,7 @@ export function useTranscriptReaderExtentStability({
       transient: inheritedCollapse,
       visualOffset: 0,
       postCorrectionSettleDeadline: 0,
+      commitAt: now + TRANSCRIPT_READER_IDLE_MS + TRANSCRIPT_READER_SETTLE_MS,
       correctionHeightSample: element.scrollHeight,
       prepaint: false,
     };


### PR DESCRIPTION
## Summary

- give history-prepend geometry commits a wall-clock bound independent from reader input settling
- prevent repeated downward wheels from postponing a covered prepend forever and blocking reader-to-tail handoff
- add deterministic continuous-wheel coverage and richer ref-resolution storm failure diagnostics

## Root cause

#9643 reused the reader transaction's `settleDeadline` as the prepend commit deadline. Every wheel extends `settleDeadline`, so sustained reader input could keep a fully covered prepend pending indefinitely. At the physical bottom, the reader remained in `manual` because tail handoff correctly waits for that prepend owner to release.

The new `commitAt` deadline is initialized for the reader transaction and extended only by prepend begin/mutation activity. Reader input continues to extend its own settle window without moving the prepend's wall-clock bound.

Relates to #8657. This is intentionally separate from #9585 so the base scroll-owner regression can be validated and merged independently before #9585 updates to the latest `main-v2`.

Documentation-impact: none - internal transcript scroll ownership timing and test diagnostics only; existing user documentation remains correct.

## Verification

- `pnpm test:transcript`
- `pnpm build`
- `pnpm check:scroll-writer`
- Chromium transcript scroll stability browser gate: 5/5 complete runs passed
- deterministic regression fails on the previous shared-deadline condition and passes with the independent prepend deadline
