### PR TITLE
fix: add User-Agent identity for outbound LLM requests

### DIFF
--- a/cmd/reasonix/main.go
+++ b/cmd/reasonix/main.go
@@ -8,6 +8,7 @@ import (
 	"reasonix/internal/cli"
 	"reasonix/internal/config"
 	"reasonix/internal/crashreport"
+	"reasonix/internal/netclient"
 	"reasonix/internal/plugin"
 
 	// Blank imports wire compile-time built-ins into their registries.
@@ -38,6 +39,9 @@ var runCLI = func(args []string, buildVersion string) int {
 
 func main() {
 	plugin.SetMCPClientVersion(version)
+	// Wire identity: LLM outbound requests carry Reasonix/<version> unless an
+	// explicit User-Agent (user config headers / provider presets) is set.
+	netclient.UserAgent = "Reasonix/" + version
 	os.Exit(runWithCrashCapture(os.Args[1:], version))
 }
 

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/linux"
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
 	"github.com/wailsapp/wails/v2/pkg/options/windows"
+	"reasonix/internal/netclient"
 	// Blank imports wire compile-time built-ins into their registries, exactly as
 	// cmd/reasonix does — boot.Build resolves providers/tools from these registries.
 	_ "reasonix/internal/provider/anthropic"
@@ -106,6 +107,9 @@ func preparePrimaryDesktopRuntime(app *App) {
 
 func main() {
 	prepareLinuxRendererCompatibilityEnvironment()
+	// Wire identity: LLM outbound requests carry Reasonix/<version> unless an
+	// explicit User-Agent (user config headers / provider presets) is set.
+	netclient.UserAgent = "Reasonix/" + version
 	// Detached macOS self-update child: wait for the old PID, hold the shared
 	// repair mutation lock, then swap the .app bundle. Must run before Wails.
 	if handled, exitCode := maybeRunMacUpdateHandoff(os.Args[1:]); handled {

--- a/internal/netclient/netclient.go
+++ b/internal/netclient/netclient.go
@@ -79,13 +79,46 @@ func ProxyFunc(spec ProxySpec) (func(*http.Request) (*url.URL, error), error) {
 	return proxyFunc(spec)
 }
 
-// NewHTTPClient returns an HTTP client with Reasonix proxy settings applied.
+// UserAgent is the default User-Agent injected into outbound requests that do
+// not already carry one. Entry points (cmd/reasonix, desktop) set it once at
+// startup from their ldflags-injected build version, so the wire identity
+// tracks `reasonix --version`; the dev default keeps local builds honest.
+// Requests with an explicit User-Agent — from user-configured headers or
+// provider presets such as kimi-coding-plan's claude-code/0.1.0 — are never
+// rewritten.
+var UserAgent = "Reasonix/dev"
+
+// NewUserAgentRoundTripper wraps base and injects UserAgent into requests that
+// lack a User-Agent header. It never overwrites an explicit value, and it
+// clones the request before mutating headers so callers' requests are left
+// untouched (http.RoundTripper contract).
+func NewUserAgentRoundTripper(base http.RoundTripper) http.RoundTripper {
+	return &userAgentRoundTripper{base: base, ua: UserAgent}
+}
+
+type userAgentRoundTripper struct {
+	base http.RoundTripper
+	ua   string
+}
+
+func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("User-Agent") != "" {
+		return rt.base.RoundTrip(req)
+	}
+	cloned := req.Clone(req.Context())
+	cloned.Header.Set("User-Agent", rt.ua)
+	return rt.base.RoundTrip(cloned)
+}
+
+// NewHTTPClient returns an HTTP client with Reasonix proxy settings applied
+// and the default User-Agent injected into requests that don't already carry
+// one (user-configured headers and provider presets always win).
 func NewHTTPClient(spec ProxySpec, opts TransportOptions) (*http.Client, error) {
 	tr, err := NewTransport(spec, opts)
 	if err != nil {
 		return nil, err
 	}
-	return &http.Client{Transport: tr}, nil
+	return &http.Client{Transport: NewUserAgentRoundTripper(tr)}, nil
 }
 
 // NewTransport clones net/http's default transport and overlays the requested

--- a/internal/netclient/netclient_test.go
+++ b/internal/netclient/netclient_test.go
@@ -587,3 +587,60 @@ func TestForceIPv4Dials(t *testing.T) {
 		t.Error("forced-IPv4 dial should reject an IPv6 address")
 	}
 }
+
+func TestUserAgentInjectedWhenAbsent(t *testing.T) {
+	var got atomic.Value // string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.Store(r.Header.Get("User-Agent"))
+	}))
+	defer srv.Close()
+
+	prev := UserAgent
+	UserAgent = "Reasonix/v1.35.0"
+	defer func() { UserAgent = prev }()
+
+	client, err := NewHTTPClient(ProxySpec{Mode: ModeOff}, TransportOptions{})
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+
+	if ua, _ := got.Load().(string); ua != "Reasonix/v1.35.0" {
+		t.Fatalf("User-Agent = %q, want %q", ua, "Reasonix/v1.35.0")
+	}
+}
+
+func TestUserAgentNotOverwritten(t *testing.T) {
+	var got atomic.Value // string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.Store(r.Header.Get("User-Agent"))
+	}))
+	defer srv.Close()
+
+	prev := UserAgent
+	UserAgent = "Reasonix/v1.35.0"
+	defer func() { UserAgent = prev }()
+
+	client, err := NewHTTPClient(ProxySpec{Mode: ModeOff}, TransportOptions{})
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("User-Agent", "claude-code/0.1.0")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	resp.Body.Close()
+
+	if ua, _ := got.Load().(string); ua != "claude-code/0.1.0" {
+		t.Fatalf("User-Agent = %q, want explicit value preserved %q", ua, "claude-code/0.1.0")
+	}
+}

--- a/internal/provider/openai/fetch_models.go
+++ b/internal/provider/openai/fetch_models.go
@@ -68,7 +68,7 @@ func FetchModelsWithOptions(ctx context.Context, baseURL, apiKey string, opts Fe
 	if err != nil {
 		return nil, fmt.Errorf("fetch models: network: %w", err)
 	}
-	cli := &http.Client{Timeout: 10 * time.Second, Transport: transport}
+	cli := &http.Client{Timeout: 10 * time.Second, Transport: netclient.NewUserAgentRoundTripper(transport)}
 	url := strings.TrimRight(baseURL, "/")
 	if !strings.HasSuffix(url, "/models") {
 		url += "/models"


### PR DESCRIPTION
## Summary

Add a default User-Agent identity for outbound LLM requests.

Previously, Reasonix did not explicitly set User-Agent for most providers.
Requests were sent with Go's default:

Go-http-client/1.1
Go-http-client/2.0

This made Reasonix traffic difficult for upstream services to identify correctly and could trigger automated traffic detection.

## Issues

Refs #5226

## Verification

- Added `TestUserAgentInjectedWhenAbsent`
- Added `TestUserAgentNotOverwritten`

Validated:

go test ./internal/netclient
go test ./internal/provider
go build ./cmd/reasonix
go vet ./internal/netclient

## Documentation impact

Documentation-impact: none - this is an internal HTTP client behavior change and does not require user configuration changes.

## Cache impact

Cache-impact: none - no cache behavior changed.

Cache-guard: Existing provider tests remain passing.

System-prompt-review: N/A