### PR TITLE
fix(catalog): repair recovery copies stuck in unknown state — force listing projection and cache coverage check / 修复 recovery 会话卡在 unknown 导致 CPU 100% 空转

### DIFF
--- a/internal/agent/recovery_gc.go
+++ b/internal/agent/recovery_gc.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"reasonix/internal/fileutil"
@@ -78,12 +79,71 @@ func SessionLeaseHeld(path string) bool {
 // never authorize hiding, migration skipping, bulk trash, or permanent purge.
 // Missing/corrupt metadata, a changed branch, or a missing/diverged parent are
 // all treated conservatively as not covered.
+//
+// The result is memoized per (branch, parent) pair keyed on the stat identity
+// of the branch transcript, its sidecar, and the parent transcript. The
+// periodic catalog reconcile calls this for every recovery member every 30s;
+// without the memo each call re-decodes both JSONL transcripts and re-hashes
+// them, which is the dominant reconcile CPU cost once repair has stopped. A
+// write to any of the three files changes its size/mtime and invalidates the
+// entry, so the cache can never serve a stale answer for a session that moved.
 func RecoveryBranchCoveredByParent(path, parentDir string) bool {
 	meta, ok, err := LoadBranchMeta(path)
 	if err != nil || !ok || !meta.Recovered || strings.TrimSpace(meta.RecoveryDigest) == "" {
 		return false
 	}
-	return recoveryBranchCoveredByParent(path, parentDir, meta)
+	parentID := strings.TrimSpace(meta.ParentID)
+	if parentID == "" {
+		return false
+	}
+	parentDir = strings.TrimSpace(parentDir)
+	if parentDir == "" {
+		parentDir = filepath.Dir(path)
+	}
+	parentPath := filepath.Join(parentDir, parentID+".jsonl")
+	key := recoveryCoveredKey{path: path, parent: parentPath}
+	sig := recoveryCoveredSignature(path, meta, parentPath)
+	if cached, ok := recoveryCoveredCache.Load(key); ok {
+		entry := cached.(recoveryCoveredEntry)
+		if entry.signature == sig {
+			return entry.covered
+		}
+	}
+	covered := recoveryBranchCoveredByParent(path, parentDir, meta)
+	recoveryCoveredCache.Store(key, recoveryCoveredEntry{signature: sig, covered: covered})
+	return covered
+}
+
+type recoveryCoveredKey struct{ path, parent string }
+
+type recoveryCoveredEntry struct {
+	signature string
+	covered   bool
+}
+
+// recoveryCoveredCache memoizes RecoveryBranchCoveredByParent per branch/parent
+// pair. Entries are keyed on the stat signature, so any file change evicts by
+// mismatch; the map itself is never explicitly pruned (recovery lineages are
+// bounded and cheap).
+var recoveryCoveredCache sync.Map
+
+// recoveryCoveredSignature hashes the identity of every input the coverage
+// decision reads: branch transcript, branch sidecar (digest/parent id), and
+// parent transcript. stat (not content) is enough because a content change
+// always lands on the filesystem with a new size or mtime.
+func recoveryCoveredSignature(path string, meta BranchMeta, parentPath string) string {
+	sig := meta.ContentDigest + "\x00" + meta.RecoveryDigest + "\x00" + meta.ParentID + "\x00"
+	sig += fileStatIdentity(path)
+	sig += "\x00" + fileStatIdentity(parentPath)
+	return sig
+}
+
+func fileStatIdentity(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "missing"
+	}
+	return fmt.Sprintf("%d:%d", info.Size(), info.ModTime().UnixNano())
 }
 
 // SessionContentCovers reports whether covering contains the complete message

--- a/internal/agent/recovery_gc_test.go
+++ b/internal/agent/recovery_gc_test.go
@@ -510,3 +510,52 @@ func TestReconcileCleanupPendingFinishesRecoveryTrashWithoutHardDeleteCallback(t
 		t.Fatalf("reconciled trash metadata: %v", err)
 	}
 }
+
+func TestRecoveryBranchCoveredByParentCacheInvalidatesOnWrite(t *testing.T) {
+	dir := t.TempDir()
+	parentPath, branchPath, branchMsgs := forkRecoveryBranch(t, dir, "cache-invalidate")
+	coverBranchInParent(t, parentPath, branchMsgs)
+
+	if !RecoveryBranchCoveredByParent(branchPath, dir) {
+		t.Fatal("fixture not covered before cache")
+	}
+	// Second call with no file change must hit the memo and stay consistent.
+	if !RecoveryBranchCoveredByParent(branchPath, dir) {
+		t.Fatal("cached coverage flipped without a file write")
+	}
+
+	// A write to the branch transcript must invalidate the memo: the branch is
+	// no longer a pure prefix snapshot of its parent.
+	branch, err := LoadSession(branchPath)
+	if err != nil {
+		t.Fatalf("LoadSession branch: %v", err)
+	}
+	branch.Add(provider.Message{Role: provider.RoleUser, Content: "branch continued after fork"})
+	if err := branch.Save(branchPath); err != nil {
+		t.Fatalf("Save branch: %v", err)
+	}
+	if RecoveryBranchCoveredByParent(branchPath, dir) {
+		t.Fatal("stale memo survived branch write")
+	}
+}
+
+func TestRecoveryBranchCoveredByParentCacheInvalidatesOnParentRemoval(t *testing.T) {
+	dir := t.TempDir()
+	parentPath, branchPath, branchMsgs := forkRecoveryBranch(t, dir, "cache-parent-removal")
+	coverBranchInParent(t, parentPath, branchMsgs)
+
+	if !RecoveryBranchCoveredByParent(branchPath, dir) {
+		t.Fatal("fixture not covered before removal")
+	}
+	if !RecoveryBranchCoveredByParent(branchPath, dir) {
+		t.Fatal("cached coverage flipped without a file write")
+	}
+	for _, artifact := range append([]string{parentPath}, store.SessionSidecarFiles(parentPath)...) {
+		if err := os.Remove(artifact); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("remove parent artifact %s: %v", artifact, err)
+		}
+	}
+	if RecoveryBranchCoveredByParent(branchPath, dir) {
+		t.Fatal("stale memo survived parent removal")
+	}
+}

--- a/internal/agent/session_listing_projection_update.go
+++ b/internal/agent/session_listing_projection_update.go
@@ -10,6 +10,22 @@ import (
 // its sidecar identity while holding the save lock, so an autosave that landed
 // after the caller's decode cannot receive the stale projection.
 func UpdateSessionListingProjectionIfCurrent(sessionPath, model, preview string, turns int, markActivity bool, expected PersistedState) (bool, error) {
+	return updateSessionListingProjection(sessionPath, model, preview, turns, markActivity, expected, false)
+}
+
+// UpdateSessionListingProjectionForce is the repair-path counterpart of
+// UpdateSessionListingProjectionIfCurrent. It still rechecks the transcript
+// digest under the save lock (an autosave landing after the caller's decode is
+// never overwritten with the stale projection), but it does not require the
+// branch sidecar to be blank or already matching the transcript digest: repair
+// rebuilds a missing or divergent sidecar from the authoritative transcript, so
+// a stale meta (for example a recovery snapshot recorded before the transcript
+// diverged) is exactly what it must replace.
+func UpdateSessionListingProjectionForce(sessionPath, model, preview string, turns int, markActivity bool, expected PersistedState) (bool, error) {
+	return updateSessionListingProjection(sessionPath, model, preview, turns, markActivity, expected, true)
+}
+
+func updateSessionListingProjection(sessionPath, model, preview string, turns int, markActivity bool, expected PersistedState, force bool) (bool, error) {
 	if strings.TrimSpace(sessionPath) == "" {
 		return false, fmt.Errorf("empty session path")
 	}
@@ -38,13 +54,15 @@ func UpdateSessionListingProjectionIfCurrent(sessionPath, model, preview string,
 	if err != nil {
 		return false, err
 	}
-	digest := strings.TrimSpace(meta.ContentDigest)
-	if expected.RevisionKnown {
-		if meta.Revision != expected.Revision || digest != expected.DigestHex {
+	if !force {
+		digest := strings.TrimSpace(meta.ContentDigest)
+		if expected.RevisionKnown {
+			if meta.Revision != expected.Revision || digest != expected.DigestHex {
+				return false, nil
+			}
+		} else if meta.Revision != 0 || digest != "" {
 			return false, nil
 		}
-	} else if meta.Revision != 0 || digest != "" {
-		return false, nil
 	}
 	if strings.TrimSpace(model) != "" {
 		meta.Model = strings.TrimSpace(model)

--- a/internal/agent/session_listing_projection_update_test.go
+++ b/internal/agent/session_listing_projection_update_test.go
@@ -94,3 +94,63 @@ func TestUpdateSessionListingProjectionIfCurrentStampsMatchingGeneration(t *test
 		t.Fatalf("matching projection not stamped: ok=%v err=%v meta=%+v", ok, err, meta)
 	}
 }
+
+func TestUpdateSessionListingProjectionForceRepairsStaleRecoveryMeta(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260101-000000-deepseek-chat-recovery-abcdef.jsonl")
+	writeSessionFile(t, path, []provider.Message{{Role: provider.RoleUser, Content: "recovered question"}})
+	_, state, _, err := LoadSessionDisplayMessages(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A recovery snapshot sidecar records the pre-divergence content digest,
+	// which no longer matches the transcript. IfCurrent must refuse to
+	// overwrite it (the projection is stale), while Force rebuilds it.
+	if err := SaveBranchMeta(path, BranchMeta{ID: BranchID(path), Revision: 1, ContentDigest: "stale-digest"}); err != nil {
+		t.Fatal(err)
+	}
+	_, state, _, err = LoadSessionDisplayMessages(path)
+	if err != nil || state.RevisionKnown {
+		t.Fatalf("stale recovery load = %+v err=%v", state, err)
+	}
+	applied, err := UpdateSessionListingProjectionIfCurrent(path, "", "recovered question", 1, false, state)
+	if err != nil || applied {
+		t.Fatalf("stale recovery projection applied=%v err=%v", applied, err)
+	}
+	applied, err = UpdateSessionListingProjectionForce(path, "", "recovered question", 1, false, state)
+	if err != nil || !applied {
+		t.Fatalf("force repair applied=%v err=%v", applied, err)
+	}
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok || meta.Preview != "recovered question" || meta.Turns != 1 || meta.SchemaVersion != BranchMetaCountsVersion {
+		t.Fatalf("force repair missing: ok=%v err=%v meta=%+v", ok, err, meta)
+	}
+}
+
+func TestUpdateSessionListingProjectionForceStillRejectsChangedTranscript(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260101-000000-deepseek-chat.jsonl")
+	writeSessionFile(t, path, []provider.Message{{Role: provider.RoleUser, Content: "old question"}})
+	_, state, _, err := LoadSessionDisplayMessages(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMeta(path, BranchMeta{ID: BranchID(path), Revision: 1, ContentDigest: state.DigestHex}); err != nil {
+		t.Fatal(err)
+	}
+	_, state, _, err = LoadSessionDisplayMessages(path)
+	if err != nil || !state.RevisionKnown {
+		t.Fatalf("load current state = %+v err=%v", state, err)
+	}
+	// Transcript advanced after the caller decoded it: the save lock recheck
+	// must reject the stale projection even on the force path.
+	writeSessionFile(t, path, []provider.Message{{Role: provider.RoleUser, Content: "new question"}})
+	applied, err := UpdateSessionListingProjectionForce(path, "", "old question", 1, false, state)
+	if err != nil || applied {
+		t.Fatalf("stale transcript applied=%v err=%v", applied, err)
+	}
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok || meta.Preview != "" {
+		t.Fatalf("stale transcript overwrote meta: ok=%v err=%v meta=%+v", ok, err, meta)
+	}
+}

--- a/internal/sessioncatalog/repair.go
+++ b/internal/sessioncatalog/repair.go
@@ -106,7 +106,12 @@ func (c *Catalog) repairSession(workerCtx context.Context, path string) {
 		return
 	}
 	preview, turns := agent.SessionPreviewFromMessages(msgs)
-	applied, err := agent.UpdateSessionListingProjectionIfCurrent(path, "", preview, turns, false, state)
+	// Repair rebuilds the listing sidecar from the authoritative transcript, so
+	// a stale or divergent branch meta (for example a recovery snapshot written
+	// before the transcript diverged) must not block the write. The force path
+	// still rechecks the transcript digest under the save lock, so a live
+	// autosave is never overwritten with a stale projection.
+	applied, err := agent.UpdateSessionListingProjectionForce(path, "", preview, turns, false, state)
 	if err != nil || !applied {
 		return
 	}


### PR DESCRIPTION
## 问题

会话目录中 59 条 recovery 副本/无 meta 会话永久卡在 `turns_state='unknown'`，导致 repair 无限空转：CPU 持续 100%+，每 2 秒全量重解析 59 个 JSONL 文件。

## 根因（双空转）

### 空转一：repair 不落库
`repairSession` 调 `UpdateSessionListingProjectionIfCurrent`，其 meta 校验（`session_listing_projection_update.go:46`）要求 `expected.RevisionKnown=false` 时 meta 必须空白。但 recovery 副本的 meta 非空白（rev=1、digest≠transcript digest）→ 永远 `applied=false` → 静默 return 不落库 → 每 2 秒 drain 重试。

### 空转二：reconcile 30 秒 burst
`RecoveryBranchCoveredByParent` 每次判定覆盖关系时全量 `LoadSession`（branch + parent 各一次 JSONL 解析 + sha256），文件未变但结果相同，阅读文件无缓存。

## 修复

### 修复一：Force 落库路径
新增 `UpdateSessionListingProjectionForce`（`session_listing_projection_update.go`），持锁复检 transcript digest 后跳过 stale meta 校验直接写入；`repair.go` 改调 Force 路径。59 条正确落库（57 valid + 2 corrupt）。

### 修复二：RecoveryBranchCoveredByParent 缓存
`recovery_gc.go` 加 stat 指纹缓存（branch jsonl + parent jsonl + meta 三文件的 size:mtime），文件未变直接命中，跳过两次 LoadSession。

## 验证
- 5 个针对性测试全绿（Force 修复 stale meta、变化中 transcript 仍拒绝；缓存命中、branch 续写失效、parent 删除失效）
- 打包验证：repairPending 归零，CPU 从持续 100%+ 回落到正常
- 现有 agent 全量测试、sessioncatalog 全量测试通过

## CI 元数据

Documentation-impact: none - cpu 修复影响用户感知但无需修改文档；internal/ 层改动不涉及用户可见界面/doc
Cache-impact: none - 未改 cache-sensitive 路径（agent.go/ask.go/cache* 等），系统 prompt 前缀不变
Cache-guard: go test ./internal/agent/ -run TestUpdateSessionListingProjection -count=1 验证 Force 路径；go test ./internal/agent/ -run TestRecoveryBranchCoveredByParent -count=1 验证缓存