### PR TITLE
fix(cli): stop reasonix setup from turning flags into config files

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1408,6 +1408,14 @@ func defaultEnvTarget() string {
 // resolveSetupTargets picks where `reasonix setup` writes. Keys always go to the
 // global env. The config goes to the user-global dir by default, to ./reasonix.toml
 // under --local, or to an explicit path argument when given.
+func setupUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage: reasonix setup [--local|-l] [path]")
+	fmt.Fprintln(w, "Interactive configuration wizard. Writes a reasonix config and stores the")
+	fmt.Fprintln(w, "provider API key in Reasonix's credential file, never in the config itself.")
+	fmt.Fprintln(w, "  --local, -l   write ./reasonix.toml instead of the user-global config")
+	fmt.Fprintln(w, "  path          write the config to this path instead of the default")
+}
+
 func resolveSetupTargets(args []string) setupTargets {
 	t := setupTargets{config: defaultConfigTarget(), env: defaultEnvTarget()}
 	for _, a := range args {
@@ -1435,6 +1443,23 @@ func displayPath(p string) string {
 // Project memory is a separate concern — the in-session `/init` skill generates
 // AGENTS.md (see initHint).
 func setupConfig(args []string) int {
+	if commandHelpRequested(args, len(args)) {
+		setupUsage(os.Stdout)
+		return 0
+	}
+	// resolveSetupTargets treats every unrecognized argument as the config path,
+	// so a mistyped flag — or --help — silently becomes the file it writes.
+	// Reject dashed arguments here instead.
+	for _, a := range args {
+		if a == "--local" || a == "-l" {
+			continue
+		}
+		if strings.HasPrefix(a, "-") {
+			fmt.Fprintf(os.Stderr, "unknown setup flag %q\n\n", a)
+			setupUsage(os.Stderr)
+			return 2
+		}
+	}
 	t := resolveSetupTargets(args)
 	path := t.config
 	if _, err := os.Stat(path); err == nil {

--- a/internal/cli/setup_flags_test.go
+++ b/internal/cli/setup_flags_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resolveSetupTargets treats any unrecognized argument as the config path, so
+// before this guard `reasonix setup --help` wrote a config file literally named
+// "--help" into the working directory — and so did every mistyped flag.
+func TestSetupRejectsDashedArgumentsInsteadOfWritingThem(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	for _, arg := range []string{"--help", "-h"} {
+		if rc := setupConfig([]string{arg}); rc != 0 {
+			t.Fatalf("setup %s returned %d, want 0 (help is not an error)", arg, rc)
+		}
+	}
+	if rc := setupConfig([]string{"--not-a-flag"}); rc != 2 {
+		t.Fatalf("setup --not-a-flag returned %d, want 2", rc)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "-") {
+			t.Fatalf("setup wrote a file from a flag argument: %s", filepath.Join(dir, e.Name()))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `resolveSetupTargets` treats every unrecognized argument as the config path, so any dashed argument silently becomes the file `setup` writes:

```
$ reasonix setup --help
Wrote --help
$ ls
--help
```

- Shell completion already advertises `--help` for `setup` (`internal/cli/shell_completion.go`), so following the tool's own suggestion drops a junk config file into the working directory instead of printing usage. Every mistyped flag does the same, and the file is a full annotated config, so it looks like a real artifact.
- Handle `-h`/`--help` with the existing `commandHelpRequested` helper, and reject other dashed arguments with usage plus exit 2 — the same shape `doctor quality` and the `mcp` subcommands already use. Positional paths and `--local`/`-l` are unaffected.

## Issues

<!-- no existing report -->

## Verification

- `reasonix setup --help` now prints usage and exits 0; `reasonix setup --typo` prints `unknown setup flag "--typo"` plus usage and exits 2; neither leaves a file behind.
- `reasonix setup ./somewhere.toml` and `reasonix setup --local` keep their previous behavior.
- `go test ./...` passes. `gofmt -l .` and `go vet ./...` clean. Go 1.26.2, darwin/arm64.
- New test `TestSetupRejectsDashedArgumentsInsteadOfWritingThem` runs setup with `--help`, `-h` and an unknown flag in a temp dir and asserts both the exit codes and that no file starting with `-` was created.

## Documentation impact

Documentation-impact: none - this makes `setup` honor the `--help` that shell completion already documents; no flag, path or config semantics change.

## Cache impact

Cache-impact: none - CLI argument handling only; no system prompt, memory prefix, tool schema, tool surface or provider serialization is touched.
Cache-guard: not applicable - no cache-sensitive path is modified.
System-prompt-review: N/A
