### PR TITLE
fix(doctor): stop warning about tools that exist

### DIFF
--- a/internal/doctor/skill_health.go
+++ b/internal/doctor/skill_health.go
@@ -78,7 +78,7 @@ func CollectSkillHealthWarnings(opts SkillHealthOptions) []string {
 			if at == "" {
 				continue
 			}
-			if !toolNames[at] && !isBuiltinOrMetaTool(at) {
+			if !toolNames[at] && !isRegisteredBuiltin(at) && !isBuiltinOrMetaTool(at) {
 				// Soft: only warn when the name looks concrete and missing.
 				out = append(out, fmt.Sprintf("skill %q allowed-tools references %q which is not in the current registry", name, at))
 			}
@@ -124,11 +124,25 @@ func normalizedTriggers(in []string) []string {
 	return out
 }
 
+// isRegisteredBuiltin asks the built-in registry, which is the only list that
+// cannot drift from the tools that actually ship. isBuiltinOrMetaTool below
+// stays as the fallback: it covers subagent and alias names that are dispatched
+// by the host rather than registered as tools, and it keeps this check working
+// in builds where the builtin package is not linked in.
+func isRegisteredBuiltin(name string) bool {
+	_, ok := tool.LookupBuiltin(name)
+	return ok
+}
+
 func isBuiltinOrMetaTool(name string) bool {
 	switch name {
 	case "bash", "read_file", "write_file", "edit_file", "grep", "glob", "ls",
 		"todo_write", "complete_step", "ask", "task", "read_only_task",
 		"parallel_tasks", "fleet",
+		// Host-wired at boot rather than registered as a compile-time built-in,
+		// so isRegisteredBuiltin cannot see it. The built-in skills name it in
+		// allowed-tools, so leaving it out warned on every session.
+		"use_capability",
 		"run_skill", "read_skill", "read_only_skill", "explore", "research",
 		"review", "security_review", "web_fetch", "multi_edit", "move_file",
 		"code_index", "wait", "bash_output", "kill_shell":

--- a/internal/doctor/skill_health_registry_test.go
+++ b/internal/doctor/skill_health_registry_test.go
@@ -1,0 +1,63 @@
+package doctor
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/skill"
+	"reasonix/internal/tool"
+)
+
+type registryProbeTool struct{}
+
+func (registryProbeTool) Name() string        { return "doctor_registry_probe" }
+func (registryProbeTool) Description() string { return "probe" }
+func (registryProbeTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object"}`)
+}
+func (registryProbeTool) ReadOnly() bool { return true }
+func (registryProbeTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "", nil
+}
+
+// A skill may name any registered built-in in allowed-tools. The hand-written
+// list in isBuiltinOrMetaTool had drifted from the tools that actually ship —
+// use_capability, compress and update_goal were all missing, so every session
+// carrying a skill that names one reported a warning for a tool that exists.
+// Consult the registry, which cannot drift, before falling back to the list.
+func TestAllowedToolsAcceptsAnyRegisteredBuiltin(t *testing.T) {
+	tool.RegisterBuiltin(registryProbeTool{})
+
+	warns := CollectSkillHealthWarnings(SkillHealthOptions{
+		Skills: []skill.Skill{{
+			Name:         "probe",
+			Description:  "ok",
+			AllowedTools: []string{"doctor_registry_probe"},
+		}},
+	})
+	for _, w := range warns {
+		if strings.Contains(w, "doctor_registry_probe") {
+			t.Fatalf("registered built-in reported as missing: %s", w)
+		}
+	}
+}
+
+// The complement: a name that is neither registered nor a known meta tool must
+// still warn, so the softened check does not silence real typos.
+func TestAllowedToolsStillWarnsOnAnUnknownName(t *testing.T) {
+	warns := CollectSkillHealthWarnings(SkillHealthOptions{
+		Skills: []skill.Skill{{
+			Name:         "probe",
+			Description:  "ok",
+			AllowedTools: []string{"definitely_not_a_tool"},
+		}},
+	})
+	for _, w := range warns {
+		if strings.Contains(w, "definitely_not_a_tool") {
+			return
+		}
+	}
+	t.Fatal("unknown allowed-tools name did not warn")
+}


### PR DESCRIPTION
## Summary

- `doctor` warns about tools that exist. `isBuiltinOrMetaTool` is a hand-written name list and it had drifted from what actually ships: `use_capability`, `compress` and `update_goal` were all missing from it.
- The built-in `review` and `security-review` skills both name `use_capability` in allowed-tools, so **every** doctor run on a default install prints two warnings for a tool that is present:

```
warning: skill "review" allowed-tools references "use_capability" which is not in the current registry
warning: skill "security-review" allowed-tools references "use_capability" which is not in the current registry
```

- Consult the built-in registry first via `tool.LookupBuiltin`, which cannot drift, and keep the hand-written list as the fallback it already was. `compress` and `update_goal` are registered built-ins and are now covered automatically. `use_capability` is wired up at boot rather than registered, so it is added to the list explicitly with a comment saying why.

## Issues

<!-- no existing report -->

## Verification

- 2 warnings before, 0 after, on an otherwise unchanged config and the same workspace.
- `go test ./...` passes. `gofmt -l .` and `go vet ./...` clean. Go 1.26.2, darwin/arm64.
- New tests in `internal/doctor/skill_health_registry_test.go`:
  - `TestAllowedToolsAcceptsAnyRegisteredBuiltin` registers a probe tool and asserts it is not reported missing — this pins the registry path rather than a name list, so the same drift cannot recur.
  - `TestAllowedToolsStillWarnsOnAnUnknownName` asserts a genuinely unknown name still warns, so the softened check does not silence real typos.

## Documentation impact

Documentation-impact: none - diagnostics output only; no CLI, config, provider, permission or tool behavior changes.

## Cache impact

Cache-impact: none - `internal/doctor` output never enters the provider request; no system prompt, memory prefix, tool schema or tool surface is touched.
Cache-guard: not applicable - no cache-sensitive path is modified. `go test ./internal/boot/ -run TestGoldenBaselineNoExtensions` still passes unchanged.
System-prompt-review: N/A
