### PR TITLE
fix(release): make Notes reruns follow public main / 让更新日志重跑跟随公开主线

### DIFF
--- a/.github/workflows/prepare-release-notes.yml
+++ b/.github/workflows/prepare-release-notes.yml
@@ -57,7 +57,11 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          node scripts/generate-release-notes.mjs --version "$VERSION"
+          # The review branch may already contain an older generated Notes
+          # commit. Generate strictly from the public release line so a local,
+          # not-yet-pushed merge commit and the Notes PR itself cannot enter
+          # the release range.
+          node scripts/generate-release-notes.mjs --version "$VERSION" --to origin/main-v2
           node scripts/release-notes.mjs validate
           node --test scripts/release-notes.test.mjs
           node scripts/release-notes.mjs render --version "$VERSION" --output /tmp/release-notes.md

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -1184,6 +1184,7 @@ grep -Fq 'branch="release-notes/v${VERSION}"' "$prepare_notes"
 grep -Fq 'GitHub Actions could not open the PR; the reviewed branch is preserved.' "$prepare_notes"
 grep -Fq 'gh pr create --repo ${{ github.repository }} --base main-v2 --head $RELEASE_NOTES_BRANCH --fill' "$prepare_notes"
 grep -Eq 'GITHUB_STEP_SUMMARY' "$prepare_notes"
+grep -Fq 'node scripts/generate-release-notes.mjs --version "$VERSION" --to origin/main-v2' "$prepare_notes"
 grep -Fq 'thinking: { type: "disabled" }' "$generate_notes"
 
 desktop_candidate_resolver="$repo_root/scripts/resolve-desktop-candidate.sh"


### PR DESCRIPTION
## Summary

- generate release records from origin/main-v2 after the review branch is refreshed
- keep the existing deterministic release-notes/vVERSION branch and review PR
- add a workflow contract so reruns cannot silently fall back to the review branch HEAD

## Root cause

A second Prepare run merges the latest main-v2 into the existing Notes branch before generation. The resulting merge commit exists only in the runner until the final push, so querying its associated pull requests returns HTTP 422. Using HEAD also makes the release range depend on the review branch instead of the public release line.

Passing --to origin/main-v2 keeps every cited PR and documentation link grounded in the exact public main-v2 tip while still allowing the existing Notes PR to be updated.

## Validation

- bash scripts/release-workflows.test.sh
- git diff --check
- reproduced by Prepare release run 33409879403 at main-v2 SHA 7b3e462cd59655e6241efe78ddc05534cce541bc

Documentation-impact: none - this only repairs the internal release preparation workflow.

Cache-impact: none - no provider request, prompt, tool schema, model runtime, or product cache behavior changes.