### PR TITLE
fix(agent): enforce complete long-file reads / 强制完成长文件读取

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unicode/utf8"
 
 	"mvdan.cc/sh/v3/syntax"
 
@@ -2758,7 +2757,9 @@ func firstLine(s string) string {
 
 // truncateToolOutput builds the stable provider-visible Content form for a tool
 // result. Under-cap bodies are byte-identical; over-cap bodies keep a tool-aware
-// head and tail while RawContent stores the full local original.
+// preview while RawContent stores the full local original. read_file is special:
+// its preview is a contiguous prefix so an exact recovery cursor can never skip
+// source text that the model did not actually see.
 func truncateToolOutput(s string) (string, string) {
 	return truncateToolOutputFor(s, "", "")
 }
@@ -2768,6 +2769,9 @@ func truncateToolOutput(s string) (string, string) {
 func truncateToolOutputFor(s, toolName, toolCallID string) (string, string) {
 	if len(s) <= maxToolOutputBytes {
 		return s, ""
+	}
+	if toolName == "read_file" {
+		return truncateReadFileOutput(s, toolName, toolCallID)
 	}
 	strategy := snipStrategy{head: 40, tail: 40, headChars: 8000, tailChars: 8000}
 	switch {
@@ -2818,18 +2822,6 @@ func truncateToolOutputFor(s, toolName, toolCallID string) (string, string) {
 	}
 	notice := fmt.Sprintf("tool output truncated: %d of %d bytes elided", len(s)-len(head)-len(tail), len(s))
 	return head + marker + tail, notice
-}
-
-// snapToRuneBoundary returns s[lo:hi] with the bounds nudged outward until
-// both land on rune-start positions.
-func snapToRuneBoundary(s string, lo, hi int) string {
-	for lo > 0 && !utf8.RuneStart(s[lo]) {
-		lo--
-	}
-	for hi < len(s) && !utf8.RuneStart(s[hi]) {
-		hi++
-	}
-	return s[lo:hi]
 }
 
 // finishReasonMessage maps an abnormal finish_reason to a one-line warning,

--- a/internal/agent/capability_list_filter.go
+++ b/internal/agent/capability_list_filter.go
@@ -14,6 +14,12 @@ func (t *restrictedCapabilityProxy) bindToolResultSession(session func() *Sessio
 	}
 }
 
+func (t *restrictedCapabilityProxy) bindReadStrategyState(state func() *incompleteReadState) {
+	if binder, ok := t.Tool.(readStrategyStateBinder); ok {
+		binder.bindReadStrategyState(state)
+	}
+}
+
 func (t *restrictedCapabilityProxy) bindMCPListObserver(observer func(mcpListObservation)) {
 	if binder, ok := t.Tool.(mcpListObserverBinder); ok {
 		binder.bindMCPListObserver(observer)
@@ -129,7 +135,7 @@ func filterCapabilityListResult(raw string, servers map[string]bool) string {
 		var entry struct {
 			ID string `json:"id"`
 		}
-		if json.Unmarshal(raw, &entry) == nil && strings.TrimSpace(entry.ID) == sessionToolResultCapabilityID {
+		if json.Unmarshal(raw, &entry) == nil && (strings.TrimSpace(entry.ID) == sessionToolResultCapabilityID || strings.TrimSpace(entry.ID) == sessionReadStrategyReceiptCapabilityID) {
 			filteredCapabilities = append(filteredCapabilities, raw)
 		}
 	}

--- a/internal/agent/errors.go
+++ b/internal/agent/errors.go
@@ -54,7 +54,35 @@ func PauseClass(err error) string {
 	if errors.As(err, &completion) {
 		return "completion_uncertain"
 	}
+	var incompleteRead *IncompleteReadError
+	if errors.As(err, &incompleteRead) {
+		return "incomplete_read"
+	}
 	return ""
+}
+
+// IncompleteReadError is a recoverable run boundary: a read_file result was
+// only partially visible and the host refused to let the model silently treat
+// it as complete. It carries only routing/size metadata, never file contents.
+type IncompleteReadError struct {
+	Reason        string
+	Path          string
+	ToolCallID    string
+	ResultRef     string
+	NextOffset    int
+	ConsumedBytes int
+	TotalBytes    int
+}
+
+func (e *IncompleteReadError) Error() string {
+	if e == nil {
+		return "read_file did not complete"
+	}
+	detail := strings.TrimSpace(e.Reason)
+	if detail == "" {
+		detail = "the retained result still has unread content"
+	}
+	return "read_file did not complete safely: " + detail
 }
 
 // RunPauseInfo is the stable host-facing description of a deliberate Run
@@ -77,6 +105,10 @@ func InspectRunPause(err error) (RunPauseInfo, bool) {
 	var budget *taskBudgetPause
 	if errors.As(err, &budget) {
 		return RunPauseInfo{Kind: "task_budget", Key: budget.axis, HostOwned: true, Reason: budget.detail}, true
+	}
+	var incompleteRead *IncompleteReadError
+	if errors.As(err, &incompleteRead) {
+		return RunPauseInfo{Kind: "incomplete_read", HostOwned: true, Reason: incompleteRead.Reason}, true
 	}
 	return RunPauseInfo{}, false
 }

--- a/internal/agent/errors_test.go
+++ b/internal/agent/errors_test.go
@@ -22,6 +22,7 @@ func TestPauseClassNamesEachGuard(t *testing.T) {
 		{&maxStepsPause{steps: 40, key: "max_steps"}, "max_steps"},
 		{&FinalReadinessError{Attempts: 3}, "final_readiness"},
 		{&RecoveryPauseError{Message: "paused"}, "recovery_paused"},
+		{&IncompleteReadError{Reason: "continuation ignored"}, "incomplete_read"},
 		{fmt.Errorf("wrapped: %w", &maxStepsPause{steps: 5}), "max_steps"},
 		{errors.New("provider 500"), ""},
 		{nil, ""},
@@ -29,5 +30,12 @@ func TestPauseClassNamesEachGuard(t *testing.T) {
 		if got := PauseClass(tc.err); got != tc.want {
 			t.Errorf("PauseClass(%v) = %q, want %q", tc.err, got, tc.want)
 		}
+	}
+}
+
+func TestIncompleteReadIsAHostOwnedRecoverablePause(t *testing.T) {
+	info, ok := InspectRunPause(&IncompleteReadError{Reason: "continuation ignored"})
+	if !ok || info.Kind != "incomplete_read" || !info.HostOwned || info.Reason != "continuation ignored" {
+		t.Fatalf("InspectRunPause = %+v, %v", info, ok)
 	}
 }

--- a/internal/agent/execute_batch.go
+++ b/internal/agent/execute_batch.go
@@ -72,6 +72,7 @@ type toolOutcome struct {
 	// recoveryStopTurn is set when Auto Episode budgets are exhausted.
 	recoveryStopTurn   bool
 	recoveryStopReason string
+	incompleteRead     *incompleteReadDeferred
 }
 
 // batchExecution is the result of one provider tool-call batch.
@@ -158,10 +159,9 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 		results[i] = outcomes[i].output
 	}
 	finalize := func(i int) {
-		if calls[i].ResolvedReadOnly != nil {
-			a.sess.conversation.UpdateToolCallResolution(calls[i])
-			a.emitResolvedToolDispatch(calls[i])
-		}
+		a.finalizeIncompleteReadOutcome(outcomes[i].incompleteRead, &outcomes[i])
+		results[i] = outcomes[i].output
+		a.commitBatchCallResolution(calls[i])
 		if surfaceWriters[i] || (outcomes[i].resolved && !outcomes[i].resolvedReadOnly) {
 			earlierWriterRan = true
 		}
@@ -378,6 +378,14 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 		recoveryStopTurn:   recoveryBatchStop,
 		recoveryStopReason: recoveryStopReason,
 	}
+}
+
+func (a *Agent) commitBatchCallResolution(call provider.ToolCall) {
+	if call.ResolvedReadOnly == nil {
+		return
+	}
+	a.sess.conversation.UpdateToolCallResolution(call)
+	a.emitResolvedToolDispatch(call)
 }
 
 // batchCallMutationFailureCause returns a sanitized effect description when a

--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -167,6 +167,9 @@ func (a *Agent) resolveToolPolicy(ctx context.Context, turn *turnRuntime, plan *
 	if blocked, early := a.applyExecutionPreflight(turn, plan); early {
 		return blocked, true
 	}
+	if msg, blocked := turn.incompleteReads.gate(plan); blocked {
+		return toolOutcome{output: msg, blocked: true, errMsg: firstLine(msg)}, true
+	}
 	if blocked, early := a.applyDeliveryPolicyGates(turn, plan); early {
 		return blocked, true
 	}
@@ -692,9 +695,6 @@ func (a *Agent) finishToolExecution(ctx context.Context, plan *toolCallPlan) too
 	// partialwritesandhooksideeffectscanchangethepreviewedpathevenwhentheconcrete tool returned an error.
 	a.finalizeObservedToolReceipts(plan, result, execution, err)
 	result = a.withRecoveryObservation(ctx, evidenceName, evidenceArgs, readOnly, mutates, result, err, recoveryGen)
-	if err == nil && readOnly {
-		a.recordModelTextObservation(plan, result)
-	}
 	if err != nil {
 		detail := result
 		// Malformed-args failures are a transient model JSON glitch (e.g. optionswritten as ["a":"b"] →
@@ -725,7 +725,7 @@ func (a *Agent) finishToolExecution(ctx context.Context, plan *toolCallPlan) too
 	if a.svc.hooks != nil && call.Name == "task" && !isBackgroundTaskCall(call.Arguments) {
 		a.svc.hooks.SubagentStop(ctx, result)
 	}
-	body, truncMsg, original := a.boundProviderVisibleResult(result, call.Name, call.ID)
+	body, truncMsg, original, readObserver := a.boundIncompleteReadAwareResult(plan, result)
 	out := toolOutcome{
 		output: body, images: images, truncated: truncMsg != "" || original != "", truncMsg: truncMsg,
 		execution: execution, mcpApp: toProviderMCPApp(plan.mcpApp), recoveryGeneration: recoveryGen,
@@ -733,11 +733,11 @@ func (a *Agent) finishToolExecution(ctx context.Context, plan *toolCallPlan) too
 	if original != "" {
 		out.rawOutput = original
 	}
+	out.incompleteRead = deferredIncompleteReadOutcome(plan, result, readObserver, original == "" && truncMsg == "")
 	return out
 }
 
-// observeBeforeMutation captures preimages for Previewable writers and recordsexplicit coverage gaps forbash
-// / opaque MCP tools. Host-internal only.
+// observeBeforeMutation captures writer preimages and opaque-tool coverage gaps.
 func (a *Agent) observeBeforeMutation(ctx context.Context, plan *toolCallPlan) {
 	if a == nil || plan == nil {
 		return

--- a/internal/agent/incomplete_read.go
+++ b/internal/agent/incomplete_read.go
@@ -89,6 +89,8 @@ type incompleteRead struct {
 	targetObserved    []tool.ModelTextObservation
 	targetEnd         int
 	pendingReceipt    *incompleteReadReceipt
+	readTool          tool.Tool
+	strategyRevision  uint64
 }
 
 // incompleteReadState is shared by all calls in one Agent.Run. Parallel calls
@@ -453,6 +455,12 @@ func (s *incompleteReadState) observeReadFile(
 		entry.readID = incompleteReadID(plan.call.ID, resultRef, entry.path)
 		entry.key = entry.readID
 	}
+	if entry.readTool == nil {
+		entry.readTool = plan.runTool
+		if entry.readTool == nil {
+			entry.readTool = plan.execTool
+		}
+	}
 
 	needsContinuation := truncated || trailer.localSafety || (implicitWholeFile && trailer.hasMore)
 	if needsContinuation && !s.reserveAutomaticLocked(resultTokens, budget) {
@@ -604,6 +612,7 @@ func (s *incompleteReadState) finishStrategyWindowLocked(entry *incompleteRead) 
 	last := window.observed[len(window.observed)-1]
 	window.endLine = last.StartLine + len(last.LineHashes) - 1
 	entry.reads[window.callID] = window
+	entry.strategyRevision++
 	entry.targetReadID = ""
 	entry.targetObserved = nil
 	entry.targetEnd = 0

--- a/internal/agent/incomplete_read.go
+++ b/internal/agent/incomplete_read.go
@@ -1,0 +1,789 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"reasonix/internal/tool"
+)
+
+type incompleteReadPhase uint8
+
+const (
+	incompleteReadAutoResultPage incompleteReadPhase = iota
+	incompleteReadAutoSourcePage
+	incompleteReadStrategy
+	incompleteReadStrategyResultPage
+	incompleteReadStrategySourcePage
+)
+
+type incompleteReadAction uint8
+
+const (
+	incompleteReadActionNone incompleteReadAction = iota
+	incompleteReadActionAutoResult
+	incompleteReadActionAutoSource
+	incompleteReadActionStrategySearch
+	incompleteReadActionStrategyRead
+	incompleteReadActionStrategyResult
+	incompleteReadActionStrategySource
+	incompleteReadActionStrategyReceipt
+)
+
+type incompleteReadFileVersion struct {
+	size    int64
+	modTime int64
+	valid   bool
+}
+
+type incompleteReadSearch struct {
+	callID     string
+	pattern    string
+	matchLines []int
+}
+
+type incompleteReadWindow struct {
+	callID    string
+	startLine int
+	endLine   int
+	observed  []tool.ModelTextObservation
+}
+
+type incompleteReadReceipt struct {
+	searchIDs  []string
+	readIDs    []string
+	conclusion string
+}
+
+// incompleteRead tracks one logical read_file request. Automatic phases prove
+// complete coverage. Strategy phases deliberately prove only the exact windows
+// named by a validated receipt and never promote that into whole-file evidence.
+type incompleteRead struct {
+	key               string
+	readID            string
+	requestPath       string
+	path              string
+	phase             incompleteReadPhase
+	implicitWholeFile bool
+	cumulativeBytes   int
+	cumulativeTokens  int
+	toolCallID        string
+	resultRef         string
+	nextByteOffset    int
+	totalBytes        int
+	sha256            string
+	nextSourceOffset  int
+	nextSourceLimit   int
+	sourceWindowEnd   int
+	pendingObserved   []tool.ModelTextObservation
+	strategyVersion   incompleteReadFileVersion
+	searches          map[string]incompleteReadSearch
+	reads             map[string]incompleteReadWindow
+	targetReadID      string
+	targetObserved    []tool.ModelTextObservation
+	targetEnd         int
+	pendingReceipt    *incompleteReadReceipt
+}
+
+// incompleteReadState is shared by all calls in one Agent.Run. Parallel calls
+// are committed to it in provider order by executeBatch.finalize.
+type incompleteReadState struct {
+	mu                    sync.Mutex
+	entries               map[string]*incompleteRead
+	order                 []string
+	budgetInitialized     bool
+	budgetMaxTokens       int
+	budgetConsumedTokens  int
+	roundProgress         bool
+	roundViolation        bool
+	consecutiveViolations int
+	failure               *IncompleteReadError
+}
+
+type incompleteReadTransition struct {
+	record           []tool.ModelTextObservation
+	detected         bool
+	completed        bool
+	strategyRequired bool
+	strategyProgress bool
+	localSafetyPaged bool
+	readID           string
+	path             string
+	totalBytes       int
+	totalTokens      int
+	limitTokens      int
+}
+
+type incompleteReadRoundResult struct {
+	record      []tool.ModelTextObservation
+	resolvedIDs []string
+	pause       *IncompleteReadError
+}
+
+type incompleteReadDeferred struct {
+	plan         *toolCallPlan
+	rawOutput    string
+	readObserver bool
+	visibleFull  bool
+}
+
+type readFileArgs struct {
+	Path           string
+	Offset         int
+	Limit          int
+	OffsetExplicit bool
+	LimitExplicit  bool
+}
+
+type readFileTrailer struct {
+	nextOffset   int
+	requestedEnd int
+	hasMore      bool
+	localSafety  bool
+}
+
+type sessionToolResultPageHeader struct {
+	ResultRef  string `json:"result_ref"`
+	Offset     int    `json:"offset"`
+	NextOffset int    `json:"next_offset"`
+	TotalBytes int    `json:"total_bytes"`
+	SHA256     string `json:"sha256"`
+	Complete   bool   `json:"complete"`
+}
+
+func parseReadFileArgs(args json.RawMessage) (readFileArgs, bool) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(args, &fields); err != nil {
+		return readFileArgs{}, false
+	}
+	var out readFileArgs
+	if raw, ok := fields["path"]; ok {
+		_ = json.Unmarshal(raw, &out.Path)
+	}
+	if strings.TrimSpace(out.Path) == "" {
+		return readFileArgs{}, false
+	}
+	if raw, ok := fields["offset"]; ok {
+		out.OffsetExplicit = true
+		_ = json.Unmarshal(raw, &out.Offset)
+	}
+	if raw, ok := fields["limit"]; ok {
+		out.LimitExplicit = true
+		_ = json.Unmarshal(raw, &out.Limit)
+	}
+	return out, true
+}
+
+func parseReadFileTrailer(output string) readFileTrailer {
+	const safetyPrefix = "\n[read_file local safety page; next_offset="
+	if start := strings.LastIndex(output, safetyPrefix); start >= 0 && strings.HasSuffix(output, "]\n") {
+		fields := strings.TrimSuffix(output[start+len(safetyPrefix):], "]\n")
+		parts := strings.Fields(fields)
+		if len(parts) == 2 {
+			next, nextErr := strconv.Atoi(parts[0])
+			endText := strings.TrimPrefix(parts[1], "requested_end=")
+			end, endErr := strconv.Atoi(endText)
+			if nextErr == nil && endErr == nil && next >= 0 && end >= next {
+				return readFileTrailer{nextOffset: next, requestedEnd: end, hasMore: true, localSafety: true}
+			}
+		}
+	}
+	const prefix = "\n[more lines below; pass offset="
+	start := strings.LastIndex(output, prefix)
+	if start < 0 || !strings.HasSuffix(output, "]\n") {
+		return readFileTrailer{}
+	}
+	value := output[start+len(prefix):]
+	if end := strings.IndexAny(value, " ]\r\n"); end >= 0 {
+		value = value[:end]
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil || n < 0 {
+		return readFileTrailer{}
+	}
+	return readFileTrailer{nextOffset: n, hasMore: true}
+}
+
+func readFileRecoveryOffset(output string) (int, bool) {
+	const marker = "\n\n…[truncated tool=read_file "
+	const field = " next_offset="
+	markerStart := strings.LastIndex(output, marker)
+	if markerStart < 0 {
+		return 0, false
+	}
+	start := strings.Index(output[markerStart:], field)
+	if start < 0 {
+		return 0, false
+	}
+	start += markerStart
+	value := output[start+len(field):]
+	if end := strings.IndexAny(value, " ]\r\n"); end >= 0 {
+		value = value[:end]
+	}
+	n, err := strconv.Atoi(value)
+	return n, err == nil && n >= 0
+}
+
+func parseSessionToolResultPage(output string) (sessionToolResultPageHeader, string, bool) {
+	headerText, body, ok := strings.Cut(output, "\n")
+	if !ok {
+		return sessionToolResultPageHeader{}, "", false
+	}
+	var header sessionToolResultPageHeader
+	if err := json.Unmarshal([]byte(headerText), &header); err != nil {
+		return sessionToolResultPageHeader{}, "", false
+	}
+	return header, body, true
+}
+
+func modelTextObservationFor(plan *toolCallPlan, output string) (tool.ModelTextObservation, bool) {
+	if plan == nil || output == "" {
+		return tool.ModelTextObservation{}, false
+	}
+	observer, ok := plan.runTool.(tool.ModelTextObserver)
+	if !ok {
+		observer, ok = plan.execTool.(tool.ModelTextObserver)
+	}
+	if !ok {
+		return tool.ModelTextObservation{}, false
+	}
+	return observer.ObserveModelText(json.RawMessage(plan.runArgs), output)
+}
+
+func snapshotIncompleteReadFile(path string) incompleteReadFileVersion {
+	info, err := os.Stat(path)
+	if err != nil {
+		return incompleteReadFileVersion{}
+	}
+	return incompleteReadFileVersion{size: info.Size(), modTime: info.ModTime().UnixNano(), valid: true}
+}
+
+func sameIncompleteReadFileVersion(a, b incompleteReadFileVersion) bool {
+	if !a.valid || !b.valid {
+		return a.valid == b.valid
+	}
+	return a.size == b.size && a.modTime == b.modTime
+}
+
+func readPathMatches(candidate string, entry *incompleteRead) bool {
+	if entry == nil || strings.TrimSpace(candidate) == "" {
+		return false
+	}
+	clean := filepath.Clean(candidate)
+	return clean == filepath.Clean(entry.path) || clean == filepath.Clean(entry.requestPath)
+}
+
+func (s *incompleteReadState) ensureEntriesLocked() {
+	if s.entries == nil {
+		s.entries = make(map[string]*incompleteRead)
+	}
+}
+
+func (s *incompleteReadState) addEntryLocked(entry *incompleteRead) {
+	s.ensureEntriesLocked()
+	if _, exists := s.entries[entry.key]; !exists {
+		s.order = append(s.order, entry.key)
+	}
+	s.entries[entry.key] = entry
+}
+
+func (s *incompleteReadState) removeEntryLocked(key string) {
+	delete(s.entries, key)
+	for i, candidate := range s.order {
+		if candidate == key {
+			s.order = append(s.order[:i], s.order[i+1:]...)
+			break
+		}
+	}
+}
+
+func (s *incompleteReadState) firstLocked() *incompleteRead {
+	for len(s.order) > 0 {
+		key := s.order[0]
+		if entry := s.entries[key]; entry != nil {
+			return entry
+		}
+		s.order = s.order[1:]
+	}
+	return nil
+}
+
+func (s *incompleteReadState) hasPending() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.failure != nil || s.firstLocked() != nil
+}
+
+func (s *incompleteReadState) hasStrategy() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, entry := range s.entries {
+		if entry != nil && (entry.phase == incompleteReadStrategy || entry.phase == incompleteReadStrategyResultPage || entry.phase == incompleteReadStrategySourcePage) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *incompleteReadState) currentFailure() *IncompleteReadError {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failure == nil {
+		return nil
+	}
+	copy := *s.failure
+	return &copy
+}
+
+func (s *incompleteReadState) setFailureLocked(entry *incompleteRead, reason string) {
+	if s.failure != nil {
+		return
+	}
+	err := &IncompleteReadError{Reason: reason}
+	if entry != nil {
+		err.Path = entry.path
+		err.ToolCallID = entry.toolCallID
+		err.ResultRef = entry.resultRef
+		err.NextOffset = entry.nextByteOffset
+		err.ConsumedBytes = entry.cumulativeBytes
+		err.TotalBytes = entry.totalBytes
+	}
+	s.failure = err
+}
+
+func (s *incompleteReadState) reserveAutomaticLocked(tokens int, budget readAutoRecoveryBudget) bool {
+	if !budget.known || budget.maxTokens <= 0 || budget.headroomTokens < tokens {
+		return false
+	}
+	if !s.budgetInitialized {
+		s.budgetInitialized = true
+		s.budgetMaxTokens = budget.maxTokens
+	}
+	if s.budgetConsumedTokens+tokens > s.budgetMaxTokens {
+		return false
+	}
+	s.budgetConsumedTokens += tokens
+	return true
+}
+
+func incompleteReadID(callID, resultRef, path string) string {
+	sum := sha256.Sum256([]byte(callID + "\x00" + resultRef + "\x00" + path))
+	return "ir-" + hex.EncodeToString(sum[:8])
+}
+
+func (s *incompleteReadState) enterStrategyLocked(entry *incompleteRead, budget readAutoRecoveryBudget) incompleteReadTransition {
+	entry.phase = incompleteReadStrategy
+	entry.toolCallID = ""
+	entry.resultRef = ""
+	entry.nextByteOffset = 0
+	entry.totalBytes = 0
+	entry.sha256 = ""
+	entry.nextSourceOffset = 0
+	entry.nextSourceLimit = 0
+	entry.strategyVersion = snapshotIncompleteReadFile(entry.path)
+	if entry.searches == nil {
+		entry.searches = make(map[string]incompleteReadSearch)
+	}
+	if entry.reads == nil {
+		entry.reads = make(map[string]incompleteReadWindow)
+	}
+	s.addEntryLocked(entry)
+	s.roundProgress = true
+	return incompleteReadTransition{
+		detected: true, strategyRequired: true, readID: entry.readID, path: entry.path,
+		totalBytes: entry.cumulativeBytes, totalTokens: entry.cumulativeTokens,
+		limitTokens: budget.maxTokens,
+	}
+}
+
+func (s *incompleteReadState) observeReadFile(
+	plan *toolCallPlan,
+	rawOutput, visibleOutput string,
+	observed tool.ModelTextObservation,
+	hasObservation bool,
+	resultTokens int,
+	budget readAutoRecoveryBudget,
+) incompleteReadTransition {
+	args, ok := parseReadFileArgs(plan.runArgs)
+	if !ok {
+		return incompleteReadTransition{}
+	}
+	trailer := parseReadFileTrailer(rawOutput)
+	recoveryOffset, truncated := readFileRecoveryOffset(visibleOutput)
+	if !truncated && len(rawOutput) > maxToolOutputBytes {
+		recoveryOffset = 0
+		truncated = true
+	}
+	resultRef := toolResultRef(plan.call.ID, rawOutput)
+	sum := sha256.Sum256([]byte(rawOutput))
+	digest := hex.EncodeToString(sum[:])
+	resolvedPath := args.Path
+	if hasObservation && observed.Path != "" {
+		resolvedPath = observed.Path
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry := s.entries[plan.incompleteReadRoot]
+	if plan.incompleteReadRoot != "" && entry == nil {
+		s.setFailureLocked(nil, "the required read_file continuation lost its host state")
+		return incompleteReadTransition{}
+	}
+
+	if plan.incompleteReadAction == incompleteReadActionStrategyRead || plan.incompleteReadAction == incompleteReadActionStrategySource {
+		return s.observeStrategyReadLocked(entry, plan, args, rawOutput, truncated, recoveryOffset, resultRef, digest, trailer, observed, hasObservation, resultTokens, budget)
+	}
+
+	implicitWholeFile := entry != nil && entry.implicitWholeFile || !args.LimitExplicit
+	if entry == nil {
+		entry = &incompleteRead{
+			requestPath:       args.Path,
+			path:              resolvedPath,
+			implicitWholeFile: implicitWholeFile,
+			searches:          make(map[string]incompleteReadSearch),
+			reads:             make(map[string]incompleteReadWindow),
+		}
+		entry.readID = incompleteReadID(plan.call.ID, resultRef, entry.path)
+		entry.key = entry.readID
+	}
+
+	needsContinuation := truncated || trailer.localSafety || (implicitWholeFile && trailer.hasMore)
+	if needsContinuation && !s.reserveAutomaticLocked(resultTokens, budget) {
+		entry.cumulativeBytes += len(rawOutput)
+		entry.cumulativeTokens += resultTokens
+		return s.enterStrategyLocked(entry, budget)
+	}
+
+	entry.cumulativeBytes += len(rawOutput)
+	entry.cumulativeTokens += resultTokens
+	if truncated {
+		if hasObservation {
+			entry.pendingObserved = append(entry.pendingObserved, observed)
+		}
+		entry.phase = incompleteReadAutoResultPage
+		entry.toolCallID = plan.call.ID
+		entry.resultRef = resultRef
+		entry.nextByteOffset = recoveryOffset
+		entry.totalBytes = len(rawOutput)
+		entry.sha256 = digest
+		s.configureAutoSourceLocked(entry, args, trailer)
+		s.addEntryLocked(entry)
+		s.roundProgress = true
+		return incompleteReadTransition{detected: true, localSafetyPaged: trailer.localSafety, readID: entry.readID, path: entry.path}
+	}
+
+	if trailer.localSafety || (implicitWholeFile && trailer.hasMore) {
+		if hasObservation {
+			entry.pendingObserved = append(entry.pendingObserved, observed)
+		}
+		entry.phase = incompleteReadAutoSourcePage
+		s.configureAutoSourceLocked(entry, args, trailer)
+		s.addEntryLocked(entry)
+		s.roundProgress = true
+		return incompleteReadTransition{detected: true, localSafetyPaged: trailer.localSafety, readID: entry.readID, path: entry.path}
+	}
+
+	transition := incompleteReadTransition{readID: entry.readID, path: entry.path}
+	if plan.incompleteReadRoot != "" {
+		if hasObservation {
+			entry.pendingObserved = append(entry.pendingObserved, observed)
+		}
+		transition.record = append(transition.record, entry.pendingObserved...)
+		s.removeEntryLocked(entry.key)
+		s.roundProgress = true
+		transition.completed = true
+	} else if hasObservation {
+		transition.record = append(transition.record, observed)
+	}
+	return transition
+}
+
+func (s *incompleteReadState) configureAutoSourceLocked(entry *incompleteRead, args readFileArgs, trailer readFileTrailer) {
+	entry.nextSourceOffset = 0
+	entry.nextSourceLimit = 0
+	entry.sourceWindowEnd = 0
+	if !trailer.hasMore {
+		return
+	}
+	entry.nextSourceOffset = trailer.nextOffset
+	if trailer.localSafety {
+		entry.sourceWindowEnd = trailer.requestedEnd
+		entry.nextSourceLimit = max(1, trailer.requestedEnd-trailer.nextOffset)
+		return
+	}
+	if entry.implicitWholeFile {
+		entry.nextSourceLimit = 2000
+	}
+}
+
+func (s *incompleteReadState) observeStrategyReadLocked(
+	entry *incompleteRead,
+	plan *toolCallPlan,
+	args readFileArgs,
+	rawOutput string,
+	truncated bool,
+	recoveryOffset int,
+	resultRef, digest string,
+	trailer readFileTrailer,
+	observed tool.ModelTextObservation,
+	hasObservation bool,
+	resultTokens int,
+	budget readAutoRecoveryBudget,
+) incompleteReadTransition {
+	if entry == nil {
+		return incompleteReadTransition{}
+	}
+	current := snapshotIncompleteReadFile(entry.path)
+	if !sameIncompleteReadFileVersion(entry.strategyVersion, current) {
+		s.resetStrategyEvidenceForVersionLocked(entry, current)
+		entry.phase = incompleteReadStrategy
+		if plan.incompleteReadAction == incompleteReadActionStrategySource {
+			return incompleteReadTransition{strategyRequired: true, readID: entry.readID, path: entry.path, totalBytes: len(rawOutput), totalTokens: resultTokens, limitTokens: budget.maxTokens}
+		}
+	}
+	// A complete provider-visible explicit window is safe even when the model's
+	// context size is unknown. Any window that itself needs recovery must fit the
+	// live dynamic budget or the model is asked to retry with a smaller limit.
+	if (truncated || trailer.localSafety) && (!budget.known || budget.maxTokens <= 0 || resultTokens > budget.maxTokens || resultTokens > budget.headroomTokens) {
+		s.roundProgress = false
+		return incompleteReadTransition{strategyRequired: true, readID: entry.readID, path: entry.path, totalBytes: len(rawOutput), totalTokens: resultTokens, limitTokens: budget.maxTokens}
+	}
+	if plan.incompleteReadAction == incompleteReadActionStrategyRead {
+		entry.targetReadID = plan.call.ID
+		entry.targetObserved = nil
+		entry.targetEnd = args.Offset + args.Limit
+	} else {
+		entry.nextSourceOffset = 0
+		entry.nextSourceLimit = 0
+	}
+	if hasObservation {
+		entry.targetObserved = append(entry.targetObserved, observed)
+	}
+	if truncated {
+		entry.phase = incompleteReadStrategyResultPage
+		entry.toolCallID = plan.call.ID
+		entry.resultRef = resultRef
+		entry.nextByteOffset = recoveryOffset
+		entry.totalBytes = len(rawOutput)
+		entry.sha256 = digest
+		if trailer.localSafety {
+			entry.nextSourceOffset = trailer.nextOffset
+			entry.nextSourceLimit = max(1, trailer.requestedEnd-trailer.nextOffset)
+		}
+		s.roundProgress = true
+		return incompleteReadTransition{strategyProgress: true, localSafetyPaged: trailer.localSafety, readID: entry.readID, path: entry.path}
+	}
+	if trailer.localSafety {
+		entry.phase = incompleteReadStrategySourcePage
+		entry.nextSourceOffset = trailer.nextOffset
+		entry.nextSourceLimit = max(1, trailer.requestedEnd-trailer.nextOffset)
+		s.roundProgress = true
+		return incompleteReadTransition{strategyProgress: true, localSafetyPaged: true, readID: entry.readID, path: entry.path}
+	}
+	if !hasObservation {
+		return incompleteReadTransition{readID: entry.readID, path: entry.path}
+	}
+	s.finishStrategyWindowLocked(entry)
+	s.roundProgress = true
+	return incompleteReadTransition{strategyProgress: true, readID: entry.readID, path: entry.path}
+}
+
+func (s *incompleteReadState) finishStrategyWindowLocked(entry *incompleteRead) {
+	if entry == nil || entry.targetReadID == "" || len(entry.targetObserved) == 0 {
+		return
+	}
+	window := incompleteReadWindow{callID: entry.targetReadID, observed: append([]tool.ModelTextObservation(nil), entry.targetObserved...)}
+	window.startLine = window.observed[0].StartLine
+	last := window.observed[len(window.observed)-1]
+	window.endLine = last.StartLine + len(last.LineHashes) - 1
+	entry.reads[window.callID] = window
+	entry.targetReadID = ""
+	entry.targetObserved = nil
+	entry.targetEnd = 0
+	entry.phase = incompleteReadStrategy
+	entry.nextSourceOffset = 0
+	entry.nextSourceLimit = 0
+}
+
+func (s *incompleteReadState) observeResultPage(plan *toolCallPlan, output string, retainedSnapshotMatches bool) incompleteReadTransition {
+	if plan == nil || plan.incompleteReadRoot == "" {
+		return incompleteReadTransition{}
+	}
+	header, body, ok := parseSessionToolResultPage(output)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry := s.entries[plan.incompleteReadRoot]
+	if entry == nil || (entry.phase != incompleteReadAutoResultPage && entry.phase != incompleteReadStrategyResultPage) {
+		return incompleteReadTransition{}
+	}
+	if !ok || !retainedSnapshotMatches || header.ResultRef != entry.resultRef || header.Offset != entry.nextByteOffset ||
+		header.TotalBytes != entry.totalBytes || header.SHA256 != entry.sha256 ||
+		header.NextOffset <= header.Offset || header.NextOffset > header.TotalBytes ||
+		len(body) != header.NextOffset-header.Offset ||
+		(header.Complete != (header.NextOffset == header.TotalBytes)) {
+		s.setFailureLocked(entry, "a retained read page failed its result_ref, SHA-256, or contiguous-offset integrity check")
+		return incompleteReadTransition{}
+	}
+	entry.nextByteOffset = header.NextOffset
+	s.roundProgress = true
+	transition := incompleteReadTransition{readID: entry.readID, path: entry.path}
+	if entry.phase == incompleteReadStrategyResultPage {
+		transition.strategyProgress = true
+	}
+	if !header.Complete {
+		return transition
+	}
+	entry.toolCallID = ""
+	entry.resultRef = ""
+	entry.nextByteOffset = 0
+	entry.totalBytes = 0
+	entry.sha256 = ""
+	if entry.nextSourceOffset > 0 {
+		if entry.phase == incompleteReadStrategyResultPage {
+			entry.phase = incompleteReadStrategySourcePage
+		} else {
+			entry.phase = incompleteReadAutoSourcePage
+		}
+		return transition
+	}
+	if entry.phase == incompleteReadStrategyResultPage {
+		s.finishStrategyWindowLocked(entry)
+		return transition
+	}
+	transition.record = append(transition.record, entry.pendingObserved...)
+	s.removeEntryLocked(entry.key)
+	transition.completed = true
+	return transition
+}
+
+func (a *Agent) retainedReadPageMatches(plan *toolCallPlan, output string) bool {
+	if a == nil || plan == nil {
+		return false
+	}
+	header, body, ok := parseSessionToolResultPage(output)
+	if !ok {
+		return false
+	}
+	var params toolResultReadParams
+	if json.Unmarshal(plan.evidenceArgs, &params) != nil {
+		return false
+	}
+	candidate, err := findToolResultCandidate(a.sess.conversation.Snapshot(), params.ToolCallID, header.ResultRef)
+	if err != nil || !candidate.recoverable || header.Offset < 0 || header.NextOffset < header.Offset || header.NextOffset > len(candidate.body) {
+		return false
+	}
+	return candidate.body[header.Offset:header.NextOffset] == body
+}
+
+func (s *incompleteReadState) gate(plan *toolCallPlan) (string, bool) {
+	if plan == nil {
+		return "", false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failure != nil {
+		return "blocked: a prior read_file result could not be completed safely; stop this run and report the incomplete read", true
+	}
+	if len(s.entries) == 0 {
+		return "", false
+	}
+
+	input := parseIncompleteReadGateInput(plan)
+	hasStrategy := false
+	for _, key := range s.order {
+		entry := s.entries[key]
+		if entry == nil {
+			continue
+		}
+		message, matched, strategy := matchIncompleteReadGateEntry(plan, input, key, entry)
+		hasStrategy = hasStrategy || strategy
+		if matched {
+			if message != "" {
+				s.roundViolation = true
+			}
+			return message, message != ""
+		}
+	}
+	if hasStrategy {
+		s.roundViolation = true
+		return "blocked: an oversized read_file is in restricted search/read mode. Only grep on the target file, read_file with explicit offset and limit, exact session:tool_result recovery, or session:read_strategy_receipt is allowed.", true
+	}
+	if plan.effects.StateMutation || plan.evidenceName == "complete_step" || plan.evidenceName == "submit_plan" {
+		s.roundViolation = true
+		return "blocked: read_file has unread content retained by the host. Complete the exact continuation requested in the latest host message before modifying state or finishing.", true
+	}
+	return "", false
+}
+
+func (s *incompleteReadState) blockFinal() (instruction string, pause *IncompleteReadError) {
+	s.mu.Lock()
+	if s.failure != nil {
+		copy := *s.failure
+		s.mu.Unlock()
+		return "", &copy
+	}
+	entry := s.firstLocked()
+	if entry == nil {
+		s.mu.Unlock()
+		return "", nil
+	}
+	s.consecutiveViolations++
+	violations := s.consecutiveViolations
+	if violations >= 2 {
+		err := s.pauseForEntryLocked(entry, "the model attempted to finish in two consecutive rounds without satisfying the required read strategy")
+		s.mu.Unlock()
+		return "", err
+	}
+	s.mu.Unlock()
+	return s.nextInstruction(), nil
+}
+
+func (s *incompleteReadState) pauseForEntryLocked(entry *incompleteRead, reason string) *IncompleteReadError {
+	return &IncompleteReadError{
+		Reason: reason, Path: entry.path, ToolCallID: entry.toolCallID,
+		ResultRef: entry.resultRef, NextOffset: entry.nextByteOffset,
+		ConsumedBytes: entry.cumulativeBytes, TotalBytes: entry.totalBytes,
+	}
+}
+
+func (s *incompleteReadState) finishToolRound() incompleteReadRoundResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := incompleteReadRoundResult{}
+	if s.failure != nil {
+		copy := *s.failure
+		result.pause = &copy
+		return result
+	}
+	if s.roundViolation {
+		s.consecutiveViolations++
+	} else if s.roundProgress {
+		s.consecutiveViolations = 0
+	}
+	for _, key := range append([]string(nil), s.order...) {
+		entry := s.entries[key]
+		if entry == nil || entry.pendingReceipt == nil {
+			continue
+		}
+		for _, id := range entry.pendingReceipt.readIDs {
+			window := entry.reads[id]
+			result.record = append(result.record, window.observed...)
+		}
+		result.resolvedIDs = append(result.resolvedIDs, entry.readID)
+		s.removeEntryLocked(key)
+	}
+	entry := s.firstLocked()
+	if entry != nil && s.consecutiveViolations >= 2 {
+		result.pause = s.pauseForEntryLocked(entry, "the model violated the restricted read strategy in two consecutive rounds")
+	}
+	s.roundProgress = false
+	s.roundViolation = false
+	return result
+}

--- a/internal/agent/incomplete_read_budget.go
+++ b/internal/agent/incomplete_read_budget.go
@@ -1,0 +1,76 @@
+package agent
+
+import (
+	"unicode/utf8"
+
+	"reasonix/internal/provider"
+)
+
+const (
+	readAutoRecoveryContextShareDivisor  = 4
+	readAutoRecoveryContextReserveTokens = 1024
+)
+
+type readAutoRecoveryBudget struct {
+	maxTokens      int
+	windowTokens   int
+	currentTokens  int
+	headroomTokens int
+	known          bool
+}
+
+// readAutoRecoveryBudgetFor derives a live budget without a product-level byte
+// or token ceiling. Unknown context windows deliberately return no automatic
+// budget so the host switches to the bounded search/read strategy instead of
+// guessing how much context is safe.
+func (a *Agent) readAutoRecoveryBudgetFor() readAutoRecoveryBudget {
+	if a == nil {
+		return readAutoRecoveryBudget{}
+	}
+	window := a.effectiveContextWindow()
+	if window <= 0 {
+		return readAutoRecoveryBudget{}
+	}
+	current := a.estimatedVisibleRequestTokens(a.modelVisibleMessages())
+	headroom := max(0, a.compactTrigger()-current-readAutoRecoveryContextReserveTokens)
+	return readAutoRecoveryBudget{
+		maxTokens:      min(max(0, window/readAutoRecoveryContextShareDivisor), headroom),
+		windowTokens:   window,
+		currentTokens:  current,
+		headroomTokens: headroom,
+		known:          true,
+	}
+}
+
+// estimatedReadResultTokens uses the larger of the calibrated provider-facing
+// estimate and the cross-language conservative estimate. The latter prices CJK
+// near one rune per token, avoiding the under-count produced by bytes/4 alone.
+func (a *Agent) estimatedReadResultTokens(result string) int {
+	conservative := estimateCrossLanguageReadTokens(result)
+	if a == nil {
+		return conservative
+	}
+	message := provider.Message{
+		Role: provider.RoleTool, Name: "read_file", Content: result,
+	}
+	calibrated := a.estimatedPromptTokens([]provider.Message{message})
+	message.Content = ""
+	calibrated -= a.estimatedPromptTokens([]provider.Message{message})
+	return max(conservative, calibrated)
+}
+
+func estimateCrossLanguageReadTokens(result string) int {
+	if result == "" {
+		return 0
+	}
+	cjkRunes := 0
+	cjkBytes := 0
+	for _, r := range result {
+		if isCJKRune(r) {
+			cjkRunes++
+			cjkBytes += utf8.RuneLen(r)
+		}
+	}
+	nonCJKBytes := len(result) - cjkBytes
+	return (nonCJKBytes+3)/4 + cjkRunes
+}

--- a/internal/agent/incomplete_read_budget_test.go
+++ b/internal/agent/incomplete_read_budget_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+func TestReadAutoRecoveryBudgetCombinesTokenWindowAndHeadroomCaps(t *testing.T) {
+	agent := New(
+		&scriptedProvider{name: "budget"}, nil, NewSession("sys"),
+		Options{ContextWindow: 64_000}, event.Discard,
+	)
+	budget := agent.readAutoRecoveryBudgetFor()
+	if budget.windowTokens != 64_000 {
+		t.Fatalf("window=%d, want 64000", budget.windowTokens)
+	}
+	if budget.maxTokens <= 0 || budget.maxTokens > 16_000 || budget.maxTokens > budget.headroomTokens {
+		t.Fatalf("budget=%+v, want a positive limit capped by window/4 and headroom", budget)
+	}
+
+	pressured := New(
+		&scriptedProvider{name: "pressured-budget"}, nil,
+		NewSession(strings.Repeat("a", 180_000)),
+		Options{ContextWindow: 64_000}, event.Discard,
+	)
+	pressuredBudget := pressured.readAutoRecoveryBudgetFor()
+	if pressuredBudget.maxTokens >= budget.maxTokens || pressuredBudget.maxTokens != pressuredBudget.headroomTokens {
+		t.Fatalf("pressured budget=%+v, ordinary=%+v; remaining headroom did not lower the limit", pressuredBudget, budget)
+	}
+}
+
+func TestReadAutoRecoveryBudgetHasNoFixed32KCeilingAndNoUnknownFallback(t *testing.T) {
+	large := New(
+		&scriptedProvider{name: "large-budget"}, nil, NewSession("sys"),
+		Options{ContextWindow: 1_000_000}, event.Discard,
+	)
+	budget := large.readAutoRecoveryBudgetFor()
+	if budget.maxTokens <= 32*1024 {
+		t.Fatalf("large dynamic budget=%+v, want above former fixed 32K ceiling", budget)
+	}
+	unknown := New(
+		&scriptedProvider{name: "unknown-budget"}, nil, NewSession("sys"),
+		Options{}, event.Discard,
+	).readAutoRecoveryBudgetFor()
+	if unknown.known || unknown.maxTokens != 0 {
+		t.Fatalf("unknown budget=%+v, want no guessed fallback", unknown)
+	}
+}
+
+func TestEstimatedReadResultTokensPricesCJKMoreConservatively(t *testing.T) {
+	agent := New(
+		&scriptedProvider{name: "token-density"}, nil, NewSession("sys"),
+		Options{}, event.Discard,
+	)
+	ascii := strings.Repeat("a", 12_000)
+	cjk := strings.Repeat("界", 4_000) // Same UTF-8 byte length as ascii.
+	asciiTokens := agent.estimatedReadResultTokens(ascii)
+	cjkTokens := agent.estimatedReadResultTokens(cjk)
+	if asciiTokens < 3_000 || asciiTokens > 3_100 {
+		t.Fatalf("ASCII estimate=%d, want approximately bytes/4", asciiTokens)
+	}
+	if cjkTokens < 4_000 || cjkTokens <= asciiTokens {
+		t.Fatalf("CJK estimate=%d ASCII=%d, want the same bytes to cost at least one token per CJK rune", cjkTokens, asciiTokens)
+	}
+}

--- a/internal/agent/incomplete_read_gate.go
+++ b/internal/agent/incomplete_read_gate.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type incompleteReadGateInput struct {
+	result    toolResultReadParams
+	read      readFileArgs
+	grep      incompleteReadGrepArgs
+	receipt   readStrategyReceiptArgs
+	resultOK  bool
+	readOK    bool
+	grepOK    bool
+	receiptOK bool
+}
+
+func parseIncompleteReadGateInput(plan *toolCallPlan) incompleteReadGateInput {
+	var input incompleteReadGateInput
+	input.resultOK = plan.evidenceName == "session_tool_result" && json.Unmarshal(plan.evidenceArgs, &input.result) == nil
+	input.read, input.readOK = parseReadFileArgs(plan.evidenceArgs)
+	input.grep, input.grepOK = parseIncompleteReadGrepArgs(plan.evidenceArgs)
+	input.receipt, input.receiptOK = parseReadStrategyReceiptArgs(plan.evidenceArgs)
+	return input
+}
+
+func matchIncompleteReadGateEntry(plan *toolCallPlan, input incompleteReadGateInput, key string, entry *incompleteRead) (string, bool, bool) {
+	switch entry.phase {
+	case incompleteReadAutoResultPage:
+		return matchIncompleteReadResultPage(plan, input, key, entry, incompleteReadActionAutoResult, "incomplete")
+	case incompleteReadAutoSourcePage:
+		return matchIncompleteReadSourcePage(plan, input, key, entry, incompleteReadActionAutoSource, "incomplete")
+	case incompleteReadStrategyResultPage:
+		message, matched, _ := matchIncompleteReadResultPage(plan, input, key, entry, incompleteReadActionStrategyResult, "targeted")
+		return message, matched, true
+	case incompleteReadStrategySourcePage:
+		message, matched, _ := matchIncompleteReadSourcePage(plan, input, key, entry, incompleteReadActionStrategySource, "targeted")
+		return message, matched, true
+	case incompleteReadStrategy:
+		return "", matchReadStrategyAction(plan, input, key, entry), true
+	default:
+		return "", false, false
+	}
+}
+
+func matchIncompleteReadResultPage(plan *toolCallPlan, input incompleteReadGateInput, key string, entry *incompleteRead, action incompleteReadAction, label string) (string, bool, bool) {
+	if !input.resultOK || input.result.ToolCallID != entry.toolCallID {
+		return "", false, false
+	}
+	if input.result.ResultRef != entry.resultRef || input.result.Offset != entry.nextByteOffset {
+		return fmt.Sprintf("blocked: %s read continuation mismatch for tool_call_id %q; require result_ref=%q offset=%d", label, entry.toolCallID, entry.resultRef, entry.nextByteOffset), true, false
+	}
+	plan.incompleteReadRoot = key
+	plan.incompleteReadAction = action
+	return "", true, false
+}
+
+func matchIncompleteReadSourcePage(plan *toolCallPlan, input incompleteReadGateInput, key string, entry *incompleteRead, action incompleteReadAction, label string) (string, bool, bool) {
+	if plan.evidenceName != "read_file" || !input.readOK || !readPathMatches(input.read.Path, entry) {
+		return "", false, false
+	}
+	if input.read.Offset != entry.nextSourceOffset || !input.read.LimitExplicit || input.read.Limit != entry.nextSourceLimit {
+		return fmt.Sprintf("blocked: %s source continuation mismatch for path %q; require offset=%d limit=%d", label, entry.path, entry.nextSourceOffset, entry.nextSourceLimit), true, false
+	}
+	plan.incompleteReadRoot = key
+	plan.incompleteReadAction = action
+	return "", true, false
+}
+
+func matchReadStrategyAction(plan *toolCallPlan, input incompleteReadGateInput, key string, entry *incompleteRead) bool {
+	var action incompleteReadAction
+	switch {
+	case plan.evidenceName == "grep" && input.grepOK && readPathMatches(input.grep.Path, entry):
+		action = incompleteReadActionStrategySearch
+	case plan.evidenceName == "read_file" && input.readOK && input.read.OffsetExplicit && input.read.LimitExplicit && readPathMatches(input.read.Path, entry):
+		action = incompleteReadActionStrategyRead
+	case plan.evidenceName == "session_read_strategy_receipt" && input.receiptOK && input.receipt.ReadID == entry.readID:
+		action = incompleteReadActionStrategyReceipt
+	default:
+		return false
+	}
+	plan.incompleteReadRoot = key
+	plan.incompleteReadAction = action
+	return true
+}
+
+func (s *incompleteReadState) nextInstruction() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry := s.firstLocked()
+	if entry == nil {
+		return ""
+	}
+	switch entry.phase {
+	case incompleteReadAutoResultPage, incompleteReadStrategyResultPage:
+		args, _ := json.Marshal(map[string]any{"tool_call_id": entry.toolCallID, "result_ref": entry.resultRef, "offset": entry.nextByteOffset, "limit": toolResultPageMaxBytes})
+		return fmt.Sprintf("The host has an INCOMPLETE read_file result. Before any state change or final answer, call use_capability with action=\"call\", capability_id=\"session:tool_result\", arguments=%s. Continue from each returned next_offset until complete=true.", args)
+	case incompleteReadAutoSourcePage, incompleteReadStrategySourcePage:
+		args, _ := json.Marshal(map[string]any{"path": entry.path, "offset": entry.nextSourceOffset, "limit": entry.nextSourceLimit})
+		return fmt.Sprintf("The read_file window has more source lines. Before any state change or final answer, call read_file with exactly %s.", args)
+	case incompleteReadStrategy:
+		readExample, _ := json.Marshal(map[string]any{"path": entry.path, "offset": 0, "limit": 200})
+		receiptExample, _ := json.Marshal(map[string]any{"read_id": entry.readID, "search_tool_call_ids": []string{"<grep tool call id>"}, "read_tool_call_ids": []string{"<read_file tool call id>"}, "conclusion": "<why these searches and exact windows are sufficient for the task>"})
+		return fmt.Sprintf("The complete file cannot fit the dynamic context budget. RESTRICTED READ STRATEGY read_id=%q path=%q. Do not modify state or answer yet. Search only this exact file with grep, then read relevant windows with explicit offset and limit (example %s). After at least one complete search and one complete exact window, call use_capability with action=\"call\", capability_id=\"session:read_strategy_receipt\", arguments=%s.", entry.readID, entry.path, readExample, receiptExample)
+	default:
+		return ""
+	}
+}

--- a/internal/agent/incomplete_read_runtime.go
+++ b/internal/agent/incomplete_read_runtime.go
@@ -1,0 +1,133 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func (a *Agent) emitIncompleteReadNotice(code, text, detail string) {
+	if a == nil || a.svc.sink == nil {
+		return
+	}
+	level := event.LevelWarn
+	if code == event.NoticeCodeReadCompleted || code == event.NoticeCodeReadStrategyProgress || code == event.NoticeCodeReadStrategyResolved {
+		level = event.LevelInfo
+	}
+	a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: level, Code: code, Text: text, Detail: detail})
+}
+
+// resolveIncompleteReadToolRoundBoundary runs after every tool result is stored,
+// commits validated receipts, and counts at most one violation per model round.
+func (a *Agent) resolveIncompleteReadToolRoundBoundary(ctx context.Context, state *turnRuntime, usage *provider.Usage) (cont bool, err error, handled bool) {
+	round := state.incompleteReads.finishToolRound()
+	for _, observed := range round.record {
+		a.recordModelTextObservationValue(observed)
+	}
+	for _, readID := range round.resolvedIDs {
+		a.emitIncompleteReadNotice(event.NoticeCodeReadStrategyResolved, "Reasonix validated a narrowed read strategy receipt.", "read_id="+readID)
+	}
+	if round.pause != nil {
+		a.contextManager().ObserveUsage(usage)
+		return false, round.pause, true
+	}
+	instruction := state.incompleteReads.nextInstruction()
+	if instruction != "" {
+		a.sess.conversation.Add(HostGeneratedUserMessage(a.withTurnPreferences(instruction)))
+		a.emitIncompleteReadNotice(event.NoticeCodeReadContinuationRequired, "Reasonix is continuing or narrowing an incomplete file read before allowing changes or completion.", "read continuation instruction appended")
+	}
+	if ctx.Err() != nil {
+		a.recordInterruptedDisplay("", "", nil, true, state.workDurationMs())
+		return false, ctx.Err(), true
+	}
+	if instruction == "" {
+		if len(round.resolvedIDs) > 0 {
+			a.contextManager().ObserveUsage(usage)
+			return true, nil, true
+		}
+		return false, nil, false
+	}
+	a.contextManager().ObserveUsage(usage)
+	if axis, detail := a.task.budget.exceeded(a.taskBudgetLimit(ctx)); axis != "" {
+		return false, &IncompleteReadError{Reason: fmt.Sprintf("the %s budget ended while a required read_file continuation was still pending: %s", axis, detail)}, true
+	}
+	return true, nil, true
+}
+
+func (a *Agent) boundIncompleteReadAwareResult(plan *toolCallPlan, result string) (body, truncMsg, original string, readObserver bool) {
+	if plan == nil {
+		return result, "", "", false
+	}
+	if plan.evidenceName == "read_file" {
+		_, readObserver = plan.runTool.(tool.ModelTextObserver)
+		if !readObserver {
+			_, readObserver = plan.execTool.(tool.ModelTextObserver)
+		}
+	}
+	body, truncMsg, original = a.boundProviderVisibleResult(result, plan.call.Name, plan.call.ID)
+	return body, truncMsg, original, readObserver
+}
+
+func deferredIncompleteReadOutcome(plan *toolCallPlan, rawOutput string, readObserver, visibleFull bool) *incompleteReadDeferred {
+	if plan == nil || !(readObserver || plan.evidenceName == "session_tool_result" || (plan.evidenceName == "grep" && plan.incompleteReadRoot != "")) {
+		return nil
+	}
+	return &incompleteReadDeferred{plan: plan, rawOutput: rawOutput, readObserver: readObserver, visibleFull: visibleFull}
+}
+
+func readStrategyPreview(raw, readID string, totalTokens, limitTokens int) string {
+	const maxPreview = 8 * 1024
+	headLimit := min(len(raw), maxPreview-1024)
+	head := snapToRuneBoundary(raw, 0, max(0, headLimit))
+	if newline := strings.LastIndexByte(head, '\n'); newline >= 0 {
+		head = head[:newline+1]
+	}
+	return fmt.Sprintf("%s\n[INCOMPLETE READ: read_id=%s; complete content does not fit the dynamic context budget (estimated_tokens=%d budget_tokens=%d). This prefix is not whole-file evidence. Follow the restricted grep/read strategy from the next host message.]\n", head, readID, totalTokens, limitTokens)
+}
+
+// finalizeIncompleteReadOutcome is called by executeBatch.finalize in provider
+// order, never from parallel execution goroutines.
+func (a *Agent) finalizeIncompleteReadOutcome(deferred *incompleteReadDeferred, out *toolOutcome) {
+	if a == nil || deferred == nil || deferred.plan == nil || out == nil {
+		return
+	}
+	plan := deferred.plan
+	var transition incompleteReadTransition
+	switch plan.evidenceName {
+	case "read_file":
+		observed, ok := modelTextObservationFor(plan, deferred.rawOutput)
+		transition = a.turn.incompleteReads.observeReadFile(plan, deferred.rawOutput, out.output, observed, ok, a.estimatedReadResultTokens(deferred.rawOutput), a.readAutoRecoveryBudgetFor())
+	case "session_tool_result":
+		transition = a.turn.incompleteReads.observeResultPage(plan, deferred.rawOutput, a.retainedReadPageMatches(plan, deferred.rawOutput))
+	case "grep":
+		transition = a.turn.incompleteReads.observeStrategySearch(plan, deferred.rawOutput, deferred.visibleFull)
+	default:
+		return
+	}
+	for _, observed := range transition.record {
+		a.recordModelTextObservationValue(observed)
+	}
+	if transition.strategyRequired {
+		out.output = readStrategyPreview(deferred.rawOutput, transition.readID, transition.totalTokens, transition.limitTokens)
+		out.rawOutput = deferred.rawOutput
+		out.truncated = true
+		out.truncMsg = fmt.Sprintf("read_file switched to restricted strategy: estimated_tokens=%d budget_tokens=%d", transition.totalTokens, transition.limitTokens)
+		a.emitIncompleteReadNotice(event.NoticeCodeReadStrategyRequired, "The complete file did not fit the dynamic context budget; Reasonix entered restricted search/read mode.", fmt.Sprintf("read_id=%s bytes=%d tokens=%d budget_tokens=%d", transition.readID, transition.totalBytes, transition.totalTokens, transition.limitTokens))
+	}
+	if transition.detected {
+		a.emitIncompleteReadNotice(event.NoticeCodeIncompleteReadDetected, "Reasonix detected an incomplete file read and armed a host continuation.", "read_id="+transition.readID)
+	}
+	if transition.strategyProgress {
+		a.emitIncompleteReadNotice(event.NoticeCodeReadStrategyProgress, "Reasonix recorded valid progress in a restricted read strategy.", "read_id="+transition.readID)
+	}
+	if transition.localSafetyPaged {
+		a.emitIncompleteReadNotice(event.NoticeCodeReadLocalSafetyPaged, "Reasonix safely paged a large local read_file result.", "read_id="+transition.readID)
+	}
+	if transition.completed {
+		a.emitIncompleteReadNotice(event.NoticeCodeReadCompleted, "Reasonix finished recovering the complete file read.", "read_id="+transition.readID)
+	}
+}

--- a/internal/agent/incomplete_read_strategy.go
+++ b/internal/agent/incomplete_read_strategy.go
@@ -1,10 +1,14 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
+
+	"reasonix/internal/tool"
 )
 
 type incompleteReadGrepArgs struct {
@@ -75,6 +79,7 @@ func (s *incompleteReadState) resetStrategyEvidenceForVersionLocked(entry *incom
 	entry.targetEnd = 0
 	entry.pendingReceipt = nil
 	entry.strategyVersion = current
+	entry.strategyRevision++
 }
 
 func (s *incompleteReadState) observeStrategySearch(plan *toolCallPlan, output string, visibleFull bool) incompleteReadTransition {
@@ -102,6 +107,7 @@ func (s *incompleteReadState) observeStrategySearch(plan *toolCallPlan, output s
 	entry.searches[plan.call.ID] = incompleteReadSearch{
 		callID: plan.call.ID, pattern: args.Pattern, matchLines: grepMatchLines(output),
 	}
+	entry.strategyRevision++
 	s.roundProgress = true
 	transition.strategyProgress = true
 	return transition
@@ -127,7 +133,84 @@ func uniqueNonEmptyIDs(ids []string) ([]string, error) {
 	return out, nil
 }
 
-func (s *incompleteReadState) submitStrategyReceipt(args readStrategyReceiptArgs) (string, error) {
+type readStrategyReceiptValidation struct {
+	entry       *incompleteRead
+	readID      string
+	path        string
+	requestPath string
+	version     incompleteReadFileVersion
+	revision    uint64
+	readTool    tool.Tool
+	searchIDs   []string
+	readIDs     []string
+	patterns    []string
+	ranges      []string
+	windows     []incompleteReadWindow
+	conclusion  string
+}
+
+func cloneIncompleteReadWindow(window incompleteReadWindow) incompleteReadWindow {
+	copyWindow := window
+	copyWindow.observed = make([]tool.ModelTextObservation, len(window.observed))
+	for i, observed := range window.observed {
+		copyWindow.observed[i] = observed
+		copyWindow.observed[i].LineHashes = append([]string(nil), observed.LineHashes...)
+	}
+	return copyWindow
+}
+
+func sameModelTextObservation(a, b tool.ModelTextObservation) bool {
+	if filepath.Clean(a.Path) != filepath.Clean(b.Path) || a.StartLine != b.StartLine || len(a.LineHashes) != len(b.LineHashes) {
+		return false
+	}
+	for i := range a.LineHashes {
+		if a.LineHashes[i] != b.LineHashes[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func validateReadStrategyWindows(ctx context.Context, check readStrategyReceiptValidation) error {
+	observer, ok := check.readTool.(tool.ModelTextObserver)
+	if check.readTool == nil || !ok {
+		return fmt.Errorf("read strategy receipt: read_file cannot revalidate the selected windows")
+	}
+	for _, window := range check.windows {
+		for _, expected := range window.observed {
+			if expected.StartLine < 1 || len(expected.LineHashes) == 0 {
+				return fmt.Errorf("read strategy receipt: selected read_file window has invalid host evidence")
+			}
+			args, _ := json.Marshal(map[string]any{
+				"path": check.requestPath, "offset": expected.StartLine - 1, "limit": len(expected.LineHashes),
+			})
+			output, err := check.readTool.Execute(ctx, args)
+			if err != nil {
+				return fmt.Errorf("read strategy receipt: re-read window %d-%d: %w", expected.StartLine, expected.StartLine+len(expected.LineHashes)-1, err)
+			}
+			actual, ok := observer.ObserveModelText(args, output)
+			if !ok || !sameModelTextObservation(actual, expected) {
+				return fmt.Errorf("read strategy receipt: selected read_file window changed; repeat grep and explicit read_file windows")
+			}
+		}
+	}
+	return nil
+}
+
+func (s *incompleteReadState) rejectStrategyReceiptValidation(check readStrategyReceiptValidation, current incompleteReadFileVersion) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry := s.entries[check.readID]
+	if entry != check.entry {
+		return
+	}
+	s.roundViolation = true
+	if entry.strategyRevision == check.revision {
+		s.resetStrategyEvidenceForVersionLocked(entry, current)
+	}
+}
+
+func (s *incompleteReadState) submitStrategyReceipt(ctx context.Context, args readStrategyReceiptArgs) (string, error) {
 	searchIDs, err := uniqueNonEmptyIDs(args.SearchToolCallIDs)
 	if err != nil {
 		return "", fmt.Errorf("read strategy receipt: search_tool_call_ids: %w", err)
@@ -142,17 +225,11 @@ func (s *incompleteReadState) submitStrategyReceipt(args readStrategyReceiptArgs
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	entry := s.entries[strings.TrimSpace(args.ReadID)]
 	if entry == nil || entry.phase != incompleteReadStrategy {
 		s.roundViolation = true
+		s.mu.Unlock()
 		return "", fmt.Errorf("read strategy receipt: active read_id %q was not found or still has an unfinished page", args.ReadID)
-	}
-	current := snapshotIncompleteReadFile(entry.path)
-	if !sameIncompleteReadFileVersion(entry.strategyVersion, current) {
-		s.resetStrategyEvidenceForVersionLocked(entry, current)
-		s.roundViolation = true
-		return "", fmt.Errorf("read strategy receipt: the target file changed; repeat grep and explicit read_file windows")
 	}
 
 	patterns := make([]string, 0, len(searchIDs))
@@ -161,6 +238,7 @@ func (s *incompleteReadState) submitStrategyReceipt(args readStrategyReceiptArgs
 		search, ok := entry.searches[id]
 		if !ok {
 			s.roundViolation = true
+			s.mu.Unlock()
 			return "", fmt.Errorf("read strategy receipt: grep tool call %q is not complete evidence for read_id %q", id, entry.readID)
 		}
 		patterns = append(patterns, search.pattern)
@@ -168,14 +246,17 @@ func (s *incompleteReadState) submitStrategyReceipt(args readStrategyReceiptArgs
 	}
 
 	ranges := make([]string, 0, len(readIDs))
+	windows := make([]incompleteReadWindow, 0, len(readIDs))
 	overlaps := len(matchedLines) == 0
 	for _, id := range readIDs {
 		window, ok := entry.reads[id]
-		if !ok {
+		if !ok || len(window.observed) == 0 {
 			s.roundViolation = true
+			s.mu.Unlock()
 			return "", fmt.Errorf("read strategy receipt: read_file tool call %q is not a fully consumed explicit window for read_id %q", id, entry.readID)
 		}
 		ranges = append(ranges, fmt.Sprintf("%d-%d", window.startLine, window.endLine))
+		windows = append(windows, cloneIncompleteReadWindow(window))
 		for _, line := range matchedLines {
 			if line >= window.startLine && line <= window.endLine {
 				overlaps = true
@@ -185,19 +266,51 @@ func (s *incompleteReadState) submitStrategyReceipt(args readStrategyReceiptArgs
 	}
 	if !overlaps {
 		s.roundViolation = true
+		s.mu.Unlock()
 		return "", fmt.Errorf("read strategy receipt: no selected read_file window overlaps a cited grep match line")
+	}
+	check := readStrategyReceiptValidation{
+		entry: entry, readID: entry.readID, path: entry.path, requestPath: entry.requestPath,
+		version: entry.strategyVersion, revision: entry.strategyRevision, readTool: entry.readTool,
+		searchIDs: searchIDs, readIDs: readIDs, patterns: patterns, ranges: ranges,
+		windows: windows, conclusion: conclusion,
+	}
+	s.mu.Unlock()
+
+	current := snapshotIncompleteReadFile(check.path)
+	if !sameIncompleteReadFileVersion(check.version, current) {
+		s.rejectStrategyReceiptValidation(check, current)
+		return "", fmt.Errorf("read strategy receipt: the target file changed; repeat grep and explicit read_file windows")
+	}
+	if err := validateReadStrategyWindows(ctx, check); err != nil {
+		s.rejectStrategyReceiptValidation(check, snapshotIncompleteReadFile(check.path))
+		return "", err
+	}
+	current = snapshotIncompleteReadFile(check.path)
+	if !sameIncompleteReadFileVersion(check.version, current) {
+		s.rejectStrategyReceiptValidation(check, current)
+		return "", fmt.Errorf("read strategy receipt: the target file changed during validation; repeat grep and explicit read_file windows")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry = s.entries[check.readID]
+	if entry != check.entry || entry.phase != incompleteReadStrategy || entry.strategyRevision != check.revision || entry.pendingReceipt != nil {
+		s.roundViolation = true
+		return "", fmt.Errorf("read strategy receipt: strategy evidence changed during validation; submit a new receipt")
 	}
 
 	entry.pendingReceipt = &incompleteReadReceipt{
-		searchIDs: searchIDs, readIDs: readIDs, conclusion: conclusion,
+		searchIDs: check.searchIDs, readIDs: check.readIDs, conclusion: check.conclusion,
 	}
+	entry.strategyRevision++
 	s.roundProgress = true
 	payload, _ := json.Marshal(map[string]any{
 		"read_id":         entry.readID,
 		"path":            entry.path,
-		"search_patterns": patterns,
-		"read_ranges":     ranges,
-		"conclusion":      conclusion,
+		"search_patterns": check.patterns,
+		"read_ranges":     check.ranges,
+		"conclusion":      check.conclusion,
 		"status":          "validated_pending_round_boundary",
 		"whole_file_read": false,
 	})

--- a/internal/agent/incomplete_read_strategy.go
+++ b/internal/agent/incomplete_read_strategy.go
@@ -1,0 +1,205 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type incompleteReadGrepArgs struct {
+	Pattern string
+	Path    string
+}
+
+type readStrategyReceiptArgs struct {
+	ReadID            string   `json:"read_id"`
+	SearchToolCallIDs []string `json:"search_tool_call_ids"`
+	ReadToolCallIDs   []string `json:"read_tool_call_ids"`
+	Conclusion        string   `json:"conclusion"`
+}
+
+func parseIncompleteReadGrepArgs(raw json.RawMessage) (incompleteReadGrepArgs, bool) {
+	var args struct {
+		Pattern string `json:"pattern"`
+		Path    string `json:"path"`
+	}
+	if json.Unmarshal(raw, &args) != nil || strings.TrimSpace(args.Pattern) == "" || strings.TrimSpace(args.Path) == "" {
+		return incompleteReadGrepArgs{}, false
+	}
+	return incompleteReadGrepArgs{Pattern: args.Pattern, Path: args.Path}, true
+}
+
+func parseReadStrategyReceiptArgs(raw json.RawMessage) (readStrategyReceiptArgs, bool) {
+	var args readStrategyReceiptArgs
+	if json.Unmarshal(raw, &args) != nil || strings.TrimSpace(args.ReadID) == "" {
+		return readStrategyReceiptArgs{}, false
+	}
+	return args, true
+}
+
+func grepMatchLines(output string) []int {
+	var lines []int
+	seen := make(map[int]bool)
+	for line := range strings.SplitSeq(output, "\n") {
+		for start := 0; start < len(line); {
+			colon := strings.IndexByte(line[start:], ':')
+			if colon < 0 {
+				break
+			}
+			colon += start
+			next := strings.IndexByte(line[colon+1:], ':')
+			if next < 0 {
+				break
+			}
+			next += colon + 1
+			n, err := strconv.Atoi(line[colon+1 : next])
+			if err == nil && n > 0 {
+				if !seen[n] {
+					seen[n] = true
+					lines = append(lines, n)
+				}
+				break
+			}
+			start = colon + 1
+		}
+	}
+	return lines
+}
+
+func (s *incompleteReadState) resetStrategyEvidenceForVersionLocked(entry *incompleteRead, current incompleteReadFileVersion) {
+	entry.searches = make(map[string]incompleteReadSearch)
+	entry.reads = make(map[string]incompleteReadWindow)
+	entry.targetReadID = ""
+	entry.targetObserved = nil
+	entry.targetEnd = 0
+	entry.pendingReceipt = nil
+	entry.strategyVersion = current
+}
+
+func (s *incompleteReadState) observeStrategySearch(plan *toolCallPlan, output string, visibleFull bool) incompleteReadTransition {
+	if plan == nil || plan.incompleteReadRoot == "" || plan.incompleteReadAction != incompleteReadActionStrategySearch {
+		return incompleteReadTransition{}
+	}
+	args, ok := parseIncompleteReadGrepArgs(plan.runArgs)
+	if !ok {
+		return incompleteReadTransition{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry := s.entries[plan.incompleteReadRoot]
+	if entry == nil || entry.phase != incompleteReadStrategy {
+		return incompleteReadTransition{}
+	}
+	transition := incompleteReadTransition{readID: entry.readID, path: entry.path}
+	if !visibleFull || strings.Contains(output, "timed out after") {
+		return transition
+	}
+	current := snapshotIncompleteReadFile(entry.path)
+	if !sameIncompleteReadFileVersion(entry.strategyVersion, current) {
+		s.resetStrategyEvidenceForVersionLocked(entry, current)
+	}
+	entry.searches[plan.call.ID] = incompleteReadSearch{
+		callID: plan.call.ID, pattern: args.Pattern, matchLines: grepMatchLines(output),
+	}
+	s.roundProgress = true
+	transition.strategyProgress = true
+	return transition
+}
+
+func uniqueNonEmptyIDs(ids []string) ([]string, error) {
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("at least one tool call id is required")
+	}
+	seen := make(map[string]bool, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, raw := range ids {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			return nil, fmt.Errorf("tool call ids must be non-empty")
+		}
+		if seen[id] {
+			return nil, fmt.Errorf("duplicate tool call id %q", id)
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+func (s *incompleteReadState) submitStrategyReceipt(args readStrategyReceiptArgs) (string, error) {
+	searchIDs, err := uniqueNonEmptyIDs(args.SearchToolCallIDs)
+	if err != nil {
+		return "", fmt.Errorf("read strategy receipt: search_tool_call_ids: %w", err)
+	}
+	readIDs, err := uniqueNonEmptyIDs(args.ReadToolCallIDs)
+	if err != nil {
+		return "", fmt.Errorf("read strategy receipt: read_tool_call_ids: %w", err)
+	}
+	conclusion := strings.TrimSpace(args.Conclusion)
+	if conclusion == "" {
+		return "", fmt.Errorf("read strategy receipt: conclusion is required")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry := s.entries[strings.TrimSpace(args.ReadID)]
+	if entry == nil || entry.phase != incompleteReadStrategy {
+		s.roundViolation = true
+		return "", fmt.Errorf("read strategy receipt: active read_id %q was not found or still has an unfinished page", args.ReadID)
+	}
+	current := snapshotIncompleteReadFile(entry.path)
+	if !sameIncompleteReadFileVersion(entry.strategyVersion, current) {
+		s.resetStrategyEvidenceForVersionLocked(entry, current)
+		s.roundViolation = true
+		return "", fmt.Errorf("read strategy receipt: the target file changed; repeat grep and explicit read_file windows")
+	}
+
+	patterns := make([]string, 0, len(searchIDs))
+	var matchedLines []int
+	for _, id := range searchIDs {
+		search, ok := entry.searches[id]
+		if !ok {
+			s.roundViolation = true
+			return "", fmt.Errorf("read strategy receipt: grep tool call %q is not complete evidence for read_id %q", id, entry.readID)
+		}
+		patterns = append(patterns, search.pattern)
+		matchedLines = append(matchedLines, search.matchLines...)
+	}
+
+	ranges := make([]string, 0, len(readIDs))
+	overlaps := len(matchedLines) == 0
+	for _, id := range readIDs {
+		window, ok := entry.reads[id]
+		if !ok {
+			s.roundViolation = true
+			return "", fmt.Errorf("read strategy receipt: read_file tool call %q is not a fully consumed explicit window for read_id %q", id, entry.readID)
+		}
+		ranges = append(ranges, fmt.Sprintf("%d-%d", window.startLine, window.endLine))
+		for _, line := range matchedLines {
+			if line >= window.startLine && line <= window.endLine {
+				overlaps = true
+				break
+			}
+		}
+	}
+	if !overlaps {
+		s.roundViolation = true
+		return "", fmt.Errorf("read strategy receipt: no selected read_file window overlaps a cited grep match line")
+	}
+
+	entry.pendingReceipt = &incompleteReadReceipt{
+		searchIDs: searchIDs, readIDs: readIDs, conclusion: conclusion,
+	}
+	s.roundProgress = true
+	payload, _ := json.Marshal(map[string]any{
+		"read_id":         entry.readID,
+		"path":            entry.path,
+		"search_patterns": patterns,
+		"read_ranges":     ranges,
+		"conclusion":      conclusion,
+		"status":          "validated_pending_round_boundary",
+		"whole_file_read": false,
+	})
+	return string(payload), nil
+}

--- a/internal/agent/incomplete_read_test.go
+++ b/internal/agent/incomplete_read_test.go
@@ -1,0 +1,719 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"unicode/utf8"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+const incompleteReadKeyRule = "KEY_RULE_362_MUST_BE_READ"
+
+type incompleteReadEventSink struct {
+	mu     sync.Mutex
+	events []event.Event
+}
+
+func (s *incompleteReadEventSink) Emit(e event.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, e)
+}
+
+func (s *incompleteReadEventSink) hasCode(code string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.events {
+		if e.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+type inspectingProvider struct {
+	inner  *scriptedProvider
+	before func(int, provider.Request)
+}
+
+func (p *inspectingProvider) Name() string { return p.inner.Name() }
+
+func (p *inspectingProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	if p.before != nil {
+		p.before(p.inner.call, req)
+	}
+	return p.inner.Stream(ctx, req)
+}
+
+type incompleteReadMutationTool struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (*incompleteReadMutationTool) Name() string { return "incomplete_read_mutation" }
+func (*incompleteReadMutationTool) Description() string {
+	return "Mutate durable state for incomplete-read tests."
+}
+func (*incompleteReadMutationTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{}}`)
+}
+func (*incompleteReadMutationTool) ReadOnly() bool { return false }
+func (t *incompleteReadMutationTool) Execute(context.Context, json.RawMessage) (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.calls++
+	return "mutated", nil
+}
+
+func (t *incompleteReadMutationTool) count() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.calls
+}
+
+func makeIncompleteReadFixture(t *testing.T, name string, lines, width, keyLine int, key string) string {
+	t.Helper()
+	var body strings.Builder
+	for line := 1; line <= lines; line++ {
+		prefix := fmt.Sprintf("rule-%04d ", line)
+		payload := strings.Repeat(string(rune('a'+line%26)), max(width-len(prefix), 1))
+		if line == keyLine {
+			payload = key + " " + strings.Repeat("k", max(width-len(prefix)-len(key)-1, 1))
+		}
+		body.WriteString(prefix)
+		body.WriteString(payload)
+		body.WriteString("\r\n")
+	}
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(body.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func makeShortPagedReadFixture(t *testing.T, name string, lines, keyLine int, key string) string {
+	t.Helper()
+	var body strings.Builder
+	for line := 1; line <= lines; line++ {
+		value := "x"
+		if line == keyLine {
+			value = key
+		}
+		body.WriteString(value)
+		body.WriteString("\r\n")
+	}
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(body.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func incompleteReadBuiltin(t *testing.T) tool.Tool {
+	t.Helper()
+	read, ok := tool.LookupBuiltin("read_file")
+	if !ok {
+		t.Fatal("read_file builtin is not registered")
+	}
+	return read
+}
+
+func expectedReadOutput(t *testing.T, read tool.Tool, args string) string {
+	t.Helper()
+	out, err := read.Execute(context.Background(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("read_file fixture: %v", err)
+	}
+	return out
+}
+
+func recoveryCapabilityArgs(t *testing.T, callID, resultRef string, offset int) string {
+	t.Helper()
+	args, err := json.Marshal(map[string]any{
+		"action":        "call",
+		"capability_id": sessionToolResultCapabilityID,
+		"arguments": map[string]any{
+			"tool_call_id": callID,
+			"result_ref":   resultRef,
+			"offset":       offset,
+			"limit":        toolResultPageMaxBytes,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(args)
+}
+
+func newIncompleteReadTestAgent(prov provider.Provider, read tool.Tool, session *Session, sink event.Sink, extra ...tool.Tool) *Agent {
+	return newIncompleteReadTestAgentWithOptions(prov, read, session, sink, Options{ContextWindow: 64_000}, extra...)
+}
+
+func newIncompleteReadTestAgentWithOptions(prov provider.Provider, read tool.Tool, session *Session, sink event.Sink, opts Options, extra ...tool.Tool) *Agent {
+	reg := tool.NewRegistry()
+	reg.Add(read)
+	for _, candidate := range extra {
+		reg.Add(candidate)
+	}
+	reg.Add(NewUseCapabilityTool(context.Background(), nil, nil, reg, nil, nil, nil))
+	return New(prov, reg, session, opts, sink)
+}
+
+func requestHasText(req provider.Request, text string) bool {
+	for _, msg := range req.Messages {
+		if strings.Contains(msg.Content, text) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestReadFileTruncationUsesContiguousUTF8PrefixAndExactRecovery(t *testing.T) {
+	path := makeIncompleteReadFixture(t, "更新笔记助手.txt", 430, 96, 362, incompleteReadKeyRule)
+	read := incompleteReadBuiltin(t)
+	args := fmt.Sprintf(`{"path":%q}`, path)
+	full := expectedReadOutput(t, read, args)
+	if len(full) < 43*1024 {
+		t.Fatalf("fixture bytes=%d, want a recoverable result of at least 43 KiB", len(full))
+	}
+
+	bounded, notice := truncateToolOutputFor(full, "read_file", "read-43k")
+	if notice == "" || len(bounded) > maxToolOutputBytes || !strings.Contains(bounded, "next_offset=") {
+		t.Fatalf("read_file was not bounded with a continuation cursor: bytes=%d notice=%q", len(bounded), notice)
+	}
+	offset, ok := readFileRecoveryOffset(bounded)
+	if !ok || offset <= 0 || offset >= len(full) {
+		t.Fatalf("recovery offset=%d ok=%v total=%d", offset, ok, len(full))
+	}
+	marker := strings.Index(bounded, "\n\n…[truncated tool=read_file ")
+	if marker != offset || bounded[:marker] != full[:offset] {
+		t.Fatalf("visible prefix is not exactly full[:next_offset]: marker=%d offset=%d", marker, offset)
+	}
+	if strings.Contains(bounded[:marker], incompleteReadKeyRule) {
+		t.Fatal("key rule unexpectedly landed in the first prefix; fixture no longer exercises continuation")
+	}
+
+	session := &Session{Messages: []provider.Message{{
+		Role: provider.RoleTool, Name: "read_file", ToolCallID: "read-43k", Content: bounded, RawContent: full,
+	}}}
+	_, proxy := newToolResultCapabilityAgent(t, session)
+	header, suffix, err := executeToolResultPage(t, proxy, "read-43k", toolResultRef("read-43k", full), offset, toolResultPageMaxBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !header.Complete || header.Offset != offset || header.NextOffset != len(full) {
+		t.Fatalf("unexpected terminal recovery header: %+v", header)
+	}
+	if got := full[:offset] + suffix; got != full {
+		t.Fatalf("prefix + suffix did not reconstruct the original: got=%d want=%d", len(got), len(full))
+	}
+	if !strings.Contains(suffix, incompleteReadKeyRule) {
+		t.Fatal("recovered suffix did not contain line 362's key rule")
+	}
+}
+
+func TestIncompleteReadBlocksFinalUntilRecoveryAndDefersObservation(t *testing.T) {
+	path := makeIncompleteReadFixture(t, "rules-crlf.txt", 430, 96, 362, incompleteReadKeyRule)
+	read := incompleteReadBuiltin(t)
+	readArgs := fmt.Sprintf(`{"path":%q}`, path)
+	full := expectedReadOutput(t, read, readArgs)
+	bounded, _ := truncateToolOutputFor(full, "read_file", "read-1")
+	offset, ok := readFileRecoveryOffset(bounded)
+	if !ok {
+		t.Fatal("missing fixture recovery offset")
+	}
+
+	inner := &scriptedProvider{name: "incomplete-read", turns: [][]provider.Chunk{
+		{toolCallChunk("read-1", "read_file", readArgs), {Type: provider.ChunkDone}},
+		textTurn("I can answer from the prefix."),
+		{toolCallChunk("recover-1", "use_capability", recoveryCapabilityArgs(t, "read-1", toolResultRef("read-1", full), offset)), {Type: provider.ChunkDone}},
+		textTurn("The full file, including line 362, has now been read."),
+	}}
+	var agent *Agent
+	prov := &inspectingProvider{inner: inner, before: func(round int, req provider.Request) {
+		if round == 1 && len(agent.task.ledger.TextObservations()) != 0 {
+			t.Errorf("truncated read was credited before recovery: %+v", agent.task.ledger.TextObservations())
+		}
+		if round == 1 && requestHasText(req, incompleteReadKeyRule) {
+			t.Error("line 362 leaked into the prefix-only provider request")
+		}
+		if round == 3 && !requestHasText(req, incompleteReadKeyRule) {
+			t.Error("final request did not receive line 362 from the recovered suffix")
+		}
+	}}
+	sink := &incompleteReadEventSink{}
+	agent = newIncompleteReadTestAgentWithOptions(
+		prov, read, NewSession("sys"), sink, Options{ContextWindow: 64_000},
+	)
+	if err := agent.Run(context.Background(), "Read the complete rules file before answering."); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if inner.call != 4 {
+		t.Fatalf("provider rounds=%d, want read + blocked final + recovery + accepted final", inner.call)
+	}
+	observations := agent.task.ledger.TextObservations()
+	observedLines := 0
+	if len(observations) > 0 {
+		observedLines = len(observations[0].LineHashes)
+	}
+	if len(observations) != 1 || len(observations[0].LineHashes) != 430 {
+		t.Fatalf("completed observation windows=%d lines=%d, want one 430-line window", len(observations), observedLines)
+	}
+	for _, code := range []string{
+		event.NoticeCodeIncompleteReadDetected,
+		event.NoticeCodeReadContinuationRequired,
+		event.NoticeCodeReadCompleted,
+	} {
+		if !sink.hasCode(code) {
+			t.Errorf("missing audit notice %q", code)
+		}
+	}
+}
+
+func TestIncompleteReadSecondIgnoredFinalPausesRecoverably(t *testing.T) {
+	path := makeIncompleteReadFixture(t, "ignored.txt", 430, 96, 362, incompleteReadKeyRule)
+	read := incompleteReadBuiltin(t)
+	readArgs := fmt.Sprintf(`{"path":%q}`, path)
+	prov := &scriptedProvider{name: "ignore-continuation", turns: [][]provider.Chunk{
+		{toolCallChunk("read-ignore", "read_file", readArgs), {Type: provider.ChunkDone}},
+		textTurn("first premature answer"),
+		textTurn("second premature answer"),
+	}}
+	agent := newIncompleteReadTestAgentWithOptions(prov, read, NewSession("sys"), event.Discard, Options{ContextWindow: 256_000})
+	err := agent.Run(context.Background(), "Read it fully.")
+	var pause *IncompleteReadError
+	if !errors.As(err, &pause) || PauseClass(err) != "incomplete_read" {
+		t.Fatalf("Run error=%T %v pause_class=%q, want IncompleteReadError", err, err, PauseClass(err))
+	}
+	if prov.call != 3 || len(agent.task.ledger.TextObservations()) != 0 {
+		t.Fatalf("rounds=%d observations=%d, want explicit pause with no read evidence", prov.call, len(agent.task.ledger.TextObservations()))
+	}
+}
+
+func TestIncompleteReadBlocksSameBatchMutationBeforeExecution(t *testing.T) {
+	path := makeIncompleteReadFixture(t, "read-before-write.txt", 430, 96, 362, incompleteReadKeyRule)
+	read := incompleteReadBuiltin(t)
+	readArgs := fmt.Sprintf(`{"path":%q}`, path)
+	writer := &incompleteReadMutationTool{}
+	prov := &scriptedProvider{name: "read-then-write", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("read-mutate", "read_file", readArgs),
+			toolCallChunk("mutate", writer.Name(), `{}`),
+			{Type: provider.ChunkDone},
+		},
+		textTurn("finish without recovery"),
+	}}
+	agent := newIncompleteReadTestAgent(prov, read, NewSession("sys"), event.Discard, writer)
+	err := agent.Run(context.Background(), "Read the rules and then update state.")
+	var pause *IncompleteReadError
+	if !errors.As(err, &pause) {
+		t.Fatalf("Run error=%T %v, want IncompleteReadError", err, err)
+	}
+	if writer.count() != 0 {
+		t.Fatalf("mutation executed %d times before recovery", writer.count())
+	}
+	if got := toolResultByID(agent.Session(), "mutate"); !strings.Contains(got, "unread content") {
+		t.Fatalf("mutation result=%q, want host incomplete-read block", got)
+	}
+}
+
+func TestIncompleteReadRecoversParallelFilesBeforeFinal(t *testing.T) {
+	const keyA = "PARALLEL_KEY_A_362"
+	const keyB = "PARALLEL_KEY_B_362"
+	pathA := makeIncompleteReadFixture(t, "parallel-a.txt", 430, 96, 362, keyA)
+	pathB := makeIncompleteReadFixture(t, "parallel-b.txt", 430, 96, 362, keyB)
+	read := incompleteReadBuiltin(t)
+	argsA := fmt.Sprintf(`{"path":%q}`, pathA)
+	argsB := fmt.Sprintf(`{"path":%q}`, pathB)
+	fullA := expectedReadOutput(t, read, argsA)
+	fullB := expectedReadOutput(t, read, argsB)
+	boundedA, _ := truncateToolOutputFor(fullA, "read_file", "read-a")
+	boundedB, _ := truncateToolOutputFor(fullB, "read_file", "read-b")
+	offsetA, okA := readFileRecoveryOffset(boundedA)
+	offsetB, okB := readFileRecoveryOffset(boundedB)
+	if !okA || !okB {
+		t.Fatal("parallel fixtures did not produce recovery offsets")
+	}
+	prov := &scriptedProvider{name: "parallel-incomplete-reads", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("read-a", "read_file", argsA),
+			toolCallChunk("read-b", "read_file", argsB),
+			{Type: provider.ChunkDone},
+		},
+		{
+			toolCallChunk("recover-a", "use_capability", recoveryCapabilityArgs(t, "read-a", toolResultRef("read-a", fullA), offsetA)),
+			toolCallChunk("recover-b", "use_capability", recoveryCapabilityArgs(t, "read-b", toolResultRef("read-b", fullB), offsetB)),
+			{Type: provider.ChunkDone},
+		},
+		textTurn("Both files were recovered completely."),
+	}}
+	agent := newIncompleteReadTestAgentWithOptions(prov, read, NewSession("sys"), event.Discard, Options{ContextWindow: 256_000})
+	if err := agent.Run(context.Background(), "Read both rules files completely."); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 3 || len(agent.task.ledger.TextObservations()) != 2 {
+		t.Fatalf("rounds=%d observations=%d, want both reads complete before final", prov.call, len(agent.task.ledger.TextObservations()))
+	}
+	if !requestHasText(prov.requests[2], keyA) || !requestHasText(prov.requests[2], keyB) {
+		t.Fatal("accepted final request did not contain both recovered tails")
+	}
+}
+
+func TestImplicitReadContinuesSourcePagesToEOF(t *testing.T) {
+	const tailKey = "SOURCE_PAGE_KEY_2050"
+	path := makeShortPagedReadFixture(t, "more-than-default-limit.txt", 2105, 2050, tailKey)
+	read := incompleteReadBuiltin(t)
+	firstArgs := fmt.Sprintf(`{"path":%q}`, path)
+	secondArgs := fmt.Sprintf(`{"path":%q,"offset":2000,"limit":2000}`, path)
+	first := expectedReadOutput(t, read, firstArgs)
+	if len(first) >= maxToolOutputBytes || !strings.Contains(first, "pass offset=2000") {
+		t.Fatalf("first source page bytes=%d does not exercise the under-cap source trailer", len(first))
+	}
+	inner := &scriptedProvider{name: "source-pages", turns: [][]provider.Chunk{
+		{toolCallChunk("source-1", "read_file", firstArgs), {Type: provider.ChunkDone}},
+		{toolCallChunk("source-2", "read_file", secondArgs), {Type: provider.ChunkDone}},
+		textTurn("Reached EOF and found the tail rule."),
+	}}
+	var agent *Agent
+	prov := &inspectingProvider{inner: inner, before: func(round int, req provider.Request) {
+		if round == 1 && len(agent.task.ledger.TextObservations()) != 0 {
+			t.Error("the first source window was credited before the implicit whole-file read reached EOF")
+		}
+		if round == 2 && !requestHasText(req, tailKey) {
+			t.Error("the accepted final request did not contain the source tail page")
+		}
+	}}
+	agent = newIncompleteReadTestAgent(prov, read, NewSession("sys"), event.Discard)
+	if err := agent.Run(context.Background(), "Read the entire file without a line limit."); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	observations := agent.task.ledger.TextObservations()
+	if len(observations) != 2 {
+		t.Fatalf("source observation windows=%d, want 2", len(observations))
+	}
+	if len(observations[0].LineHashes) != 2000 || len(observations[1].LineHashes) != 105 {
+		t.Fatalf("source observation lines=(%d,%d), want deferred (2000,105)", len(observations[0].LineHashes), len(observations[1].LineHashes))
+	}
+}
+
+func TestExplicitReadLimitConsumesOnlyRequestedWindow(t *testing.T) {
+	path := makeShortPagedReadFixture(t, "explicit-window.txt", 2105, 2050, "outside-window")
+	read := incompleteReadBuiltin(t)
+	args := fmt.Sprintf(`{"path":%q,"offset":0,"limit":2000}`, path)
+	prov := &scriptedProvider{name: "explicit-window", turns: [][]provider.Chunk{
+		{toolCallChunk("window", "read_file", args), {Type: provider.ChunkDone}},
+		textTurn("The requested window is complete."),
+	}}
+	agent := newIncompleteReadTestAgent(prov, read, NewSession("sys"), event.Discard)
+	if err := agent.Run(context.Background(), "Read only the specified window."); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	observations := agent.task.ledger.TextObservations()
+	if prov.call != 2 || len(observations) != 1 || len(observations[0].LineHashes) != 2000 {
+		t.Fatalf("rounds=%d observations=%+v, explicit limit should not arm an EOF continuation", prov.call, observations)
+	}
+}
+
+func TestIncompleteReadAutomaticallyRecoversBeyondFormerByteAndTokenCaps(t *testing.T) {
+	path := makeIncompleteReadFixture(t, "oversize.txt", 1500, 96, 1400, "OVERSIZE_TAIL_RULE")
+	read := incompleteReadBuiltin(t)
+	readArgs := fmt.Sprintf(`{"path":%q}`, path)
+	full := expectedReadOutput(t, read, readArgs)
+	if len(full) <= 128*1024 || estimateCrossLanguageReadTokens(full) <= 32*1024 {
+		t.Fatalf("fixture bytes=%d tokens=%d, want beyond former byte and token caps", len(full), estimateCrossLanguageReadTokens(full))
+	}
+	sink := &incompleteReadEventSink{}
+	turns := [][]provider.Chunk{
+		{toolCallChunk("read-oversize", "read_file", readArgs), {Type: provider.ChunkDone}},
+	}
+	bounded, _ := truncateToolOutputFor(full, "read_file", "read-oversize")
+	next, ok := readFileRecoveryOffset(bounded)
+	if !ok {
+		t.Fatal("large fixture did not truncate")
+	}
+	for page := 0; next < len(full); page++ {
+		turns = append(turns, []provider.Chunk{
+			toolCallChunk(fmt.Sprintf("recover-large-%d", page), "use_capability", recoveryCapabilityArgs(t, "read-oversize", toolResultRef("read-oversize", full), next)),
+			{Type: provider.ChunkDone},
+		})
+		end := min(len(full), next+toolResultPageMaxBytes)
+		for end > next && end < len(full) && !utf8.RuneStart(full[end]) {
+			end--
+		}
+		next = end
+	}
+	turns = append(turns, textTurn("The entire large file was read."))
+	prov := &scriptedProvider{name: "large-auto-recovery", turns: turns}
+	agent := newIncompleteReadTestAgentWithOptions(prov, read, NewSession("sys"), sink, Options{ContextWindow: 1_000_000})
+	if err := agent.Run(context.Background(), "Read the complete oversized file."); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	observations := agent.task.ledger.TextObservations()
+	if len(observations) != 1 || len(observations[0].LineHashes) != 1500 {
+		t.Fatalf("observations=%+v, want complete 1500-line evidence", observations)
+	}
+	if sink.hasCode(event.NoticeCodeReadStrategyRequired) || sink.hasCode(event.NoticeCodeReadOversizeRejected) {
+		t.Fatal("large read incorrectly entered strategy or legacy oversize rejection")
+	}
+}
+
+func TestIncompleteReadContextLimitEntersSearchReadReceiptStrategy(t *testing.T) {
+	path := makeIncompleteReadFixture(t, "context-soft-limit.txt", 430, 96, 362, incompleteReadKeyRule)
+	read := incompleteReadBuiltin(t)
+	readArgs := fmt.Sprintf(`{"path":%q}`, path)
+	full := expectedReadOutput(t, read, readArgs)
+	readID := incompleteReadID("read-context-soft", toolResultRef("read-context-soft", full), path)
+	grepTool, ok := tool.LookupBuiltin("grep")
+	if !ok {
+		t.Fatal("grep builtin unavailable")
+	}
+	sink := &incompleteReadEventSink{}
+	receipt, err := json.Marshal(map[string]any{
+		"action": "call", "capability_id": sessionReadStrategyReceiptCapabilityID,
+		"arguments": map[string]any{
+			"read_id": readID, "search_tool_call_ids": []string{"grep-key"},
+			"read_tool_call_ids": []string{"read-key-window"}, "conclusion": "The key rule and its surrounding section were searched and read.",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prov := &scriptedProvider{name: "context-strategy", turns: [][]provider.Chunk{
+		{toolCallChunk("read-context-soft", "read_file", readArgs), {Type: provider.ChunkDone}},
+		{toolCallChunk("grep-key", "grep", fmt.Sprintf(`{"pattern":%q,"path":%q}`, incompleteReadKeyRule, path)), {Type: provider.ChunkDone}},
+		{toolCallChunk("read-key-window", "read_file", fmt.Sprintf(`{"path":%q,"offset":350,"limit":30}`, path)), {Type: provider.ChunkDone}},
+		{toolCallChunk("strategy-receipt", "use_capability", string(receipt)), {Type: provider.ChunkDone}},
+		textTurn("The answer is based on the searched and explicitly read rule window."),
+	}}
+	agent := newIncompleteReadTestAgentWithOptions(
+		prov, read, NewSession("sys"), sink, Options{ContextWindow: 32_000}, grepTool,
+	)
+	if err := agent.Run(context.Background(), "Find and apply the key rule from the large rules file."); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 5 {
+		t.Fatalf("provider rounds=%d, want read + grep + exact read + receipt + next-round final", prov.call)
+	}
+	observations := agent.task.ledger.TextObservations()
+	if len(observations) != 1 || len(observations[0].LineHashes) != 30 {
+		t.Fatalf("observations=%+v, want only the explicit 30-line strategy window", observations)
+	}
+	result := toolResultByID(agent.Session(), "read-context-soft")
+	if !strings.Contains(result, "INCOMPLETE READ") || strings.Contains(result, incompleteReadKeyRule) {
+		t.Fatalf("provider-visible strategy result is ambiguous or leaks an unseen tail: %.500q", result)
+	}
+	for _, code := range []string{event.NoticeCodeReadStrategyRequired, event.NoticeCodeReadStrategyProgress, event.NoticeCodeReadStrategyResolved} {
+		if !sink.hasCode(code) {
+			t.Errorf("missing strategy audit notice %q", code)
+		}
+	}
+}
+
+func TestIncompleteReadUnknownContextEntersStrategyWithoutImmediatePause(t *testing.T) {
+	path := makeIncompleteReadFixture(t, "unknown-context.txt", 430, 96, 362, incompleteReadKeyRule)
+	read := incompleteReadBuiltin(t)
+	readArgs := fmt.Sprintf(`{"path":%q}`, path)
+	prov := &scriptedProvider{name: "unknown-context", turns: [][]provider.Chunk{
+		{toolCallChunk("read-unknown", "read_file", readArgs), {Type: provider.ChunkDone}},
+		textTurn("first premature answer"),
+		textTurn("second premature answer"),
+	}}
+	sink := &incompleteReadEventSink{}
+	agent := newIncompleteReadTestAgentWithOptions(prov, read, NewSession("sys"), sink, Options{})
+	err := agent.Run(context.Background(), "Read the complete file.")
+	var pause *IncompleteReadError
+	if !errors.As(err, &pause) {
+		t.Fatalf("Run error=%T %v, want pause only after two ignored strategy rounds", err, err)
+	}
+	if prov.call != 3 || !sink.hasCode(event.NoticeCodeReadStrategyRequired) {
+		t.Fatalf("rounds=%d strategy_notice=%v, want strategy plus two ignored finals", prov.call, sink.hasCode(event.NoticeCodeReadStrategyRequired))
+	}
+	if got := toolResultByID(agent.Session(), "read-unknown"); !strings.Contains(got, "INCOMPLETE READ") {
+		t.Fatalf("unknown-context result=%q, want explicit strategy marker", got)
+	}
+}
+
+func TestReadStrategyReceiptUnlocksOnlyAfterBatchBoundary(t *testing.T) {
+	path := makeIncompleteReadFixture(t, "receipt-boundary.txt", 430, 96, 362, incompleteReadKeyRule)
+	read := incompleteReadBuiltin(t)
+	grepTool, ok := tool.LookupBuiltin("grep")
+	if !ok {
+		t.Fatal("grep builtin unavailable")
+	}
+	full := expectedReadOutput(t, read, fmt.Sprintf(`{"path":%q}`, path))
+	readID := incompleteReadID("read-boundary", toolResultRef("read-boundary", full), path)
+	receipt, err := json.Marshal(map[string]any{
+		"action": "call", "capability_id": sessionReadStrategyReceiptCapabilityID,
+		"arguments": map[string]any{
+			"read_id": readID, "search_tool_call_ids": []string{"grep-boundary"},
+			"read_tool_call_ids": []string{"read-boundary-window"}, "conclusion": "searched and read the key rule",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := &incompleteReadMutationTool{}
+	prov := &scriptedProvider{name: "receipt-boundary", turns: [][]provider.Chunk{
+		{toolCallChunk("read-boundary", "read_file", fmt.Sprintf(`{"path":%q}`, path)), {Type: provider.ChunkDone}},
+		{toolCallChunk("grep-boundary", "grep", fmt.Sprintf(`{"pattern":%q,"path":%q}`, incompleteReadKeyRule, path)), {Type: provider.ChunkDone}},
+		{toolCallChunk("read-boundary-window", "read_file", fmt.Sprintf(`{"path":%q,"offset":350,"limit":30}`, path)), {Type: provider.ChunkDone}},
+		{
+			toolCallChunk("receipt-boundary-call", "use_capability", string(receipt)),
+			toolCallChunk("write-same-batch", writer.Name(), `{}`),
+			{Type: provider.ChunkDone},
+		},
+		textTurn("The receipt is now committed; no write was attempted again."),
+	}}
+	agent := newIncompleteReadTestAgentWithOptions(prov, read, NewSession("sys"), event.Discard, Options{ContextWindow: 32_000}, grepTool, writer)
+	if err := agent.Run(context.Background(), "Search and read the key rule, then mutate only after the receipt boundary."); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if writer.count() != 0 {
+		t.Fatalf("same-batch writer executed %d times", writer.count())
+	}
+	if got := toolResultByID(agent.Session(), "write-same-batch"); !strings.Contains(got, "restricted search/read mode") {
+		t.Fatalf("same-batch write result=%q, want strategy gate", got)
+	}
+	if prov.call != 5 {
+		t.Fatalf("provider rounds=%d, want final only after receipt batch boundary", prov.call)
+	}
+}
+
+func TestReadStrategyViolationsCountOncePerModelRound(t *testing.T) {
+	state := incompleteReadState{}
+	state.addEntryLocked(&incompleteRead{
+		key: "ir-round", readID: "ir-round", path: "rules.txt", requestPath: "rules.txt",
+		phase: incompleteReadStrategy, searches: map[string]incompleteReadSearch{}, reads: map[string]incompleteReadWindow{},
+	})
+	for range 3 {
+		if _, blocked := state.gate(&toolCallPlan{evidenceName: "ls"}); !blocked {
+			t.Fatal("strategy did not block unrelated read-only tool")
+		}
+	}
+	if round := state.finishToolRound(); round.pause != nil || state.consecutiveViolations != 1 {
+		t.Fatalf("first violating round pause=%v consecutive=%d, want one violation", round.pause, state.consecutiveViolations)
+	}
+	if _, blocked := state.gate(&toolCallPlan{evidenceName: "glob"}); !blocked {
+		t.Fatal("strategy did not block second unrelated tool")
+	}
+	if round := state.finishToolRound(); round.pause == nil {
+		t.Fatal("second consecutive violating model round did not pause")
+	}
+}
+
+func TestReadStrategyReceiptRejectsChangedFileAndClearsEvidence(t *testing.T) {
+	path := makeIncompleteReadFixture(t, "receipt-file-change.txt", 430, 96, 362, incompleteReadKeyRule)
+	state := incompleteReadState{}
+	entry := &incompleteRead{
+		key: "ir-change", readID: "ir-change", path: path, phase: incompleteReadStrategy,
+		strategyVersion: snapshotIncompleteReadFile(path),
+		searches:        map[string]incompleteReadSearch{"grep": {callID: "grep", pattern: incompleteReadKeyRule, matchLines: []int{362}}},
+		reads:           map[string]incompleteReadWindow{"read": {callID: "read", startLine: 350, endLine: 380}},
+	}
+	state.addEntryLocked(entry)
+	entry.reads["read"] = incompleteReadWindow{callID: "read", startLine: 1, endLine: 20}
+	_, err := state.submitStrategyReceipt(readStrategyReceiptArgs{ReadID: "ir-change", SearchToolCallIDs: []string{"grep"}, ReadToolCallIDs: []string{"read"}, Conclusion: "wrong range"})
+	if err == nil || !strings.Contains(err.Error(), "overlaps") || entry.pendingReceipt != nil {
+		t.Fatalf("non-overlap receipt error=%v receipt=%v", err, entry.pendingReceipt)
+	}
+	entry.reads["read"] = incompleteReadWindow{callID: "read", startLine: 350, endLine: 380}
+	if err := os.WriteFile(path, []byte("changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err = state.submitStrategyReceipt(readStrategyReceiptArgs{
+		ReadID: "ir-change", SearchToolCallIDs: []string{"grep"}, ReadToolCallIDs: []string{"read"}, Conclusion: "stale evidence",
+	})
+	if err == nil || !strings.Contains(err.Error(), "changed") {
+		t.Fatalf("receipt error=%v, want changed-file rejection", err)
+	}
+	if len(entry.searches) != 0 || len(entry.reads) != 0 || entry.pendingReceipt != nil {
+		t.Fatalf("stale evidence was retained: searches=%v reads=%v receipt=%v", entry.searches, entry.reads, entry.pendingReceipt)
+	}
+}
+
+func TestReadStrategyKeepsOtherPendingFilesLocked(t *testing.T) {
+	state := incompleteReadState{}
+	first := &incompleteRead{
+		key: "ir-a", readID: "ir-a", path: "a.txt", phase: incompleteReadStrategy,
+		reads:          map[string]incompleteReadWindow{"read-a": {callID: "read-a", startLine: 1, endLine: 2}},
+		pendingReceipt: &incompleteReadReceipt{readIDs: []string{"read-a"}},
+	}
+	second := &incompleteRead{
+		key: "ir-b", readID: "ir-b", path: "b.txt", phase: incompleteReadStrategy,
+		searches: map[string]incompleteReadSearch{}, reads: map[string]incompleteReadWindow{},
+	}
+	state.addEntryLocked(first)
+	state.addEntryLocked(second)
+	state.roundProgress = true
+	round := state.finishToolRound()
+	if len(round.resolvedIDs) != 1 || round.resolvedIDs[0] != "ir-a" || !state.hasPending() {
+		t.Fatalf("round=%+v pending=%v, want only first file resolved", round, state.hasPending())
+	}
+	if instruction := state.nextInstruction(); !strings.Contains(instruction, "ir-b") {
+		t.Fatalf("next instruction=%q, want remaining file", instruction)
+	}
+}
+
+func TestReadStrategyCapabilityIsDynamicWithoutChangingProviderSchema(t *testing.T) {
+	reg := tool.NewRegistry()
+	proxy := NewUseCapabilityTool(context.Background(), nil, nil, reg, nil, nil, nil)
+	reg.Add(proxy)
+	schemaBefore := string(proxy.Schema())
+	agent := New(&scriptedProvider{name: "strategy-capability"}, reg, NewSession("sys"), Options{}, event.Discard)
+	agent.turn.incompleteReads.addEntryLocked(&incompleteRead{
+		key: "ir-cap", readID: "ir-cap", path: "rules.txt", phase: incompleteReadStrategy,
+		searches: map[string]incompleteReadSearch{}, reads: map[string]incompleteReadWindow{},
+	})
+	listed, err := proxy.listCapabilities()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(listed, sessionReadStrategyReceiptCapabilityID) {
+		t.Fatalf("active strategy capability missing from list: %s", listed)
+	}
+	if schemaAfter := string(proxy.Schema()); schemaAfter != schemaBefore {
+		t.Fatalf("use_capability schema changed after dynamic strategy activation\nbefore=%s\nafter=%s", schemaBefore, schemaAfter)
+	}
+}
+
+func TestIncompleteReadRequiresExactContinuationMetadata(t *testing.T) {
+	state := incompleteReadState{}
+	entry := &incompleteRead{
+		key: "root", path: "rules.txt", phase: incompleteReadAutoResultPage,
+		toolCallID: "read-1", resultRef: "tr-correct", nextByteOffset: 32000,
+		totalBytes: 43000, sha256: strings.Repeat("a", 64),
+	}
+	state.addEntryLocked(entry)
+	plan := &toolCallPlan{
+		evidenceName: "session_tool_result",
+		evidenceArgs: json.RawMessage(`{"tool_call_id":"read-1","result_ref":"tr-wrong","offset":0,"limit":24576}`),
+	}
+	if msg, blocked := state.gate(plan); !blocked || !strings.Contains(msg, "require result_ref=\"tr-correct\" offset=32000") {
+		t.Fatalf("wrong continuation blocked=%v msg=%q", blocked, msg)
+	}
+	for _, finalizer := range []string{"complete_step", "submit_plan"} {
+		finalizerState := incompleteReadState{}
+		finalizerState.addEntryLocked(&incompleteRead{key: "pending", phase: incompleteReadAutoResultPage})
+		if msg, blocked := finalizerState.gate(&toolCallPlan{evidenceName: finalizer}); !blocked || !strings.Contains(msg, "unread content") {
+			t.Errorf("%s blocked=%v msg=%q", finalizer, blocked, msg)
+		}
+	}
+
+	goodPlan := &toolCallPlan{incompleteReadRoot: "root"}
+	badHeader := fmt.Sprintf(`{"result_ref":"tr-correct","offset":32000,"next_offset":43000,"total_bytes":43000,"sha256":%q,"complete":true}`,
+		strings.Repeat("b", 64))
+	state.observeResultPage(goodPlan, badHeader+"\n"+strings.Repeat("x", 11000), true)
+	if failure := state.currentFailure(); failure == nil || !strings.Contains(failure.Reason, "integrity check") {
+		t.Fatalf("digest mismatch failure=%+v", failure)
+	}
+}

--- a/internal/agent/incomplete_read_test.go
+++ b/internal/agent/incomplete_read_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"reasonix/internal/event"
@@ -621,16 +622,22 @@ func TestReadStrategyReceiptRejectsChangedFileAndClearsEvidence(t *testing.T) {
 		reads:           map[string]incompleteReadWindow{"read": {callID: "read", startLine: 350, endLine: 380}},
 	}
 	state.addEntryLocked(entry)
-	entry.reads["read"] = incompleteReadWindow{callID: "read", startLine: 1, endLine: 20}
-	_, err := state.submitStrategyReceipt(readStrategyReceiptArgs{ReadID: "ir-change", SearchToolCallIDs: []string{"grep"}, ReadToolCallIDs: []string{"read"}, Conclusion: "wrong range"})
+	entry.reads["read"] = incompleteReadWindow{
+		callID: "read", startLine: 1, endLine: 20,
+		observed: []tool.ModelTextObservation{{Path: path, StartLine: 1, LineHashes: []string{"synthetic"}}},
+	}
+	_, err := state.submitStrategyReceipt(context.Background(), readStrategyReceiptArgs{ReadID: "ir-change", SearchToolCallIDs: []string{"grep"}, ReadToolCallIDs: []string{"read"}, Conclusion: "wrong range"})
 	if err == nil || !strings.Contains(err.Error(), "overlaps") || entry.pendingReceipt != nil {
 		t.Fatalf("non-overlap receipt error=%v receipt=%v", err, entry.pendingReceipt)
 	}
-	entry.reads["read"] = incompleteReadWindow{callID: "read", startLine: 350, endLine: 380}
+	entry.reads["read"] = incompleteReadWindow{
+		callID: "read", startLine: 350, endLine: 380,
+		observed: []tool.ModelTextObservation{{Path: path, StartLine: 350, LineHashes: []string{"synthetic"}}},
+	}
 	if err := os.WriteFile(path, []byte("changed\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, err = state.submitStrategyReceipt(readStrategyReceiptArgs{
+	_, err = state.submitStrategyReceipt(context.Background(), readStrategyReceiptArgs{
 		ReadID: "ir-change", SearchToolCallIDs: []string{"grep"}, ReadToolCallIDs: []string{"read"}, Conclusion: "stale evidence",
 	})
 	if err == nil || !strings.Contains(err.Error(), "changed") {
@@ -638,6 +645,66 @@ func TestReadStrategyReceiptRejectsChangedFileAndClearsEvidence(t *testing.T) {
 	}
 	if len(entry.searches) != 0 || len(entry.reads) != 0 || entry.pendingReceipt != nil {
 		t.Fatalf("stale evidence was retained: searches=%v reads=%v receipt=%v", entry.searches, entry.reads, entry.pendingReceipt)
+	}
+}
+
+func TestReadStrategyReceiptRevalidatesWindowHashesWhenStatIsUnchanged(t *testing.T) {
+	path := makeIncompleteReadFixture(t, "receipt-same-stat-change.txt", 430, 96, 362, incompleteReadKeyRule)
+	stableTime := time.Unix(1_700_000_000, 0)
+	if err := os.Chtimes(path, stableTime, stableTime); err != nil {
+		t.Fatal(err)
+	}
+	read := incompleteReadBuiltin(t)
+	args := fmt.Sprintf(`{"path":%q,"offset":349,"limit":31}`, path)
+	output := expectedReadOutput(t, read, args)
+	observer, ok := read.(tool.ModelTextObserver)
+	if !ok {
+		t.Fatal("read_file does not expose model-text observations")
+	}
+	observed, ok := observer.ObserveModelText(json.RawMessage(args), output)
+	if !ok {
+		t.Fatal("read_file window did not produce an observation")
+	}
+
+	state := incompleteReadState{}
+	entry := &incompleteRead{
+		key: "ir-same-stat", readID: "ir-same-stat", path: path, requestPath: path,
+		phase: incompleteReadStrategy, strategyVersion: snapshotIncompleteReadFile(path), readTool: read,
+		searches: map[string]incompleteReadSearch{"grep": {callID: "grep", pattern: incompleteReadKeyRule, matchLines: []int{362}}},
+		reads: map[string]incompleteReadWindow{"read": {
+			callID: "read", startLine: 350, endLine: 380,
+			observed: []tool.ModelTextObservation{observed},
+		}},
+	}
+	state.addEntryLocked(entry)
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := strings.Repeat("X", len(incompleteReadKeyRule))
+	after := strings.Replace(string(before), incompleteReadKeyRule, replacement, 1)
+	if len(after) != len(before) || after == string(before) {
+		t.Fatal("fixture mutation did not preserve byte size")
+	}
+	if err := os.WriteFile(path, []byte(after), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, stableTime, stableTime); err != nil {
+		t.Fatal(err)
+	}
+	if current := snapshotIncompleteReadFile(path); !sameIncompleteReadFileVersion(entry.strategyVersion, current) {
+		t.Fatalf("fixture stat changed: before=%+v after=%+v", entry.strategyVersion, current)
+	}
+
+	_, err = state.submitStrategyReceipt(context.Background(), readStrategyReceiptArgs{
+		ReadID: "ir-same-stat", SearchToolCallIDs: []string{"grep"}, ReadToolCallIDs: []string{"read"}, Conclusion: "stale same-stat evidence",
+	})
+	if err == nil || !strings.Contains(err.Error(), "window changed") {
+		t.Fatalf("receipt error=%v, want line-hash revalidation failure", err)
+	}
+	if len(entry.searches) != 0 || len(entry.reads) != 0 || entry.pendingReceipt != nil {
+		t.Fatalf("same-stat stale evidence was retained: searches=%v reads=%v receipt=%v", entry.searches, entry.reads, entry.pendingReceipt)
 	}
 }
 

--- a/internal/agent/incomplete_read_truncate.go
+++ b/internal/agent/incomplete_read_truncate.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// truncateReadFileOutput returns a contiguous prefix on a complete rendered
+// line when possible. Its recovery cursor is exactly the first unseen byte, so
+// paging can reconstruct the original without a gap or duplicate.
+func truncateReadFileOutput(s, toolName, toolCallID string) (string, string) {
+	resultRef := toolResultRef(toolCallID, s)
+	headKeep := maxToolOutputBytes - 1024
+	if headKeep < 1024 {
+		headKeep = maxToolOutputBytes / 2
+	}
+	head := snapToRuneBoundary(s, 0, min(headKeep, len(s)))
+	if newline := strings.LastIndexByte(head, '\n'); newline >= 1024 {
+		head = head[:newline+1]
+	}
+	for range 4 {
+		marker := toolOutputRecoveryMarkerAt(toolName, toolCallID, resultRef, len(s), len(head), len(head))
+		if len(head)+len(marker) <= maxToolOutputBytes {
+			notice := fmt.Sprintf("tool output truncated: %d of %d bytes elided", len(s)-len(head), len(s))
+			return head + marker, notice
+		}
+		trimTo := len(head) - (len(head) + len(marker) - maxToolOutputBytes)
+		if trimTo <= 0 {
+			head = ""
+			continue
+		}
+		head = snapToRuneBoundary(head, 0, trimTo)
+		if newline := strings.LastIndexByte(head, '\n'); newline >= 0 {
+			head = head[:newline+1]
+		}
+	}
+	marker := toolOutputRecoveryMarkerAt(toolName, toolCallID, resultRef, len(s), len(head), len(head))
+	if len(marker) > maxToolOutputBytes {
+		marker = snapToRuneBoundary(marker, 0, maxToolOutputBytes)
+	}
+	notice := fmt.Sprintf("tool output truncated: %d of %d bytes elided", len(s)-len(head), len(s))
+	return head + marker, notice
+}
+
+func snapToRuneBoundary(s string, lo, hi int) string {
+	for lo > 0 && !utf8.RuneStart(s[lo]) {
+		lo--
+	}
+	for hi < len(s) && !utf8.RuneStart(s[hi]) {
+		hi++
+	}
+	return s[lo:hi]
+}

--- a/internal/agent/mcp_list_observer.go
+++ b/internal/agent/mcp_list_observer.go
@@ -26,6 +26,7 @@ type mcpListObserverActivator interface {
 
 func (a *Agent) bindCapabilityObservers() {
 	a.bindToolResultSessionCapability()
+	a.bindReadStrategyCapability()
 	a.bindMCPListObserverCapability()
 }
 

--- a/internal/agent/path_bound_tools.go
+++ b/internal/agent/path_bound_tools.go
@@ -35,6 +35,12 @@ func (p pathBoundCapabilityProxy) bindToolResultSession(session func() *Session)
 	}
 }
 
+func (p pathBoundCapabilityProxy) bindReadStrategyState(state func() *incompleteReadState) {
+	if binder, ok := p.inner.(readStrategyStateBinder); ok {
+		binder.bindReadStrategyState(state)
+	}
+}
+
 func (p pathBoundCapabilityProxy) bindMCPListObserver(observer func(mcpListObservation)) {
 	if binder, ok := p.inner.(mcpListObserverBinder); ok {
 		binder.bindMCPListObserver(observer)

--- a/internal/agent/read_strategy_capability.go
+++ b/internal/agent/read_strategy_capability.go
@@ -39,7 +39,7 @@ func (*sessionReadStrategyReceiptTool) Schema() json.RawMessage {
 	}`)
 }
 
-func (t *sessionReadStrategyReceiptTool) Execute(_ context.Context, raw json.RawMessage) (string, error) {
+func (t *sessionReadStrategyReceiptTool) Execute(ctx context.Context, raw json.RawMessage) (string, error) {
 	args, ok := parseReadStrategyReceiptArgs(raw)
 	if !ok {
 		return "", fmt.Errorf("read strategy receipt: invalid arguments")
@@ -47,7 +47,7 @@ func (t *sessionReadStrategyReceiptTool) Execute(_ context.Context, raw json.Raw
 	if t == nil || t.state == nil || t.state() == nil {
 		return "", fmt.Errorf("read strategy receipt: current agent state is unavailable")
 	}
-	return t.state().submitStrategyReceipt(args)
+	return t.state().submitStrategyReceipt(ctx, args)
 }
 
 func (a *Agent) bindReadStrategyCapability() {

--- a/internal/agent/read_strategy_capability.go
+++ b/internal/agent/read_strategy_capability.go
@@ -1,0 +1,131 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"reasonix/internal/tool"
+)
+
+const sessionReadStrategyReceiptCapabilityID = "session:read_strategy_receipt"
+
+type readStrategyStateBinder interface {
+	bindReadStrategyState(func() *incompleteReadState)
+}
+
+type sessionReadStrategyReceiptTool struct {
+	state func() *incompleteReadState
+}
+
+func (*sessionReadStrategyReceiptTool) Name() string { return "session_read_strategy_receipt" }
+
+func (*sessionReadStrategyReceiptTool) Description() string {
+	return "Validate search and exact read_file evidence for one host-restricted incomplete read."
+}
+
+func (*sessionReadStrategyReceiptTool) ReadOnly() bool { return true }
+
+func (*sessionReadStrategyReceiptTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"read_id":{"type":"string"},
+			"search_tool_call_ids":{"type":"array","items":{"type":"string"},"minItems":1},
+			"read_tool_call_ids":{"type":"array","items":{"type":"string"},"minItems":1},
+			"conclusion":{"type":"string"}
+		},
+		"required":["read_id","search_tool_call_ids","read_tool_call_ids","conclusion"]
+	}`)
+}
+
+func (t *sessionReadStrategyReceiptTool) Execute(_ context.Context, raw json.RawMessage) (string, error) {
+	args, ok := parseReadStrategyReceiptArgs(raw)
+	if !ok {
+		return "", fmt.Errorf("read strategy receipt: invalid arguments")
+	}
+	if t == nil || t.state == nil || t.state() == nil {
+		return "", fmt.Errorf("read strategy receipt: current agent state is unavailable")
+	}
+	return t.state().submitStrategyReceipt(args)
+}
+
+func (a *Agent) bindReadStrategyCapability() {
+	if a == nil || a.svc.tools == nil {
+		return
+	}
+	proxy, ok := a.svc.tools.Get("use_capability")
+	if !ok {
+		return
+	}
+	binder, ok := proxy.(readStrategyStateBinder)
+	if !ok {
+		return
+	}
+	binder.bindReadStrategyState(func() *incompleteReadState {
+		return &a.turn.incompleteReads
+	})
+}
+
+func (t *UseCapabilityTool) bindReadStrategyState(state func() *incompleteReadState) {
+	if t == nil {
+		return
+	}
+	t.toolResultMu.Lock()
+	t.readStrategyState = state
+	t.toolResultMu.Unlock()
+}
+
+func (t *UseCapabilityTool) currentReadStrategyReceiptTarget() *sessionReadStrategyReceiptTool {
+	if t == nil {
+		return nil
+	}
+	t.toolResultMu.RLock()
+	stateFn := t.readStrategyState
+	t.toolResultMu.RUnlock()
+	if stateFn == nil {
+		return nil
+	}
+	state := stateFn()
+	if state == nil || !state.hasStrategy() {
+		return nil
+	}
+	return &sessionReadStrategyReceiptTool{state: stateFn}
+}
+
+func (t *UseCapabilityTool) resolveSessionReadStrategyReceipt(args json.RawMessage, base tool.ResolvedCall) (tool.ResolvedCall, error) {
+	target := t.currentReadStrategyReceiptTarget()
+	if target == nil {
+		return tool.ResolvedCall{}, fmt.Errorf("capability %q is available only while a restricted read strategy is active", sessionReadStrategyReceiptCapabilityID)
+	}
+	base.TargetName = target.Name()
+	base.Target = target
+	base.Args = args
+	base.ReadOnly = true
+	return base, nil
+}
+
+func (t *UseCapabilityTool) resolveSessionCapability(id string, args json.RawMessage, base tool.ResolvedCall) (tool.ResolvedCall, error) {
+	if id == sessionToolResultCapabilityID {
+		return t.resolveSessionToolResult(args, base)
+	}
+	return t.resolveSessionReadStrategyReceipt(args, base)
+}
+
+func (t *UseCapabilityTool) inspectSessionReadStrategyReceipt() (string, error) {
+	target := t.currentReadStrategyReceiptTarget()
+	if target == nil {
+		return "", fmt.Errorf("capability %q is not active", sessionReadStrategyReceiptCapabilityID)
+	}
+	payload := map[string]any{
+		"id":          sessionReadStrategyReceiptCapabilityID,
+		"kind":        "session",
+		"name":        "read_strategy_receipt",
+		"status":      "ready",
+		"read_only":   true,
+		"description": target.Description(),
+		"arguments":   json.RawMessage(target.Schema()),
+	}
+	b, err := json.MarshalIndent(payload, "", "  ")
+	return string(b), err
+}

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -247,7 +247,7 @@ func (a *Agent) runToolLoop(ctx context.Context, state *turnRuntime) (runErr err
 		releaseMCPListObserver()
 	}()
 	ctx = a.withAgentContext(ctx)
-	for step := 0; state.runMaxSteps <= 0 || step < state.runMaxSteps || state.graceRound || state.recoveryGraceRound; step++ {
+	for step := 0; state.runMaxSteps <= 0 || step < state.runMaxSteps || state.graceRound || state.recoveryGraceRound || state.incompleteReads.hasPending(); step++ {
 		// Consume a queued steer and persist it to the session so it
 		// survives tab switches and history replay. The model sees it as
 		// guidance (with a prefix), not a new task. One cache miss per
@@ -532,6 +532,22 @@ func sleepStreamRetryBackoff(ctx context.Context, attempt int) bool {
 // and final compaction. cont=true continues the tool loop; cont=false returns
 // err from Run (err may be nil for a clean final answer).
 func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, text, reasoning string, usage *provider.Usage) (cont bool, err error) {
+	// A partial read is a host-owned protocol state, not advisory prose. Refuse
+	// a candidate final before every ordinary readiness/validator path so a
+	// model cannot silently answer from the visible prefix alone.
+	if instruction, pause := state.incompleteReads.blockFinal(); pause != nil {
+		a.contextManager().ObserveUsage(usage)
+		return false, pause
+	} else if instruction != "" {
+		a.sess.conversation.Add(HostGeneratedUserMessage(a.withTurnPreferences(instruction)))
+		a.emitIncompleteReadNotice(
+			event.NoticeCodeReadContinuationRequired,
+			"Reasonix refused to finish because a file read still has unread content.",
+			"final answer blocked pending read continuation",
+		)
+		a.contextManager().ObserveUsage(usage)
+		return true, nil
+	}
 	// Recovery finalization produced a summary. Keep it in the session,
 	// but still pause so Goal auto-continue cannot open another Run with
 	// a fresh finalization round. turn_done reports recovery_paused.
@@ -685,11 +701,8 @@ func (a *Agent) handleToolRound(ctx context.Context, state *turnRuntime, step in
 		}
 		a.sess.conversation.Add(msg)
 	}
-	// If the context was cancelled during tool execution, return after storing
-	// the batch results so the session keeps paired tool-call history.
-	if ctx.Err() != nil {
-		a.recordInterruptedDisplay("", "", nil, true, state.workDurationMs())
-		return false, ctx.Err()
+	if cont, boundaryErr, handled := a.resolveIncompleteReadToolRoundBoundary(ctx, state, usage); handled {
+		return cont, boundaryErr
 	}
 	if a.successfulTurnFinalizer(ctx, calls, batch) {
 		// submit_plan is the planner's data-bearing final answer. Its paired tool
@@ -734,7 +747,15 @@ func (a *Agent) handleToolRound(ctx context.Context, state *turnRuntime, step in
 	// Spend is checked before rounds: it is the axis a runaway is actually
 	// reported in, so on the turns both would catch it should be the one named.
 	if axis, detail := a.task.budget.exceeded(a.taskBudgetLimit(ctx)); axis != "" {
+		if state.incompleteReads.hasPending() {
+			return false, &IncompleteReadError{Reason: fmt.Sprintf("the %s budget ended while a required read_file continuation was still pending: %s", axis, detail)}
+		}
 		a.armFinalizationRound(ctx, state, landCause{kind: "task_budget", axis: axis, detail: detail})
+		return true, nil
+	}
+	// A bounded read-recovery sequence is a correctness repair, so it may use
+	// extra tool rounds beyond max_steps. Hard spend budgets above still win.
+	if state.incompleteReads.hasPending() {
 		return true, nil
 	}
 	if state.runMaxSteps > 0 && step+1 >= state.runMaxSteps {

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -1184,7 +1184,7 @@ func (t *restrictedCapabilityProxy) check(args json.RawMessage) error {
 	if id == "" {
 		return fmt.Errorf("capability_id is required")
 	}
-	if id == sessionToolResultCapabilityID {
+	if id == sessionToolResultCapabilityID || id == sessionReadStrategyReceiptCapabilityID {
 		return nil
 	}
 	if !t.allowed[id] {

--- a/internal/agent/text_observation.go
+++ b/internal/agent/text_observation.go
@@ -34,23 +34,10 @@ func observationBoundary(ctx context.Context, fallback uint64) uint64 {
 	return fallback
 }
 
-// recordModelTextObservation records only the line hashes returned by an
-// optional reader capability. It runs after host recovery guidance has been
-// applied but before compatibility truncation, matching the canonical result
-// promoted through RawContent on the next provider request.
-func (a *Agent) recordModelTextObservation(plan *toolCallPlan, output string) {
-	if a == nil || plan == nil || a.task.ledger == nil || output == "" {
-		return
-	}
-	observer, ok := plan.runTool.(tool.ModelTextObserver)
-	if !ok {
-		observer, ok = plan.execTool.(tool.ModelTextObserver)
-	}
-	if !ok {
-		return
-	}
-	observed, ok := observer.ObserveModelText(json.RawMessage(plan.runArgs), output)
-	if !ok {
+// recordModelTextObservationValue records only a fully model-visible window.
+// Incomplete read_file results reach this helper only after exact recovery.
+func (a *Agent) recordModelTextObservationValue(observed tool.ModelTextObservation) {
+	if a == nil || a.task.ledger == nil || observed.Path == "" || len(observed.LineHashes) == 0 {
 		return
 	}
 	a.task.ledger.RecordTextObservation(evidence.TextObservation{

--- a/internal/agent/tool_call_plan.go
+++ b/internal/agent/tool_call_plan.go
@@ -40,6 +40,10 @@ type toolCallPlan struct {
 	hooksMayMutateWorkspace                                bool
 	perCallWriteRoots                                      []string
 	skipOrdinaryGate                                       bool
+	// incompleteReadRoot binds an exact host-requested source/result page to
+	// the read chain it advances. Empty means an independent tool call.
+	incompleteReadRoot   string
+	incompleteReadAction incompleteReadAction
 }
 
 func (p *toolCallPlan) classifyEffects() {

--- a/internal/agent/tool_result_capability.go
+++ b/internal/agent/tool_result_capability.go
@@ -90,6 +90,28 @@ func toolOutputRecoveryMarker(toolName, toolCallID, resultRef string, originalBy
 	)
 }
 
+// toolOutputRecoveryMarkerAt builds the recoverable provider-visible marker.
+// recoverOffset is the first byte the model has not seen. It is intentionally
+// read_file-only; generic head/tail previews retain their byte-compatible marker
+// above and continue to recover from zero.
+func toolOutputRecoveryMarkerAt(toolName, toolCallID, resultRef string, originalBytes, keptBytes, recoverOffset int) string {
+	namePart := boundedMarkerField(toolName, 128, "tool")
+	idPart := boundedMarkerField(toolCallID, 128, "-")
+	exampleID := toolCallID
+	if len(exampleID) > 256 {
+		exampleID = "<full tool_call_id from this tool result>"
+	}
+	args, _ := json.Marshal(struct {
+		ToolCallID string `json:"tool_call_id"`
+		ResultRef  string `json:"result_ref"`
+		Offset     int    `json:"offset"`
+	}{ToolCallID: exampleID, ResultRef: resultRef, Offset: recoverOffset})
+	return fmt.Sprintf(
+		"\n\n…[truncated tool=%s call_id=%s result_ref=%s original_bytes=%d kept_bytes=%d next_offset=%d — full original retained locally; recover with use_capability(action=\"call\", capability_id=\"session:tool_result\", arguments=%s). INCOMPLETE READ: only a contiguous prefix is visible; do not answer, modify state, or finish until recovery reaches complete=true. If use_capability is unavailable, re-run the original tool with narrower arguments]…\n\n",
+		namePart, idPart, resultRef, originalBytes, keptBytes, recoverOffset, args,
+	)
+}
+
 func boundedMarkerField(value string, maxBytes int, fallback string) string {
 	if value == "" {
 		return fallback

--- a/internal/agent/turnruntime.go
+++ b/internal/agent/turnruntime.go
@@ -97,6 +97,11 @@ type turnRuntime struct {
 	// read by the governor trigger (live policy and fork capture alike).
 	lastReasoning int
 
+	// incompleteReads tracks unread read_file results within one Agent.Run; a
+	// fresh user turn may choose a different strategy, but this run cannot write
+	// or finish from a silent partial read.
+	incompleteReads incompleteReadState
+
 	phase phaseClock
 }
 

--- a/internal/agent/usecapability.go
+++ b/internal/agent/usecapability.go
@@ -496,11 +496,11 @@ type UseCapabilityTool struct {
 	ledger   *capability.Ledger
 	audit    *capability.Audit
 	catalog  func() capability.Catalog
-	// toolResultSession is bound by Agent.New to that frontend's own session.
-	// CloneForAgent intentionally leaves it empty so parent transcripts cannot
+	// toolResultSession is bound by Agent.New; clones leave it empty so parent transcripts cannot
 	// leak into planner or child frontends before their Agent binds them.
 	toolResultMu      sync.RWMutex
 	toolResultSession func() *Session
+	readStrategyState func() *incompleteReadState
 	mcpListMu         sync.RWMutex
 	mcpListObserver   func(mcpListObservation)
 	// state is session-shared connection observation when built via
@@ -690,8 +690,8 @@ func (t *UseCapabilityTool) ResolveCall(ctx context.Context, args json.RawMessag
 		if id == "" {
 			return tool.ResolvedCall{}, fmt.Errorf("capability_id is required for action=call")
 		}
-		if id == sessionToolResultCapabilityID {
-			return t.resolveSessionToolResult(p.Arguments, base)
+		if id == sessionToolResultCapabilityID || id == sessionReadStrategyReceiptCapabilityID {
+			return t.resolveSessionCapability(id, p.Arguments, base)
 		}
 		return t.resolveCall(ctx, id, p.Arguments, base)
 	default:

--- a/internal/agent/usecapability_inspect.go
+++ b/internal/agent/usecapability_inspect.go
@@ -61,6 +61,16 @@ func (t *UseCapabilityTool) resolveDiscovery(ctx context.Context, p useCapabilit
 			base.ReadOnly = true
 			return base, nil
 		}
+		if id == sessionReadStrategyReceiptCapabilityID {
+			out, err := t.inspectSessionReadStrategyReceipt()
+			if err != nil {
+				return tool.ResolvedCall{}, err
+			}
+			base.SkipExecute = true
+			base.Result = out
+			base.ReadOnly = true
+			return base, nil
+		}
 		out, err := t.inspect(ctx, id)
 		if err != nil {
 			if t.audit != nil {

--- a/internal/agent/usecapability_list.go
+++ b/internal/agent/usecapability_list.go
@@ -39,6 +39,12 @@ func (t *UseCapabilityTool) listCapabilities() (string, error) {
 			Description: "Read one bounded page from a complete tool result retained in this agent's current session.",
 		})
 	}
+	if target := t.currentReadStrategyReceiptTarget(); target != nil {
+		caps = append(caps, capInfo{
+			ID: sessionReadStrategyReceiptCapabilityID, Kind: "session", Name: "read_strategy_receipt", Status: "ready", ReadOnly: true,
+			Description: target.Description(),
+		})
+	}
 	if t.catalog != nil {
 		for _, e := range t.catalog().Entries {
 			// Servers already have a compact representation below. Keep concrete

--- a/internal/event/notice_codes.go
+++ b/internal/event/notice_codes.go
@@ -29,5 +29,13 @@ const (
 	NoticeCodeSessionRecoveryDepthCap                           = "session_recovery_depth_cap"
 	NoticeCodeSessionShutdownRecoveryForked                     = "session_shutdown_recovery_forked"
 	NoticeCodeCompletionUncertain                               = "completion_uncertain"
+	NoticeCodeIncompleteReadDetected                            = "incomplete_read_detected"
+	NoticeCodeReadContinuationRequired                          = "continuation_required"
+	NoticeCodeReadCompleted                                     = "read_completed"
+	NoticeCodeReadOversizeRejected                              = "oversize_rejected"
+	NoticeCodeReadStrategyRequired                              = "read_strategy_required"
+	NoticeCodeReadStrategyProgress                              = "read_strategy_progress"
+	NoticeCodeReadStrategyResolved                              = "read_strategy_resolved"
+	NoticeCodeReadLocalSafetyPaged                              = "read_local_safety_paged"
 	NoticeCodeDecisionReceipt, NoticeCodeContextEditingFallback = "decision_receipt", "context_editing_fallback"
 )

--- a/internal/fileutil/encoding/encoding.go
+++ b/internal/fileutil/encoding/encoding.go
@@ -11,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
 
@@ -172,10 +173,16 @@ func Decoder(enc Kind) transform.Transformer {
 		return nil
 	case GB18030:
 		return simplifiedchinese.GB18030.NewDecoder()
+	case UTF16LE:
+		return unicode.UTF16(unicode.LittleEndian, unicode.ExpectBOM).NewDecoder()
+	case UTF16BE:
+		return unicode.UTF16(unicode.BigEndian, unicode.ExpectBOM).NewDecoder()
+	case UTF16LENoBOM:
+		return unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewDecoder()
+	case UTF16BENoBOM:
+		return unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM).NewDecoder()
 	}
-	// UTF16LE/BE are not self-synchronising and cannot be streamed
-	// line-by-line without full-file buffering. Callers must handle
-	// them separately. UTF8 and LossyUTF8 need no transformation.
+	// UTF8 and LossyUTF8 need no transformation.
 	return nil
 }
 

--- a/internal/tool/builtin/clientio_test.go
+++ b/internal/tool/builtin/clientio_test.go
@@ -71,6 +71,55 @@ func TestReadFileOverlayFallsBackToDisk(t *testing.T) {
 	}
 }
 
+func TestGrepOverlayServesUnsavedBufferContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "overlay-only.go")
+	overlay := &fakeOverlay{files: map[string]string{
+		path: "package overlay\n// BUFFER_NEEDLE exists only in the unsaved buffer\n",
+	}}
+	grep := byName(Workspace{
+		Dir: dir,
+		// Overlay-backed single-file searches must not delegate to ripgrep,
+		// which can only see the disk snapshot.
+		Search:      SearchSpec{RgPath: filepath.Join(dir, "must-not-run-rg")},
+		FileOverlay: overlay,
+	}.Tools("grep"))["grep"]
+
+	out, err := grep.Execute(context.Background(), json.RawMessage(`{"pattern":"BUFFER_NEEDLE","path":"overlay-only.go"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "BUFFER_NEEDLE") || !strings.Contains(out, ":2:") {
+		t.Fatalf("grep did not search the unsaved overlay content:\n%s", out)
+	}
+}
+
+func TestGrepOverlayDoesNotBypassReadConfinement(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	overlay := &fakeOverlay{files: map[string]string{path: "OVERLAY_SECRET\n"}}
+	grep := grepTool{workDir: dir, forbidRoots: realRoots([]string{dir}), overlay: overlay}
+
+	out, err := grep.Execute(context.Background(), json.RawMessage(`{"pattern":"OVERLAY_SECRET","path":"secret.txt"}`))
+	if err == nil && strings.Contains(out, "OVERLAY_SECRET") {
+		t.Fatalf("forbidden overlay content escaped confinement: %q", out)
+	}
+}
+
+func TestGrepOverlayFallsBackToDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "disk-only.txt")
+	if err := os.WriteFile(path, []byte("DISK_NEEDLE\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	grep := byName(Workspace{Dir: dir, FileOverlay: &fakeOverlay{files: map[string]string{}}}.Tools("grep"))["grep"]
+
+	out, err := grep.Execute(context.Background(), json.RawMessage(`{"pattern":"DISK_NEEDLE","path":"disk-only.txt"}`))
+	if err != nil || !strings.Contains(out, "DISK_NEEDLE") {
+		t.Fatalf("overlay miss did not fall back to disk: out=%q err=%v", out, err)
+	}
+}
+
 func TestWriteFileOverlayAppliesWrite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "c.go")

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -77,6 +77,10 @@ type grepTool struct {
 	forbidRoots []string
 	sb          sandbox.Spec
 	sessionTemp *sessiontemp.Manager
+	// overlay serves exact-file searches from the same unsaved editor buffer as
+	// read_file. Directory searches still use disk/ripgrep because FileOverlay
+	// intentionally has no directory-enumeration contract.
+	overlay FileOverlay
 }
 
 func (grepTool) Name() string { return "grep" }
@@ -122,22 +126,29 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	ctx, cancel := context.WithTimeout(ctx, to)
 	defer cancel()
 
+	if confineRead(g.forbidRoots, p.Path) {
+		info, err := os.Stat(p.Path)
+		if err == nil && info.IsDir() {
+			return formatGrep(ctx, nil, false, to), nil
+		}
+		pathErr := &os.PathError{Op: "stat", Path: p.Path, Err: os.ErrNotExist}
+		if rp.External {
+			return "", fmt.Errorf("grep %s: %s", rp.DisplayPath, rp.ErrorText(pathErr))
+		}
+		return "", pathErr
+	}
+	if g.overlay != nil && !rp.External && filepath.IsAbs(p.Path) {
+		if content, ok := g.overlay.ReadTextFile(ctx, p.Path); ok {
+			return g.runOverlay(ctx, p.Pattern, p.Path, content, to, rp)
+		}
+	}
+
 	info, err := os.Stat(p.Path)
 	if err != nil {
 		if rp.External {
 			return "", fmt.Errorf("grep %s: %s", rp.DisplayPath, rp.ErrorText(err))
 		}
 		return "", fmt.Errorf("grep %s: %w", rp.DisplayPath, err)
-	}
-	if confineRead(g.forbidRoots, p.Path) {
-		if info.IsDir() {
-			return formatGrep(ctx, nil, false, to), nil
-		}
-		err := &os.PathError{Op: "stat", Path: p.Path, Err: os.ErrNotExist}
-		if rp.External {
-			return "", fmt.Errorf("grep %s: %s", rp.DisplayPath, rp.ErrorText(err))
-		}
-		return "", err
 	}
 
 	if g.rg != "" {
@@ -150,6 +161,37 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	}
 
 	return g.runNative(ctx, p.Pattern, p.Path, info, to, rp)
+}
+
+func (g grepTool) runOverlay(ctx context.Context, pattern, path, content string, to time.Duration, rp ResolvedPath) (string, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", fmt.Errorf("invalid pattern: %w", err)
+	}
+	var out []string
+	sc := bufio.NewScanner(strings.NewReader(content))
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	line := 0
+	for sc.Scan() {
+		if ctx.Err() != nil {
+			break
+		}
+		line++
+		text := sc.Text()
+		if strings.IndexByte(text, 0) >= 0 {
+			return formatGrep(ctx, nil, false, to), nil
+		}
+		if re.MatchString(text) {
+			out = append(out, fmt.Sprintf("%s:%d:%s", rp.DisplayFor(path), line, text))
+			if len(out) >= grepMaxMatches {
+				return formatGrep(ctx, out, true, to), nil
+			}
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return "", fmt.Errorf("grep overlay: %w", err)
+	}
+	return formatGrep(ctx, out, false, to), nil
 }
 
 func (g grepTool) runNative(ctx context.Context, pattern, path string, info os.FileInfo, to time.Duration, rp ResolvedPath) (string, error) {

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -183,38 +183,29 @@ func (g grepTool) runNative(ctx context.Context, pattern, path string, info os.F
 		peek := peekBuf[:n]
 
 		bomKind := fileenc.DetectQuick(peek)
+		enc := bomKind
 		if bomKind != fileenc.UTF16LE && bomKind != fileenc.UTF16BE && bomKind != fileenc.UTF8BOM {
-			if bytes.IndexByte(peek, 0) >= 0 {
-				return nil // binary, skip
+			if detected, ok := fileenc.DetectUTF16NoBOM(peek); ok {
+				enc = detected
+			} else {
+				if bytes.IndexByte(peek, 0) >= 0 {
+					return nil // binary, skip
+				}
+				// Detect encoding from the peek alone — sufficient for the
+				// UTF-8 vs GB18030 distinction (utf8.Valid on 8 KiB is reliable).
+				enc, _ = fileenc.Detect(peek)
 			}
 		}
 
-		// Detect encoding from the peek alone — sufficient for the
-		// UTF-8 vs GB18030 distinction (utf8.Valid on 8 KiB is reliable).
-		// Then stream the rest through a decoder so the 200-match cap can
-		// stop reading early instead of buffering the entire file.
-		enc, _ := fileenc.Detect(peek)
-
 		var src io.Reader
-		if enc == fileenc.UTF16LE || enc == fileenc.UTF16BE {
-			// UTF-16 needs full-file decode (multi-byte units span the
-			// whole stream). These files are rare in grep targets.
-			rest, err := io.ReadAll(f)
-			if err != nil {
-				return nil
-			}
-			all := append(peek, rest...)
-			src = bytes.NewReader(fileenc.Decode(all, enc))
+		// Stream through the decoder so the 200-match cap can stop reading
+		// early. x/text's UTF-16 decoder preserves split code units across reads.
+		dec := fileenc.Decoder(enc)
+		if dec != nil {
+			src = transform.NewReader(io.MultiReader(bytes.NewReader(peek), f), dec)
 		} else {
-			// Non-BOM path: stream through the decoder so the scanner can
-			// stop as soon as the cap is reached without buffering the file.
-			dec := fileenc.Decoder(enc)
-			if dec != nil {
-				src = transform.NewReader(io.MultiReader(bytes.NewReader(peek), f), dec)
-			} else {
-				// UTF-8 or LossyUTF8 — no transformation needed.
-				src = io.MultiReader(bytes.NewReader(peek), f)
-			}
+			// UTF-8 or LossyUTF8 — no transformation needed.
+			src = io.MultiReader(bytes.NewReader(peek), f)
 		}
 
 		sc := bufio.NewScanner(src)

--- a/internal/tool/builtin/grep_engine_test.go
+++ b/internal/tool/builtin/grep_engine_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	fileenc "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/sandbox"
 )
 
@@ -136,5 +137,28 @@ func TestGrepRipgrepFallsBackWhenForbidReadIsNotSandboxed(t *testing.T) {
 	}
 	if strings.Contains(out, "secret") {
 		t.Fatalf("fallback grep leaked forbidden matches:\n%s", out)
+	}
+}
+
+func TestGrepNativeStreamsUTF16WithAndWithoutBOM(t *testing.T) {
+	content := strings.Repeat("ordinary line\n", 20000) + "needle UTF16-END\n"
+	cases := []struct {
+		name string
+		kind fileenc.Kind
+	}{
+		{"le-bom", fileenc.UTF16LE}, {"be-bom", fileenc.UTF16BE},
+		{"le-no-bom", fileenc.UTF16LENoBOM}, {"be-no-bom", fileenc.UTF16BENoBOM},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "windows-utf16.txt")
+			if err := os.WriteFile(path, fileenc.Encode(content, tc.kind), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			out := runTool(t, grepTool{}, map[string]any{"pattern": "UTF16-END", "path": path})
+			if !strings.Contains(out, "20001:needle UTF16-END") || strings.Contains(out, "\x00") {
+				t.Fatalf("native UTF-16 grep output=%q", out)
+			}
+		})
 	}
 }

--- a/internal/tool/builtin/readfile.go
+++ b/internal/tool/builtin/readfile.go
@@ -23,8 +23,10 @@ import (
 )
 
 const (
-	readFileBinaryPeek   = 8 * 1024   // bytes scanned for NUL before reading further
-	readFileDetectSample = 256 * 1024 // bytes sampled for encoding detection before streaming
+	readFileBinaryPeek        = 8 * 1024   // bytes scanned for NUL before reading further
+	readFileDetectSample      = 256 * 1024 // bytes sampled for encoding detection before streaming
+	readFileMaxLineBytes      = 1024 * 1024
+	readFileMaxFormattedBytes = 8 << 20
 )
 
 func init() { tool.RegisterBuiltin(readFile{}) }
@@ -180,18 +182,8 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	// naive NUL check would misidentify them as binary.
 	switch fileenc.DetectQuick(peek) {
 	case fileenc.UTF16LE, fileenc.UTF16BE:
-		// UTF-16 is not self-synchronising and can't be streamed line-by-line, so
-		// buffer it fully (these files are rare and usually small).
-		rest, rerr := io.ReadAll(f)
-		if rerr != nil {
-			if rp.External {
-				return "", fmt.Errorf("read %s: %s", displayPath, rp.ErrorText(rerr))
-			}
-			return "", fmt.Errorf("read %s: %w", displayPath, rerr)
-		}
-		all := append(peek, rest...)
-		bom := fileenc.DetectQuick(all)
-		return r.scan(bytes.NewReader(fileenc.Decode(all, bom)), p.Offset, p.Limit)
+		enc := fileenc.DetectQuick(peek)
+		return r.scan(transform.NewReader(io.MultiReader(bytes.NewReader(peek), f), fileenc.Decoder(enc)), p.Offset, p.Limit)
 	case fileenc.UTF8BOM:
 		// Strip the 3-byte BOM; the content is valid UTF-8 and streams directly.
 		body := peek
@@ -205,15 +197,7 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	// no BOM, so it reaches here; recognise it by its NUL pattern and decode it
 	// rather than rejecting it as binary.
 	if k, ok := fileenc.DetectUTF16NoBOM(peek); ok {
-		rest, rerr := io.ReadAll(f)
-		if rerr != nil {
-			if rp.External {
-				return "", fmt.Errorf("read %s: %s", displayPath, rp.ErrorText(rerr))
-			}
-			return "", fmt.Errorf("read %s: %w", displayPath, rerr)
-		}
-		all := append(peek, rest...)
-		return r.scan(bytes.NewReader(fileenc.Decode(all, k)), p.Offset, p.Limit)
+		return r.scan(transform.NewReader(io.MultiReader(bytes.NewReader(peek), f), fileenc.Decoder(k)), p.Offset, p.Limit)
 	}
 
 	if bytes.IndexByte(peek, 0) >= 0 {
@@ -254,18 +238,33 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 // scan reads lines from src and returns the formatted output with line numbers.
 func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 	scanner := bufio.NewScanner(src)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), readFileMaxLineBytes)
 
 	var collected []string
+	textBytes := 0
 	lineNo := 0
 	hasMore := false
+	safetyPaged := false
+	requestedEnd := offset + limit
 	for scanner.Scan() {
 		lineNo++
 		if lineNo <= offset {
 			continue
 		}
 		if len(collected) < limit {
-			collected = append(collected, scanner.Text())
+			line := scanner.Text()
+			count := len(collected) + 1
+			width := len(strconv.Itoa(offset + count))
+			nextOffset := offset + count
+			bodyBytes := textBytes + len(line) + count*(width+len("→")+1)
+			trailer := readFileSafetyTrailer(nextOffset, requestedEnd)
+			if bodyBytes+len(trailer) > readFileMaxFormattedBytes {
+				hasMore = true
+				safetyPaged = true
+				break
+			}
+			collected = append(collected, line)
+			textBytes += len(line)
 			continue
 		}
 		// A line past the requested window exists — stop here rather than reading
@@ -274,6 +273,9 @@ func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 		break
 	}
 	if err := scanner.Err(); err != nil {
+		if strings.Contains(err.Error(), "token too long") {
+			return "", fmt.Errorf("scan: source line exceeds the 1 MiB local safety limit: %w", err)
+		}
 		return "", fmt.Errorf("scan: %w", err)
 	}
 
@@ -291,8 +293,14 @@ func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 	for i, line := range collected {
 		fmt.Fprintf(&b, "%*d→%s\n", w, offset+i+1, line)
 	}
-	if hasMore {
+	if safetyPaged {
+		b.WriteString(readFileSafetyTrailer(offset+len(collected), requestedEnd))
+	} else if hasMore {
 		fmt.Fprintf(&b, "\n[more lines below; pass offset=%d to continue]\n", offset+len(collected))
 	}
 	return b.String(), nil
+}
+
+func readFileSafetyTrailer(nextOffset, requestedEnd int) string {
+	return fmt.Sprintf("\n[read_file local safety page; next_offset=%d requested_end=%d]\n", nextOffset, requestedEnd)
 }

--- a/internal/tool/builtin/readfile_safety_test.go
+++ b/internal/tool/builtin/readfile_safety_test.go
@@ -1,0 +1,83 @@
+package builtin
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func numberedReadLines(t *testing.T, output string) map[int]string {
+	t.Helper()
+	lines := make(map[int]string)
+	for line := range strings.SplitSeq(output, "\n") {
+		before, after, ok := strings.Cut(line, "→")
+		if !ok {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimSpace(before))
+		if err != nil {
+			t.Fatalf("parse numbered line %q: %v", line, err)
+		}
+		lines[n] = after
+	}
+	return lines
+}
+
+func TestReadFileLocalSafetyPagesExplicitWindowWithoutGaps(t *testing.T) {
+	const totalLines = 2000
+	var source strings.Builder
+	for line := 1; line <= totalLines; line++ {
+		fmt.Fprintf(&source, "line-%04d-%s\r\n", line, strings.Repeat(string(rune('a'+line%26)), 5000))
+	}
+	first, err := (readFile{}).scan(strings.NewReader(source.String()), 0, totalLines)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) > readFileMaxFormattedBytes {
+		t.Fatalf("first page bytes=%d, limit=%d", len(first), readFileMaxFormattedBytes)
+	}
+	const prefix = "[read_file local safety page; next_offset="
+	start := strings.LastIndex(first, prefix)
+	if start < 0 {
+		t.Fatal("first page did not include the local safety trailer")
+	}
+	fields := strings.Fields(strings.TrimSuffix(first[start+len(prefix):], "]\n"))
+	if len(fields) != 2 || !strings.HasPrefix(fields[1], "requested_end=") {
+		t.Fatalf("safety trailer fields=%q", fields)
+	}
+	next, err := strconv.Atoi(fields[0])
+	if err != nil || next <= 0 || next >= totalLines {
+		t.Fatalf("next_offset=%d err=%v", next, err)
+	}
+	requestedEnd, err := strconv.Atoi(strings.TrimPrefix(fields[1], "requested_end="))
+	if err != nil || requestedEnd != totalLines {
+		t.Fatalf("requested_end=%d err=%v", requestedEnd, err)
+	}
+	second, err := (readFile{}).scan(strings.NewReader(source.String()), next, requestedEnd-next)
+	if err != nil {
+		t.Fatal(err)
+	}
+	combined := numberedReadLines(t, first)
+	for line, text := range numberedReadLines(t, second) {
+		if _, duplicate := combined[line]; duplicate {
+			t.Fatalf("duplicate line %d", line)
+		}
+		combined[line] = text
+	}
+	if len(combined) != totalLines {
+		t.Fatalf("reconstructed lines=%d, want %d", len(combined), totalLines)
+	}
+	for line := 1; line <= totalLines; line++ {
+		if !strings.HasPrefix(combined[line], fmt.Sprintf("line-%04d-", line)) || strings.Contains(combined[line], "\r") {
+			t.Fatalf("line %d was missing, reordered, or retained CR: %q", line, combined[line])
+		}
+	}
+}
+
+func TestReadFileRejectsLineAboveLocalSafetyLimit(t *testing.T) {
+	_, err := (readFile{}).scan(strings.NewReader(strings.Repeat("x", readFileMaxLineBytes+1)+"\n"), 0, 1)
+	if err == nil || !strings.Contains(err.Error(), "1 MiB local safety limit") {
+		t.Fatalf("oversized line error=%v", err)
+	}
+}

--- a/internal/tool/builtin/readfile_stream_test.go
+++ b/internal/tool/builtin/readfile_stream_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"golang.org/x/text/encoding/simplifiedchinese"
+
+	fileenc "reasonix/internal/fileutil/encoding"
 )
 
 // TestReadFileStreamsLargeGB18030 proves GB18030 content far past the 256KB
@@ -66,5 +68,43 @@ func TestReadFileLargeBoundedMemory(t *testing.T) {
 	}
 	if !strings.Contains(out, "1→a line") {
 		t.Fatalf("unexpected output: %q", out[:min(80, len(out))])
+	}
+}
+
+func TestReadFileLargeUTF16UsesStreamingDecoder(t *testing.T) {
+	var sb strings.Builder
+	for range 100000 {
+		sb.WriteString("a line of ordinary UTF-16 text with a searchable marker\n")
+	}
+	content := sb.String()
+	cases := []struct {
+		name string
+		kind fileenc.Kind
+	}{
+		{"le-bom", fileenc.UTF16LE}, {"be-bom", fileenc.UTF16BE},
+		{"le-no-bom", fileenc.UTF16LENoBOM}, {"be-no-bom", fileenc.UTF16BENoBOM},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "big-utf16.txt")
+			if err := os.WriteFile(path, fileenc.Encode(content, tc.kind), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			args, _ := json.Marshal(map[string]any{"path": path, "limit": 5})
+			runtime.GC()
+			var m0, m1 runtime.MemStats
+			runtime.ReadMemStats(&m0)
+			out, err := readFile{}.Execute(context.Background(), args)
+			runtime.ReadMemStats(&m1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if alloc := m1.TotalAlloc - m0.TotalAlloc; alloc > 4<<20 {
+				t.Fatalf("UTF-16 read allocated %d bytes for a five-line window", alloc)
+			}
+			if !strings.Contains(out, "UTF-16 text") || strings.Contains(out, "\x00") {
+				t.Fatalf("unexpected streamed UTF-16 output: %q", out)
+			}
+		})
 	}
 }

--- a/internal/tool/builtin/workspace.go
+++ b/internal/tool/builtin/workspace.go
@@ -86,7 +86,7 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 		"bash":          bash{workDir: w.Dir, sb: w.Bash, timeout: w.BashTimeout, guard: w.SessionGuard, terminal: w.Terminal, sessionTemp: w.SessionTemp},
 		"ls":            listDir{workDir: w.Dir, paths: w.ReadPaths, forbidRoots: forbidRoots},
 		"glob":          globTool{workDir: w.Dir, paths: w.ReadPaths, forbidRoots: forbidRoots},
-		"grep":          grepTool{workDir: w.Dir, paths: w.ReadPaths, rg: w.Search.RgPath, forbidRoots: forbidRoots, sb: w.Bash, sessionTemp: w.SessionTemp},
+		"grep":          grepTool{workDir: w.Dir, paths: w.ReadPaths, rg: w.Search.RgPath, forbidRoots: forbidRoots, sb: w.Bash, sessionTemp: w.SessionTemp, overlay: w.FileOverlay},
 		"web_fetch":     webFetch{proxySpec: w.ProxySpec},
 	}
 	all := tool.Builtins()

--- a/internal/tool/observation.go
+++ b/internal/tool/observation.go
@@ -16,9 +16,8 @@ type ModelTextObservation struct {
 }
 
 // ModelTextObserver is an optional reader capability. The agent passes the
-// final unbounded tool result before compatibility truncation, so a reader can
-// report exactly the text window that will be available through RawContent on
-// the next provider request without retaining source text.
+// final unbounded tool result, but records the returned hashes only after that
+// complete result has crossed the provider-visible recovery boundary.
 type ModelTextObserver interface {
 	ObserveModelText(args json.RawMessage, output string) (ModelTextObservation, bool)
 }


### PR DESCRIPTION
## Problem

Long `read_file` results could exceed the provider-visible result cap while the complete formatted output remained only in local `RawContent`. The model could continue from the visible prefix as if the read had completed, silently missing rules near the end of a file.

## Root cause

Recovery was advisory text rather than host-owned protocol state. There was no incomplete-read gate preventing writes or final answers, and text observations could be recorded before the model had consumed the retained result.

## What changed

- Replace the fixed 128 KiB and 32K-token automatic recovery ceilings with a dynamic budget derived from the effective context window and live compaction headroom.
- Recover retained results and implicit source pages with contiguous UTF-8-safe cursors, SHA-256 validation, and provider-order budget accounting.
- Enter an automatic restricted `grep` plus explicit `read_file` strategy when a complete read cannot fit safely.
- Add the dynamic private `session:read_strategy_receipt` capability and verify search IDs, fully consumed read windows, line overlap, file versions, and line hashes.
- Block mutations, finalizers, plan submission, and ordinary final answers until every incomplete read is resolved. Two consecutive violating model rounds return a recoverable `IncompleteReadError`.
- Keep a separate 8 MiB per-result local safety page and a 1 MiB single-line guard without imposing a file-size limit.
- Stream UTF-16 LE/BE, with or without BOM, through `read_file` and native `grep` instead of buffering the complete file.
- Record complete-file evidence only after full automatic recovery; narrowed mode records only validated explicit windows.
- Add structured incomplete-read and strategy audit notices without file contents.

## Compatibility and cache impact

- No provider-visible `read_file` or `use_capability` schema changes.
- No stable system-prompt changes.
- Strategy capabilities and instructions are injected only while a long read is active.
- `RawContent` remains excluded from ordinary provider requests.
- No persisted-data migration.
- Short `read_file` output remains byte-compatible; only tasks that actually encounter long reads add dynamic continuation turns.

## Verification

- `go test ./...`
- `go test -race ./internal/agent -run 'Test(IncompleteRead|ReadStrategy|ReadAutoRecovery)' -count=1`
- `go vet ./...`
- `make lint`
- `cd desktop && go test ./...`

Regression coverage includes a 43 KiB CRLF file with a key rule on line 362, automatic reads beyond the former byte/token ceilings, low and unknown context windows, restricted strategy receipts, same-batch write blocking, multiple pending files, exact result integrity, file changes, 8 MiB source paging, over-1-MiB lines, and streaming UTF-16 LE/BE with and without BOM.

## Related open work

PRs #7152, #8321, and #8322 touch pagination or encoding files, but they do not implement this host-level completion gate or restricted strategy state machine. This PR does not adopt their unrelated changes.

Cache-impact: low - Stable system-prompt and tool-schema bytes remain unchanged; only affected long-read turns add append-only dynamic continuation messages.
Cache-guard: go test ./internal/agent -run 'TestReadStrategyCapabilityIsDynamicWithoutChangingProviderSchema|TestReadAutoRecoveryBudget' -count=1; make lint
System-prompt-review: SivanCola review - internal/agent/task.go only forwards the private dynamic receipt capability; no stable system-prompt bytes or tool-schema bytes changed.
Documentation-impact: none - The behavior is host-internal and self-describing at runtime; the existing read_file schema and user documentation remain correct.