### PR TITLE
fix(desktop): prevent Ask prompt replay loops / 修复 Ask 提示循环

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -169,7 +169,10 @@ console.log("\nbundle budgets");
 // one-decimal ratchet. Completion uncertainty adds a terminal outcome and
 // notice without exposing evaluator audits to the frontend; the final merged
 // build measures 458.287 KiB gzip.
-const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 458.3 : 458.3;
+// Transactional Ask resolution and authoritative rejected-submit recovery add
+// 0.3 KiB gzip to the initial controller path. Retain the exact turn fence,
+// bounded ListTabs retry, and stale-prompt guard with a 0.1 KiB headroom.
+const initialJSBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 458.7 : 458.7;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -298,6 +301,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // 2454.719 KiB on the release toolchain. Completion uncertainty brings the
 // final merged payload to 2455.154 KiB; retain the smallest one-decimal
 // ratchet.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_455.2 : 2_455.2;
+// Ask turn fencing and rejection reconciliation measure 2455.9 KiB raw;
+// retain the same narrow 0.1 KiB headroom as the gzip ratchet above.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_456.0 : 2_456.0;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -301,8 +301,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // 2454.719 KiB on the release toolchain. Completion uncertainty brings the
 // final merged payload to 2455.154 KiB; retain the smallest one-decimal
 // ratchet.
-// Ask turn fencing and rejection reconciliation measure 2455.9 KiB raw;
-// retain the same narrow 0.1 KiB headroom as the gzip ratchet above.
-const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_456.0 : 2_456.0;
+// Ask turn fencing, rejection reconciliation, and the localized submit-failure
+// notice measure 2456.044 KiB raw; retain 0.056 KiB of one-decimal headroom.
+const rawInitialBudgetKiB = process.env.REASONIX_CHANNEL === "test" ? 2_456.1 : 2_456.1;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -136,7 +136,7 @@ console.log("\nask card layout");
       React.createElement(LocaleProvider, null,
         React.createElement(AskCard, {
           ask,
-          onAnswer: (_id: string, next: QuestionAnswer[]) => answers.push(next),
+          onAnswer: (_id: string, next: QuestionAnswer[]) => { answers.push(next); },
           onDismiss: () => undefined,
           onStop: () => undefined,
         }),
@@ -313,7 +313,7 @@ console.log("\nask card layout");
       React.createElement(LocaleProvider, null,
         React.createElement(AskCard, {
           ask,
-          onAnswer: (_id: string, next: QuestionAnswer[]) => answers.push(next),
+          onAnswer: (_id: string, next: QuestionAnswer[]) => { answers.push(next); },
           onDismiss: () => undefined,
           onStop: () => undefined,
         }),
@@ -389,7 +389,7 @@ console.log("\nask card layout");
       React.createElement(LocaleProvider, null,
         React.createElement(AskCard, {
           ask,
-          onAnswer: (_id: string, next: QuestionAnswer[]) => answers.push(next),
+          onAnswer: (_id: string, next: QuestionAnswer[]) => { answers.push(next); },
           onDismiss: () => undefined,
           onStop: () => undefined,
         }),
@@ -448,7 +448,7 @@ console.log("\nask card layout");
       React.createElement(LocaleProvider, null,
         React.createElement(AskCard, {
           ask,
-          onAnswer: (_id: string, next: QuestionAnswer[]) => answers.push(next),
+          onAnswer: (_id: string, next: QuestionAnswer[]) => { answers.push(next); },
           onDismiss: () => undefined,
           onStop: () => undefined,
         }),
@@ -510,7 +510,7 @@ console.log("\nask card layout");
       React.createElement(LocaleProvider, null,
         React.createElement(AskCard, {
           ask,
-          onAnswer: (_id: string, next: QuestionAnswer[]) => answers.push(next),
+          onAnswer: (_id: string, next: QuestionAnswer[]) => { answers.push(next); },
           onDismiss: () => undefined,
           onStop: () => undefined,
         }),
@@ -592,6 +592,125 @@ console.log("\nask card layout");
   await act(async () => {
     root.unmount();
   });
+  dom.window.close();
+}
+
+// A failed asynchronous submit must preserve multi-question progress and
+// selections instead of remounting the card at question 1.
+{
+  const dom = installDom();
+  const rootEl = document.getElementById("root");
+  if (!rootEl) throw new Error("missing root");
+  const root = createRoot(rootEl);
+  const submitted: QuestionAnswer[][] = [];
+  let attempts = 0;
+  const ask: WireAsk = {
+    id: "ask-async-retry",
+    questions: [
+      { id: "q1", prompt: "First choice?", options: [{ label: "First A" }, { label: "First B" }] },
+      { id: "q2", prompt: "Second choice?", options: [{ label: "Second A" }, { label: "Second B" }] },
+    ],
+  };
+
+  await act(async () => {
+    root.render(
+      React.createElement(LocaleProvider, null,
+        React.createElement(AskCard, {
+          ask,
+          onAnswer: async (_id: string, answers: QuestionAnswer[]) => {
+            attempts += 1;
+            submitted.push(answers);
+            if (attempts === 1) throw new Error("bridge rejected answer");
+          },
+          onDismiss: () => undefined,
+          onStop: () => undefined,
+        }),
+      ),
+    );
+    await flushTimers();
+  });
+
+  await act(async () => {
+    [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")]
+      .find((button) => button.textContent?.includes("First A"))?.click();
+    document.querySelector<HTMLButtonElement>(".decision-confirm-bar__confirm")?.click();
+    await flushTimers();
+  });
+  eq(document.querySelector(".ask-shelf__header-text--progress")?.textContent?.includes("2/2"), true, "multi-question Ask advances to question 2");
+
+  await act(async () => {
+    [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")]
+      .find((button) => button.textContent?.includes("Second B"))?.click();
+    document.querySelector<HTMLButtonElement>(".decision-confirm-bar__confirm")?.click();
+    await flushTimers();
+  });
+
+  eq(attempts, 1, "failed final submit is attempted exactly once");
+  eq(document.querySelector(".ask-shelf__header-text--progress")?.textContent?.includes("2/2"), true, "failed final submit stays on question 2");
+  eq(document.querySelector(".ask-shelf__crumbs")?.textContent?.includes("First A"), true, "failed final submit preserves the first answer");
+  eq(
+    [...document.querySelectorAll<HTMLElement>(".prompt-action")]
+      .some((button) => button.getAttribute("aria-selected") === "true" && button.textContent?.includes("Second B")),
+    true,
+    "failed final submit preserves the second answer",
+  );
+  eq(document.querySelector<HTMLButtonElement>(".decision-confirm-bar__confirm")?.disabled, false, "failed final submit re-enables retry");
+
+  await act(async () => {
+    document.querySelector<HTMLButtonElement>(".decision-confirm-bar__confirm")?.click();
+    await flushTimers();
+  });
+  eq(attempts, 2, "retry submits once after the failure");
+  eq(submitted[1]?.map((answer) => answer.selected?.[0]).join("|"), "First A|Second B", "retry submits the preserved answer batch");
+
+  await act(async () => { root.unmount(); });
+  dom.window.close();
+}
+
+// Skip uses the same retry contract as an answered Ask.
+{
+  const dom = installDom();
+  const rootEl = document.getElementById("root");
+  if (!rootEl) throw new Error("missing root");
+  const root = createRoot(rootEl);
+  let dismissAttempts = 0;
+  const ask: WireAsk = {
+    id: "ask-skip-retry",
+    questions: [{ id: "q1", prompt: "Skip this?", options: [{ label: "Continue" }] }],
+  };
+
+  await act(async () => {
+    root.render(
+      React.createElement(LocaleProvider, null,
+        React.createElement(AskCard, {
+          ask,
+          onAnswer: () => undefined,
+          onDismiss: async () => {
+            dismissAttempts += 1;
+            if (dismissAttempts === 1) throw new Error("skip failed");
+          },
+          onStop: () => undefined,
+        }),
+      ),
+    );
+    await flushTimers();
+  });
+
+  await act(async () => {
+    document.querySelector<HTMLButtonElement>(".decision-confirm-bar__secondary")?.click();
+    await flushTimers();
+  });
+  eq(dismissAttempts, 1, "failed skip is attempted exactly once");
+  eq(Boolean(document.querySelector(".prompt-shelf--ask")), true, "failed skip keeps the Ask visible");
+  eq(document.querySelector<HTMLButtonElement>(".decision-confirm-bar__secondary")?.disabled, false, "failed skip re-enables the action");
+
+  await act(async () => {
+    document.querySelector<HTMLButtonElement>(".decision-confirm-bar__secondary")?.click();
+    await flushTimers();
+  });
+  eq(dismissAttempts, 2, "skip can be retried once after failure");
+
+  await act(async () => { root.unmount(); });
   dom.window.close();
 }
 

--- a/desktop/frontend/src/__tests__/ask-submit.test.ts
+++ b/desktop/frontend/src/__tests__/ask-submit.test.ts
@@ -1,0 +1,117 @@
+// Run: tsx src/__tests__/ask-submit.test.ts
+
+import type { AppBindings } from "../lib/bridge";
+import { answerPromptForActiveTurn } from "../lib/inboxSubmit";
+import type { QuestionAnswer, TabMeta } from "../lib/types";
+
+let passed = 0;
+let failed = 0;
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (actual === expected) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}\n`);
+    failed += 1;
+  }
+}
+
+function binding(overrides: Partial<AppBindings>): AppBindings {
+  return overrides as AppBindings;
+}
+
+const answers: QuestionAnswer[] = [{ questionId: "q1", selected: ["yes"] }];
+const tab = { id: "tab-ask", turnId: "turn-authoritative" } as TabMeta;
+
+console.log("\nAsk prompt active-turn submission");
+
+{
+  let listCalls = 0;
+  const exactCalls: string[] = [];
+  await answerPromptForActiveTurn(binding({
+    ListTabs: async () => { listCalls += 1; return [tab]; },
+    AnswerQuestionForTab: async () => { throw new Error("legacy must not run"); },
+    AnswerPromptForTab: async (tabId, turnId, promptId) => { exactCalls.push(`${tabId}:${turnId}:${promptId}`); },
+  }), "tab-ask", "ask-1", answers, "turn-known");
+  eq(listCalls, 0, "known turn id avoids an unnecessary ListTabs lookup");
+  eq(exactCalls.join("|"), "tab-ask:turn-known:ask-1", "known turn id uses the exact prompt endpoint");
+}
+
+{
+  let listCalls = 0;
+  const exactCalls: string[] = [];
+  await answerPromptForActiveTurn(binding({
+    ListTabs: async () => { listCalls += 1; return [tab]; },
+    AnswerQuestionForTab: async () => { throw new Error("legacy must not run"); },
+    AnswerPromptForTab: async (tabId, turnId, promptId) => { exactCalls.push(`${tabId}:${turnId}:${promptId}`); },
+  }), "tab-ask", "ask-2", answers);
+  eq(listCalls, 1, "missing local turn id is resolved from ListTabs once");
+  eq(exactCalls.join("|"), "tab-ask:turn-authoritative:ask-2", "resolved turn id fences the exact answer");
+}
+
+{
+  let legacyCalls = 0;
+  let exactCalls = 0;
+  let rejected = "";
+  try {
+    await answerPromptForActiveTurn(binding({
+      ListTabs: async () => [],
+      AnswerQuestionForTab: async () => { legacyCalls += 1; },
+      AnswerPromptForTab: async () => { exactCalls += 1; },
+    }), "tab-ask", "ask-3", answers);
+  } catch (error) {
+    rejected = error instanceof Error ? error.message : String(error);
+  }
+  eq(rejected.includes("active turn id is unavailable"), true, "missing authoritative turn id rejects visibly");
+  eq(exactCalls, 0, "missing turn id never calls the exact endpoint with an empty fence");
+  eq(legacyCalls, 0, "missing turn id never falls back to the unfenced endpoint");
+}
+
+{
+  let legacyCalls = 0;
+  let exactCalls = 0;
+  let rejected = "";
+  try {
+    await answerPromptForActiveTurn(binding({
+      ListTabs: async () => { throw new Error("ListTabs failed"); },
+      AnswerQuestionForTab: async () => { legacyCalls += 1; },
+      AnswerPromptForTab: async () => { exactCalls += 1; },
+    }), "tab-ask", "ask-rpc", answers);
+  } catch (error) {
+    rejected = error instanceof Error ? error.message : String(error);
+  }
+  eq(rejected, "ListTabs failed", "authoritative turn lookup failure propagates");
+  eq(exactCalls, 0, "failed turn lookup never calls the exact endpoint");
+  eq(legacyCalls, 0, "failed turn lookup never falls back to the unfenced endpoint");
+}
+
+{
+  let legacyCalls = 0;
+  let rejected = "";
+  try {
+    await answerPromptForActiveTurn(binding({
+      ListTabs: async () => [tab],
+      AnswerQuestionForTab: async () => { legacyCalls += 1; },
+      AnswerPromptForTab: async () => { throw new Error("stale turn"); },
+    }), "tab-ask", "ask-4", answers);
+  } catch (error) {
+    rejected = error instanceof Error ? error.message : String(error);
+  }
+  eq(rejected, "stale turn", "exact endpoint rejection propagates to the decision surface");
+  eq(legacyCalls, 0, "exact endpoint rejection never retries through the unfenced endpoint");
+}
+
+{
+  let listCalls = 0;
+  const legacyCalls: string[] = [];
+  await answerPromptForActiveTurn(binding({
+    ListTabs: async () => { listCalls += 1; return [tab]; },
+    AnswerQuestionForTab: async (tabId, promptId) => { legacyCalls.push(`${tabId}:${promptId}`); },
+  }), "tab-ask", "ask-legacy", answers);
+  eq(listCalls, 0, "legacy bridge compatibility does not require turn metadata");
+  eq(legacyCalls.join("|"), "tab-ask:ask-legacy", "legacy endpoint remains available only when the exact method is absent");
+}
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/remote-session-surface.test.tsx
+++ b/desktop/frontend/src/__tests__/remote-session-surface.test.tsx
@@ -75,6 +75,7 @@ let snapshotHistory: unknown[] = [];
 let blockApproval = false;
 let releaseApproval: (() => void) | undefined;
 let blockAnswer = false;
+let failAnswer = false;
 let releaseAnswer: (() => void) | undefined;
 let resolveRaceSnapshot: ((value: { history: unknown[]; status: unknown }) => void) | undefined;
 const resolveStateRaceSnapshots: Array<(value: { history: unknown[]; status: unknown }) => void> = [];
@@ -209,8 +210,9 @@ window.go = { main: { App: {
 	},
 	async AnswerRemoteTab(tabId: string, callId: string, answers: Array<{ QuestionID: string; Selected: string[] }>) {
 		tape.push(`answer:${tabId}:${callId}:${JSON.stringify(answers)}`);
+		if (failAnswer) throw new Error("remote answer failed");
 		if (blockAnswer) await new Promise<void>((resolve) => { releaseAnswer = resolve; });
-  },
+	},
   async SubmitRemoteTabExtensionForm(tabId: string, pluginId: string, surfaceId: string, values: Record<string, unknown>) {
     tape.push(`extension-form:${tabId}:${pluginId}:${surfaceId}:${JSON.stringify(values)}`);
   },
@@ -397,6 +399,30 @@ await act(async () => {
 	});
 	ok(tape.includes('answer:tab-remote-1:ask-7:[{"QuestionID":"q1","Selected":["yes"]}]'), "submit forwards the question id and complete selection batch");
 }
+
+await act(async () => {
+  failAnswer = true;
+  __emitMockRemoteTab("tab-remote-1", "event", { kind: "ask_request", ask: { id: "ask-fail", questions: [{ id: "q-fail", prompt: "Keep on failure?", options: [{ label: "yes" }] }] } });
+  await flush();
+});
+await act(async () => {
+  [...document.querySelectorAll<HTMLButtonElement>(".prompt-shelf--ask .prompt-action")].find((button) => button.textContent?.includes("yes"))?.click();
+  await flush();
+});
+await act(async () => {
+  document.querySelector<HTMLButtonElement>(".prompt-shelf--ask .decision-confirm-bar__confirm")?.click();
+  await flush();
+});
+ok(tape.some((entry) => entry.startsWith("answer:tab-remote-1:ask-fail:")), "failed remote Ask reaches the answer endpoint");
+ok(Boolean(document.querySelector(".prompt-shelf--ask")), "a failed remote Ask answer preserves the card");
+ok(document.body.textContent?.includes("remote answer failed") === true, "a failed remote Ask answer surfaces the error");
+ok(document.querySelector<HTMLButtonElement>(".prompt-shelf--ask .decision-confirm-bar__confirm")?.disabled === false, "a failed remote Ask answer re-enables retry");
+await act(async () => {
+  failAnswer = false;
+  document.querySelector<HTMLButtonElement>(".prompt-shelf--ask .decision-confirm-bar__confirm")?.click();
+  await flush();
+});
+ok(!document.querySelector(".prompt-shelf--ask"), "a successful remote Ask retry clears the matching card");
 
 await act(async () => {
   __emitMockRemoteTab("tab-remote-1", "event", { kind: "ask_request", ask: { id: "ask-custom", questions: [{ id: "q-custom", prompt: "Where?", options: [{ label: "staging" }] }] } });

--- a/desktop/frontend/src/__tests__/remote-session-surface.test.tsx
+++ b/desktop/frontend/src/__tests__/remote-session-surface.test.tsx
@@ -74,8 +74,7 @@ let statusPendingPrompt = false, replayedPrompts: unknown[] = [];
 let snapshotHistory: unknown[] = [];
 let blockApproval = false;
 let releaseApproval: (() => void) | undefined;
-let blockAnswer = false;
-let failAnswer = false;
+let blockAnswer = false, failAnswer = false;
 let releaseAnswer: (() => void) | undefined;
 let resolveRaceSnapshot: ((value: { history: unknown[]; status: unknown }) => void) | undefined;
 const resolveStateRaceSnapshots: Array<(value: { history: unknown[]; status: unknown }) => void> = [];
@@ -209,8 +208,7 @@ window.go = { main: { App: {
 		tape.push(`plan-decision:${tabId}:${callId}:${action}:${feedback}`);
 	},
 	async AnswerRemoteTab(tabId: string, callId: string, answers: Array<{ QuestionID: string; Selected: string[] }>) {
-		tape.push(`answer:${tabId}:${callId}:${JSON.stringify(answers)}`);
-		if (failAnswer) throw new Error("remote answer failed");
+		tape.push(`answer:${tabId}:${callId}:${JSON.stringify(answers)}`); if (failAnswer) throw new Error("remote answer failed");
 		if (blockAnswer) await new Promise<void>((resolve) => { releaseAnswer = resolve; });
 	},
   async SubmitRemoteTabExtensionForm(tabId: string, pluginId: string, surfaceId: string, values: Record<string, unknown>) {
@@ -393,36 +391,12 @@ await act(async () => {
 		await flush();
 	});
 	ok(!tape.some((entry) => entry.startsWith("answer:tab-remote-1:ask-7")), "selecting an option keeps the ask open until explicit submit");
-	await act(async () => {
+	failAnswer = true; await act(async () => {
 		[...document.querySelectorAll<HTMLButtonElement>("button")].find((b) => b.textContent?.trim() === "Submit")?.click();
 		await flush();
 	});
-	ok(tape.includes('answer:tab-remote-1:ask-7:[{"QuestionID":"q1","Selected":["yes"]}]'), "submit forwards the question id and complete selection batch");
+	ok(Boolean(document.querySelector(".prompt-shelf--ask")) && document.body.textContent?.includes("remote answer failed") === true && document.querySelector<HTMLButtonElement>(".prompt-shelf--ask .decision-confirm-bar__confirm")?.disabled === false, "a failed remote Ask answer preserves the card, surfaces the error, and re-enables retry"); failAnswer = false; await act(async () => { document.querySelector<HTMLButtonElement>(".prompt-shelf--ask .decision-confirm-bar__confirm")?.click(); await flush(); }); ok(tape.filter((entry) => entry.startsWith("answer:tab-remote-1:ask-7:")).length === 2 && !document.querySelector(".prompt-shelf--ask"), "a successful remote Ask retry resubmits the complete answer and clears the card");
 }
-
-await act(async () => {
-  failAnswer = true;
-  __emitMockRemoteTab("tab-remote-1", "event", { kind: "ask_request", ask: { id: "ask-fail", questions: [{ id: "q-fail", prompt: "Keep on failure?", options: [{ label: "yes" }] }] } });
-  await flush();
-});
-await act(async () => {
-  [...document.querySelectorAll<HTMLButtonElement>(".prompt-shelf--ask .prompt-action")].find((button) => button.textContent?.includes("yes"))?.click();
-  await flush();
-});
-await act(async () => {
-  document.querySelector<HTMLButtonElement>(".prompt-shelf--ask .decision-confirm-bar__confirm")?.click();
-  await flush();
-});
-ok(tape.some((entry) => entry.startsWith("answer:tab-remote-1:ask-fail:")), "failed remote Ask reaches the answer endpoint");
-ok(Boolean(document.querySelector(".prompt-shelf--ask")), "a failed remote Ask answer preserves the card");
-ok(document.body.textContent?.includes("remote answer failed") === true, "a failed remote Ask answer surfaces the error");
-ok(document.querySelector<HTMLButtonElement>(".prompt-shelf--ask .decision-confirm-bar__confirm")?.disabled === false, "a failed remote Ask answer re-enables retry");
-await act(async () => {
-  failAnswer = false;
-  document.querySelector<HTMLButtonElement>(".prompt-shelf--ask .decision-confirm-bar__confirm")?.click();
-  await flush();
-});
-ok(!document.querySelector(".prompt-shelf--ask"), "a successful remote Ask retry clears the matching card");
 
 await act(async () => {
   __emitMockRemoteTab("tab-remote-1", "event", { kind: "ask_request", ask: { id: "ask-custom", questions: [{ id: "q-custom", prompt: "Where?", options: [{ label: "staging" }] }] } });

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -169,6 +169,64 @@ eq(notice.kind === "notice" && notice.level, "warn", "the notice is a warning");
 eq(failedState.running, false, "send_failed stops the running indicator");
 eq(failedState.pendingUser, undefined, "send_failed clears the pending marker");
 
+const waitingAsk = reducer({ ...initialState }, {
+  type: "event",
+  e: {
+    kind: "ask_request",
+    turnId: "turn-existing",
+    ask: { id: "ask-existing", questions: [{ id: "q1", prompt: "Choose", options: [{ label: "A" }] }] },
+  } as WireEvent,
+});
+const collidingSubmit = reducer(waitingAsk, { type: "user", text: "continue", seq: waitingAsk.seq, submissionId: "send-collision" });
+const rejectedCollision = reducer(collidingSubmit, {
+  type: "turn_submit_rejected",
+  submissionId: "send-collision",
+  error: "Send failed: turn already running",
+});
+eq(rejectedCollision.items.some((item) => item.kind === "user" && item.failed), true, "rejected admission marks the exact optimistic bubble failed");
+eq(rejectedCollision.running, true, "rejected admission stays conservatively running until reconciliation");
+eq(rejectedCollision.pendingPrompt, true, "rejected admission restores the visible Ask gate");
+eq(rejectedCollision.ask?.id, "ask-existing", "rejected admission preserves the pending Ask");
+
+const reconciledCollision = reducer(rejectedCollision, {
+  type: "backend_status",
+  running: true,
+  pendingPrompt: true,
+  backgroundJobs: 0,
+  cancelRequested: false,
+  cancellable: true,
+  turnId: "turn-existing",
+});
+eq(reconciledCollision.activeTurnId, "turn-existing", "authoritative active snapshot restores the existing turn id");
+eq(reconciledCollision.running, true, "authoritative active snapshot keeps the composer blocked");
+
+const reconciledIdle = reducer(rejectedCollision, {
+  type: "backend_status",
+  running: false,
+  pendingPrompt: false,
+  backgroundJobs: 0,
+  cancelRequested: false,
+  cancellable: false,
+});
+eq(reconciledIdle.running, false, "authoritative idle snapshot releases the rejected submit gate");
+eq(reconciledIdle.ask, undefined, "authoritative idle snapshot clears a stale Ask");
+
+const answeredAsk = reducer(waitingAsk, { type: "ask_submit_succeeded", id: "ask-existing", epoch: waitingAsk.promptEpoch });
+eq(answeredAsk.ask, undefined, "successful Ask submission clears the matching prompt");
+eq(answeredAsk.resolvedPromptId, "ask-existing", "successful Ask submission tombstones the matching prompt id");
+const nextAsk = reducer(waitingAsk, {
+  type: "event",
+  e: { kind: "ask_request", turnId: "turn-existing", ask: { id: "ask-next", questions: [] } } as WireEvent,
+});
+const lateAskSuccess = reducer(nextAsk, { type: "ask_submit_succeeded", id: "ask-existing", epoch: nextAsk.promptEpoch });
+eq(lateAskSuccess.ask?.id, "ask-next", "late Ask success cannot clear a newer prompt");
+const rebuiltAsk = reducer(reducer(waitingAsk, { type: "controller_rebuilt" }), {
+  type: "event",
+  e: { kind: "ask_request", turnId: "turn-new", ask: { id: "ask-existing", questions: [] } } as WireEvent,
+});
+const oldEpochSuccess = reducer(rebuiltAsk, { type: "ask_submit_succeeded", id: "ask-existing", epoch: waitingAsk.promptEpoch });
+eq(oldEpochSuccess.ask?.id, "ask-existing", "old prompt epoch cannot clear an id reused by a rebuilt controller");
+
 const readinessStarted = reducer(sent, { type: "event", e: { kind: "turn_started" } as WireEvent });
 const readinessState = reducer(readinessStarted, {
   type: "event",

--- a/desktop/frontend/src/__tests__/use-controller-send-fallback.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-send-fallback.test.tsx
@@ -4,6 +4,7 @@ import { JSDOM } from "jsdom";
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import type { AppBindings } from "../lib/bridge";
+import { LocaleProvider, preloadLocale, useI18n } from "../lib/i18n";
 import { useController } from "../lib/useController";
 import type { BalanceInfo, CheckpointMeta, ContextInfo, EffortInfo, HistoryMessage, JobView, Meta, TabMeta, WireEvent } from "../lib/types";
 
@@ -151,8 +152,10 @@ window.go = {
 
 type Controller = ReturnType<typeof useController>;
 let controller: Controller | undefined;
+let setLocale: ReturnType<typeof useI18n>["setPref"] | undefined;
 
 function Probe() {
+  setLocale = useI18n().setPref;
   controller = useController();
   return null;
 }
@@ -162,7 +165,7 @@ if (!rootEl) throw new Error("missing root");
 const root = createRoot(rootEl);
 
 await act(async () => {
-  root.render(<Probe />);
+  root.render(<LocaleProvider><Probe /></LocaleProvider>);
   await flushPromises();
 });
 eq(controller?.activeTabId, undefined, "startup has no active tab when backend has no tabs");
@@ -214,6 +217,11 @@ await act(async () => {
 });
 rejectAnswer = true;
 let answerRejected = false;
+await preloadLocale("zh");
+await act(async () => {
+  setLocale?.("zh");
+  await flushPromises();
+});
 await act(async () => {
   try {
     await controller?.answerQuestion("ask-retry", [{ questionId: "q2", selected: ["yes"] }]);
@@ -225,6 +233,7 @@ await act(async () => {
 eq(answerRejected, true, "failed exact answer propagates to AskCard");
 eq(controller?.state.ask?.id, "ask-retry", "failed exact answer preserves the pending Ask");
 eq(controller?.state.pendingPrompt, true, "failed exact answer keeps the prompt gate active");
+eq(controller?.state.items.find((item) => item.kind === "notice" && item.text.includes("prompt write failed"))?.text, "提交回答失败：prompt write failed", "failed Ask answer uses the active locale");
 rejectAnswer = false;
 
 rejectSubmit = true;

--- a/desktop/frontend/src/__tests__/use-controller-send-fallback.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-send-fallback.test.tsx
@@ -5,7 +5,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import type { AppBindings } from "../lib/bridge";
 import { useController } from "../lib/useController";
-import type { BalanceInfo, CheckpointMeta, ContextInfo, EffortInfo, HistoryMessage, JobView, Meta, TabMeta } from "../lib/types";
+import type { BalanceInfo, CheckpointMeta, ContextInfo, EffortInfo, HistoryMessage, JobView, Meta, TabMeta, WireEvent } from "../lib/types";
 
 let passed = 0;
 let failed = 0;
@@ -91,7 +91,7 @@ globalThis.localStorage = dom.window.localStorage;
 globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
 globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
 
-const backendTab = tabMeta({ backgroundJobs: 2 });
+let backendTab = tabMeta({ backgroundJobs: 2 });
 const context: ContextInfo = { used: 0, window: 100, sessionTokens: 0 };
 const effort: EffortInfo = { supported: true, current: "auto", default: "auto", levels: ["auto"] };
 const balance: BalanceInfo = { available: false, display: "" };
@@ -99,15 +99,29 @@ const jobs: JobView[] = [];
 const checkpoints: CheckpointMeta[] = [];
 let tabsAvailable = false;
 let submitCalls = 0;
+let rejectSubmit = false;
+let rejectAnswer = false;
+let rejectListTabs = false;
+let listTabsCalls = 0;
+const exactAnswerCalls: Array<{ tabId: string; turnId: string; promptId: string; answers: unknown[] }> = [];
+const legacyAnswerCalls: string[] = [];
+const eventHandlers: Array<(event: WireEvent) => void> = [];
 
 window.runtime = {
-  EventsOn: () => () => {},
+  EventsOn: (name: string, callback: (...data: unknown[]) => void) => {
+    if (name === "agent:event") eventHandlers.push(callback as (event: WireEvent) => void);
+    return () => {};
+  },
   BrowserOpenURL: () => {},
 };
 window.go = {
   main: {
     App: {
-      ListTabs: async () => (tabsAvailable ? [backendTab] : []),
+      ListTabs: async () => {
+        listTabsCalls += 1;
+        if (rejectListTabs) throw new Error("runtime status unavailable");
+        return tabsAvailable ? [backendTab] : [];
+      },
       MetaForTab: async () => metaFor(backendTab),
       ContextUsageForTab: async () => context,
       EffortForTab: async () => effort,
@@ -118,11 +132,18 @@ window.go = {
       HistoryPageForTab: async () => ({ messages: [], startTurn: 0, endTurn: 0, totalTurns: 0, hasOlder: false }),
       HistoryCheckpointTurnsForTab: async () => [],
       ReplayPendingPrompts: async () => {},
+      ReplayPendingPromptsForTab: async () => {},
       SubmitToTab: async (tabId: string) => {
         submitCalls += tabId === "tab-send" ? 1 : 0;
       },
       SubmitToTabWithID: async (tabId: string) => {
         submitCalls += tabId === "tab-send" ? 1 : 0;
+        if (rejectSubmit) throw new Error("turn already running");
+      },
+      AnswerQuestionForTab: async (_tabId: string, promptId: string) => { legacyAnswerCalls.push(promptId); },
+      AnswerPromptForTab: async (tabId: string, turnId: string, promptId: string, answers: unknown[]) => {
+        exactAnswerCalls.push({ tabId, turnId, promptId, answers });
+        if (rejectAnswer) throw new Error("prompt write failed");
       },
     } as Partial<AppBindings> as AppBindings,
   },
@@ -156,6 +177,88 @@ eq(controller?.activeTabId, "tab-send", "send fallback activates the backend-sel
 eq(controller?.state.backgroundJobs, 2, "send fallback reconciles backend runtime metadata");
 ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "hello from fallback") ?? false, "send fallback keeps the optimistic user turn");
 eq(submitCalls, 1, "send fallback submits to the activated tab");
+
+await act(async () => {
+  for (const handler of eventHandlers) handler({ kind: "turn_done", tabId: "tab-send" } as WireEvent);
+  await flushPromises();
+});
+
+backendTab = tabMeta({ running: true, pendingPrompt: true, turnId: "turn-authoritative" });
+await act(async () => {
+  for (const handler of eventHandlers) handler({
+    kind: "ask_request",
+    tabId: "tab-send",
+    ask: { id: "ask-fallback", questions: [{ id: "q1", prompt: "Proceed?", options: [{ label: "yes" }] }] },
+  } as WireEvent);
+  await flushPromises();
+});
+eq(controller?.state.activeTurnId, undefined, "Ask fixture starts without a local turn id");
+const beforeAnswerListCalls = listTabsCalls;
+await act(async () => {
+  await controller?.answerQuestion("ask-fallback", [{ questionId: "q1", selected: ["yes"] }]);
+  await flushPromises();
+});
+eq(listTabsCalls, beforeAnswerListCalls + 1, "Ask answer resolves one authoritative ListTabs fallback");
+eq(exactAnswerCalls.at(-1)?.turnId, "turn-authoritative", "Ask answer uses the authoritative turn fence");
+eq(legacyAnswerCalls.length, 0, "Ask answer never falls back to the unfenced endpoint");
+eq(controller?.state.ask, undefined, "successful exact answer clears the matching Ask without replay");
+
+await act(async () => {
+  for (const handler of eventHandlers) handler({
+    kind: "ask_request",
+    tabId: "tab-send",
+    turnId: "turn-authoritative",
+    ask: { id: "ask-retry", questions: [{ id: "q2", prompt: "Retry?", options: [{ label: "yes" }] }] },
+  } as WireEvent);
+  await flushPromises();
+});
+rejectAnswer = true;
+let answerRejected = false;
+await act(async () => {
+  try {
+    await controller?.answerQuestion("ask-retry", [{ questionId: "q2", selected: ["yes"] }]);
+  } catch {
+    answerRejected = true;
+  }
+  await flushPromises();
+});
+eq(answerRejected, true, "failed exact answer propagates to AskCard");
+eq(controller?.state.ask?.id, "ask-retry", "failed exact answer preserves the pending Ask");
+eq(controller?.state.pendingPrompt, true, "failed exact answer keeps the prompt gate active");
+rejectAnswer = false;
+
+rejectSubmit = true;
+await act(async () => {
+  await controller?.send("continue while prompt is pending");
+  await flushPromises();
+  await flushPromises();
+});
+eq(controller?.state.items.some((item) => item.kind === "user" && item.text === "continue while prompt is pending" && item.failed), true, "colliding submit marks its optimistic bubble failed");
+eq(controller?.state.ask?.id, "ask-retry", "colliding submit preserves the pending Ask");
+eq(controller?.state.running, true, "active backend snapshot keeps the composer blocked after rejection");
+eq(controller?.state.pendingPrompt, true, "active backend snapshot restores the prompt gate after rejection");
+eq(controller?.state.activeTurnId, "turn-authoritative", "active backend snapshot restores the authoritative turn id");
+
+await act(async () => {
+  for (const handler of eventHandlers) handler({ kind: "turn_done", tabId: "tab-send", turnId: "turn-authoritative" } as WireEvent);
+  backendTab = tabMeta({ running: false, pendingPrompt: false, turnId: undefined });
+  await flushPromises();
+  await controller?.send("retry against an idle backend");
+  await flushPromises();
+  await flushPromises();
+});
+eq(controller?.state.running, false, "authoritative idle snapshot releases a rejected submit");
+eq(controller?.state.pendingPrompt, false, "authoritative idle snapshot leaves no prompt gate");
+
+rejectListTabs = true;
+const beforeFailedReconcileCalls = listTabsCalls;
+await act(async () => {
+  await controller?.send("retry while runtime status is unavailable");
+  await new Promise((resolve) => setTimeout(resolve, 1_500));
+});
+eq(listTabsCalls - beforeFailedReconcileCalls, 4, "rejected submit retries failed ListTabs reads at every bounded delay");
+eq(controller?.state.running, true, "exhausted status reads leave the composer conservatively blocked");
+rejectListTabs = false;
 
 await act(async () => {
   root.unmount();

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -19,8 +19,8 @@ export function AskCard({
   onStop,
 }: {
   ask: WireAsk;
-  onAnswer: (id: string, answers: QuestionAnswer[]) => void;
-  onDismiss: () => void;
+  onAnswer: (id: string, answers: QuestionAnswer[]) => void | Promise<void>;
+  onDismiss: () => void | Promise<void>;
   onStop: () => void;
 }) {
   const t = useT();
@@ -100,11 +100,18 @@ export function AskCard({
 
   const currentAnswered = q ? answered(q) : false;
 
+  const submitAction = (action: () => void | Promise<void>) => {
+    if (submitting) return;
+    setSubmitting(true);
+    void Promise.resolve()
+      .then(action)
+      .catch(() => setSubmitting(false));
+  };
+
   const finishOrAdvance = (nextSel = sel, nextCustom = custom) => {
     if (submitting) return;
     if (isLast) {
-      setSubmitting(true);
-      onAnswer(ask.id, answersFrom(nextSel, nextCustom));
+      submitAction(() => onAnswer(ask.id, answersFrom(nextSel, nextCustom)));
       return;
     }
     setActive((i) => Math.min(i + 1, questions.length - 1));
@@ -359,9 +366,7 @@ export function AskCard({
           onConfirm={confirmSelected}
           secondaryLabel={t("ask.justChat")}
           onSecondary={() => {
-            if (submitting) return;
-            setSubmitting(true);
-            onDismiss();
+            submitAction(onDismiss);
           }}
           disabled={submitting}
           confirmDisabled={!canConfirm()}

--- a/desktop/frontend/src/components/RemoteSessionSurface.tsx
+++ b/desktop/frontend/src/components/RemoteSessionSurface.tsx
@@ -26,9 +26,14 @@ export function RemoteSessionSurface({ tab, session }: { tab: TabMeta; session: 
   const [actionError, setActionError] = useState("");
   const [extensionFormBusy, setExtensionFormBusy] = useState(false);
   useEffect(() => { setActionError(""); setExtensionFormBusy(false); }, [session.state, tab.id]);
-  const runAction = (action: () => Promise<unknown>) => {
+  const runAction = async (action: () => Promise<unknown>, propagate = false): Promise<void> => {
     setActionError("");
-    void action().catch((error) => setActionError(error instanceof Error ? error.message : String(error)));
+    try {
+      await action();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : String(error));
+      if (propagate) throw error;
+    }
   };
   const submitExtensionForm = (values: Record<string, unknown>) => {
     if (!extensionForm || extensionFormBusy) return;
@@ -133,8 +138,8 @@ export function RemoteSessionSurface({ tab, session }: { tab: TabMeta; session: 
           onAnswer={(id, answers) => runAction(() => session.answer(id, answers.map((answer) => ({
             QuestionID: answer.questionId,
             Selected: answer.selected,
-          }))))}
-          onDismiss={() => runAction(() => session.answer(ask.id, []))}
+          }))), true)}
+          onDismiss={() => runAction(() => session.answer(ask.id, []), true)}
           onStop={() => runAction(() => session.cancelTurn())}
         />
       ) : null}

--- a/desktop/frontend/src/lib/inboxSubmit.ts
+++ b/desktop/frontend/src/lib/inboxSubmit.ts
@@ -1,6 +1,7 @@
 import type { AppBindings } from "./bridge";
 import type { StructuredInvocationSubmit } from "./invocationDisplay";
 import { asArray } from "./array";
+import type { QuestionAnswer } from "./types";
 
 type InboxEnqueueBindings = Pick<AppBindings, "EnqueueInboxFollowup" | "EnqueueInboxFollowupWithInvocations" | "EnqueueInboxSteer" | "EnqueueInboxSteerForTurn">;
 type ActiveTurnBindings = Pick<AppBindings, "ListTabs" | "SteerInboxItem" | "SteerInboxItemForTurn">;
@@ -8,6 +9,24 @@ type ActiveTurnBindings = Pick<AppBindings, "ListTabs" | "SteerInboxItem" | "Ste
 export async function resolveActiveTurnId(binding: Pick<AppBindings, "ListTabs">, tabId: string, known?: string): Promise<string | undefined> {
   if (known) return known;
   return asArray(await binding.ListTabs()).find((tab) => tab.id === tabId)?.turnId;
+}
+
+type AskAnswerBindings = Pick<AppBindings, "ListTabs" | "AnswerQuestionForTab" | "AnswerPromptForTab">;
+
+export async function answerPromptForActiveTurn(
+  binding: AskAnswerBindings,
+  tabId: string,
+  promptId: string,
+  answers: QuestionAnswer[],
+  knownTurnId?: string,
+): Promise<void> {
+  if (typeof binding.AnswerPromptForTab !== "function") {
+    await binding.AnswerQuestionForTab(tabId, promptId, answers);
+    return;
+  }
+  const turnId = await resolveActiveTurnId(binding, tabId, knownTurnId);
+  if (!turnId) throw new Error("active turn id is unavailable");
+  await binding.AnswerPromptForTab(tabId, turnId, promptId, answers);
 }
 
 export async function steerInboxItemForActiveTurn(binding: ActiveTurnBindings, tabId: string, itemId: string, knownTurnId?: string) {

--- a/desktop/frontend/src/lib/inboxSubmit.ts
+++ b/desktop/frontend/src/lib/inboxSubmit.ts
@@ -13,6 +13,20 @@ export async function resolveActiveTurnId(binding: Pick<AppBindings, "ListTabs">
 
 type AskAnswerBindings = Pick<AppBindings, "ListTabs" | "AnswerQuestionForTab" | "AnswerPromptForTab">;
 
+// Final frontend boundary before optimistic transcript state is created.
+export function normalizeTurnSubmit(displayText: string, submitText: string) {
+  const display = displayText.trim();
+  const submit = submitText.trim();
+  if (!submit) throw new Error("Message cannot be empty.");
+  return { display, submit };
+}
+
+// Host-only commands do not create an agent turn or receive a turn id.
+export function isLocalRuntimeCommand(input: string): boolean {
+  const trimmed = input.trim();
+  return trimmed === "/reload" || trimmed === "/effort" || trimmed.startsWith("/effort ");
+}
+
 export async function answerPromptForActiveTurn(
   binding: AskAnswerBindings,
   tabId: string,

--- a/desktop/frontend/src/lib/turnSubmissionFailure.ts
+++ b/desktop/frontend/src/lib/turnSubmissionFailure.ts
@@ -1,0 +1,61 @@
+import type { AppBindings } from "./bridge";
+import { asArray } from "./array";
+import { removeEmptyAssistantItems } from "./assistantItems";
+import type { Item, State } from "./useController";
+
+export function reduceSubmitFailure(
+  state: State,
+  submissionId: string,
+  error: string,
+  conservative: boolean,
+  observedAt: number,
+): State {
+  if (state.pendingSubmissionId !== submissionId) return state;
+  const index = state.items.findIndex((item) => item.kind === "user" && item.submissionId === submissionId);
+  const items = index < 0
+    ? state.items
+    : state.items.map((item, itemIndex) => itemIndex === index ? { ...item, submissionId: undefined, failed: true } : item);
+  const next = {
+    ...state,
+    pendingUser: undefined,
+    pendingSubmissionId: undefined,
+    deliveryRecoveryActive: false,
+    cancelRequested: false,
+    seq: state.seq + 1,
+    items: [...removeEmptyAssistantItems(items), { kind: "notice", id: `n${state.seq}`, level: "warn", text: error } as Item],
+  };
+  return {
+    ...next,
+    running: conservative,
+    turnActive: conservative,
+    pendingPrompt: conservative && Boolean(state.approval || state.ask || state.mcpInteraction),
+    cancellable: conservative,
+    ...(conservative ? {} : {
+      activeTurnId: undefined,
+      currentAssistant: undefined,
+      assistantSegmentOrdinal: 0,
+      live: undefined,
+      streamAttemptJournal: undefined,
+      turnLifecycleObservedAt: observedAt,
+    }),
+  };
+}
+
+export async function findTabAfterSubmitFailure(
+  binding: Pick<AppBindings, "ListTabs">,
+  tabId: string,
+  delays: readonly number[],
+  clock: () => number,
+) {
+  for (const delay of delays) {
+    if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
+    const snapshotAt = clock();
+    try {
+      const tab = asArray(await binding.ListTabs()).find((candidate) => candidate.id === tabId);
+      return [tab, snapshotAt] as const;
+    } catch {
+      // The caller's stale-turn watchdog remains the long-tail backstop.
+    }
+  }
+  return undefined;
+}

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -12,7 +12,7 @@ import { settleForkConversationForTab } from "./forkWorktree";
 import type { MessageActionScope, MessageActionState } from "./messageActions";
 import { mergeRateBand, type AggregatedRateBand } from "./costRateBand";
 import { requestInboxCancel, type CancelOutcome } from "./inboxCancel";
-import { resolveActiveTurnId } from "./inboxSubmit";
+import { answerPromptForActiveTurn, resolveActiveTurnId } from "./inboxSubmit";
 import { formatContextMaintenanceNotice, isNewMaintenanceOperation, rememberMaintenanceOperation } from "./contextMaintenanceTypes";
 import { formatGuardianAssessmentNotice } from "./guardianEvents";
 import { completionSummaryPresentation, normalizeCompletionSummary, sessionQualityFloor } from "./completionSummary";
@@ -804,6 +804,7 @@ type Action =
   | { type: "unsend" }
   | { type: "send_confirmed"; submissionId: string }
   | { type: "turn_admitted"; turnId: string; submissionId: string }
+  | { type: "turn_submit_rejected"; submissionId: string; error: string }
   | { type: "send_failed"; submissionId: string; error: string }
   | { type: "turn_interrupted" }
   | { type: "backend_status"; running: boolean; turnStartedAt?: number; pendingPrompt?: boolean; backgroundJobs?: number; cancelRequested?: boolean; cancellable?: boolean; turnId?: string; turnStatus?: string; snapshotAt?: number }
@@ -839,6 +840,7 @@ type Action =
   | { type: "clearExtensionForm" }
   | { type: "extension_notifications_drained" }
   | { type: "approval_drained"; ids: string[]; epoch: number }
+  | { type: "ask_submit_succeeded"; id: string; epoch: number }
   | { type: "submit_prompt_failed"; id: string; epoch: number }
   | { type: "controller_rebuilt" }
   | { type: "reset" }
@@ -2089,12 +2091,19 @@ export function reducer(s: State, a: Action): State {
       return s.pendingSubmissionId === a.submissionId && a.turnId
         ? { ...s, activeTurnId: a.turnId }
         : s;
+    case "turn_submit_rejected":
     case "send_failed": {
       if (s.pendingSubmissionId !== a.submissionId) return s;
       const idx = s.items.findIndex((it) => it.kind === "user" && it.submissionId === a.submissionId);
       const items = idx >= 0 ? s.items.map((it, i) => (i === idx ? { ...it, submissionId: undefined, failed: true } : it)) : s.items;
       const notice: Item = { kind: "notice", id: `n${s.seq}`, level: "warn", text: a.error };
-      return { ...s, pendingUser: undefined, pendingSubmissionId: undefined, deliveryRecoveryActive: false, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, activeTurnId: undefined, currentAssistant: undefined, assistantSegmentOrdinal: 0, live: undefined, streamAttemptJournal: undefined, turnLifecycleObservedAt: promptEventClock(), seq: s.seq + 1, items: [...removeEmptyAssistantItems(items), notice] };
+      const next = { ...s, pendingUser: undefined, pendingSubmissionId: undefined, deliveryRecoveryActive: false, cancelRequested: false, seq: s.seq + 1, items: [...removeEmptyAssistantItems(items), notice] };
+      if (a.type === "turn_submit_rejected") {
+        // Admission failed, but the backend may still own an older turn. Stay
+        // conservatively blocked until ListTabs supplies authoritative truth.
+        return { ...next, running: true, turnActive: true, pendingPrompt: Boolean(s.approval || s.ask || s.mcpInteraction), cancellable: true };
+      }
+      return { ...next, running: false, turnActive: false, pendingPrompt: false, cancellable: false, activeTurnId: undefined, currentAssistant: undefined, assistantSegmentOrdinal: 0, live: undefined, streamAttemptJournal: undefined, turnLifecycleObservedAt: promptEventClock() };
     }
     case "turn_interrupted": {
       return withRemoteTurnInterrupted(s);
@@ -2107,6 +2116,7 @@ export function reducer(s: State, a: Action): State {
       const cancelRequested = Boolean(a.cancelRequested);
       const foregroundRunning = foregroundRunningFromRuntimeMeta({ running: a.running, pendingPrompt, backgroundJobs, cancellable: a.cancellable });
       const turnStartedAt = foregroundRunning ? resolveSnapshotTurnStartedAt(s.running || s.turnActive ? s.turnStartAt : 0, a.turnStartedAt) : s.turnStartAt;
+      const activeTurnId = foregroundRunning ? a.turnId ?? s.activeTurnId : undefined;
       // A retry event is newer evidence of foreground activity than an idle
       // snapshot whose fetch started earlier. Keep the turn cancellable until
       // a snapshot started after the retry confirms that it is actually idle.
@@ -2120,6 +2130,7 @@ export function reducer(s: State, a: Action): State {
         cancelRequested === s.cancelRequested &&
         cancellable === s.cancellable &&
         turnStartedAt === s.turnStartAt &&
+        activeTurnId === s.activeTurnId &&
         !clearsRetry
       ) return s;
       if (foregroundRunning) {
@@ -2131,7 +2142,7 @@ export function reducer(s: State, a: Action): State {
           backgroundJobs,
           cancelRequested,
           cancellable,
-          activeTurnId: a.turnId ?? s.activeTurnId,
+          activeTurnId,
           turnStartAt: turnStartedAt,
         };
       }
@@ -2354,6 +2365,11 @@ export function reducer(s: State, a: Action): State {
     case "approval_drained": {
       if (s.promptEpoch !== a.epoch || !s.approval || !a.ids.includes(s.approval.id)) return s;
       const next = { ...s, approval: undefined, pendingPrompt: Boolean(s.ask), resolvedPromptId: s.approval.id };
+      return endPromptWaitIfIdle(next);
+    }
+    case "ask_submit_succeeded": {
+      if (s.promptEpoch !== a.epoch || s.ask?.id !== a.id) return s;
+      const next = { ...s, ask: undefined, pendingPrompt: Boolean(s.approval), resolvedPromptId: a.id };
       return endPromptWaitIfIdle(next);
     }
     // The optimistic clearApproval/clearAsk tombstone was wrong: the backend
@@ -3281,6 +3297,25 @@ export function useController() {
     return tabs;
   }, [dispatchRuntimeStatusForTab, loadSessionDataForTab, refreshBalanceForTab]);
 
+  // A rejected mutation can race an already-running backend turn. Unlike the
+  // general background reconciler, this path must distinguish bridge failure
+  // from a successful empty snapshot: bridge failure keeps the composer
+  // conservatively blocked, while a confirmed missing tab settles it idle.
+  const reconcileRuntimeAfterRejectedMutation = useCallback(async (tabId: string): Promise<void> => {
+    for (const delay of CANCEL_RECONCILE_DELAYS_MS) {
+      if (delay) await new Promise((resolve) => window.setTimeout(resolve, delay));
+      const snapshotAt = promptEventClock();
+      try {
+        const tab = asArray(await app.ListTabs()).find((candidate) => candidate.id === tabId);
+        if (tab?.runtime?.epoch) runtimeEpochByTabRef.current.set(tabId, tab.runtime.epoch);
+        dispatchRuntimeStatusForTab(tabId, tab ?? { running: false }, snapshotAt);
+        return;
+      } catch {
+        // The stale-turn watchdog is the long-tail backstop after this burst.
+      }
+    }
+  }, [dispatchRuntimeStatusForTab]);
+
   // Authoritative backstop for the prompt-freshness heuristic: after the reducer
   // rejects a stale idle snapshot, refetch backend state once. If the backend
   // resolved the prompt, the fresh snapshot (fetched after any in-flight replay)
@@ -3680,6 +3715,16 @@ export function useController() {
     lastTurnActivityAtByTab, reconcile: reconcileStaleTurn,
   });
 
+  const rejectTurnSubmission = useCallback((tabId: string, submissionId: string, error: unknown) => {
+    if (statesRef.current.get(tabId)?.pendingSubmissionId !== submissionId) return;
+    dispatchTo(tabId, {
+      type: "turn_submit_rejected",
+      submissionId,
+      error: `Send failed: ${errorMessage(error)}`,
+    });
+    void reconcileRuntimeAfterRejectedMutation(tabId);
+  }, [dispatchTo, reconcileRuntimeAfterRejectedMutation]);
+
   // Replay any pending approval/ask prompts when switching tabs, so a
   // plan-mode session left awaiting confirmation rebuilds its modal (#4275).
   useEffect(() => {
@@ -3748,13 +3793,13 @@ export function useController() {
           }
           dispatchTo(tabId, { type: "send_confirmed", submissionId });
         },
-        (error) => dispatchTo(tabId, { type: "send_failed", submissionId, error: `Send failed: ${error instanceof Error ? error.message : String(error)}` }),
+        (error) => rejectTurnSubmission(tabId, submissionId, error),
       );
     } catch (error) {
-      dispatchTo(tabId, { type: "send_failed", submissionId, error: `Send failed: ${error instanceof Error ? error.message : String(error)}` });
+      rejectTurnSubmission(tabId, submissionId, error);
       throw error;
     }
-  }, [bumpCancelHydrateSeq, dispatchTo]);
+  }, [bumpCancelHydrateSeq, dispatchTo, rejectTurnSubmission]);
 
   const recoverDeliveryToTab = useCallback(async (tabId: string, displayText: string, submitText = displayText) => {
     if (!tabId) throw new Error(t("composer.workspaceStarting"));
@@ -3772,13 +3817,13 @@ export function useController() {
     try {
       void app.SubmitDeliveryRecoveryToTabWithID(tabId, display, submit, submissionId).then(
         () => dispatchTo(tabId, { type: "send_confirmed", submissionId }),
-        (error) => dispatchTo(tabId, { type: "send_failed", submissionId, error: `Send failed: ${error instanceof Error ? error.message : String(error)}` }),
+        (error) => rejectTurnSubmission(tabId, submissionId, error),
       );
     } catch (error) {
-      dispatchTo(tabId, { type: "send_failed", submissionId, error: `Send failed: ${error instanceof Error ? error.message : String(error)}` });
+      rejectTurnSubmission(tabId, submissionId, error);
       throw error;
     }
-  }, [dispatchTo]);
+  }, [dispatchTo, rejectTurnSubmission]);
 
   const send = useCallback((displayText: string, submitText = displayText) => {
     const tabId = activeTabIdRef.current ?? activeTabId;
@@ -3932,22 +3977,25 @@ export function useController() {
     });
   }, [activeTabId, dispatchTo]);
 
-  const answerQuestion = useCallback((id: string, answers: QuestionAnswer[]) => {
-    if (!activeTabId) return;
+  const answerQuestion = useCallback(async (id: string, answers: QuestionAnswer[]): Promise<void> => {
+    if (!activeTabId) throw new Error("active tab is unavailable");
     const tabId = activeTabId;
-    const epoch = statesRef.current.get(tabId)?.promptEpoch ?? 0;
-    const turnId = statesRef.current.get(tabId)?.activeTurnId;
-    dispatchTo(tabId, { type: "clearAsk" });
-    const request = typeof app.AnswerPromptForTab === "function"
-      ? turnId
-        ? app.AnswerPromptForTab(tabId, turnId, id, answers)
-        : Promise.reject(new Error("active turn id is unavailable"))
-      : app.AnswerQuestionForTab(tabId, id, answers);
-    request.catch(() => {
-      dispatchTo(tabId, { type: "submit_prompt_failed", id, epoch });
-      replayPendingPromptsForActiveTab(tabId);
-    });
-  }, [activeTabId, dispatchTo]);
+    const state = statesRef.current.get(tabId);
+    const epoch = state?.promptEpoch ?? 0;
+    try {
+      await answerPromptForActiveTurn(app, tabId, id, answers, state?.activeTurnId);
+      dispatchTo(tabId, { type: "ask_submit_succeeded", id, epoch });
+    } catch (error) {
+      dispatchTo(tabId, {
+        type: "local_notice",
+        level: "warn",
+        text: `Unable to submit answer: ${errorMessage(error)}`,
+        preserveRuntime: true,
+      });
+      void reconcileRuntimeAfterRejectedMutation(tabId);
+      throw error;
+    }
+  }, [activeTabId, dispatchTo, reconcileRuntimeAfterRejectedMutation]);
 
   const answerMCPInteraction = useCallback(
     (id: string, action: "accept" | "decline" | "cancel", content?: Record<string, unknown>) => {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -12,7 +12,8 @@ import { settleForkConversationForTab } from "./forkWorktree";
 import type { MessageActionScope, MessageActionState } from "./messageActions";
 import { mergeRateBand, type AggregatedRateBand } from "./costRateBand";
 import { requestInboxCancel, type CancelOutcome } from "./inboxCancel";
-import { answerPromptForActiveTurn, resolveActiveTurnId } from "./inboxSubmit";
+import { answerPromptForActiveTurn, isLocalRuntimeCommand, normalizeTurnSubmit, resolveActiveTurnId } from "./inboxSubmit";
+import { findTabAfterSubmitFailure, reduceSubmitFailure } from "./turnSubmissionFailure";
 import { formatContextMaintenanceNotice, isNewMaintenanceOperation, rememberMaintenanceOperation } from "./contextMaintenanceTypes";
 import { formatGuardianAssessmentNotice } from "./guardianEvents";
 import { completionSummaryPresentation, normalizeCompletionSummary, sessionQualityFloor } from "./completionSummary";
@@ -705,28 +706,7 @@ export function runtimeReadyForSubmit(meta?: Meta): boolean {
   return !meta.runtime || meta.runtime.phase === "ready";
 }
 
-// normalizeTurnSubmit is the final frontend boundary before optimistic
-// transcript state is created. Display text may intentionally be shorter than
-// the provider input, but a visible-only message must never start an empty model
-// turn (#6869).
-export function normalizeTurnSubmit(displayText: string, submitText: string): {
-  display: string;
-  submit: string;
-} {
-  const display = displayText.trim();
-  const submit = submitText.trim();
-  if (!submit) throw new Error("Message cannot be empty.");
-  return { display, submit };
-}
-
-// These commands are handled entirely by the desktop host and deliberately do
-// not create an agent turn. Keep them on the compatibility submit entry point:
-// StartTurnForTab must return a durable turnId and would correctly reject a
-// successful local command for having no admitted turn.
-export function isLocalRuntimeCommand(input: string): boolean {
-  const trimmed = input.trim();
-  return trimmed === "/reload" || trimmed === "/effort" || trimmed.startsWith("/effort ");
-}
+export { isLocalRuntimeCommand, normalizeTurnSubmit } from "./inboxSubmit";
 
 const frontendSubmissionEpoch = typeof globalThis.crypto?.randomUUID === "function"
   ? globalThis.crypto.randomUUID()
@@ -2092,19 +2072,7 @@ export function reducer(s: State, a: Action): State {
         ? { ...s, activeTurnId: a.turnId }
         : s;
     case "turn_submit_rejected":
-    case "send_failed": {
-      if (s.pendingSubmissionId !== a.submissionId) return s;
-      const idx = s.items.findIndex((it) => it.kind === "user" && it.submissionId === a.submissionId);
-      const items = idx >= 0 ? s.items.map((it, i) => (i === idx ? { ...it, submissionId: undefined, failed: true } : it)) : s.items;
-      const notice: Item = { kind: "notice", id: `n${s.seq}`, level: "warn", text: a.error };
-      const next = { ...s, pendingUser: undefined, pendingSubmissionId: undefined, deliveryRecoveryActive: false, cancelRequested: false, seq: s.seq + 1, items: [...removeEmptyAssistantItems(items), notice] };
-      if (a.type === "turn_submit_rejected") {
-        // Admission failed, but the backend may still own an older turn. Stay
-        // conservatively blocked until ListTabs supplies authoritative truth.
-        return { ...next, running: true, turnActive: true, pendingPrompt: Boolean(s.approval || s.ask || s.mcpInteraction), cancellable: true };
-      }
-      return { ...next, running: false, turnActive: false, pendingPrompt: false, cancellable: false, activeTurnId: undefined, currentAssistant: undefined, assistantSegmentOrdinal: 0, live: undefined, streamAttemptJournal: undefined, turnLifecycleObservedAt: promptEventClock() };
-    }
+    case "send_failed": return reduceSubmitFailure(s, a.submissionId, a.error, a.type === "turn_submit_rejected", promptEventClock());
     case "turn_interrupted": {
       return withRemoteTurnInterrupted(s);
     }
@@ -3297,23 +3265,12 @@ export function useController() {
     return tabs;
   }, [dispatchRuntimeStatusForTab, loadSessionDataForTab, refreshBalanceForTab]);
 
-  // A rejected mutation can race an already-running backend turn. Unlike the
-  // general background reconciler, this path must distinguish bridge failure
-  // from a successful empty snapshot: bridge failure keeps the composer
-  // conservatively blocked, while a confirmed missing tab settles it idle.
   const reconcileRuntimeAfterRejectedMutation = useCallback(async (tabId: string): Promise<void> => {
-    for (const delay of CANCEL_RECONCILE_DELAYS_MS) {
-      if (delay) await new Promise((resolve) => window.setTimeout(resolve, delay));
-      const snapshotAt = promptEventClock();
-      try {
-        const tab = asArray(await app.ListTabs()).find((candidate) => candidate.id === tabId);
-        if (tab?.runtime?.epoch) runtimeEpochByTabRef.current.set(tabId, tab.runtime.epoch);
-        dispatchRuntimeStatusForTab(tabId, tab ?? { running: false }, snapshotAt);
-        return;
-      } catch {
-        // The stale-turn watchdog is the long-tail backstop after this burst.
-      }
-    }
+    const result = await findTabAfterSubmitFailure(app, tabId, CANCEL_RECONCILE_DELAYS_MS, promptEventClock);
+    if (!result) return;
+    const [tab, snapshotAt] = result;
+    if (tab?.runtime?.epoch) runtimeEpochByTabRef.current.set(tabId, tab.runtime.epoch);
+    dispatchRuntimeStatusForTab(tabId, tab ?? { running: false }, snapshotAt);
   }, [dispatchRuntimeStatusForTab]);
 
   // Authoritative backstop for the prompt-freshness heuristic: after the reducer
@@ -3717,11 +3674,7 @@ export function useController() {
 
   const rejectTurnSubmission = useCallback((tabId: string, submissionId: string, error: unknown) => {
     if (statesRef.current.get(tabId)?.pendingSubmissionId !== submissionId) return;
-    dispatchTo(tabId, {
-      type: "turn_submit_rejected",
-      submissionId,
-      error: `Send failed: ${errorMessage(error)}`,
-    });
+    dispatchTo(tabId, { type: "turn_submit_rejected", submissionId, error: `Send failed: ${errorMessage(error)}` });
     void reconcileRuntimeAfterRejectedMutation(tabId);
   }, [dispatchTo, reconcileRuntimeAfterRejectedMutation]);
 
@@ -3977,24 +3930,19 @@ export function useController() {
     });
   }, [activeTabId, dispatchTo]);
 
-  const answerQuestion = useCallback(async (id: string, answers: QuestionAnswer[]): Promise<void> => {
-    if (!activeTabId) throw new Error("active tab is unavailable");
+  const answerQuestion = useCallback((id: string, answers: QuestionAnswer[]): Promise<void> => {
+    if (!activeTabId) return Promise.reject(new Error("active tab is unavailable"));
     const tabId = activeTabId;
     const state = statesRef.current.get(tabId);
     const epoch = state?.promptEpoch ?? 0;
-    try {
-      await answerPromptForActiveTurn(app, tabId, id, answers, state?.activeTurnId);
-      dispatchTo(tabId, { type: "ask_submit_succeeded", id, epoch });
-    } catch (error) {
-      dispatchTo(tabId, {
-        type: "local_notice",
-        level: "warn",
-        text: `Unable to submit answer: ${errorMessage(error)}`,
-        preserveRuntime: true,
-      });
-      void reconcileRuntimeAfterRejectedMutation(tabId);
-      throw error;
-    }
+    return answerPromptForActiveTurn(app, tabId, id, answers, state?.activeTurnId).then(
+      () => dispatchTo(tabId, { type: "ask_submit_succeeded", id, epoch }),
+      (error) => {
+        dispatchTo(tabId, { type: "local_notice", level: "warn", text: `Unable to submit answer: ${errorMessage(error)}`, preserveRuntime: true });
+        void reconcileRuntimeAfterRejectedMutation(tabId);
+        throw error;
+      },
+    );
   }, [activeTabId, dispatchTo, reconcileRuntimeAfterRejectedMutation]);
 
   const answerMCPInteraction = useCallback(

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -3938,7 +3938,7 @@ export function useController() {
     return answerPromptForActiveTurn(app, tabId, id, answers, state?.activeTurnId).then(
       () => dispatchTo(tabId, { type: "ask_submit_succeeded", id, epoch }),
       (error) => {
-        dispatchTo(tabId, { type: "local_notice", level: "warn", text: `Unable to submit answer: ${errorMessage(error)}`, preserveRuntime: true });
+        dispatchTo(tabId, { type: "local_notice", level: "warn", text: t("notice.askSubmitFailed", { error: errorMessage(error) }), preserveRuntime: true });
         void reconcileRuntimeAfterRejectedMutation(tabId);
         throw error;
       },

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -3069,6 +3069,7 @@ export const en = {
   "notice.remoteTurnInterrupted": "The remote connection dropped mid-turn; the session will re-sync from the server after reconnecting.",
   "notice.remoteProviderUnreachable": "The credential channel (desktop key proxy) is unreachable, retrying: {detail}",
   "notice.warning": "Warning",
+  "notice.askSubmitFailed": "Unable to submit answer: {error}",
   "notice.details": "Details",
   "notice.decisionReceiptTitle": "Decision recorded",
   "notice.decisionReceiptTool": "Tool approval",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2130,6 +2130,7 @@ export const zhTW: Record<DictKey, string> = {
   "notice.remoteTurnInterrupted": "遠端連線已中斷，本輪對話的狀態暫不可知；重連後會話將從伺服器恢復。",
   "notice.remoteProviderUnreachable": "憑證通道（桌面金鑰代理）不可達，正在重試：{detail}",
   "notice.warning": "警告",
+  "notice.askSubmitFailed": "提交回答失敗：{error}",
   "notice.details": "詳情",
   "notice.decisionReceiptTitle": "已記錄決策",
   "notice.decisionReceiptTool": "工具核准",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -3072,6 +3072,7 @@ export const zh: Record<DictKey, string> = {
   "notice.remoteTurnInterrupted": "远程连接已中断，本轮对话的状态暂不可知；重连后会话将从服务端恢复。",
   "notice.remoteProviderUnreachable": "凭证通道（桌面密钥代理）不可达，正在重试：{detail}",
   "notice.warning": "警告",
+  "notice.askSubmitFailed": "提交回答失败：{error}",
   "notice.details": "详情",
   "notice.decisionReceiptTitle": "已记录决策",
   "notice.decisionReceiptTool": "工具审批",


### PR DESCRIPTION
## Summary

- Resolve a missing local turn id from authoritative `ListTabs` state before answering an Ask prompt, and never fall back to the unfenced endpoint when the exact bridge exists.
- Keep Ask progress and selections mounted until the answer or skip RPC succeeds; fence cleanup by prompt id and controller epoch so late completions cannot clear a newer prompt.
- Reconcile rejected normal and delivery submissions against backend runtime truth with bounded retries, preserving the active prompt gate while an older turn still owns the tab.
- Apply the same Promise-based failure recovery to remote Ask surfaces.
- Localize Ask submission-failure warnings for English, Simplified Chinese, and Traditional Chinese desktop locales.
- Install frontend dependencies from the frozen lockfile; no dependency or lockfile versions changed.

## Problem

Users could enter a loop between the two Ask questions. Selecting Skip and keep chatting could also replay the Ask, while subsequent sends repeatedly failed with `turn already running`.

## Root cause

The frontend optimistically cleared the Ask before the bridge accepted the answer, attempted prompt recovery by replaying after failure, and settled rejected sends as locally idle before reconciling the authoritative backend turn. A missing local turn id also prevented use of the exact turn-fenced answer API.

## Verification

- `cd desktop/frontend && pnpm install --frozen-lockfile`
- `cd desktop/frontend && pnpm exec tsx --version` (`tsx v4.23.11`)
- `cd desktop/frontend && pnpm test:all`
- `cd desktop/frontend && pnpm build` (raw startup payload: 2456.044 KiB; narrow 2456.1 KiB budget)
- Active-locale Ask failure regression: Simplified Chinese warning retained alongside the retryable Ask card
- `go test ./internal/control -run 'TestDismissedAskCancelsTurnWithoutModelContinuation|TestAskResolutionRemainsPendingWhenPersistenceFails' -count=1`
- `cd desktop && go test ./...`
- `cd desktop && wails build -s -skipbindings -nopackage`
- Isolated Wails startup smoke
- Headless Chromium `/mock-ask` smoke: two-question submit and skip both completed; no Ask replay, no `turn already running`, and no console errors or warnings

Documentation-impact: none - this restores the existing Ask and turn-recovery behavior.

Cache-impact: none - no provider-visible prompt, cache input, provider routing, or persistence semantics changed.

Cache-guard: `cd desktop/frontend && pnpm exec tsx src/__tests__/ask-submit.test.ts && pnpm exec tsx src/__tests__/use-controller-send-fallback.test.tsx`

System-prompt-review: N/A