### PR TITLE
fix(cli): name the valid operations when rejecting an unknown one

### DIFF
--- a/internal/cli/hook_machine.go
+++ b/internal/cli/hook_machine.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -54,7 +55,7 @@ func runHookCommand(args []string, out io.Writer) int {
 	operation := args[0]
 	command = "hook." + operation
 	if operation != "list" && operation != "status" {
-		return writeMachineError(out, command, "unknown_command", "unknown hook operation")
+		return writeMachineError(out, command, "unknown_command", fmt.Sprintf("unknown hook operation %q; expected list or status", operation))
 	}
 	options, code, message := parseHookMachineOptions(args[1:])
 	if code != "" {

--- a/internal/cli/session_machine.go
+++ b/internal/cli/session_machine.go
@@ -97,7 +97,7 @@ func runSessionCommand(args []string, out io.Writer) int {
 	operation := args[0]
 	command = "session." + operation
 	if operation != "list" && operation != "show" && operation != "status" && operation != "recovery" {
-		return writeMachineError(out, command, "unknown_command", "unknown session operation")
+		return writeMachineError(out, command, "unknown_command", fmt.Sprintf("unknown session operation %q; expected list, show, status or recovery", operation))
 	}
 	options, code, message := parseSessionMachineOptions(args[1:], operation)
 	if code != "" {

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -101,6 +101,7 @@ func taskCommand(args []string) int {
 		return taskTmuxCmd(store, args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown task subcommand: %s\n", args[0])
+		fmt.Fprintln(os.Stderr, "usage: reasonix task <list|show|monitor|status|events|stop|cancel|requeue|open-session|tmux> [flags]")
 		return 2
 	}
 }

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -13,6 +13,12 @@ import (
 	"reasonix/internal/taskmonitor"
 )
 
+const (
+	taskCommandUsage = "usage: reasonix task <list|show|monitor|status|events|stop|cancel|requeue|open-session|tmux> [flags]"
+	taskMonitorUsage = "usage: reasonix task monitor <list|status|events|stop|cancel|requeue|open-session> [flags]"
+	taskTmuxUsage    = "usage: reasonix task tmux <attach|status|open|detach>"
+)
+
 // taskStore is the taskmonitor.Store used by the task CLI commands.
 // Tests override it with mock stores via SetTaskStore.  When nil, the
 // CLI defaults to a FileStore backed by .reasonix/tasks under the
@@ -64,7 +70,7 @@ func contentFreeTaskEvents(events []taskmonitor.TaskEvent) []taskmonitor.TaskEve
 
 func taskCommand(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: reasonix task <list|show|monitor|status|events|stop|cancel|requeue|open-session|tmux> [flags]")
+		fmt.Fprintln(os.Stderr, taskCommandUsage)
 		return 2
 	}
 	store := taskStore
@@ -101,14 +107,14 @@ func taskCommand(args []string) int {
 		return taskTmuxCmd(store, args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown task subcommand: %s\n", args[0])
-		fmt.Fprintln(os.Stderr, "usage: reasonix task <list|show|monitor|status|events|stop|cancel|requeue|open-session|tmux> [flags]")
+		fmt.Fprintln(os.Stderr, taskCommandUsage)
 		return 2
 	}
 }
 
 func taskMonitorCommand(store taskmonitor.Store, args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: reasonix task monitor <list|status|events|stop|cancel|requeue|open-session> [flags]")
+		fmt.Fprintln(os.Stderr, taskMonitorUsage)
 		return 2
 	}
 	switch args[0] {
@@ -128,13 +134,14 @@ func taskMonitorCommand(store taskmonitor.Store, args []string) int {
 		return taskOpenSessionCmd(store, args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown task monitor subcommand: %s\n", args[0])
+		fmt.Fprintln(os.Stderr, taskMonitorUsage)
 		return 2
 	}
 }
 
 func taskTmuxCmd(store taskmonitor.Store, args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: reasonix task tmux <attach|status|open|detach>")
+		fmt.Fprintln(os.Stderr, taskTmuxUsage)
 		return 2
 	}
 	a := taskmonitor.NewTmuxAdapter(store, ".reasonix/tasks")
@@ -149,6 +156,7 @@ func taskTmuxCmd(store taskmonitor.Store, args []string) int {
 		return taskTmuxDetachCmd(a, args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown task tmux subcommand: %s\n", args[0])
+		fmt.Fprintln(os.Stderr, taskTmuxUsage)
 		return 2
 	}
 }

--- a/internal/cli/task_machine.go
+++ b/internal/cli/task_machine.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -49,7 +50,7 @@ func runTaskCommand(args []string, out io.Writer) int {
 	operation := args[0]
 	command = "task." + operation
 	if operation != "list" && operation != "show" {
-		return writeMachineError(out, command, "unknown_command", "unknown task operation")
+		return writeMachineError(out, command, "unknown_command", fmt.Sprintf("unknown task operation %q; expected list or show", operation))
 	}
 	options, code, message := parseTaskMachineOptions(args[1:], operation)
 	if code != "" {

--- a/internal/cli/task_test.go
+++ b/internal/cli/task_test.go
@@ -469,15 +469,6 @@ func TestTaskCommand_PreservesMachineShowRoute(t *testing.T) {
 	}
 }
 
-func TestTaskCommand_UnknownSubcommand(t *testing.T) {
-	exit, _ := captureOut(func() int {
-		return taskCommand([]string{"bogus"})
-	})
-	if exit != 2 {
-		t.Errorf("exit=%d, want 2", exit)
-	}
-}
-
 // FileStore integration tests (real filesystem)
 
 // writeTaskData creates a FileStore-compatible task tree in dir and resets

--- a/internal/cli/unknown_operation_test.go
+++ b/internal/cli/unknown_operation_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Rejecting an operation without naming the valid ones leaves the caller to
+// guess or read source. taskMonitorCommand in task.go already lists its
+// subcommands on the same kind of failure; these three did not.
+func TestUnknownOperationNamesTheValidOnes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(args []string, out *bytes.Buffer) int
+		want []string
+	}{
+		{
+			name: "hook",
+			run:  func(a []string, o *bytes.Buffer) int { return runHookCommand(a, o) },
+			want: []string{"list", "status"},
+		},
+		{
+			name: "session",
+			run:  func(a []string, o *bytes.Buffer) int { return runSessionCommand(a, o) },
+			want: []string{"list", "show", "status", "recovery"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if rc := tc.run([]string{"bogus", "--json"}, &out); rc == 0 {
+				t.Fatal("unknown operation returned success")
+			}
+			var payload struct {
+				Error struct {
+					Code    string `json:"code"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+				t.Fatalf("machine output is not JSON: %v (%s)", err, out.String())
+			}
+			if payload.Error.Code != "unknown_command" {
+				t.Fatalf("code = %q, want unknown_command", payload.Error.Code)
+			}
+			if !strings.Contains(payload.Error.Message, "bogus") {
+				t.Fatalf("message does not echo the rejected operation: %s", payload.Error.Message)
+			}
+			for _, op := range tc.want {
+				if !strings.Contains(payload.Error.Message, op) {
+					t.Fatalf("message omits valid operation %q: %s", op, payload.Error.Message)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/unknown_operation_test.go
+++ b/internal/cli/unknown_operation_test.go
@@ -3,13 +3,38 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"os"
 	"strings"
 	"testing"
+
+	"reasonix/internal/taskmonitor"
 )
 
-// Rejecting an operation without naming the valid ones leaves the caller to
-// guess or read source. taskMonitorCommand in task.go already lists its
-// subcommands on the same kind of failure; these three did not.
+func captureErr(t *testing.T, fn func() int) (int, string) {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	ec := fn()
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return ec, string(data)
+}
+
 func TestUnknownOperationNamesTheValidOnes(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -26,11 +51,16 @@ func TestUnknownOperationNamesTheValidOnes(t *testing.T) {
 			run:  func(a []string, o *bytes.Buffer) int { return runSessionCommand(a, o) },
 			want: []string{"list", "show", "status", "recovery"},
 		},
+		{
+			name: "task",
+			run:  func(a []string, o *bytes.Buffer) int { return runTaskCommand(a, o) },
+			want: []string{"list", "show"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var out bytes.Buffer
-			if rc := tc.run([]string{"bogus", "--json"}, &out); rc == 0 {
-				t.Fatal("unknown operation returned success")
+			if rc := tc.run([]string{"bogus", "--json"}, &out); rc != 2 {
+				t.Fatalf("exit code = %d, want 2", rc)
 			}
 			var payload struct {
 				Error struct {
@@ -51,6 +81,48 @@ func TestUnknownOperationNamesTheValidOnes(t *testing.T) {
 				if !strings.Contains(payload.Error.Message, op) {
 					t.Fatalf("message omits valid operation %q: %s", op, payload.Error.Message)
 				}
+			}
+		})
+	}
+}
+
+func TestTaskUnknownSubcommandsNameValidOnes(t *testing.T) {
+	store := taskmonitor.NewInMemoryStore()
+	originalStore := taskStore
+	taskStore = store
+	t.Cleanup(func() { taskStore = originalStore })
+
+	for _, tc := range []struct {
+		name      string
+		run       func() int
+		wantUsage string
+	}{
+		{
+			name:      "task",
+			run:       func() int { return taskCommand([]string{"bogus"}) },
+			wantUsage: "usage: reasonix task <list|show|monitor|status|events|stop|cancel|requeue|open-session|tmux> [flags]",
+		},
+		{
+			name:      "task monitor",
+			run:       func() int { return taskMonitorCommand(store, []string{"bogus"}) },
+			wantUsage: "usage: reasonix task monitor <list|status|events|stop|cancel|requeue|open-session> [flags]",
+		},
+		{
+			name:      "task tmux",
+			run:       func() int { return taskTmuxCmd(store, []string{"bogus"}) },
+			wantUsage: "usage: reasonix task tmux <attach|status|open|detach>",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			exit, stderr := captureErr(t, tc.run)
+			if exit != 2 {
+				t.Fatalf("exit = %d, want 2", exit)
+			}
+			if !strings.Contains(stderr, "bogus") {
+				t.Fatalf("stderr does not echo the rejected subcommand: %s", stderr)
+			}
+			if !strings.Contains(stderr, tc.wantUsage) {
+				t.Fatalf("stderr does not include usage %q: %s", tc.wantUsage, stderr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- `hook`, `session` and `task` reject an unrecognised operation without saying what is accepted:

```
$ reasonix hook bogus --json
{"error":{"code":"unknown_command","message":"unknown hook operation"}}
$ reasonix task bogus
unknown task subcommand: bogus
```

- The caller has to read source or guess. It also makes `--help` a dead end on the two machine commands, which have no usage text at all: `reasonix hook --help` answers `unknown hook operation` and nothing else.
- Name the valid operations, and echo the rejected one back.

`taskMonitorCommand`, ten lines below the `task` dispatcher it shares a file with, already prints its own subcommand list on exactly this failure — so this brings the three outer dispatchers in line with a convention the package already follows rather than introducing a new one.

The machine error codes are unchanged (`unknown_command`), so JSON consumers keep the same contract; only the human-readable `message` gains the list.

## Issues

<!-- no existing report -->

## Verification

- `go test ./...` passes. `gofmt -l .` and `go vet ./...` clean. Go 1.26.2, darwin/arm64.
- New `TestUnknownOperationNamesTheValidOnes` drives `runHookCommand` and `runSessionCommand` with an unknown operation, asserts the output is still valid JSON with code `unknown_command`, that the rejected name is echoed, and that every valid operation appears in the message.
- Checked by hand that `task bogus` now prints the usage line and still exits 2.

## Documentation impact

Documentation-impact: none - error message text only; the accepted operations, exit codes and machine error codes are unchanged.

## Cache impact

Cache-impact: none - CLI error strings only; no system prompt, memory prefix, tool schema, tool surface or provider serialization is touched.
Cache-guard: not applicable - no cache-sensitive path is modified.
System-prompt-review: N/A
