### PR TITLE
fix(context): report exact instruction source paths

### DIFF
--- a/docs/SESSION_MEMORY_RETRIEVAL.md
+++ b/docs/SESSION_MEMORY_RETRIEVAL.md
@@ -181,8 +181,11 @@ The trace includes the query, selected IDs and revisions, scores, match reasons,
 freshness, budget use, omitted count, and suppression reason.
 
 The explicit read-only `memory` tool remains available for deeper `search`,
-`read`, and `list` operations. Use `history` instead when exact wording or tool
-output matters.
+`read`, and `list` operations. The separate read-only `instruction_sources`
+capability reports the exact host paths of the standing instruction files
+active for the session; the cache-stable system prompt continues to use
+provider-relative labels such as `user/AGENTS.md`. Use `history` instead when
+exact wording or tool output matters.
 
 ## Safe writes and confirmation
 

--- a/docs/SESSION_MEMORY_RETRIEVAL.zh-CN.md
+++ b/docs/SESSION_MEMORY_RETRIEVAL.zh-CN.md
@@ -155,8 +155,10 @@ freshness 是提醒和排序信号，不代表事实真假。召回文本会明�
 trace 包含 query、选中的 ID/revision、score、命中原因、freshness、预算使用量、
 omitted 数量和 suppressed 原因。
 
-需要更深检索时仍可使用只读 `memory` tool 的 `search`、`read`、`list`。需要原始措辞或
-工具输出时，应使用 `history`。
+需要更深检索时仍可使用只读 `memory` tool 的 `search`、`read`、`list`。独立的只读
+`instruction_sources` capability 会返回当前会话生效的常驻指令文件的精确主机路径；缓存稳定的
+system prompt 仍使用 `user/AGENTS.md` 这类 provider 相对标签。需要原始措辞或工具输出时，应
+使用 `history`。
 
 ## 安全写入与确认
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -350,6 +350,10 @@ when the sole automatic threshold is crossed.
   TUI, desktop panel) but are excluded from active-memory retrieval. Memory
   search uses the same relative BM25 floor and guides the agent to fall back to
   history when exact original wording or tool output matters.
+- The read-only `instruction_sources` capability reports exact host paths for
+  the standing instruction files active in the session. Provider-visible
+  instruction headings remain stable, root-independent provenance labels and
+  route exact-path questions to this capability instead of inviting inference.
 - Before each real user turn, bounded BM25 recall selects relevant active facts
   from the raw user message and appends them as a low-authority user-turn suffix.
   Generic turns are suppressed, project facts override equivalent global

--- a/docs/SPEC.zh-CN.md
+++ b/docs/SPEC.zh-CN.md
@@ -193,7 +193,9 @@ transcript，仅在唯一自动阈值被跨越时安装 provider 可见的短 **
   不再创建 prune archive。
 
 `history` tool 支持对 session 与归档进行 BM25 搜索；`memory` tool 用于检索自动记忆，
-`remember` 与 `forget` 负责写入和归档。每个真实用户回合前，Reasonix 会用原始用户消息执行
+`remember` 与 `forget` 负责写入和归档。只读 `instruction_sources` capability 按需返回当前
+会话生效的常驻指令文件的精确主机路径，而 provider 可见的指令标题继续使用稳定、与根目录
+无关的来源标签，并把精确路径问题引导到该 capability。每个真实用户回合前，Reasonix 会用原始用户消息执行
 有预算的 BM25 自动召回，把命中作为低权限 user-turn 后缀追加；泛化请求会被抑制，等价事实优先
 项目级版本，stale 内容会降权。这不会修改稳定 system prompt 或工具 schema。
 

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -54,7 +54,6 @@ import (
 	"reasonix/internal/outputstyle"
 	"reasonix/internal/permission"
 	"reasonix/internal/plugin"
-	"reasonix/internal/productdocs"
 	"reasonix/internal/provider"
 	"reasonix/internal/recovery"
 	"reasonix/internal/sandbox"
@@ -1139,7 +1138,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 			return "docs is already enabled."
 		}
 		docsToolAdded = true
-		reg.Add(productdocs.NewTool())
+		registerDocumentationTools(reg, mem.Docs)
 		return "enabled docs."
 	}
 	sessionToolsAdded := false

--- a/internal/boot/documentation_tools.go
+++ b/internal/boot/documentation_tools.go
@@ -1,0 +1,12 @@
+package boot
+
+import (
+	"reasonix/internal/instruction"
+	"reasonix/internal/productdocs"
+	"reasonix/internal/tool"
+)
+
+func registerDocumentationTools(registry *tool.Registry, documents []instruction.Document) {
+	registry.Add(productdocs.NewTool())
+	registry.Add(instruction.NewSourcesTool(documents))
+}

--- a/internal/boot/instruction_path_tool_test.go
+++ b/internal/boot/instruction_path_tool_test.go
@@ -1,0 +1,72 @@
+package boot
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+func TestBuildMemoryToolReportsExactActiveInstructionPaths(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	userInstructionPath := filepath.Join(config.MemoryUserDir(), "AGENTS.md")
+	writeFile(t, config.MemoryUserDir(), "AGENTS.md", "Always report the configured Reasonix instruction path exactly.")
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "boot-retrieval-tool-test"
+model = "x"
+`)
+
+	registerBootRetrievalToolTestProvider()
+	prov := testutil.NewMock("boot-retrieval-tool-test",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{
+			ID: "instructions-1", Name: "use_capability",
+			Arguments: `{"action":"call","capability_id":"tool:instruction_sources","arguments":{}}`,
+		}}},
+		testutil.Turn{Text: "done"},
+	)
+	setBootRetrievalToolTestProvider(t, prov)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard, SessionDir: filepath.Join(t.TempDir(), "sessions")})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	sys := systemMessage(ctrl.History())
+	if strings.Contains(sys, userInstructionPath) {
+		t.Fatalf("cache-stable prompt exposed exact host path %q:\n%s", userInstructionPath, sys)
+	}
+	if !strings.Contains(sys, "user/AGENTS.md") {
+		t.Fatalf("cache-stable prompt missing provider-relative instruction label:\n%s", sys)
+	}
+	if !strings.Contains(sys, "instruction_sources capability") {
+		t.Fatalf("instruction prompt does not route exact-path questions to instruction_sources:\n%s", sys)
+	}
+
+	if err := ctrl.Run(context.Background(), "Where is the active global instruction file?"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	var combined string
+	for _, msg := range ctrl.History() {
+		if msg.Role == provider.RoleTool {
+			combined += "\n" + msg.Content
+		}
+	}
+	if !strings.Contains(combined, userInstructionPath) || !strings.Contains(combined, "exact host-provided paths") {
+		t.Fatalf("instruction tool result did not include exact active path %q:\n%s", userInstructionPath, combined)
+	}
+}

--- a/internal/instruction/render.go
+++ b/internal/instruction/render.go
@@ -15,7 +15,8 @@ func Block(documents []Document) string {
 	}
 	var b strings.Builder
 	b.WriteString("# Instructions\n\n")
-	b.WriteString("Standing guidance resolved for this workspace and target path. Later entries are more specific and take precedence when rules conflict; the current user request still has highest priority.\n")
+	b.WriteString("Standing guidance resolved for this workspace and target path. Later entries are more specific and take precedence when rules conflict; the current user request still has highest priority. " +
+		"Source labels such as user/AGENTS.md are stable provider-relative provenance labels, not host filesystem paths. When asked for an exact path, resolve and call the read-only instruction_sources capability; do not infer a path from another agent application.\n")
 	workspaceRoot := providerWorkspaceRoot(documents)
 	for _, doc := range documents {
 		fmt.Fprintf(&b, "\n## %s (%s", providerDocumentPath(doc, workspaceRoot), doc.Scope)

--- a/internal/instruction/sources_tool.go
+++ b/internal/instruction/sources_tool.go
@@ -1,0 +1,58 @@
+package instruction
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"reasonix/internal/tool"
+)
+
+type sourcesTool struct {
+	documents []Document
+}
+
+// NewSourcesTool returns a read-only capability for resolving the exact host
+// paths behind provider-relative instruction labels such as user/AGENTS.md.
+func NewSourcesTool(documents []Document) tool.Tool {
+	return sourcesTool{documents: append([]Document(nil), documents...)}
+}
+
+func (sourcesTool) Name() string { return "instruction_sources" }
+
+func (sourcesTool) Description() string {
+	return "Report the exact host filesystem paths and scopes of standing instruction files active in this session. Use this when the user asks where a global, project, ancestor, or local instruction file is stored; do not infer a path from provider-relative labels or another agent application."
+}
+
+func (sourcesTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`)
+}
+
+func (t sourcesTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	if len(strings.TrimSpace(string(args))) > 0 {
+		var in struct{}
+		if err := json.Unmarshal(args, &in); err != nil {
+			return "", fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+	return formatSourcePaths(t.documents), nil
+}
+
+func (sourcesTool) ReadOnly() bool { return true }
+
+func formatSourcePaths(documents []Document) string {
+	if len(documents) == 0 {
+		return "No standing instruction files are active."
+	}
+	var b strings.Builder
+	b.WriteString("Active standing instruction files (low to high precedence):\n")
+	for index, document := range documents {
+		fmt.Fprintf(&b, "%d. scope=%s path=%s\n", index+1, document.Scope, document.Path)
+		if strings.TrimSpace(document.Directory) != "" {
+			fmt.Fprintf(&b, "   applies_to=%s\n", document.Directory)
+		}
+	}
+	b.WriteString("These are the exact host-provided paths. Report them as shown; do not infer or substitute a path from another agent application.")
+	return strings.TrimSpace(b.String())
+}

--- a/internal/instruction/sources_tool_test.go
+++ b/internal/instruction/sources_tool_test.go
@@ -1,0 +1,40 @@
+package instruction
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestSourcesToolReturnsExactActiveInstructionPaths(t *testing.T) {
+	root := t.TempDir()
+	userPath := root + "/reasonix-home/AGENTS.md"
+	projectPath := root + "/workspace/AGENTS.md"
+	tool := NewSourcesTool([]Document{
+		{Path: userPath, Scope: ScopeUser, Directory: root + "/reasonix-home"},
+		{Path: projectPath, Scope: ScopeProject, Directory: root + "/workspace"},
+	})
+
+	out, err := tool.Execute(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, want := range []string{userPath, projectPath, "scope=user", "scope=project", "exact host-provided paths", "do not infer"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("instruction source output missing %q:\n%s", want, out)
+		}
+	}
+	if !tool.ReadOnly() {
+		t.Fatal("instruction_sources must remain read-only")
+	}
+}
+
+func TestSourcesToolReportsNoActiveInstructions(t *testing.T) {
+	out, err := NewSourcesTool(nil).Execute(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "No standing instruction files are active." {
+		t.Fatalf("empty output = %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

- keep cache-stable instruction headings provider-relative while clarifying that they are not host filesystem paths
- add a read-only `instruction_sources` capability for reporting the exact active instruction paths, scopes, and precedence
- register the capability alongside documentation tools and cover it with unit and boot-level tests
- document the behavior in the English and Chinese memory retrieval and specification documents

## Issues

Fixes #9661

## Verification

- `go test ./internal/instruction ./internal/memory`
- `go test -timeout 5m ./internal/agent`
- `go test -timeout 5m ./internal/boot`
- `go vet ./...`
- `go run ./tools/repolint` — clean
- `git diff --check`

## Documentation impact

Documentation-impact: updated - documented `instruction_sources` and provider-relative instruction labels in the English and Chinese session-memory and specification documents.

## Cache impact

Cache-impact: low - adds one stable instruction-routing sentence while keeping exact machine paths out of the provider-visible prefix; the fixed default tool schema remains unchanged.
Cache-guard: `go test -timeout 5m ./internal/boot` covers both the unchanged baseline golden and the exact-path capability integration.
System-prompt-review: requested - review the stable exact-path routing sentence added to `internal/instruction/render.go`.
