### PR TITLE
fix(desktop): stabilize long transcript scrolling

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -167,7 +167,9 @@ console.log("\nbundle budgets");
 // isolated conversation forks and their extracted browser mock adapter bring
 // the combined tree to 458.158 KiB. Retain 0.042 KiB with the smallest
 // one-decimal ratchet.
-const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 458.2 : 458.2;
+// Stable-window transcript mounting and bounded correction guards bring the
+// measured path to 458.4 KiB; retain the next one-decimal ratchet.
+const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 458.5 : 458.5;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -293,6 +295,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // 2452.773 KiB; isolated conversation forks bring the combined tree to
 // 2454.719 KiB on the release toolchain. Retain 0.081 KiB with the smallest
 // one-decimal ratchet.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_454.8 : 2_454.8;
+// Stable-window transcript mounting and bounded correction guards measure
+// 2456.2 KiB raw; retain the next one-decimal ratchet.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_456.3 : 2_456.3;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/__tests__/transcript-anchor-compensation-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-anchor-compensation-race.test.tsx
@@ -114,6 +114,7 @@ scrollElement.getBoundingClientRect = () => rectAt(0);
 rowElement.getBoundingClientRect = () => rectAt(200);
 Object.defineProperty(scrollElement, "clientHeight", { configurable: true, value: 100 });
 let scrollExtent = 500;
+let ignoreOffsetWrites = false;
 Object.defineProperty(scrollElement, "scrollHeight", { configurable: true, get: () => scrollExtent });
 Object.defineProperty(scrollElement, "scrollTop", { configurable: true, writable: true, value: 0 });
 Object.defineProperty(scrollElement, "offsetWidth", { configurable: true, value: 800 });
@@ -125,6 +126,7 @@ const virtuosoHandle = {
   scrollToIndex: () => {},
   // Browser semantics: an offset write clamps against the current extent.
   scrollTo: (options?: { top?: number }) => {
+    if (ignoreOffsetWrites) return;
     const top = options?.top ?? 0;
     scrollElement.scrollTop = Math.max(0, Math.min(scrollExtent - scrollElement.clientHeight, top));
   },
@@ -230,6 +232,33 @@ await flushFrames();
 check(scrollElement.scrollTop === 800, "post-release remeasurement reconverges the claimed native bottom");
 scrollExtent = 500;
 
+// A native-thumb drag changes the visible anchor while the arbiter is in
+// native-thumb mode, where SCROLL_DELIVERED is intentionally observational.
+// Rebase on release so the next geometry notification cannot compensate from
+// the pre-drag row offset and pull the viewport back toward its old position.
+await act(async () => arbiter?.reset());
+scrollElement.appendChild(rowElement);
+scrollElement.scrollTop = 100;
+rowElement.getBoundingClientRect = () => rectAt(10);
+await act(async () => arbiter?.setMode("manual", "test-native-thumb-anchor"));
+await act(async () => arbiter?.deliverScroll());
+await act(async () => arbiter?.onPointerDownIntent({
+  button: 0,
+  nativeEvent: { button: 0, clientX: 795 },
+} as React.PointerEvent<HTMLElement>));
+scrollElement.scrollTop = 300;
+rowElement.getBoundingClientRect = () => rectAt(50);
+await act(async () => arbiter?.deliverScroll());
+await act(async () => window.dispatchEvent(new dom.window.Event("pointerup")));
+check(arbiter?.modeRef.current === "manual", "native thumb release away from bottom resumes manual mode");
+scrollWrites.length = 0;
+await act(async () => arbiter?.followGrowingTail());
+for (let i = 0; i < 4; i += 1) await flushFrames();
+check(
+  scrollWrites.filter((write) => write.owner === "anchor-compensation").length === 0,
+  "native thumb release rebases the anchor before the next geometry notification",
+);
+
 // ── Manual-mode viewport anchor compensation (#8438/#8488/#8897): an
 // above-viewport height change (fold auto-collapse, history patch) must not
 // push the reading position. The drift is measured against the anchor sampled
@@ -261,6 +290,21 @@ check(scrollElement.dataset.transcriptReaderVisualGuard === undefined,
   "the idle-manual visual guard clears after the writer commits the physical offset");
 check(arbiter?.modeRef.current === "manual", "anchor compensation preserves manual reading ownership");
 check(rowElement.getBoundingClientRect().top === 50, "the anchor row is physically back at its pre-change offset");
+
+// An ineffective browser write must end this geometry transaction instead of
+// submitting every animation frame until the one-second budget expires.
+await act(async () => arbiter?.deliverScroll());
+scrollWrites.length = 0;
+ignoreOffsetWrites = true;
+rowElement.getBoundingClientRect = () => rectAt(guardedRowTop(550 - scrollElement.scrollTop));
+await act(async () => arbiter?.followGrowingTail());
+for (let frame = 0; frame < 12; frame += 1) await flushFrames();
+check(
+  scrollWrites.filter((write) => write.owner === "anchor-compensation").length === 1,
+  "one geometry transaction submits at most one anchor correction",
+);
+ignoreOffsetWrites = false;
+rowElement.getBoundingClientRect = () => rectAt(guardedRowTop(350 - scrollElement.scrollTop));
 
 // Growth below the viewport (streaming tail) leaves the anchor row put:
 // zero measured drift, zero writes.

--- a/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
@@ -111,6 +111,24 @@ await act(async () => {
   arbiter!.scrollerRef(scrollElement);
 });
 
+// A redundant downward wheel at an already-owned physical tail must not enter
+// the browser/Virtuoso native range-replacement lane. Upward input remains the
+// normal way to release tail ownership for manual reading.
+scrollExtent = 2_000;
+scrollElement.scrollTop = 1_275;
+let tailWheelPrevented = 0;
+await act(async () => arbiter?.deliverScroll());
+const tailWheelAccepted = arbiter?.onWheelIntent({
+  ctrlKey: false,
+  deltaMode: 0,
+  deltaX: 0,
+  deltaY: 120,
+  target: scrollElement,
+  preventDefault: () => { tailWheelPrevented += 1; },
+} as unknown as React.WheelEvent<HTMLElement>);
+check(tailWheelAccepted === false && tailWheelPrevented === 1,
+  "downward wheel at an owned physical tail is suppressed before native range replacement");
+
 // Composer wrap shrinks the in-flow viewport. Tail-follow must pin the native
 // tail synchronously so jump-bottom cannot flash before the coalesced frame.
 await act(async () => arbiter?.reset());
@@ -210,6 +228,41 @@ check(
   "the post-growth collapse receives one reader-owned anchor correction",
 );
 Date.now = growthRaceRealNow;
+
+// WebView2 may deliver several observers before the newly assigned list
+// transform is reflected by getBoundingClientRect. The first guard must stay
+// absolute: repeated callbacks cannot multiply one 2,537px displacement into
+// 5,074px, 7,611px, and beyond (frontend diagnostic db21a6c0).
+await act(async () => arbiter?.reset());
+scrollExtent = 23_806;
+scrollElement.scrollTop = 20_000;
+rowElement.getBoundingClientRect = () => rectAt(12);
+await act(async () => arbiter?.deliverScroll());
+await act(async () => arbiter?.releaseTailFollow());
+await act(async () => arbiter?.onWheelIntent({
+  ctrlKey: false,
+  deltaMode: 0,
+  deltaX: 0,
+  deltaY: 24,
+  target: scrollElement,
+} as React.WheelEvent<HTMLElement>));
+scrollByCalls = 0;
+scrollWrites.length = 0;
+scrollExtent += 2_537;
+// Intentionally omit the CSS variable from this rect, matching the delayed
+// WebView2 transform observation captured in the field trace.
+rowElement.getBoundingClientRect = () => rectAt(2_549);
+for (let sample = 0; sample < 4; sample += 1) {
+  await act(async () => arbiter?.deliverScroll());
+}
+check(
+  scrollElement.style.getPropertyValue("--transcript-reader-visual-offset") === "-2537px",
+  "repeated pre-paint observers freeze one absolute visual guard",
+);
+rowElement.getBoundingClientRect = () => rectAt(12);
+await flushFrames();
+check(scrollByCalls === 1 && Math.abs(lastScrollByTop - 2_537) <= 1,
+  `the frozen guard commits one bounded correction (${lastScrollByTop}px)`);
 
 // WKWebView can replace estimates above the viewport without moving native
 // scrollTop. The logical rows still jump backwards on screen, so the reader
@@ -694,6 +747,54 @@ check(String(arbiter?.modeRef.current) === "manual",
 Date.now = realDateNow;
 delete rowElement.dataset.transcriptLastRow;
 setTranscriptScrollDiagnosticSink(() => {});
+
+// Field race: a downward reader reaches a collapsed physical bottom, then
+// Virtuoso restores 1,446px of extent without moving scrollTop. The collapsed
+// sample is genuine only after prior forward travel; preserve that proof until
+// stable geometry can hand the range to the dedicated tail owner.
+await act(async () => arbiter?.reset());
+Object.defineProperty(scrollElement, "clientHeight", { configurable: true, value: 363 });
+scrollExtent = 27_975;
+scrollElement.scrollTop = 25_000;
+rowElement.dataset.transcriptLastRow = "true";
+rowElement.getBoundingClientRect = () => rectAt(20);
+await act(async () => arbiter?.deliverScroll());
+await act(async () => arbiter?.setMode("manual", "test-collapsed-tail-rebound"));
+let collapsedTailNow = realDateNow();
+Date.now = () => collapsedTailNow;
+scrollWrites.length = 0;
+scrollByCalls = 0;
+await act(async () => arbiter?.onWheelIntent({
+  ctrlKey: false,
+  deltaMode: 0,
+  deltaX: 0,
+  deltaY: 120,
+  target: scrollElement,
+} as React.WheelEvent<HTMLElement>));
+scrollElement.scrollTop = 25_804.67;
+scrollExtent = 26_168;
+await act(async () => arbiter?.deliverScroll());
+// The first collapsed delivery accepts the 804px native travel; the second
+// records that this moving gesture reached the temporary physical tail.
+await act(async () => arbiter?.deliverScroll());
+scrollExtent = 27_976;
+delete rowElement.dataset.transcriptLastRow;
+await act(async () => arbiter?.followGrowingTail("items-rendered"));
+collapsedTailNow += 181;
+for (let frame = 0; frame < 4; frame += 1) await flushFrames();
+check(String(arbiter?.modeRef.current) === "tail-follow",
+  "a proven collapsed-tail sample survives the 1,446px extent rebound");
+check(
+  scrollWrites.filter((write) => write.owner === "reader-stability" || write.owner === "anchor-compensation").length === 0
+    && scrollByCalls === 0,
+  "collapsed-tail handoff does not restore arbitrary reader or anchor corrections",
+);
+await act(async () => arbiter?.followGrowingTail("data-change"));
+for (let frame = 0; frame < 4; frame += 1) await flushFrames();
+check(Math.abs(scrollElement.scrollTop - (scrollExtent - scrollElement.clientHeight)) <= 1,
+  "the existing tail owner converges on the restored physical bottom");
+Date.now = realDateNow;
+Object.defineProperty(scrollElement, "clientHeight", { configurable: true, value: 725 });
 
 // A large extent contraction is transient for its first painted sample and is
 // accepted only after two consecutive stable frames.

--- a/desktop/frontend/src/__tests__/transcript-reader-extent-stability.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-reader-extent-stability.test.ts
@@ -11,6 +11,7 @@ import {
   transcriptReaderIdleDeadlineReached,
   transcriptReaderTransactionCanReuse,
   transcriptReaderExtentCanCorrect,
+  transcriptViewportCorrectionIsSafe,
 } from "../lib/transcriptReaderExtentStability";
 
 console.log("\ntranscript reader extent stability");
@@ -20,6 +21,10 @@ assert.equal(transcriptReaderIdleDeadlineReached(1_000, 1_180), true, "180ms ent
 assert.equal(transcriptReaderIdleDeadlineReached(1_000, 1_181), true, "181ms remains past the idle boundary");
 assert.equal(transcriptReaderTransactionCanReuse(1, 12), true, "same-direction wheel input reuses one transaction");
 assert.equal(transcriptReaderTransactionCanReuse(1, -1), false, "direction changes create a new ownership transaction");
+assert.equal(transcriptViewportCorrectionIsSafe(-1_400, 363), true,
+  "a bounded correction inside four viewports remains eligible");
+assert.equal(transcriptViewportCorrectionIsSafe(-5_554, 363), false,
+  "a many-viewport field correction rebases instead of jumping backwards");
 
 const reported = createTranscriptReaderExtentGuard(
   { scrollTop: 14_567.47, scrollHeight: 15_829, clientHeight: 725 },

--- a/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
@@ -6,6 +6,9 @@ import type { StateSnapshot, VirtuosoHandle } from "react-virtuoso";
 import { useTranscriptScrollArbiter, type TranscriptRecoveryTerminal } from "../lib/useTranscriptScrollArbiter";
 import { useTranscriptLayoutIntegrity } from "../lib/useTranscriptLayoutIntegrity";
 import { createTranscriptMeasuredSizes } from "../lib/transcriptMeasuredSizes";
+import {
+  TRANSCRIPT_STATIC_WINDOW_ROW_LIMIT,
+} from "../lib/transcriptReaderMountPolicy";
 import type { TranscriptScrollWriteRecord } from "../lib/transcriptScrollProbe";
 import { buildTranscriptRows, buildTurnModels, EMPTY_FOLDS, transcriptRowMeasurementVersion, type TranscriptRow } from "../lib/transcriptRows";
 import type { Item } from "../lib/useController";
@@ -26,6 +29,15 @@ function check(condition: unknown, label: string) {
 }
 
 console.log("\ntranscript recovery races");
+
+check(
+  TRANSCRIPT_STATIC_WINDOW_ROW_LIMIT >= 653,
+  "the field-reproduced 653-row transcript remains in the stable mounted window",
+);
+check(
+  TRANSCRIPT_STATIC_WINDOW_ROW_LIMIT === 1_000,
+  "larger transcripts retain a bounded virtualization cutoff",
+);
 
 const { dom, flushFrames } = installTranscriptRecoveryRaceDom();
 

--- a/desktop/frontend/src/__tests__/transcript-virtualization.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-virtualization.test.tsx
@@ -1,8 +1,8 @@
 // Run: tsx src/__tests__/transcript-virtualization.test.tsx
 //
-// Block-level DOM virtualization of the transcript:
-// - a small viewport mounts only the visible rows + overscan (offscreen rows
-//   create no Markdown/ToolCard subtrees),
+// Stable-window and block-level DOM virtualization of the transcript:
+// - moderate transcripts stay fully mounted to prevent range-replacement
+//   scroll jitter; sessions beyond the policy cutoff retain virtualization,
 // - prepending an older-history page keeps the reading position (key-anchored
 //   compensation),
 // - the active turn streams in the pinned live region outside the list:
@@ -104,8 +104,9 @@ function firstTextNode(root: Node): Text | null {
     const container = harness.container;
     const mountedRows = container.querySelectorAll(".transcript__row").length;
     const mountedAnswers = container.querySelectorAll(".msg--assistant").length;
-    ok(mountedRows > 0 && mountedRows <= 24, `small viewport mounts only a window of rows (mounted ${mountedRows} of 90)`);
-    ok(mountedAnswers > 0 && mountedAnswers < 30, `offscreen answers mount no Markdown subtree (mounted ${mountedAnswers} of 30)`);
+    ok(harness.scrollElement().dataset.transcriptStaticWindow === "true", "moderate transcripts opt into the stable mounted window");
+    ok(mountedRows === 90, `stable window mounts every transcript row (mounted ${mountedRows} of 90)`);
+    ok(mountedAnswers === 30, `stable window keeps every answer subtree mounted (mounted ${mountedAnswers} of 30)`);
     ok(harness.scrollElement().scrollHeight > 2000, "Virtuoso exposes the full virtual height to the transcript scrollbar");
   } finally {
     await harness.unmount();
@@ -409,13 +410,13 @@ function firstTextNode(root: Node): Text | null {
       document.dispatchEvent(new Event("selectionchange"));
       await harness.flush();
       const storeModule = await harness.loadModule<typeof import("../lib/transcriptSelectionStore")>("/src/lib/transcriptSelectionStore.ts");
-      ok(storeModule.transcriptSelectionStore.getSnapshot().mode === "logical-dragging", "cross-row selection promotes before virtualization can unmount its anchor");
+      ok(storeModule.transcriptSelectionStore.getSnapshot().mode === "logical-dragging", "cross-row selection promotes before the viewport moves away from its anchor");
 
       el.scrollTop = 6000;
       dispatchScroll(el);
       await harness.flush();
-      ok(harness.container.querySelectorAll(".transcript__row").length <= 30, "logical selection keeps the transcript windowed across virtual pages");
-      ok(storeModule.transcriptSelectionStore.getSnapshot().mode === "logical-dragging", "logical selection survives its native anchor row unmounting");
+      ok(harness.container.querySelectorAll(".transcript__row").length === 90, "logical selection keeps the moderate transcript in its stable window");
+      ok(storeModule.transcriptSelectionStore.getSnapshot().mode === "logical-dragging", "logical selection survives scrolling its native anchor row offscreen");
 
       document.dispatchEvent(new MouseEvent("pointerup", { bubbles: true, button: 0 }));
       await harness.flush();

--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -108,6 +108,10 @@ ok(
   "virtual transcript rows do not measure markdown through 72px placeholders",
 );
 ok(
+  /\.transcript\[data-transcript-static-window="true"\][^{]*data-transcript-geometry-pending\][^{]*\{[^}]*height:\s*auto;[^}]*overflow:\s*visible;/.test(styles),
+  "static transcript baseline uses the pending Markdown fallback's natural height",
+);
+ok(
   hasDeclaration(".transcript__row .msg", "content-visibility", "visible") &&
     hasDeclaration(".transcript__row .turn-collapse", "content-visibility", "visible"),
   "virtual transcript cards stay measurable after the markdown override",

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -65,6 +65,9 @@ import { useTranscriptQuestionJump, useTranscriptQuestions } from "../lib/useTra
 import { useTranscriptHistoryAutoFill, useTranscriptPagingAuthorization, useTranscriptSurfaceCommit } from "../lib/useTranscriptNavigationSurface";
 import { useTranscriptGeometryLifecycle } from "../lib/useTranscriptGeometryLifecycle";
 import {
+  TRANSCRIPT_STATIC_WINDOW_ROW_LIMIT,
+} from "../lib/transcriptReaderMountPolicy";
+import {
   LiveAssistantMessage,
   SHOW_SCROLL_DIAGNOSTICS,
   TRANSCRIPT_VIRTUOSO_COMPONENTS,
@@ -856,6 +859,7 @@ export function Transcript({
   const readerMountCorridorRows = readerTransactionActive && virtualRows.length <= TRANSCRIPT_READER_FULL_MOUNT_ROW_LIMIT
     ? Math.max(READER_MOUNT_CORRIDOR_ROWS, virtualRows.length)
     : READER_MOUNT_CORRIDOR_ROWS;
+  const staticWindow = virtualRows.length <= TRANSCRIPT_STATIC_WINDOW_ROW_LIMIT;
   const { handleItemsRendered, handleTotalListHeightChanged } = useTranscriptGeometryLifecycle({
     virtualRowCount: virtualRows.length, hydrating, readerTransactionActive, historyMutation, historyPrependLease, scrollModeRef,
     followGrowingTail, revalidateTail,
@@ -956,6 +960,7 @@ export function Transcript({
             className={`transcript${creationMode ? " transcript--creation-scrollbar" : ""}${creationMode && creationScrollbar.hot ? " transcript--scrollbar-hot" : ""}`}
             data-transcript-hydrating={hydrating ? "true" : "false"}
             data-transcript-reader-layout-lease={readerTransactionActive ? "true" : "false"}
+            data-transcript-static-window={staticWindow ? "true" : undefined}
             data-transcript-row-count={virtualRows.length}
             data-transcript-estimated-total={estimatedTotalHeight}
             data-transcript-reset-key={virtuosoResetKey}
@@ -980,10 +985,14 @@ export function Transcript({
             atBottomStateChange={atBottomStateChange}
             heightEstimates={heightEstimates}
             itemSize={itemSize}
-            minOverscanItemCount={layoutSafeMode || readerTransactionActive
+            minOverscanItemCount={staticWindow
+              ? { top: virtualRows.length, bottom: virtualRows.length }
+              : layoutSafeMode || readerTransactionActive
               ? { top: readerMountCorridorRows, bottom: readerMountCorridorRows }
               : { top: VIRTUAL_OVERSCAN_ROWS, bottom: VIRTUAL_OVERSCAN_ROWS }}
-            increaseViewportBy={layoutSafeMode || readerTransactionActive
+            increaseViewportBy={staticWindow
+              ? { top: estimatedTotalHeight, bottom: estimatedTotalHeight }
+              : layoutSafeMode || readerTransactionActive
               ? {
                   top: (scrollElement?.clientHeight ?? 0) * READER_MOUNT_CORRIDOR_VIEWPORTS,
                   bottom: (scrollElement?.clientHeight ?? 0) * READER_MOUNT_CORRIDOR_VIEWPORTS,

--- a/desktop/frontend/src/lib/transcriptAnchorCompensation.ts
+++ b/desktop/frontend/src/lib/transcriptAnchorCompensation.ts
@@ -8,7 +8,7 @@ import {
   captureVisibleTranscriptLayoutAnchor,
   type TranscriptLayoutAnchor,
 } from "./transcriptVirtuosoRecovery";
-import { MIN_REVERSE_JUMP_PX } from "./transcriptReaderExtentStability";
+import { MIN_REVERSE_JUMP_PX, TRANSCRIPT_MANUAL_STABILITY_CORRECTIONS, transcriptViewportCorrectionIsSafe } from "./transcriptReaderExtentStability";
 
 // Fractional row metrics can shift by 1-2px while Virtuoso's estimate tree is
 // converging during ordinary traversal. Treat that as layout noise so a
@@ -123,6 +123,7 @@ export function createTranscriptAnchorCompensation({
   };
 
   const schedule = () => {
+    if (!TRANSCRIPT_MANUAL_STABILITY_CORRECTIONS) return;
     const element = scrollRef.current;
     if (!element) return;
     if (modeRef.current !== "manual") return;
@@ -181,9 +182,20 @@ export function createTranscriptAnchorCompensation({
         return;
       }
       if (Math.abs(correction) > ANCHOR_COMPENSATION_TOLERANCE_PX) {
+        if (!transcriptViewportCorrectionIsSafe(correction, current.clientHeight)) {
+          clearVisualGuard(compensation);
+          active = null;
+          anchor = captureVisibleTranscriptLayoutAnchor(current) ?? null;
+          return;
+        }
         compensation.stableFrames = 0;
         dispatch({ type: "SCROLL_TO_OFFSET", owner: "anchor-compensation", top: current.scrollTop + correction, behavior: "auto" });
         clearVisualGuard(compensation);
+        // One geometry transaction receives one physical correction. A later
+        // scroll delivery or geometry revision must establish a fresh anchor
+        // before another transaction can write.
+        active = null;
+        return;
       } else {
         clearVisualGuard(compensation);
         compensation.stableFrames += 1;
@@ -203,10 +215,12 @@ export function createTranscriptAnchorCompensation({
       schedule();
       return;
     }
-    if (event.type === "SCROLL_DELIVERED") {
+    if (event.type === "SCROLL_DELIVERED" || event.type === "NATIVE_SCROLLBAR_END") {
       const element = scrollRef.current;
       // Scroll deliveries caused by a geometry commit must not replace the
-      // reader transaction's last accepted logical anchor.
+      // reader transaction's last accepted logical anchor. Native-thumb
+      // deliveries cannot sample in native-thumb mode, so its end event
+      // rebases the anchor after the reducer publishes manual mode.
       if (element && !readerExtentIsActive()) sample(element);
       return;
     }

--- a/desktop/frontend/src/lib/transcriptReaderExtentStability.ts
+++ b/desktop/frontend/src/lib/transcriptReaderExtentStability.ts
@@ -7,6 +7,15 @@ import type { TranscriptScrollEvent } from "./transcriptScrollArbiter";
 export const MIN_REVERSE_JUMP_PX = 96;
 export const TRANSCRIPT_READER_IDLE_MS = 180;
 export const TRANSCRIPT_READER_SETTLE_MS = 1_000;
+export const TRANSCRIPT_VIEWPORT_CORRECTION_LIMIT = 4;
+export const TRANSCRIPT_MANUAL_STABILITY_CORRECTIONS = typeof __BUILD_COMMIT__ === "undefined"
+  || !__BUILD_COMMIT__.includes("native-scroll-ab");
+
+export function transcriptViewportCorrectionIsSafe(correction: number, clientHeight: number): boolean {
+  return Number.isFinite(correction)
+    && clientHeight > 0
+    && Math.abs(correction) <= clientHeight * TRANSCRIPT_VIEWPORT_CORRECTION_LIMIT;
+}
 
 export function transcriptReaderIdleDeadlineReached(startedAt: number, now: number): boolean {
   return now - startedAt >= TRANSCRIPT_READER_IDLE_MS;

--- a/desktop/frontend/src/lib/transcriptReaderMountPolicy.ts
+++ b/desktop/frontend/src/lib/transcriptReaderMountPolicy.ts
@@ -1,0 +1,5 @@
+// Keep moderately sized transcripts mounted as one stable window. Replacing
+// non-overlapping Virtuoso ranges while Markdown heights settle can otherwise
+// move the native scroll extent underneath an active reading gesture.
+// Larger sessions retain the bounded reader corridor to cap DOM growth.
+export const TRANSCRIPT_STATIC_WINDOW_ROW_LIMIT = 1_000;

--- a/desktop/frontend/src/lib/useTranscriptReaderExtentStability.ts
+++ b/desktop/frontend/src/lib/useTranscriptReaderExtentStability.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import type { TranscriptScrollMode } from "./transcriptScrollArbiter";
-import { MIN_REVERSE_JUMP_PX, TRANSCRIPT_READER_IDLE_MS, TRANSCRIPT_READER_SETTLE_MS, transcriptReaderDirection } from "./transcriptReaderExtentStability";
+import { MIN_REVERSE_JUMP_PX, TRANSCRIPT_MANUAL_STABILITY_CORRECTIONS, TRANSCRIPT_READER_IDLE_MS, TRANSCRIPT_READER_SETTLE_MS, transcriptReaderDirection, transcriptViewportCorrectionIsSafe } from "./transcriptReaderExtentStability";
 import { nativeTranscriptBottomTop, nativeTranscriptDistanceFromBottom, TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX } from "./transcriptScrollGeometry";
 import { recordTranscriptScrollDiagnostic, type TranscriptScrollWriteRecord } from "./transcriptScrollProbe";
 import { transcriptElementViewportIsBlank } from "./transcriptVirtuosoRecovery";
@@ -40,6 +40,11 @@ type ActiveReaderTransaction = TranscriptReaderTransaction & {
    *  proof that the reader genuinely navigated this range; a collapse clamp
    *  or in-place wheel at a fabricated bottom adds nothing. */
   directionalTravelPx: number;
+  /** A downward gesture with real native travel reached the physical tail
+   *  while Virtuoso was publishing a collapsed extent. Preserve that proof
+   *  across the later size-tree rebound so the existing tail owner can finish
+   *  the navigation without restoring arbitrary reader corrections. */
+  reachedCollapsedTailWithForwardProgress: boolean;
   anchorDisplacementObserved: boolean;
   transientCandidateHeight: number;
   transientStableFrames: number;
@@ -241,6 +246,25 @@ export function useTranscriptReaderExtentStability({
     const rejected = (extentCollapsed && reverse >= threshold) || anchorDisplaced;
     const remainsCollapsed = extentCollapsed
       && element.scrollHeight < transaction.baselineHeight - Math.max(8, element.clientHeight * 0.5);
+    if (
+      !transaction.reachedCollapsedTailWithForwardProgress
+      &&
+      transaction.direction > 0
+      && transaction.canClaimTail
+      && transaction.directionalTravelPx >= MIN_REVERSE_JUMP_PX
+      && extentCollapsed
+      && nativeTranscriptDistanceFromBottom(element) <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX
+      && tailNodesMounted(element)
+    ) {
+      transaction.reachedCollapsedTailWithForwardProgress = true;
+      recordTranscriptScrollDiagnostic("reader-transaction", {
+        transactionId: transaction.id,
+        ownershipEpoch: transaction.ownershipEpoch,
+        direction: transaction.direction,
+        phase: transaction.phase,
+        result: "collapsed-tail-reached",
+      });
+    }
     if (remainsCollapsed) {
       if (Math.abs(element.scrollHeight - transaction.transientCandidateHeight) <= GEOMETRY_EPSILON_PX) {
         transaction.transientStableFrames += 1;
@@ -263,11 +287,13 @@ export function useTranscriptReaderExtentStability({
           Date.now() + POST_CORRECTION_SETTLE_MS,
         );
       }
-      if (anchorRow && transaction.anchor) {
-        // DOM geometry includes the transform already applied by a previous
-        // observation. Subtract it before deriving the next absolute guard so
-        // repeated scroll events cannot compound the visual compensation.
-        transaction.visualOffset = -physicalAnchorDrift;
+      if (TRANSCRIPT_MANUAL_STABILITY_CORRECTIONS && anchorRow && transaction.anchor) {
+        // Freeze the first pre-paint guard until it is committed or cleared.
+        // WebView2 can deliver several geometry observations before the list
+        // transform reaches getBoundingClientRect(); recomputing in that gap
+        // subtracts the unapplied guard repeatedly and amplifies one drift on
+        // every callback.
+        transaction.visualOffset ||= -physicalAnchorDrift;
         element.dataset.transcriptReaderVisualGuard = "true";
         element.style.setProperty("--transcript-reader-visual-offset", `${transaction.visualOffset}px`);
       }
@@ -283,7 +309,8 @@ export function useTranscriptReaderExtentStability({
       // the single correction budget synchronously before paint; the tick's
       // prepaint lane shares the same budget as the covered-frame fallback.
       if (
-        !transaction.correctionWritten
+        TRANSCRIPT_MANUAL_STABILITY_CORRECTIONS
+        && !transaction.correctionWritten
         && transaction.collapseObserved
         && !transaction.transient
         && reverse >= threshold
@@ -407,7 +434,8 @@ export function useTranscriptReaderExtentStability({
       // A recovered extent or a row-only displacement remains immediately
       // correctable, so ordinary measurement drift does not linger onscreen.
       if (
-        !geometryCommitBlockedRef.current
+        TRANSCRIPT_MANUAL_STABILITY_CORRECTIONS
+        && !geometryCommitBlockedRef.current
         && !transaction.correctionWritten
         && correctionReady
         && (!extentStillCollapsed || !beforeIdleDeadline)
@@ -455,7 +483,19 @@ export function useTranscriptReaderExtentStability({
           ? element.scrollTop + anchorRow.getBoundingClientRect().top - transaction.visualOffset - viewportTop - transaction.anchor.offset
           : transaction.expectedTop;
         const correction = Math.max(0, Math.min(nativeTranscriptBottomTop(element), targetTop)) - element.scrollTop;
-        if ((transaction.mountAnchorWritten ? Math.abs(correction) : transaction.direction * correction) > 1) {
+        if (!stableAnchorRequiredRef.current && !transcriptViewportCorrectionIsSafe(correction, element.clientHeight)) {
+          // A many-viewport correction is a replaced virtual range, not a
+          // trustworthy continuation of the old screen anchor. Rebase on the
+          // content the reader can actually see instead of jumping backwards.
+          transaction.correctionWritten = true;
+          transaction.anchor = captureLogicalAnchor(element) ?? transaction.anchor;
+          transaction.lastAcceptedTop = element.scrollTop;
+          transaction.baselineHeight = element.scrollHeight;
+          transaction.minimumHeight = element.scrollHeight;
+          transaction.collapseObserved = false;
+          transaction.anchorDisplacementObserved = false;
+          clearVisualGuard(transaction);
+        } else if ((transaction.mountAnchorWritten ? Math.abs(correction) : transaction.direction * correction) > 1) {
           correctionWrittenThisFrame = writeCorrection({
             owner: "reader-stability",
             kind: "scrollBy",
@@ -505,8 +545,11 @@ export function useTranscriptReaderExtentStability({
         && !transaction.transient
         && (!transaction.collapseObserved
           || element.scrollHeight >= transaction.baselineHeight - collapseThreshold(element))
-        && bottomDistance <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX
-        && tailNodesMounted(element);
+        && ((bottomDistance <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX && tailNodesMounted(element))
+          // The collapsed sample already proved that the real tail nodes were
+          // mounted. Virtuoso may unmount them during the rebound itself; the
+          // dedicated tail owner is responsible for mounting LAST again.
+          || transaction.reachedCollapsedTailWithForwardProgress);
       callbacksRef.current.onStabilitySample(transaction, stable, tailEligible);
       transaction.lastGeometryRevision = revision;
       transaction.lastHeight = element.scrollHeight;
@@ -662,6 +705,9 @@ export function useTranscriptReaderExtentStability({
       // A follow-up epoch of one continuous same-direction gesture keeps the
       // travel proof the gesture already earned; a fresh gesture starts at 0.
       directionalTravelPx: inheritsGesture ? current.directionalTravelPx : 0,
+      reachedCollapsedTailWithForwardProgress: inheritsGesture
+        ? current.reachedCollapsedTailWithForwardProgress
+        : false,
       anchorDisplacementObserved: false,
       transientCandidateHeight: element.scrollHeight,
       transientStableFrames: 0,

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -717,6 +717,14 @@ export function useTranscriptScrollArbiter({
       releaseTailFollow(delta.y > 0, delta.y);
       return true;
     }
+    // Once the reader has explicitly handed ownership to the physical tail,
+    // another downward wheel has nowhere meaningful to navigate. Letting the
+    // browser consume it makes Virtuoso replace its measured tail range with
+    // transient estimates (field trace: 41k -> 35k -> 57k -> 41k), producing
+    // a large native clamp/rebound even though no application writer ran.
+    // Keep tail ownership and suppress that redundant native input; upward
+    // input still takes manual ownership through the branch above.
+    event.preventDefault();
     return false;
   }, [releaseTailFollow, restoreTailIfNotScrollable]);
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3646,6 +3646,15 @@ a[href] {
   height: max(0px, calc(var(--transcript-row-estimate) - 32px));
   overflow: hidden;
 }
+/* The static-window architecture baseline keeps the actual row mounted, so a
+   virtual size-tree placeholder only creates a visible blank band while the
+   Markdown worker catches up. Let its readable plain-text fallback own the
+   natural height; the production virtual path keeps the estimate above. */
+.transcript[data-transcript-static-window="true"]
+  .transcript__row .msg--assistant .msg__body > .md[data-transcript-geometry-pending] {
+  height: auto;
+  overflow: visible;
+}
 /* Offscreen rows are unmounted by the virtualizer, so content-visibility
 /* Offscreen rows are unmounted by the virtualizer, so content-visibility
    culling is redundant inside rows — and skipping it keeps offsetHeight


### PR DESCRIPTION
## Summary

- keep transcripts up to 1,000 loaded rows in one stable mounted window, avoiding Virtuoso range replacement while Markdown geometry settles
- retain bounded virtualization for larger sessions and preserve the latest history-prepend lease behavior
- use natural height for pending Markdown in static-window mode to prevent estimated-height gaps
- bound reader corrections, preserve collapsed-tail progress, and keep stable-key prepend correction authoritative

## Why

Field diagnostics showed scroll jitter aligned with virtual range replacement and stale row-height estimates. A static-window A/B build removed the jitter, while the pending Markdown fallback initially exposed large estimated-height gaps. The natural-height override removed those gaps in the validated build.

## Validation

- corepack pnpm test:transcript
- ESLint hooks
- TypeScript (	sc --noEmit)
- single-scroll-writer contract
- WAAPI, CSS syntax, z-index, and theme-token checks
- Vite production build
- bundle-budget checks

Cache-impact: none

Cache-guard: not applicable; desktop-only transcript path

Documentation-impact: none - this change only fixes transcript scrolling behavior; existing documentation remains correct