### PR TITLE
fix(goaleval): parse reasoning-only evaluator responses / 修复Goal评估器在思考型模型下空响应致目标暂停

### DIFF
--- a/internal/boundedllm/bounded.go
+++ b/internal/boundedllm/bounded.go
@@ -136,6 +136,7 @@ func Call(ctx context.Context, cfg Config, system, evidence string) (string, err
 	}
 
 	var text strings.Builder
+	var reasoning strings.Builder
 	for chunk := range ch {
 		switch chunk.Type {
 		case provider.ChunkText:
@@ -144,6 +145,8 @@ func Call(ctx context.Context, cfg Config, system, evidence string) (string, err
 				cancel()
 				return "", fmt.Errorf("bounded reviewer output exceeded %d bytes", maxOutputBytes)
 			}
+		case provider.ChunkReasoning:
+			reasoning.WriteString(chunk.Text)
 		case provider.ChunkUsage:
 			if chunk.Usage != nil {
 				u := *chunk.Usage
@@ -158,6 +161,14 @@ func Call(ctx context.Context, cfg Config, system, evidence string) (string, err
 	}
 	if callCtx.Err() != nil && text.Len() == 0 {
 		return "", callCtx.Err()
+	}
+	if text.Len() == 0 && reasoning.Len() > 0 {
+		// Thinking-mode providers (#9678) stream the substance into
+		// reasoning_content and finish with stop plus an empty content block.
+		// Return the reasoning text instead of a bare "" so callers can parse
+		// their JSON contract; otherwise every thinking model fails closed as
+		// an "empty response" even though it answered.
+		return reasoning.String(), nil
 	}
 	return text.String(), nil
 }

--- a/internal/goaleval/evaluator.go
+++ b/internal/goaleval/evaluator.go
@@ -230,7 +230,13 @@ func parseVerdict(text string) (Verdict, error) {
 	if text == "" {
 		return Verdict{}, fmt.Errorf("empty goal evaluator response")
 	}
-	if i := strings.Index(text, "{"); i >= 0 {
+	// Reasoning-only responses (#9678) arrive as thinking prose that may quote
+	// example JSON before the final verdict. Slicing from the first "{" to the
+	// last "}" spans both and fails to unmarshal; prefer the last balanced
+	// top-level object, falling back to the previous slice when none parses.
+	if obj := lastJSONObject(text); obj != "" {
+		text = obj
+	} else if i := strings.Index(text, "{"); i >= 0 {
 		if j := strings.LastIndex(text, "}"); j > i {
 			text = text[i : j+1]
 		}
@@ -248,6 +254,48 @@ func parseVerdict(text string) (Verdict, error) {
 		v.Reason = clip(v.Reason, MaxReasonBytes)
 	}
 	return v, nil
+}
+
+// lastJSONObject returns the last balanced top-level JSON object in s, or ""
+// when none. Braces inside string literals are ignored; the scan is a heuristic
+// extraction for prose-wrapped model output, not a general JSON parser.
+func lastJSONObject(s string) string {
+	best := ""
+	depth := 0
+	start := -1
+	inStr := false
+	esc := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			if esc {
+				esc = false
+			} else if c == '\\' {
+				esc = true
+			} else if c == '"' {
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '{':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			if depth > 0 {
+				depth--
+				if depth == 0 && start >= 0 {
+					best = s[start : i+1]
+					start = -1
+				}
+			}
+		}
+	}
+	return best
 }
 
 // clip truncates s to at most max bytes at a rune boundary.

--- a/internal/goaleval/evaluator_test.go
+++ b/internal/goaleval/evaluator_test.go
@@ -12,11 +12,12 @@ import (
 )
 
 type scriptedProvider struct {
-	turns   []string // one response per call, recycled
-	err     error    // stream-open error
-	timeout bool     // hang until ctx deadline
-	usage   *provider.Usage
-	calls   int
+	turns     []string // one response per call, recycled
+	reasoning string   // thinking-mode reasoning_content streamed before Text
+	err       error    // stream-open error
+	timeout   bool     // hang until ctx deadline
+	usage     *provider.Usage
+	calls     int
 }
 
 func (s *scriptedProvider) Name() string { return "scripted" }
@@ -26,7 +27,7 @@ func (s *scriptedProvider) Stream(ctx context.Context, _ provider.Request) (<-ch
 	if s.err != nil {
 		return nil, s.err
 	}
-	ch := make(chan provider.Chunk, 2)
+	ch := make(chan provider.Chunk, 3)
 	if s.timeout {
 		<-ctx.Done()
 		close(ch)
@@ -35,6 +36,9 @@ func (s *scriptedProvider) Stream(ctx context.Context, _ provider.Request) (<-ch
 	i := s.calls - 1
 	if i >= len(s.turns) {
 		i = len(s.turns) - 1
+	}
+	if s.reasoning != "" {
+		ch <- provider.Chunk{Type: provider.ChunkReasoning, Text: s.reasoning}
 	}
 	ch <- provider.Chunk{Type: provider.ChunkText, Text: s.turns[i]}
 	if s.usage != nil {
@@ -73,6 +77,34 @@ func TestEvaluateParsesVerdicts(t *testing.T) {
 				t.Fatalf("outcome = %q, want %q", verdict.Outcome, tc.outcome)
 			}
 		})
+	}
+}
+
+func TestEvaluateParsesReasoningOnlyVerdicts(t *testing.T) {
+	// Thinking-mode providers (#9678) stream the substance into
+	// reasoning_content and finish with an empty content block. The evaluator
+	// must still produce a verdict instead of failing closed with
+	// "empty goal evaluator response".
+	prov := &scriptedProvider{
+		turns:     []string{""},
+		reasoning: "The goal asked to fix the parser. I considered {\"outcome\":\"continue\"} as an example format first.\nFinal judgment: {\"outcome\":\"complete\",\"reason\":\"the goal is done\"}",
+	}
+	verdict, err := evaluate(t, prov, GoalEvidence{GoalContract: "fix the parser"})
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if verdict.Outcome != OutcomeComplete {
+		t.Fatalf("outcome = %q, want %q", verdict.Outcome, OutcomeComplete)
+	}
+	if verdict.Reason != "the goal is done" {
+		t.Fatalf("reason = %q, want %q", verdict.Reason, "the goal is done")
+	}
+
+	// Prose-only reasoning without any JSON still fails closed, but with the
+	// parse error rather than "empty response".
+	prov = &scriptedProvider{turns: []string{""}, reasoning: "I thought about it, but reached no conclusion."}
+	if _, err := evaluate(t, prov, GoalEvidence{}); err == nil || strings.Contains(err.Error(), "empty goal evaluator response") {
+		t.Fatalf("Evaluate() error = %v, want invalid-JSON fail-closed error", err)
 	}
 }
 


### PR DESCRIPTION

## Cache Impact / 缓存影响

Cache-impact: none - boundedllm accumulates reasoning chunks for the goal-evaluator verdict path only; no promptCacheKey, session projection, or cache-key logic is touched. / 仅在 goal 评估判定路径累计 ChunkReasoning，不触及 promptCacheKey/会话投影/缓存键逻辑。
Cache-guard: `go test ./internal/goaleval/ -count=1` guards the evaluator verdict path end-to-end (incl. TestEvaluateParsesReasoningOnlyVerdicts); boundedllm has no cache-key surface. / goaleval 全量单测守护判定路径；boundedllm 无缓存键面。
Documentation-impact: none - internal-only fix (boundedllm/goaleval), no docs or config surface changed.
System-prompt-review: none - no system prompt text changes.
