### PR TITLE
feat(config): configurable review sub-agent step cap ([agent].review_max_steps) / review 类子代理步数上限可配置

### DIFF
--- a/internal/agent/subagent_context.go
+++ b/internal/agent/subagent_context.go
@@ -49,14 +49,18 @@ func ctxHasFacts(ctx ContextRequest) bool {
 		len(ctx.FileAnchors) > 0 || strings.TrimSpace(ctx.OutputFormat) != ""
 }
 
-func applyReviewBudget(spec *ProfileExecSpec) {
+func applyReviewBudget(spec *ProfileExecSpec, reviewMaxSteps int) {
 	if spec == nil {
 		return
 	}
 	switch strings.TrimSpace(spec.Worker.Profile) {
 	case "review", "security-review", "security_review", "team-architect":
 		if spec.Sched.MaxSteps <= 0 {
-			spec.Sched.MaxSteps = defaultReviewMaxSteps
+			if reviewMaxSteps > 0 {
+				spec.Sched.MaxSteps = reviewMaxSteps
+			} else {
+				spec.Sched.MaxSteps = defaultReviewMaxSteps
+			}
 		}
 		if spec.Sched.MaxOutputTokens <= 0 {
 			spec.Sched.MaxOutputTokens = defaultReviewOutputTokens
@@ -70,12 +74,14 @@ func applyReviewBudget(spec *ProfileExecSpec) {
 // PrepareReviewSubagentContext applies the same bounded review contract used
 // by task/profile delegation to built-in skill runners. The returned boolean
 // is false for non-review profiles so their existing budgets remain unchanged.
-func PrepareReviewSubagentContext(ctx context.Context, profile, objective string) (prompt string, maxSteps, maxOutputTokens int, ok bool) {
+// reviewMaxSteps > 0 overrides the built-in review step cap (see
+// [agent].review_max_steps); an explicit spec max_steps still wins.
+func PrepareReviewSubagentContext(ctx context.Context, profile, objective string, reviewMaxSteps int) (prompt string, maxSteps, maxOutputTokens int, ok bool) {
 	spec := ProfileExecSpec{
 		Task:   TaskSpec{Objective: objective},
 		Worker: WorkerSpec{Profile: profile},
 	}
-	applyReviewBudget(&spec)
+	applyReviewBudget(&spec, reviewMaxSteps)
 	if spec.Sched.MaxSteps == 0 && spec.Sched.MaxOutputTokens == 0 {
 		return objective, 0, 0, false
 	}

--- a/internal/agent/subagent_context_test.go
+++ b/internal/agent/subagent_context_test.go
@@ -28,9 +28,33 @@ func TestComposeChildTaskPromptUsesFactsPack(t *testing.T) {
 
 func TestApplyReviewBudgetDefaults(t *testing.T) {
 	spec := ProfileExecSpec{Worker: WorkerSpec{Profile: "review"}}
-	applyReviewBudget(&spec)
+	applyReviewBudget(&spec, 0)
 	if spec.Sched.MaxSteps != defaultReviewMaxSteps || spec.Sched.MaxOutputTokens != defaultReviewOutputTokens {
 		t.Fatalf("budget = %+v", spec.Sched)
+	}
+}
+
+func TestApplyReviewBudgetConfiguredOverride(t *testing.T) {
+	spec := ProfileExecSpec{Worker: WorkerSpec{Profile: "review"}}
+	applyReviewBudget(&spec, 24)
+	if spec.Sched.MaxSteps != 24 {
+		t.Fatalf("configured review max steps = %d, want 24", spec.Sched.MaxSteps)
+	}
+	if spec.Sched.MaxOutputTokens != defaultReviewOutputTokens {
+		t.Fatalf("output budget = %+v", spec.Sched)
+	}
+	// An explicit spec max_steps still wins over the configured override.
+	explicit := ProfileExecSpec{Worker: WorkerSpec{Profile: "review"}}
+	explicit.Sched.MaxSteps = 12
+	applyReviewBudget(&explicit, 24)
+	if explicit.Sched.MaxSteps != 12 {
+		t.Fatalf("explicit max steps = %d, want 12", explicit.Sched.MaxSteps)
+	}
+	// Non-review profiles keep their existing budgets regardless.
+	other := ProfileExecSpec{Worker: WorkerSpec{Profile: "explore"}}
+	applyReviewBudget(&other, 24)
+	if other.Sched.MaxSteps != 0 || other.Sched.MaxOutputTokens != 0 {
+		t.Fatalf("non-review budget = %+v", other.Sched)
 	}
 }
 
@@ -83,7 +107,7 @@ func TestPrepareReviewSubagentContextAddsBoundedVerifiedFacts(t *testing.T) {
 		ToolName: "go_test", Success: true, Read: true, Paths: []string{"z.go", "a.go"},
 		OutputBytes: 42, OutputDigest: "0123456789abcdef", ExitCode: &exit, Verification: evidence.VerificationPassed,
 	})
-	prompt, steps, tokens, ok := PrepareReviewSubagentContext(evidence.WithLedger(context.Background(), ledger), "review", "review change")
+	prompt, steps, tokens, ok := PrepareReviewSubagentContext(evidence.WithLedger(context.Background(), ledger), "review", "review change", 0)
 	if !ok || steps != defaultReviewMaxSteps || tokens != defaultReviewOutputTokens {
 		t.Fatalf("review budget = ok:%v steps:%d tokens:%d", ok, steps, tokens)
 	}
@@ -92,7 +116,7 @@ func TestPrepareReviewSubagentContextAddsBoundedVerifiedFacts(t *testing.T) {
 			t.Fatalf("review prompt missing %q:\n%s", want, prompt)
 		}
 	}
-	if _, _, _, ok := PrepareReviewSubagentContext(context.Background(), "explore", "look"); ok {
+	if _, _, _, ok := PrepareReviewSubagentContext(context.Background(), "explore", "look", 0); ok {
 		t.Fatal("non-review profile must retain its existing runner budget")
 	}
 }

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -250,6 +250,7 @@ type TaskTool struct {
 	quoteContext                  *event.QuoteContext
 	parentReg                     *tool.Registry
 	maxSteps                      int
+	reviewMaxSteps                int
 	contextWindow                 int
 	compactRatio                  float64
 	recentKeep                    int
@@ -302,6 +303,9 @@ type TaskToolOptions struct {
 	QuoteContext                          *event.QuoteContext
 	ParentRegistry                        *tool.Registry
 	MaxSteps                              int
+	// ReviewMaxSteps overrides the built-in step cap for review-family
+	// sub-agents (see [agent].review_max_steps). 0 keeps the built-in default.
+	ReviewMaxSteps                        int
 	ContextWindow                         int
 	RecentKeep                            int
 	SoftCompactRatio                      float64
@@ -332,6 +336,7 @@ func NewTaskToolWithOptions(opts TaskToolOptions) *TaskTool {
 		quoteContext:     opts.QuoteContext,
 		parentReg:        opts.ParentRegistry,
 		maxSteps:         opts.MaxSteps,
+		reviewMaxSteps:   opts.ReviewMaxSteps,
 		contextWindow:    opts.ContextWindow,
 		recentKeep:       opts.RecentKeep,
 		compactRatio:     opts.CompactRatio,

--- a/internal/agent/task_budget.go
+++ b/internal/agent/task_budget.go
@@ -22,7 +22,7 @@ func (t *TaskTool) childMaxStepsForContext(_ context.Context, requested int) int
 }
 
 func (t *TaskTool) childMaxStepsForSpec(ctx context.Context, spec *ProfileExecSpec) (context.Context, int) {
-	applyReviewBudget(spec)
+	applyReviewBudget(spec, t.reviewMaxSteps)
 	fillChildFacts(ctx, spec)
 	if spec == nil {
 		return ctx, t.childMaxStepsForContext(ctx, 0)

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1065,6 +1065,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 			QuoteContext:        quoteCtx,
 			ParentRegistry:      reg,
 			MaxSteps:            maxSteps,
+			ReviewMaxSteps:      cfg.Agent.ReviewMaxSteps,
 			ContextWindow:       entry.ContextWindow,
 			RecentKeep:          cfg.Agent.RecentKeep,
 			SoftCompactRatio:    cfg.Agent.SoftCompactRatio,
@@ -1243,7 +1244,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		if sysPrompt == "" {
 			sysPrompt = agent.DefaultReadOnlyTaskSystemPrompt
 		}
-		task, runOptions := reviewSubagentSkillOptions(sctx, sk.Name, task, steps, price, ctxWin, childDepth, subagentSkillOptions)
+		task, runOptions := reviewSubagentSkillOptions(sctx, sk.Name, task, steps, price, ctxWin, childDepth, cfg.Agent.ReviewMaxSteps, subagentSkillOptions)
 		usageModelRef, _ := subagentIdentity(modelRef, effortRef)
 		runOptions.ModelRef = usageModelRef
 		// Review gates consume typed, host-verifiable reports so a review
@@ -1362,7 +1363,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 				steps = 5
 			}
 		}
-		task, runOptions := reviewSubagentSkillOptions(sctx, sk.Name, task, steps, price, ctxWin, childDepth, subagentSkillOptions)
+		task, runOptions := reviewSubagentSkillOptions(sctx, sk.Name, task, steps, price, ctxWin, childDepth, cfg.Agent.ReviewMaxSteps, subagentSkillOptions)
 		runOptions.WriteRoots = childWriteRoots
 		usageModelRef, _ := subagentIdentity(modelRef, effortRef)
 		runOptions.ModelRef = usageModelRef

--- a/internal/boot/write_access.go
+++ b/internal/boot/write_access.go
@@ -48,10 +48,11 @@ func reviewSubagentSkillOptions(
 	steps int,
 	price *provider.Pricing,
 	ctxWin, childDepth int,
+	reviewMaxSteps int,
 	factory func(context.Context, int, *provider.Pricing, int, int) agent.Options,
 ) (string, agent.Options) {
 	reviewTokens := 0
-	if reviewTask, reviewSteps, tokens, ok := agent.PrepareReviewSubagentContext(ctx, profile, task); ok {
+	if reviewTask, reviewSteps, tokens, ok := agent.PrepareReviewSubagentContext(ctx, profile, task, reviewMaxSteps); ok {
 		task, steps, reviewTokens = reviewTask, reviewSteps, tokens
 	}
 	opts := factory(ctx, steps, price, ctxWin, childDepth)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1322,6 +1322,11 @@ type AgentConfig struct {
 	// declare non-overlapping write_paths. 0 means the default (3). Must not
 	// exceed MaxSubagentConcurrency after normalization.
 	MaxParallelWriters int `toml:"max_parallel_writers"`
+	// ReviewMaxSteps overrides the built-in step cap for review-family
+	// sub-agents (review / security-review / team-architect; built-in default
+	// is 8 rounds). 0 keeps the built-in default; an explicit task max_steps
+	// argument still wins over this value.
+	ReviewMaxSteps int `toml:"review_max_steps"`
 	// OutputStyle selects a persona/tone block folded into the system prompt at
 	// startup (a built-in like "explanatory"/"learning"/"concise", or a custom
 	// .reasonix/output-styles/<name>.md). Empty = the unmodified prompt.


### PR DESCRIPTION
## Summary / 摘要

Make the review-family sub-agent step cap configurable via `[agent].review_max_steps` (#9652). / 让 review 类子代理的步数上限可配置（`[agent].review_max_steps`，#9652）。

The review / security-review / team-architect sub-agent budget is hardcoded to 8 rounds (`defaultReviewMaxSteps`, `internal/agent/subagent_context.go`), so larger reviews pause mid-work ("paused after 8 tool-call rounds"). The task tool's explicit `max_steps` argument already wins over the default, but review sub-agents dispatched implicitly (skills, guardrails) had no knob. This PR promotes the constant to a config value while keeping 8 as the built-in default and keeping an explicit spec `max_steps` as the highest-priority override. / review 类子代理默认 8 轮写死，隐式派发（技能/guardrails）无法调大；本 PR 将其提升为配置项，默认仍 8，显式 `max_steps` 参数优先级不变（最高）。

## Changes

- `internal/config`: new `[agent].review_max_steps` (int; `0` = built-in default 8, documented).
- `internal/agent`: `applyReviewBudget` takes the configured cap; `TaskToolOptions.ReviewMaxSteps` → `TaskTool.reviewMaxSteps`; `PrepareReviewSubagentContext` takes the cap (used by built-in review skill runners).
- `internal/boot`: wire `cfg.Agent.ReviewMaxSteps` into the task tool options and `reviewSubagentSkillOptions`.

## Behavior / 优先级

1. explicit task `max_steps` argument (highest, unchanged)
2. `[agent].review_max_steps` when > 0
3. built-in `defaultReviewMaxSteps = 8` (unchanged default)

## Issues Fixes

Fixes #9652

## Verification

- `go build ./...` — clean.
- `go test ./internal/agent -run "Review|ChildMaxSteps|SubagentContext" -count=1` — ok (includes new `TestApplyReviewBudgetConfiguredOverride`: configured override, explicit-spec-wins, non-review untouched).
- `go test ./internal/config -count=1` — ok; `go test ./internal/boot -run "Review|Subagent|WriteAccess" -count=1` — ok.
## Guard / 提交护栏

Cache-impact: none - config-only change; no promptCacheKey or session projection touched.
Cache-guard: `go test ./internal/agent -run "Review|ChildMaxSteps|SubagentContext" -count=1` && `go test ./internal/config -count=1` && `go test ./internal/boot -run "Review|Subagent|WriteAccess" -count=1` cover the changed paths; no cache-key surface.
Documentation-impact: none - no docs files changed; [agent].review_max_steps documented in config code comments.
System-prompt-review: none - no system prompt text changes.
