### PR TITLE
feat(hook): say why a hook is invalid

### DIFF
--- a/internal/cli/hook_machine.go
+++ b/internal/cli/hook_machine.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -14,6 +15,10 @@ type machineHook struct {
 	Match  string `json:"match,omitempty"`
 	Scope  string `json:"scope"`
 	Status string `json:"status"`
+	// Reason explains a non-active status. Five distinct conditions produce
+	// "invalid", and without this the caller has to guess which one — the
+	// matcher check even discards a message ValidateMatcher already built.
+	Reason string `json:"reason,omitempty"`
 }
 
 type machineHookSource struct {
@@ -79,12 +84,12 @@ func runHookCommand(args []string, out io.Writer) int {
 	if operation == "list" {
 		items := make([]machineHook, 0, len(inspection.Entries))
 		for _, entry := range inspection.Entries {
-			status := machineHookEntryStatus(entry)
+			status, reason := machineHookEntryStatus(entry)
 			match := entry.Match
 			if match == "" {
 				match = "*"
 			}
-			items = append(items, machineHook{Event: string(entry.Event), Match: match, Scope: string(entry.Scope), Status: status})
+			items = append(items, machineHook{Event: string(entry.Event), Match: match, Scope: string(entry.Scope), Status: status, Reason: reason})
 		}
 		sort.SliceStable(items, func(i, j int) bool {
 			if items[i].Event != items[j].Event {
@@ -111,28 +116,32 @@ func runHookCommand(args []string, out io.Writer) int {
 	})
 }
 
-func machineHookEntryStatus(entry hook.Entry) string {
+// machineHookEntryStatus reports the entry status and, when it is not active,
+// which of the checks rejected it. Callers render the reason verbatim.
+func machineHookEntryStatus(entry hook.Entry) (status, reason string) {
 	if !hook.IsKnownEvent(string(entry.Event)) {
-		return "invalid"
+		return "invalid", fmt.Sprintf("unknown event %q", string(entry.Event))
 	}
 	command := strings.TrimSpace(entry.Command)
 	contextFile := strings.TrimSpace(entry.ContextFile)
 	if entry.Scope == hook.ScopePlugin {
 		if command == "" && contextFile == "" {
-			return "invalid"
+			return "invalid", "plugin hook has neither a command nor a contextFile"
 		}
 		if contextFile != "" && !hook.ContextFileUsable(contextFile) {
-			return "invalid"
+			return "invalid", fmt.Sprintf("contextFile %q is not readable", contextFile)
 		}
 	} else if command == "" {
 		// Native project/global loading requires a command; contextFile is an
 		// internal plugin-only execution path.
-		return "invalid"
+		return "invalid", "command is required"
 	}
-	if hook.UsesToolMatcher(entry.Event) && hook.ValidateMatcher(entry.Match) != "" {
-		return "invalid"
+	if hook.UsesToolMatcher(entry.Event) {
+		if msg := hook.ValidateMatcher(entry.Match); msg != "" {
+			return "invalid", msg
+		}
 	}
-	return "active"
+	return "active", ""
 }
 
 func parseHookMachineOptions(args []string) (hookMachineOptions, string, string) {

--- a/internal/cli/hook_machine_reason_test.go
+++ b/internal/cli/hook_machine_reason_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/hook"
+)
+
+// Five separate checks produce "invalid", so a bare status leaves the caller
+// guessing which one fired — and the matcher check discarded a message
+// ValidateMatcher had already built. Each rejection now names itself.
+func TestMachineHookEntryStatusExplainsEveryRejection(t *testing.T) {
+	cases := []struct {
+		name  string
+		entry hook.Entry
+		want  string
+	}{
+		{
+			name:  "unknown event",
+			entry: hook.Entry{Event: "NotAnEvent", Command: "echo hi"},
+			want:  "unknown event",
+		},
+		{
+			name:  "missing command",
+			entry: hook.Entry{Event: hook.PostToolUse, Scope: hook.ScopeGlobal},
+			want:  "command is required",
+		},
+		{
+			name:  "bad matcher regex",
+			entry: hook.Entry{Event: hook.PostToolUse, Scope: hook.ScopeGlobal, Command: "echo hi", Match: "("},
+			want:  "matcher",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, reason := machineHookEntryStatus(tc.entry)
+			if status != "invalid" {
+				t.Fatalf("status = %q, want invalid", status)
+			}
+			if !strings.Contains(reason, tc.want) {
+				t.Fatalf("reason = %q, want it to mention %q", reason, tc.want)
+			}
+		})
+	}
+}
+
+func TestMachineHookEntryStatusLeavesActiveEntriesUnexplained(t *testing.T) {
+	status, reason := machineHookEntryStatus(hook.Entry{
+		Event:   hook.PostToolUse,
+		Scope:   hook.ScopeGlobal,
+		Command: "echo hi",
+		Match:   "write_file",
+	})
+	if status != "active" {
+		t.Fatalf("status = %q, want active", status)
+	}
+	if reason != "" {
+		t.Fatalf("active entry carries a reason: %q", reason)
+	}
+}

--- a/internal/cli/hook_machine_test.go
+++ b/internal/cli/hook_machine_test.go
@@ -105,7 +105,7 @@ func TestHookMachineEntryStatusRejectsNonRegularContextFile(t *testing.T) {
 		Scope:       hook.ScopePlugin,
 		ContextFile: contextDir,
 	}
-	if got := machineHookEntryStatus(entry); got != "invalid" {
+	if got, _ := machineHookEntryStatus(entry); got != "invalid" {
 		t.Fatalf("directory context status = %q, want invalid", got)
 	}
 
@@ -114,7 +114,7 @@ func TestHookMachineEntryStatusRejectsNonRegularContextFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	entry.ContextFile = contextFile
-	if got := machineHookEntryStatus(entry); got != "active" {
+	if got, _ := machineHookEntryStatus(entry); got != "active" {
 		t.Fatalf("readable regular context status = %q, want active", got)
 	}
 }


### PR DESCRIPTION
## Summary

- `reasonix hook list --json` reports `"status": "invalid"` for five distinct conditions without saying which one fired, so a misconfigured hook gives the operator nothing to act on.
- The matcher branch is the clearest case: it calls `hook.ValidateMatcher`, which already builds a full error message, and then discards it.
- Report the reason alongside the status. Active entries carry no `reason`, so existing consumers see an unchanged shape.

```
invalid — unknown event "NotAnEvent"
invalid — command is required
invalid — contextFile "…" is not readable
invalid — plugin hook has neither a command nor a contextFile
invalid — invalid matcher regex: error parsing regexp: missing closing ): `^(?:()$`
```

This matters most when porting hooks from Claude Code, which `internal/hook` goes to some length to support elsewhere — tool-name aliases across Claude renames (`Task`→`Agent`, `BashOutput`→`TaskOutput`), `PayloadFormat "claude"`, `CLAUDE_PROJECT_DIR`/`CLAUDE_PLUGIN_ROOT`. Claude's nested form:

```json
{"matcher":"*","hooks":[{"type":"command","command":"…"}]}
```

leaves `Command` empty, so it lands on the command check and now answers `command is required` instead of a bare `invalid`.

## Issues

<!-- no existing report -->

## Verification

- `go test ./...` passes. `gofmt -l .` and `go vet ./...` clean. Go 1.26.2, darwin/arm64.
- The existing `TestHookMachineEntryStatusRejectsNonRegularContextFile` is updated for the two-value signature and still passes unchanged in intent.
- New `TestMachineHookEntryStatusExplainsEveryRejection` covers unknown event, missing command and a malformed matcher regex; `TestMachineHookEntryStatusLeavesActiveEntriesUnexplained` pins that an active entry emits no `reason`, so the JSON shape is unchanged for the common case.
- Checked against a real config on each of the five paths, plus the Claude-style nested form.

## Documentation impact

Documentation-impact: none - additive, optional field on an existing diagnostics payload; no CLI, config, provider, permission or tool behavior changes.

## Cache impact

Cache-impact: none - `hook list --json` output never enters the provider request; no system prompt, memory prefix, tool schema, tool surface or provider serialization is touched.
Cache-guard: not applicable - no cache-sensitive path is modified.
System-prompt-review: N/A
