### PR TITLE
fix(agent): keep small shared windows admissible / 避免小型共享窗口压缩后卡死

### DIFF
--- a/internal/agent/output_budget.go
+++ b/internal/agent/output_budget.go
@@ -13,7 +13,10 @@ import (
 	"reasonix/internal/provider"
 )
 
-const outputBudgetReserve = 8 * 1024
+const (
+	outputBudgetReserve    = 8 * 1024
+	minOutputBudgetReserve = protocolReserveTokens
+)
 
 const learnedOutputBudgetTTL = 24 * time.Hour
 
@@ -479,7 +482,18 @@ func (a *Agent) effectiveOutputBudget(req provider.Request) (int, bool, error) {
 }
 
 func (a *Agent) admitOutputBudget(req provider.Request) (contextAdmission, error) {
-	return a.admitOutputBudgetWithReserve(req, outputBudgetReserve, false)
+	return a.admitOutputBudgetWithReserve(req, outputBudgetReserveForWindow(a.effectiveContextWindow()), false)
+}
+
+// outputBudgetReserveForWindow preserves the original safety ratio: the 8K
+// tokenizer/protocol cushion was chosen for a 1M-token window, so smaller
+// windows reserve roughly the same 1/128 share. A 256-token floor covers
+// framing, while the 8K cap keeps larger windows byte-stable.
+func outputBudgetReserveForWindow(window int) int {
+	if window <= 0 {
+		return outputBudgetReserve
+	}
+	return min(outputBudgetReserve, max(minOutputBudgetReserve, window/128))
 }
 
 // admitSummaryOutputBudget uses the summary request's dedicated protocol

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -277,8 +277,10 @@ func TestCalibratedOutputBudgetIncludesReplayedReasoning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("effectiveOutputBudget: %v", err)
 	}
-	if !clipped || budget > 20_000 {
-		t.Fatalf("replayed reasoning budget = %d clipped=%v, want a clipped budget <= 20000", budget, clipped)
+	adm := a.lastAdmission()
+	if !clipped || budget <= 0 || budget >= prov.budget ||
+		budget+adm.PromptTokens+adm.ReserveTokens > a.contextWindow {
+		t.Fatalf("replayed reasoning budget = %d clipped=%v admission=%+v, want a clipped request within the shared window", budget, clipped, adm)
 	}
 }
 

--- a/internal/agent/small_window_admission_test.go
+++ b/internal/agent/small_window_admission_test.go
@@ -1,0 +1,78 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/tool"
+)
+
+type largeSchemaTool struct {
+	description string
+}
+
+func (largeSchemaTool) Name() string            { return "large_schema" }
+func (t largeSchemaTool) Description() string   { return t.description }
+func (largeSchemaTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (largeSchemaTool) ReadOnly() bool          { return true }
+func (largeSchemaTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "ok", nil
+}
+
+func TestOutputBudgetReserveScalesWithWindow(t *testing.T) {
+	tests := []struct {
+		window int
+		want   int
+	}{
+		{window: 0, want: 8 * 1024},
+		{window: 20_000, want: 256},
+		{window: 128_000, want: 1_000},
+		{window: 1_048_576, want: 8 * 1024},
+		{window: 2_000_000, want: 8 * 1024},
+	}
+	for _, tt := range tests {
+		if got := outputBudgetReserveForWindow(tt.window); got != tt.want {
+			t.Fatalf("window %d reserve = %d, want %d", tt.window, got, tt.want)
+		}
+	}
+}
+
+func TestPrepareSamplingRequestAdmitsCompactedSmallWindowDeadZone(t *testing.T) {
+	const window = 20_000
+	prov := &overflowSummaryProvider{}
+	reg := tool.NewRegistry()
+	reg.Add(largeSchemaTool{description: strings.Repeat("large deterministic schema. ", 1200)})
+	sess := foldableSessionOverForce(20)
+	a := New(prov, reg, sess, Options{
+		ContextWindow:   window,
+		CompactRatio:    defaultCompactRatio,
+		MaxOutputTokens: 8192,
+	}, event.Discard)
+
+	before := a.estimatedVisibleRequestTokens(a.modelVisibleMessages())
+	if before < a.compactTrigger() || before >= a.hardInputCeiling() {
+		t.Fatalf("fixture prompt = %d, want pressure range [%d, %d)", before, a.compactTrigger(), a.hardInputCeiling())
+	}
+
+	prepared, err := a.prepareSamplingRequest(context.Background())
+	if err != nil {
+		t.Fatalf("prepareSamplingRequest: %v", err)
+	}
+	if len(prov.requests) != 1 {
+		t.Fatalf("summary requests = %d, want 1", len(prov.requests))
+	}
+	adm := a.lastAdmission()
+	if adm.PromptTokens <= window-outputBudgetReserve {
+		t.Fatalf("fixture missed former admission dead zone: prompt = %d, old ceiling = %d", adm.PromptTokens, window-outputBudgetReserve)
+	}
+	if adm.ReserveTokens != outputBudgetReserveForWindow(window) {
+		t.Fatalf("reserve = %d, want scaled %d", adm.ReserveTokens, outputBudgetReserveForWindow(window))
+	}
+	if prepared.req.MaxTokens <= 0 || prepared.req.MaxTokens+adm.PromptTokens+adm.ReserveTokens > window {
+		t.Fatalf("prepared request does not fit: prompt=%d output=%d reserve=%d window=%d",
+			adm.PromptTokens, prepared.req.MaxTokens, adm.ReserveTokens, window)
+	}
+}


### PR DESCRIPTION
## Summary

- scale the ordinary shared-window admission cushion with the effective context window: 1/128, with a 256-token floor and 8K cap
- keep the provider-error recovery path conservative and retain its fixed 8K cushion
- leave compact_ratio, compaction planning, prompts, messages, and tool schemas unchanged

## Root cause

The release E2E deliberately uses a 20K context window to exercise compaction. After a successful pressure summary, the provider-visible prompt was 12,869 tokens. The fixed 8K ordinary cushion required the prompt to fit below 11,808, so admission forced a second overflow fold. Tool schemas made up the non-foldable remainder, and the turn failed with no foldable region even though physical completion room remained.

The scaled cushion preserves the original 8K-to-1M safety ratio. It also keeps the 20K stress window usable through the hard 256-token protocol ceiling.

## Validation

- go test ./internal/agent -count=1
- focused admission and recovery regressions
- real DeepSeek e2ebench compaction task at context_window = 20000: PASS; generated the expected answer after following the full chapter trail
- git diff --check

Documentation-impact: none - no configuration, CLI, tool surface, or documented workflow changes.

Cache-impact: low - ordinary unpressured requests are byte-stable. Only near-limit shared-window requests below the 1M cap may receive a larger clipped MaxTokens value; provider-visible prompts, messages, tools, cacheable prefixes, compact_ratio, and summary requests are unchanged.
Cache-guard: focused admission/recovery tests and the real compaction E2E pass.
System-prompt-review: N/A - no system prompt or tool schema bytes changed.