### PR TITLE
fix(openai): accept provider-prefixed model refs in the DeepSeek vision SKU check / DeepSeek 视觉 SKU 判定容忍 provider 前缀（#9671）

### DIFF
--- a/internal/provider/openai/host.go
+++ b/internal/provider/openai/host.go
@@ -43,9 +43,17 @@ func IsDeepSeek(baseURL string) bool {
 const OfficialDeepSeekVisionModel = "deepseek-v4-flash-vision-exp"
 
 // IsOfficialDeepSeekVisionModel reports whether model is the pinned official
-// DeepSeek vision SKU. Matching is case-insensitive and trims surrounding space.
+// DeepSeek vision SKU. Matching is case-insensitive and trims surrounding
+// space. Model refs may carry a provider prefix ("deepseek/deepseek-v4-flash-
+// vision-exp" from a multi-provider config), so only the segment after the
+// last "/" — the actual model id — participates in the SKU check (#9671).
+// Flash, Pro, and future names that merely contain "vision" still fail.
 func IsOfficialDeepSeekVisionModel(model string) bool {
-	return strings.EqualFold(strings.TrimSpace(model), OfficialDeepSeekVisionModel)
+	model = strings.TrimSpace(model)
+	if i := strings.LastIndex(model, "/"); i >= 0 {
+		model = model[i+1:]
+	}
+	return strings.EqualFold(model, OfficialDeepSeekVisionModel)
 }
 
 // OfficialDeepSeekAllowsVision reports whether this official DeepSeek endpoint

--- a/internal/provider/openai/host_test.go
+++ b/internal/provider/openai/host_test.go
@@ -45,6 +45,14 @@ func TestIsOfficialDeepSeekVisionModel(t *testing.T) {
 		{OfficialDeepSeekVisionModel, true},
 		{"DEEPSEEK-V4-FLASH-VISION-EXP", true},
 		{" deepseek-v4-flash-vision-exp ", true},
+		// Provider-prefixed model refs (#9671): the segment after the last "/"
+		// is the model id, so a prefixed ref of the vision SKU matches.
+		{"deepseek/deepseek-v4-flash-vision-exp", true},
+		{"DEEPSEEK/Deepseek-V4-Flash-Vision-Exp", true},
+		{" deepseek/deepseek-v4-flash-vision-exp ", true},
+		// Prefixed non-SKU names must still fail.
+		{"deepseek/deepseek-v4-flash", false},
+		{"gateway/deepseek-v4-flash-vision-exp/extra", false},
 		{"deepseek-v4-flash", false},
 		{"deepseek-v4-pro", false},
 		{"deepseek-v5-vision", false},


### PR DESCRIPTION
**TL;DR**: 修复 DeepSeek 视觉 SKU 判定拒绝带 provider 前缀 model ref 的 bug（`deepseek/deepseek-v4-flash-vision-exp` → vision 被静默关闭、图片永远读不到）。#9671 根因部分。

## Summary

`IsOfficialDeepSeekVisionModel` matched `cfg.Model` as a **whole string**, so a multi-provider model ref like `deepseek/deepseek-v4-flash-vision-exp` failed the pinned-SKU check → `vision=false` → `image_url` was never embedded on official DeepSeek endpoints. The vision model could not see images **even for an explicit `@` image reference** — the gate effectively disabled the only official DeepSeek vision SKU (MiniMax-M3 was unaffected because its vision gate is not an exact model-name match; this contrast is what narrowed the root cause, see #9671).

Fix: match only the segment after the last `/` (the actual model id). Flash, Pro, prefixed non-SKU names, and future "vision"-containing names still fail the check, so the original intent — pinning image input to the one official vision SKU — is unchanged.

The same helper gates vision in 6 places (`config/deepseek_vision.go`, `config/vision.go`, `anthropic`, `responses`, `openai` ×2), so one change fixes all DeepSeek vision paths.

## Scope note

#9671 also carries a feature request (attached images without an `@` reference only feed the OCR summary). This PR addresses the root-cause bug only; the no-`@` injection design is better discussed on the issue.

## Issues fixes

Partially addresses #9671 (the DeepSeek vision gate root cause; the no-`@` injection feature remains open on the issue).

## Verification

- `go build ./...` — pass
- `go test ./internal/provider/openai/ ./internal/config/ -run 'TestIsOfficialDeepSeekVisionModel|...'` — pass (new table cases: prefixed SKU match, case/space combos, prefixed non-SKU rejection, deeper-path rejection)
- `go test ./internal/provider/...` — pass (covers the anthropic/responses call sites)

Cache-impact: none- provider-layer gate only; no cache format or version changes

Cache-guard: updated- go build ./... + internal/provider/... test suites

Documentation-impact: none- provider behavior fix; no user-facing docs

System-prompt-review: none- no prompt text changes
