### PR TITLE
fix(desktop): avoid empty project loading flash

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-rename-optimistic.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-rename-optimistic.test.ts
@@ -67,9 +67,9 @@ eq(
   "commitRenameTopic paints the new label optimistically before the refresh round-trip",
 );
 eq(
-  projectTreeSource.includes("project-tree__skeleton"),
+  projectTreeSource.includes("if (backendPage?.loading && classicTopics)"),
   true,
-  "an expanded folder with a loading first topic page renders skeleton rows",
+  "only classic folders render first-page skeletons, so empty workbench projects do not flash",
 );
 eq(
   /projectTreeRevisionIsFresh\(latestRevisionRef\.current, event\.revision\)\) \{\s*void refresh\(\)/.test(projectTreeSource),

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1619,10 +1619,11 @@ export function ProjectTree({
           busy={remoteBusy} error={remoteError} ready={remoteServers[node.remote.hostId]?.[node.remote.workspace]?.state === "ready"}
           isExpanded={isExpanded} depth={depth} classicTopics={classicTopics} t={t} onEnsure={() => ensureRemoteGroupSessions(node.remote!.hostId, node.remote!.workspace)}
         />;
-        // While the first topic page is still loading (cold start, catalog
-        // reconcile in flight), show a skeleton instead of a blank folder or
-        // a premature "no topics" placeholder.
-        if (backendPage?.loading) {
+        // Classic has an explicit empty-state row, so keep its loading skeleton
+        // until the catalog can distinguish loading from "no topics". Workbench
+        // and creation render no empty row; painting a transient skeleton there
+        // makes a genuinely empty project flash every time it is expanded.
+        if (backendPage?.loading && classicTopics) {
           return (
             <div className={`project-tree__children${isExpanded ? " project-tree__children--expanded" : ""}`}>
               <div className="project-tree__children-inner">


### PR DESCRIPTION
## Summary

- avoid rendering transient skeleton rows for empty Workbench and creation projects
- retain the loading skeleton for Classic folders, which have an explicit empty state
- update the regression assertion to preserve the expected mode-specific behavior

## Issues

Fixes #9576

## Verification

- targeted project-tree regression tests — 6/6 passed
- ProjectTree runtime tests — 88/88 passed
- `pnpm typecheck`
- `pnpm build`
- `go vet ./...`
- repository lint passed
- full `pnpm test` encountered an unrelated existing locale assertion mismatch (`Over context limit` vs `已超过窗口上限`)

## Documentation impact

Documentation-impact: none - the change only removes a transient loading placeholder for empty project trees; existing documentation remains accurate.

## Cache impact

Cache-impact: none - frontend-only project tree rendering change.
Cache-guard: N/A - no provider-visible prompt, tool schema, or request serialization changes.
System-prompt-review: N/A
