### PR TITLE
feat(acp): handle /clear in ACP sessions, skipping confirmation in YOLO mode / ACP 会话内支持 /clear，YOLO 模式跳过确认

### DIFF
--- a/docs/ACP.md
+++ b/docs/ACP.md
@@ -170,6 +170,13 @@ Hosts should keep the `session/prompt` request open until Reasonix returns its
 stop reason, while continuing to process requests and notifications in both
 directions.
 
+A prompt of `/clear` clears the current session in place (a fresh transcript,
+same session id), matching the CLI's `/clear`. When the session's tool-approval
+mode is Yolo the clear happens immediately; in Ask, Auto, and Plan modes
+Reasonix first asks the client with a `session/request_permission` round-trip
+whose `Clear the session` option confirms the clear and `Cancel` aborts it.
+The command is advertised in `available_commands_update` as `clear`.
+
 Reasonix emits only ACP v1 stop reasons. A completed turn that still needs a
 final-readiness check sends a `[warning]` message chunk and returns `end_turn`;
 its vendor status remains `readiness_paused` so the host can offer recovery.

--- a/docs/ACP.zh-CN.md
+++ b/docs/ACP.zh-CN.md
@@ -154,6 +154,11 @@ Reasonix 把互不相关的选择拆成独立控制轴，而不是混在一个 m
 Host 应让 `session/prompt` 请求保持打开，直到 Reasonix 返回停止原因；期间仍需同时处理
 双向 request 和 notification。
 
+提交 `/clear` 会在原地清空当前会话（新 transcript、同一 session id），与 CLI 的
+`/clear` 一致。当会话的工具审批模式为 Yolo 时立即清空；Ask、Auto 与 Plan 模式下，
+Reasonix 会先通过 `session/request_permission` 往返询问客户端，选择 `Clear the session`
+确认清空，`Cancel` 则中止。该命令会以 `clear` 出现在 `available_commands_update` 中。
+
 Reasonix 只会返回 ACP v1 规定的停止原因。工作已完成但仍需 final-readiness 检查时，
 agent 会发送带 `[warning]` 的消息 chunk 并返回 `end_turn`；厂商状态仍保持
 `readiness_paused`，便于 host 提供恢复入口。客户端取消始终返回 `cancelled`，即使被中断

--- a/docs/TOOL_APPROVAL_MODES.md
+++ b/docs/TOOL_APPROVAL_MODES.md
@@ -90,9 +90,12 @@ requirement and explicit interactive memory `ask` rules. Auto also skips the
 default memory fallback prompt, but preserves explicit `ask` rules. Neither mode
 bypasses explicit `deny` rules, the sandbox, plan confirmation, or managed config writes.
 
-Because Yolo already opts out of confirmations, the CLI `/clear` command clears
+Because Yolo already opts out of confirmations, the `/clear` command clears
 the session immediately in Yolo mode instead of opening its confirmation
-overlay; Ask, Auto, and Plan keep the confirmation.
+overlay; Ask, Auto, and Plan keep the confirmation. This applies to the CLI
+composer and to ACP sessions (`reasonix acp`): ACP asks the host through a
+`session/request_permission` round-trip in non-Yolo modes and clears directly
+in Yolo mode.
 
 ### How to enable
 

--- a/docs/TOOL_APPROVAL_MODES.zh-CN.md
+++ b/docs/TOOL_APPROVAL_MODES.zh-CN.md
@@ -106,7 +106,7 @@ Yolo 模式用于最大化连续执行。开启后，普通工具审批会被跳
 
 Yolo 是唯一可以绕过嵌套/间接 Bash 人工审批要求的工具权限姿态；显式 `deny` 与 Sandbox 仍然生效。
 
-因为 Yolo 本就承诺跳过确认，CLI 的 `/clear` 命令在 Yolo 模式下会直接清空会话，不再弹出确认覆盖层；Ask、Auto 与 Plan 模式保留确认。
+因为 Yolo 本就承诺跳过确认，`/clear` 命令在 Yolo 模式下会直接清空会话，不再弹出确认覆盖层；Ask、Auto 与 Plan 模式保留确认。此行为同时适用于 CLI 输入框与 ACP 会话（`reasonix acp`）：ACP 在非 Yolo 模式下通过 `session/request_permission` 往返询问 host，在 Yolo 模式下直接清空。
 
 ### 怎么开启
 

--- a/internal/acp/clear.go
+++ b/internal/acp/clear.go
@@ -1,0 +1,76 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"reasonix/internal/control"
+)
+
+// handleClearPrompt resolves the ACP /clear verb, mirroring the CLI's /clear
+// confirmation contract: YOLO mode clears immediately (the mode already opted
+// out of confirmations), every other approval mode asks the client through a
+// session/request_permission round-trip first. The turn path never reaches
+// submitCommandOrTurnReady, so the verb lives here instead of the controller.
+func (s *service) handleClearPrompt(ctx context.Context, sess *acpSession, text string) (bool, any, error) {
+	if strings.TrimSpace(text) != "/clear" {
+		return false, nil, nil
+	}
+	ctrl := sess.currentCtrl()
+	if ctrl == nil {
+		return true, nil, &RPCError{Code: ErrInternal, Message: "session/prompt: no active controller for /clear"}
+	}
+	if ctrl.ToolApprovalMode() != control.ToolApprovalYolo {
+		approved, err := s.confirmSessionClear(ctx, sess)
+		if err != nil {
+			return true, nil, &RPCError{Code: ErrInternal, Message: "session/prompt: clear confirmation failed: " + err.Error()}
+		}
+		if !approved {
+			return true, clearPromptResult(sess), nil
+		}
+	}
+	if err := ctrl.ClearSession(); err != nil {
+		return true, nil, &RPCError{Code: ErrInternal, Message: "session/prompt: clear failed: " + err.Error()}
+	}
+	sess.transcript = ctrl.SessionPath()
+	return true, clearPromptResult(sess), nil
+}
+
+// clearPromptResult is the successful /clear prompt response, carrying the
+// (rotated) transcript path exactly like the ordinary end_turn path does.
+func clearPromptResult(sess *acpSession) *SessionPromptResult {
+	res := &SessionPromptResult{StopReason: StopEndTurn}
+	if sess.transcript != "" {
+		res.TranscriptPath = &sess.transcript
+	}
+	return res
+}
+
+// confirmSessionClear asks the client whether the current session may be
+// cleared. It reuses the tool-approval round-trip because ACP v1 has no
+// dedicated in-place clear; clients already render session/request_permission.
+func (s *service) confirmSessionClear(ctx context.Context, sess *acpSession) (bool, error) {
+	params := PermissionRequestParams{
+		SessionID: sess.id,
+		ToolCall: PermissionToolCall{
+			ToolCallID: "clear-" + sess.id,
+			Title:      "Clear the current session?",
+			Kind:       "other",
+			Status:     "pending",
+		},
+		Options: []PermissionOption{
+			{OptionID: "reasonix_clear_confirm", Name: "Clear the session", Kind: OptAllowOnce},
+			{OptionID: "reasonix_clear_cancel", Name: "Cancel", Kind: OptRejectOnce},
+		},
+	}
+	raw, err := s.conn.Request(ctx, "session/request_permission", params)
+	if err != nil {
+		return false, err
+	}
+	var res PermissionRequestResult
+	if json.Unmarshal(raw, &res) != nil || res.Outcome.Outcome != "selected" {
+		return false, nil
+	}
+	return res.Outcome.OptionID == "reasonix_clear_confirm", nil
+}

--- a/internal/acp/clear_e2e_test.go
+++ b/internal/acp/clear_e2e_test.go
@@ -1,0 +1,178 @@
+package acp
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"reasonix/internal/control"
+	"reasonix/internal/permission"
+	"reasonix/internal/provider"
+)
+
+// clearTurnPath runs one prompt and returns its transcript path; a helper for
+// the /clear e2e tests.
+func clearTurnPath(t *testing.T, client *rpcClient, sid, text string) string {
+	t.Helper()
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: sid,
+		Prompt:    []ContentBlock{{Type: "text", Text: text}},
+	})
+	_, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("prompt %q: %+v", text, resp.Error)
+	}
+	var result SessionPromptResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("prompt %q result: %v", text, err)
+	}
+	if result.StopReason != StopEndTurn {
+		t.Fatalf("prompt %q stopReason = %q, want end_turn", text, result.StopReason)
+	}
+	if result.TranscriptPath == nil {
+		t.Fatalf("prompt %q returned no transcriptPath", text)
+	}
+	return *result.TranscriptPath
+}
+
+func clearTestFactory(t *testing.T) *e2eFactory {
+	return &e2eFactory{
+		prov: &scriptedProvider{name: "fake", responses: [][]provider.Chunk{
+			{{Type: provider.ChunkText, Text: "hello"}, {Type: provider.ChunkDone}},
+		}},
+		tool:       fakeTool{name: "peek", ro: true, out: "ok"},
+		policy:     permission.New("ask", nil, nil, nil),
+		sessionDir: t.TempDir(),
+	}
+}
+
+// TestE2EClearAskModeAsksAndClearsOnConfirm pins the non-Yolo /clear contract:
+// the server round-trips a session/request_permission before clearing, and the
+// cleared session rotates to a fresh transcript path under the same session id.
+func TestE2EClearAskModeAsksAndClearsOnConfirm(t *testing.T) {
+	client, stop := startServer(t, clearTestFactory(t))
+	defer stop()
+
+	sid := openSession(t, client)
+	before := clearTurnPath(t, client, sid, "plain turn")
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: sid,
+		Prompt:    []ContentBlock{{Type: "text", Text: "/clear"}},
+	})
+	var req frame
+	select {
+	case req = <-client.reqs:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no clear confirmation was requested")
+	}
+	var pr PermissionRequestParams
+	if err := json.Unmarshal(req.Params, &pr); err != nil {
+		t.Fatalf("clear confirmation params: %v", err)
+	}
+	if pr.SessionID != sid {
+		t.Errorf("clear confirmation sessionId = %q, want %q", pr.SessionID, sid)
+	}
+	ids := map[string]bool{}
+	for _, o := range pr.Options {
+		ids[o.OptionID] = true
+	}
+	if !ids["reasonix_clear_confirm"] || !ids["reasonix_clear_cancel"] {
+		t.Errorf("clear confirmation options = %v, want confirm+cancel", pr.Options)
+	}
+	client.reply(req.ID, PermissionRequestResult{
+		Outcome: PermissionOutcome{Outcome: "selected", OptionID: "reasonix_clear_confirm"},
+	})
+
+	_, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("/clear: %+v", resp.Error)
+	}
+	var result SessionPromptResult
+	json.Unmarshal(resp.Result, &result)
+	if result.StopReason != StopEndTurn {
+		t.Errorf("/clear stopReason = %q, want end_turn", result.StopReason)
+	}
+	if result.TranscriptPath == nil || *result.TranscriptPath == before {
+		t.Errorf("/clear transcriptPath = %v, want a fresh path != %q", result.TranscriptPath, before)
+	}
+	// The cleared session keeps its id and persists to the new path.
+	if after := clearTurnPath(t, client, sid, "after clear"); after != *result.TranscriptPath {
+		t.Errorf("post-clear transcriptPath = %q, want %q", after, *result.TranscriptPath)
+	}
+}
+
+// TestE2EClearAskModeCancelAborts pins that declining the confirmation leaves
+// the session and its transcript untouched.
+func TestE2EClearAskModeCancelAborts(t *testing.T) {
+	client, stop := startServer(t, clearTestFactory(t))
+	defer stop()
+
+	sid := openSession(t, client)
+	before := clearTurnPath(t, client, sid, "plain turn")
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: sid,
+		Prompt:    []ContentBlock{{Type: "text", Text: "/clear"}},
+	})
+	select {
+	case req := <-client.reqs:
+		client.reply(req.ID, PermissionRequestResult{
+			Outcome: PermissionOutcome{Outcome: "selected", OptionID: "reasonix_clear_cancel"},
+		})
+	case <-time.After(2 * time.Second):
+		t.Fatal("no clear confirmation was requested")
+	}
+	_, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("/clear: %+v", resp.Error)
+	}
+	var result SessionPromptResult
+	json.Unmarshal(resp.Result, &result)
+	if result.StopReason != StopEndTurn {
+		t.Errorf("/clear stopReason = %q, want end_turn", result.StopReason)
+	}
+	if result.TranscriptPath == nil || *result.TranscriptPath != before {
+		t.Errorf("cancelled /clear transcriptPath = %v, want unchanged %q", result.TranscriptPath, before)
+	}
+}
+
+// TestE2EClearYoloModeSkipsConfirmation pins the Yolo fast path: /clear clears
+// immediately, without a session/request_permission round-trip.
+func TestE2EClearYoloModeSkipsConfirmation(t *testing.T) {
+	client, stop := startServer(t, clearTestFactory(t))
+	defer stop()
+
+	sid := openSession(t, client)
+	setResp := client.call(t, "session/set_config_option", SetSessionConfigOptionParams{
+		SessionID: sid,
+		ConfigID:  "tool_approval",
+		Value:     control.ToolApprovalYolo,
+	})
+	if setResp.Error != nil {
+		t.Fatalf("set tool_approval=yolo: %+v", setResp.Error)
+	}
+	before := clearTurnPath(t, client, sid, "plain turn")
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: sid,
+		Prompt:    []ContentBlock{{Type: "text", Text: "/clear"}},
+	})
+	_, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("/clear: %+v", resp.Error)
+	}
+	var result SessionPromptResult
+	json.Unmarshal(resp.Result, &result)
+	if result.StopReason != StopEndTurn {
+		t.Errorf("/clear stopReason = %q, want end_turn", result.StopReason)
+	}
+	if result.TranscriptPath == nil || *result.TranscriptPath == before {
+		t.Errorf("/clear transcriptPath = %v, want a fresh path != %q", result.TranscriptPath, before)
+	}
+	select {
+	case req := <-client.reqs:
+		t.Fatalf("Yolo /clear must not ask the client, got request %q", req.Method)
+	default:
+	}
+}

--- a/internal/acp/commands.go
+++ b/internal/acp/commands.go
@@ -1,0 +1,99 @@
+package acp
+
+import (
+	"sort"
+	"strings"
+)
+
+// availableCommandsFor lists the slash commands a session advertises to the
+// client: custom commands, skills, MCP prompts, and extension actions, plus
+// the builtin /clear the ACP server handles itself.
+func availableCommandsFor(ctrl acpController) []AvailableCommand {
+	if ctrl == nil {
+		return nil
+	}
+	byName := map[string]AvailableCommand{}
+	for _, cmd := range ctrl.Commands() {
+		if cmd.Hidden {
+			continue
+		}
+		name := strings.TrimSpace(cmd.Name)
+		if name == "" {
+			continue
+		}
+		desc := strings.TrimSpace(cmd.Description)
+		if desc == "" {
+			desc = "Run the " + name + " command"
+		}
+		ac := AvailableCommand{Name: name, Description: desc}
+		if hint := strings.TrimSpace(cmd.ArgHint); hint != "" {
+			ac.Input = &AvailableCommandInput{Hint: hint}
+		}
+		byName[name] = ac
+	}
+	for _, sk := range ctrl.SlashSkills() {
+		name := strings.TrimSpace(sk.SlashName())
+		if name == "" {
+			continue
+		}
+		if _, exists := byName[name]; exists {
+			continue
+		}
+		desc := strings.TrimSpace(sk.Description)
+		if desc == "" {
+			desc = "Run the " + name + " skill"
+		}
+		byName[name] = AvailableCommand{
+			Name:        name,
+			Description: desc,
+			Input:       &AvailableCommandInput{Hint: "instructions"},
+		}
+	}
+	if host := ctrl.Host(); host != nil {
+		for _, prompt := range host.Prompts() {
+			name := strings.TrimSpace(prompt.Name)
+			if name == "" {
+				continue
+			}
+			desc := strings.TrimSpace(prompt.Description)
+			if desc == "" {
+				desc = "Run the " + name + " MCP prompt"
+			}
+			ac := AvailableCommand{Name: name, Description: desc}
+			if len(prompt.Args) > 0 {
+				ac.Input = &AvailableCommandInput{Hint: "arguments"}
+			}
+			byName[name] = ac
+		}
+	}
+	// Extension actions surface as "<plugin>:<action>" commands so ACP clients
+	// can discover them in the slash menu alongside commands/skills/prompts.
+	for _, action := range ctrl.ExtensionActions() {
+		name := strings.TrimPrefix(strings.TrimSpace(action.Slash), "/")
+		if name == "" {
+			continue
+		}
+		if _, exists := byName[name]; exists {
+			continue
+		}
+		desc := strings.TrimSpace(action.Label)
+		if desc == "" {
+			desc = "Run the " + name + " extension action"
+		}
+		byName[name] = AvailableCommand{
+			Name:        name,
+			Description: desc,
+			Input:       &AvailableCommandInput{Hint: "arguments"},
+		}
+	}
+	// /clear is a builtin the ACP server handles itself (handleClearPrompt), so
+	// advertise it like any other slash command; a custom command of the same
+	// name is shadowed, matching Submit's builtin-first precedence.
+	byName["clear"] = AvailableCommand{Name: "clear", Description: "Clear the current session"}
+	out := make([]AvailableCommand, 0, len(byName))
+	for _, cmd := range byName {
+		out = append(out, cmd)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/internal/acp/e2e_test.go
+++ b/internal/acp/e2e_test.go
@@ -92,14 +92,20 @@ func (f *e2eFactory) NewSession(_ context.Context, p SessionParams) (*control.Co
 	}
 	executor := agent.New(f.prov, reg, agent.NewSession("you are a test agent"),
 		opts, p.Sink)
-	return control.New(control.Options{
-		Runner:     executor,
-		Executor:   executor,
-		Sink:       p.Sink,
-		Policy:     f.policy,
-		Label:      "fake-model",
-		SessionDir: f.sessionDir,
-	}), nil
+	ctrl := control.New(control.Options{
+		Runner:       executor,
+		Executor:     executor,
+		Sink:         p.Sink,
+		Policy:       f.policy,
+		Label:        "fake-model",
+		SessionDir:   f.sessionDir,
+		SystemPrompt: "you are a test agent",
+	})
+	// The composition root wires these through boot.Options; the e2e factory
+	// must too, or path transitions (e.g. /clear) fail closed.
+	ctrl.SetOnSessionRecovered(p.OnSessionRecovered)
+	ctrl.SetOnSessionTransition(p.OnSessionTransition)
+	return ctrl, nil
 }
 
 func TestE2EExplicitMaxStepsReturnsSuccessfulPause(t *testing.T) {

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -1149,6 +1149,12 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 		recovery = true
 		text = prompt
 	} else {
+		// The builtin /clear verb is handled here, ahead of custom commands and
+		// skills (matching Submit's precedence), because the ACP turn path never
+		// reaches submitCommandOrTurnReady's verb dispatch.
+		if cleared, res, err := s.handleClearPrompt(ctx, sess, text); cleared {
+			return res, err
+		}
 		text = s.resolveSlashPrompt(ctx, sess, text)
 	}
 
@@ -2542,92 +2548,6 @@ func (s *service) sendAvailableCommands(sess *acpSession) {
 		SessionUpdate:     "available_commands_update",
 		AvailableCommands: cmds,
 	})
-}
-
-func availableCommandsFor(ctrl acpController) []AvailableCommand {
-	if ctrl == nil {
-		return nil
-	}
-	byName := map[string]AvailableCommand{}
-	for _, cmd := range ctrl.Commands() {
-		if cmd.Hidden {
-			continue
-		}
-		name := strings.TrimSpace(cmd.Name)
-		if name == "" {
-			continue
-		}
-		desc := strings.TrimSpace(cmd.Description)
-		if desc == "" {
-			desc = "Run the " + name + " command"
-		}
-		ac := AvailableCommand{Name: name, Description: desc}
-		if hint := strings.TrimSpace(cmd.ArgHint); hint != "" {
-			ac.Input = &AvailableCommandInput{Hint: hint}
-		}
-		byName[name] = ac
-	}
-	for _, sk := range ctrl.SlashSkills() {
-		name := strings.TrimSpace(sk.SlashName())
-		if name == "" {
-			continue
-		}
-		if _, exists := byName[name]; exists {
-			continue
-		}
-		desc := strings.TrimSpace(sk.Description)
-		if desc == "" {
-			desc = "Run the " + name + " skill"
-		}
-		byName[name] = AvailableCommand{
-			Name:        name,
-			Description: desc,
-			Input:       &AvailableCommandInput{Hint: "instructions"},
-		}
-	}
-	if host := ctrl.Host(); host != nil {
-		for _, prompt := range host.Prompts() {
-			name := strings.TrimSpace(prompt.Name)
-			if name == "" {
-				continue
-			}
-			desc := strings.TrimSpace(prompt.Description)
-			if desc == "" {
-				desc = "Run the " + name + " MCP prompt"
-			}
-			ac := AvailableCommand{Name: name, Description: desc}
-			if len(prompt.Args) > 0 {
-				ac.Input = &AvailableCommandInput{Hint: "arguments"}
-			}
-			byName[name] = ac
-		}
-	}
-	// Extension actions surface as "<plugin>:<action>" commands so ACP clients
-	// can discover them in the slash menu alongside commands/skills/prompts.
-	for _, action := range ctrl.ExtensionActions() {
-		name := strings.TrimPrefix(strings.TrimSpace(action.Slash), "/")
-		if name == "" {
-			continue
-		}
-		if _, exists := byName[name]; exists {
-			continue
-		}
-		desc := strings.TrimSpace(action.Label)
-		if desc == "" {
-			desc = "Run the " + name + " extension action"
-		}
-		byName[name] = AvailableCommand{
-			Name:        name,
-			Description: desc,
-			Input:       &AvailableCommandInput{Hint: "arguments"},
-		}
-	}
-	out := make([]AvailableCommand, 0, len(byName))
-	for _, cmd := range byName {
-		out = append(out, cmd)
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
-	return out
 }
 
 func (s *service) resolveSlashPrompt(ctx context.Context, sess *acpSession, text string) string {


### PR DESCRIPTION
Follow-up to #9488 (/clear + YOLO). The CLI got YOLO-mode confirmation skipping for `/clear`; `reasonix acp` never did — its turn path runs `RunTurn` directly and skips the controller's slash-verb dispatch, so `/clear` went to the model as plain text (agentic.nvim worked around this client-side by mapping `/clear` to its own new-session flow).

**Changes**
- `session/prompt` with text `/clear` now clears the session in place (fresh transcript, same session id), matching the CLI's `/clear`.
- YOLO tool-approval mode clears immediately — the same question-skipping behaviour as #9488.
- Ask, Auto, and Plan modes first ask the client via a `session/request_permission` round-trip (`Clear the session` / `Cancel`); declining leaves the session untouched.
- The verb is advertised in `available_commands_update` as `clear`, like any other slash command.
- Docs updated (ACP.md / ACP.zh-CN.md, TOOL_APPROVAL_MODES.md / zh-CN).

**Tests**
- `TestE2EClearAskModeAsksAndClearsOnConfirm` — permission round-trip, then clear + fresh transcript path under the same session id.
- `TestE2EClearAskModeCancelAborts` — declining keeps the session and path.
- `TestE2EClearYoloModeSkipsConfirmation` — clears without any client round-trip.

Verified: `go test ./internal/acp/`, `go test ./internal/cli/ ./internal/control/`, `go build ./...`, `go vet`, repolint clean.

With this, the agentic.nvim `/clear` interception kludge can be removed.
