### PR TITLE
fix(frontend): restore release bundle budget headroom / 恢复发布包体预算余量

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -291,7 +291,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // the smallest one-decimal headroom without widening unrelated chunk ceilings.
 // Latest-base transcript settle ownership brings the measured path to
 // 2452.773 KiB; isolated conversation forks bring the combined tree to
-// 2454.679 KiB. Retain 0.021 KiB with the smallest one-decimal ratchet.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_454.7 : 2_454.7;
+// 2454.719 KiB on the release toolchain. Retain 0.081 KiB with the smallest
+// one-decimal ratchet.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_454.8 : 2_454.8;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);


### PR DESCRIPTION
## Summary

- measure the merged isolated-worktree startup graph at 2454.719 KiB
- retain 0.081 KiB of explicit headroom with the existing one-decimal ratchet
- keep all gzip, chunk, locale, and CSS budgets unchanged

## Validation

- `pnpm --dir desktop/frontend build`

## CI context

The current main-v2 CI run fails the macOS and Windows desktop builds because the exact 2454.719 KiB payload exceeds the 2454.7 KiB raw budget by about 19 bytes.

Documentation-impact: none - this only corrects an internal build budget and does not change product behavior or documentation.

Cache-impact: none - no provider-visible prompt, tool schema, request serialization, memory prefix, or compaction behavior changes.
