### PR TITLE
fix(provider): 补全 OpenCode Go 的 DeepSeek 视觉模型

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -434,8 +434,10 @@ variant uses stateless context replay. The existing mixed OpenCode Go Anthropic
 preset remains scoped to Qwen and MiniMax so server tools are not sent to
 unverified models. DeepSeek Pro remains on the Chat Completions preset because
 live Anthropic and Responses requests currently fail in the OpenCode Go upstream
-conversion. The OpenCode Go preset includes its native `kimi-k3` subscription
-route with image input,
+conversion. The OpenCode Go Chat preset includes
+`deepseek-v4-flash-vision-exp` with image input and the same 1,000,000-token
+context and 384,000-token upstream output limits as Flash. It also includes its
+native `kimi-k3` subscription route with image input,
 `high`/`max` reasoning effort, and a 1,048,576-token context window. Existing untouched
 OpenCode Go preset installs are upgraded automatically; edited model catalogs
 are preserved. The Kimi CN and Kimi Global direct-API presets also include

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -370,8 +370,10 @@ DeepSeek Responses 预设接入已验证的 Flash 线路，并默认启用 provi
 Responses 变体使用无状态上下文回放。原有混合 OpenCode Go Anthropic 预设仍只包含 Qwen
 与 MiniMax，避免把服务端搜索工具发送给未验证模型。DeepSeek Pro 暂时仍只放在 Chat
 Completions 预设中，因为真实 Anthropic
-和 Responses 请求目前会在 OpenCode Go 的上游转换阶段失败。OpenCode Go 预设原生包含
-订阅线路的 `kimi-k3`，并配置图像输入、`high`/`max` 推理强度和 1,048,576 token 上下文窗口。未修改过
+和 Responses 请求目前会在 OpenCode Go 的上游转换阶段失败。OpenCode Go Chat 预设包含
+`deepseek-v4-flash-vision-exp`，支持图片输入，并沿用 Flash 的 1,000,000 token 上下文与
+384,000 token 上游输出上限。该预设也原生包含订阅线路的 `kimi-k3`，并配置图像输入、
+`high`/`max` 推理强度和 1,048,576 token 上下文窗口。未修改过
 模型目录的既有 OpenCode Go 预设会自动升级；用户编辑过的模型目录保持不变。
 Kimi CN 和 Kimi Global 直连 API 预设也包含 `kimi-k3`，支持图像输入、1,048,576 token
 上下文窗口以及官方 `low`/`high`/`max` 推理强度（默认 `max`）。对官方 K3 端点，Reasonix

--- a/internal/config/backfill_test.go
+++ b/internal/config/backfill_test.go
@@ -545,6 +545,47 @@ func TestNormalizeLegacyOpenCodeGoKimiK3CatalogMigratesOnlyUntouchedPreset(t *te
 	}
 }
 
+func TestNormalizeLegacyOpenCodeGoVisionCatalogMigratesOnlyUntouchedPreset(t *testing.T) {
+	preVisionModels := []string{"glm-5.3", "glm-5.2", "glm-5.1", "kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "deepseek-v4-pro", "deepseek-v4-flash", "mimo-v2.5-pro", "mimo-v2.5", "hy3"}
+	base := ProviderEntry{
+		Name:          "opencode-go",
+		Kind:          "openai",
+		BaseURL:       "https://opencode.ai/zen/go/v1",
+		Models:        append([]string(nil), preVisionModels...),
+		VisionModels:  []string{"kimi-k3"},
+		Default:       "glm-5.2",
+		PresetID:      "opencode-go",
+		ContextWindow: 128_000,
+	}
+	customCatalog := base
+	customCatalog.Name = "opencode-go-custom"
+	customCatalog.Models = append(customCatalog.Models, "private-model")
+	explicitNoVision := base
+	explicitNoVision.Name = "opencode-go-no-vision"
+	explicitNoVision.VisionModels = []string{}
+	c := &Config{Providers: []ProviderEntry{base, customCatalog, explicitNoVision}}
+
+	if !normalizeLegacyOpenCodeGoVisionCatalog(c) {
+		t.Fatal("legacy OpenCode Go vision catalog migration did not report a change")
+	}
+	got := &c.Providers[0]
+	if !got.HasModel("deepseek-v4-flash-vision-exp") || !got.HasVisionModel("deepseek-v4-flash-vision-exp") {
+		t.Fatalf("migrated OpenCode Go catalog = %+v, want DeepSeek vision SKU", got)
+	}
+	visionOverride := got.ModelOverrides["deepseek-v4-flash-vision-exp"]
+	if visionOverride.ReasoningProtocol != ReasoningProtocolDeepSeek ||
+		!stringSlicesEqual(visionOverride.SupportedEfforts, []string{"disabled", "low", "high", "max"}) ||
+		visionOverride.DefaultEffort != "high" || visionOverride.ContextWindow != 1_000_000 {
+		t.Fatalf("migrated vision override = %+v", visionOverride)
+	}
+	if c.Providers[1].HasModel("deepseek-v4-flash-vision-exp") {
+		t.Fatal("custom model catalog was unexpectedly migrated")
+	}
+	if !c.Providers[2].HasModel("deepseek-v4-flash-vision-exp") || c.Providers[2].VisionModels == nil || len(c.Providers[2].VisionModels) != 0 {
+		t.Fatalf("explicit no-vision choice = models:%v vision:%#v, want model added without enabling images", c.Providers[2].ModelList(), c.Providers[2].VisionModels)
+	}
+}
+
 func TestNormalizeLegacyKimiK3CatalogMigratesOnlyOfficialUntouchedPresets(t *testing.T) {
 	legacyEntry := func(id, baseURL string) ProviderEntry {
 		return ProviderEntry{

--- a/internal/config/fetch_test.go
+++ b/internal/config/fetch_test.go
@@ -332,3 +332,30 @@ func TestProviderFetchModelsFiltersOfficialOpenCodeGoCatalogByWireFormat(t *test
 		t.Fatalf("models = %v, want %v", got, want)
 	}
 }
+
+func TestProviderFetchModelsKeepsOpenCodeGoVisionModelOnChatRoute(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]string{
+				{"id": "deepseek-v4-flash"},
+				{"id": "deepseek-v4-flash-vision-exp"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := ProviderEntry{
+		Name:      "opencode-go",
+		Kind:      "openai",
+		BaseURL:   "https://opencode.ai/zen/go/v1",
+		ModelsURL: srv.URL,
+	}
+	got, err := p.FetchModels(context.Background())
+	if err != nil {
+		t.Fatalf("FetchModels: %v", err)
+	}
+	want := []string{"deepseek-v4-flash", "deepseek-v4-flash-vision-exp"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("models = %v, want %v", got, want)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -16,6 +16,7 @@ import (
 	"reasonix/internal/fileutil"
 	fileencoding "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/provider"
+	"reasonix/internal/provider/openai"
 )
 
 // Load builds the configuration: defaults, then user config, then project
@@ -1543,17 +1544,77 @@ func normalizeLegacyOpenCodeGoKimiK3Catalog(c *Config) (changed bool) {
 			strings.TrimSpace(p.Model) != "" {
 			continue
 		}
+		originalVisionModels := p.VisionModels
 		p.Models = append([]string(nil), opencodeGoModels...)
 		p.VisionModels = migrateKimiK3VisionModels(p.VisionModels, nil)
+		if originalVisionModels == nil {
+			p.VisionModels = mergeModelLists(p.VisionModels, []string{openai.OfficialDeepSeekVisionModel})
+		}
 		mergeMissingKimiK3Override(p, ProviderModelOverride{
 			ReasoningProtocol: ReasoningProtocolOpenAI,
 			SupportedEfforts:  []string{"high", "max"},
 			DefaultEffort:     "max",
 			ContextWindow:     1_048_576,
 		})
+		mergeMissingOpenCodeGoVisionOverride(p)
 		changed = true
 	}
 	return changed
+}
+
+// normalizeLegacyOpenCodeGoVisionCatalog upgrades only the untouched Chat
+// catalog that predates OpenCode Go's DeepSeek vision SKU. Custom model lists
+// and explicit image-input choices remain user-owned.
+func normalizeLegacyOpenCodeGoVisionCatalog(c *Config) (changed bool) {
+	if c == nil {
+		return false
+	}
+	for i := range c.Providers {
+		p := &c.Providers[i]
+		presetID := strings.TrimSpace(p.PresetID)
+		if (presetID != "opencode-go" && (presetID != "" || strings.TrimSpace(p.Name) != "opencode-go")) ||
+			!strings.EqualFold(strings.TrimSpace(p.Kind), "openai") ||
+			normalizedBaseURLForMigration(p.BaseURL) != "https://opencode.ai/zen/go/v1" ||
+			!stringSlicesEqual(p.Models, preVisionOpenCodeGoModels) ||
+			strings.TrimSpace(p.Model) != "" {
+			continue
+		}
+		p.Models = append([]string(nil), opencodeGoModels...)
+		if p.VisionModels == nil || stringSlicesEqual(p.VisionModels, preVisionOpenCodeGoVisionModels) {
+			p.VisionModels = append([]string(nil), opencodeGoVisionModels...)
+		}
+		mergeMissingOpenCodeGoVisionOverride(p)
+		changed = true
+	}
+	return changed
+}
+
+func mergeMissingOpenCodeGoVisionOverride(p *ProviderEntry) {
+	if p.ModelOverrides == nil {
+		p.ModelOverrides = map[string]ProviderModelOverride{}
+	}
+	const model = "deepseek-v4-flash-vision-exp"
+	key := model
+	for candidate := range p.ModelOverrides {
+		if strings.EqualFold(strings.TrimSpace(candidate), model) {
+			key = candidate
+			break
+		}
+	}
+	override := p.ModelOverrides[key]
+	if strings.TrimSpace(override.ReasoningProtocol) == "" {
+		override.ReasoningProtocol = ReasoningProtocolDeepSeek
+	}
+	if override.SupportedEfforts == nil {
+		override.SupportedEfforts = []string{"disabled", "low", "high", "max"}
+	}
+	if strings.TrimSpace(override.DefaultEffort) == "" && containsString(normalizedEffortLevels(override.SupportedEfforts), "high") {
+		override.DefaultEffort = "high"
+	}
+	if override.ContextWindow <= 0 {
+		override.ContextWindow = 1_000_000
+	}
+	p.ModelOverrides[key] = override
 }
 
 func normalizeLegacyMimoProviderCatalogs(c *Config) bool {

--- a/internal/config/opencode_go_context.go
+++ b/internal/config/opencode_go_context.go
@@ -15,6 +15,7 @@ const (
 
 func normalizeLegacyOpenCodeGoInstalls(c *Config) bool {
 	changed := normalizeLegacyOpenCodeGoKimiK3Catalog(c)
+	changed = normalizeLegacyOpenCodeGoVisionCatalog(c) || changed
 	changed = normalizeLegacyOpenCodeGoRouteCatalog(c) || changed
 	changed = normalizeLegacyOpenCodeGoContextWindows(c) || changed
 	changed = normalizeLegacyOpenCodeGoBilling(c) || changed

--- a/internal/config/provider_presets.go
+++ b/internal/config/provider_presets.go
@@ -140,8 +140,10 @@ var (
 	stepfunAPIVisionModels = []string{"step-3.7-flash"}
 
 	legacyOpenCodeGoModels           = []string{"glm-5.2", "glm-5.1", "kimi-k2.7-code", "kimi-k2.6", "deepseek-v4-pro", "deepseek-v4-flash", "mimo-v2.5-pro", "mimo-v2.5"}
-	opencodeGoModels                 = []string{"glm-5.3", "glm-5.2", "glm-5.1", "kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "deepseek-v4-pro", "deepseek-v4-flash", "mimo-v2.5-pro", "mimo-v2.5", "hy3"}
-	opencodeGoVisionModels           = []string{"kimi-k3"}
+	preVisionOpenCodeGoModels        = []string{"glm-5.3", "glm-5.2", "glm-5.1", "kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "deepseek-v4-pro", "deepseek-v4-flash", "mimo-v2.5-pro", "mimo-v2.5", "hy3"}
+	preVisionOpenCodeGoVisionModels  = []string{"kimi-k3"}
+	opencodeGoModels                 = []string{"glm-5.3", "glm-5.2", "glm-5.1", "kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "deepseek-v4-pro", "deepseek-v4-flash", openai.OfficialDeepSeekVisionModel, "mimo-v2.5-pro", "mimo-v2.5", "hy3"}
+	opencodeGoVisionModels           = []string{"kimi-k3", openai.OfficialDeepSeekVisionModel}
 	opencodeZenAnthropicModels       = []string{"claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5", "qwen3.6-plus", "qwen3.5-plus", "qwen3.6-plus-free"}
 	opencodeZenAnthropicVisionModels = []string{"claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5"}
 
@@ -723,6 +725,11 @@ var curatedProviderPresets = []ProviderPreset{
 				"deepseek-v4-flash": {
 					ReasoningProtocol: ReasoningProtocolDeepSeek,
 					SupportedEfforts:  []string{"disabled", "high", "max"},
+					DefaultEffort:     "high",
+				},
+				"deepseek-v4-flash-vision-exp": {
+					ReasoningProtocol: ReasoningProtocolDeepSeek,
+					SupportedEfforts:  []string{"disabled", "low", "high", "max"},
 					DefaultEffort:     "high",
 				},
 				"deepseek-v4-pro": {

--- a/internal/config/provider_presets_opencode_go.go
+++ b/internal/config/provider_presets_opencode_go.go
@@ -63,6 +63,11 @@ func openCodeGoRecommendedChatOverrides() map[string]ProviderModelOverride {
 			SupportedEfforts:  []string{"disabled", "high", "max"},
 			DefaultEffort:     "high",
 		},
+		"deepseek-v4-flash-vision-exp": {
+			ReasoningProtocol: ReasoningProtocolDeepSeek,
+			SupportedEfforts:  []string{"disabled", "low", "high", "max"},
+			DefaultEffort:     "high",
+		},
 		"deepseek-v4-pro": {
 			ReasoningProtocol: ReasoningProtocolDeepSeek,
 			SupportedEfforts:  []string{"disabled", "high", "max"},

--- a/internal/config/provider_presets_test.go
+++ b/internal/config/provider_presets_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"reasonix/internal/provider"
+	"reasonix/internal/provider/openai"
 )
 
 func TestCurrentBuiltInAnthropicCompatibleProvidersRemainLocalByCapability(t *testing.T) {
@@ -147,6 +148,37 @@ func TestOpenCodeGoContextWindowPresetsMatchModelsDev(t *testing.T) {
 	dsResp, _ := CuratedProviderPreset("opencode-go-deepseek-responses")
 	if dsResp.Entries[0].ContextWindow != 1_000_000 {
 		t.Fatalf("deepseek responses window = %d", dsResp.Entries[0].ContextWindow)
+	}
+}
+
+func TestOpenCodeGoChatPresetsExposeDeepSeekVisionModel(t *testing.T) {
+	for _, presetID := range []string{"opencode-go", "opencode-go-recommended"} {
+		preset, ok := CuratedProviderPreset(presetID)
+		if !ok {
+			t.Fatalf("missing %s preset", presetID)
+		}
+		var entry *ProviderEntry
+		for i := range preset.Entries {
+			if preset.Entries[i].Name == "opencode-go" {
+				entry = &preset.Entries[i]
+				break
+			}
+		}
+		if entry == nil || !entry.HasModel(openai.OfficialDeepSeekVisionModel) || !entry.HasVisionModel(openai.OfficialDeepSeekVisionModel) {
+			t.Fatalf("%s Chat entry = %+v, want DeepSeek vision SKU in model and vision catalogs", presetID, entry)
+		}
+		resolved := *entry
+		resolved.Model = openai.OfficialDeepSeekVisionModel
+		resolved.applyModelOverride()
+		if !EffectiveVision(&resolved) || resolved.ContextWindow != 1_000_000 || resolved.MaxOutputTokens != 32_768 {
+			t.Fatalf("%s vision capability = vision:%t context:%d output:%d", presetID, EffectiveVision(&resolved), resolved.ContextWindow, resolved.MaxOutputTokens)
+		}
+		cap := EffortCapabilityForEntry(&resolved)
+		for _, level := range []string{"disabled", "low", "high", "max"} {
+			if !containsString(cap.Levels, level) {
+				t.Fatalf("%s vision effort capability = %+v, want %q", presetID, cap, level)
+			}
+		}
 	}
 }
 

--- a/internal/provider/opencode_go.go
+++ b/internal/provider/opencode_go.go
@@ -29,17 +29,18 @@ const (
 // OpenCodeGoChatModels is the official Chat Completions catalog.
 func OpenCodeGoChatModels() map[string]OpenCodeGoModelLimits {
 	return map[string]OpenCodeGoModelLimits{
-		"glm-5.3":           {Context: 1_000_000, MaxOutput: 131_072},
-		"glm-5.2":           {Context: 1_000_000, MaxOutput: 131_072},
-		"glm-5.1":           {Context: 202_752, MaxOutput: 32_768},
-		"kimi-k3":           {Context: 1_048_576, MaxOutput: 131_072},
-		"kimi-k2.7-code":    {Context: 262_144, MaxOutput: 262_144},
-		"kimi-k2.6":         {Context: 262_144, MaxOutput: 65_536},
-		"deepseek-v4-pro":   {Context: 1_000_000, MaxOutput: 384_000},
-		"deepseek-v4-flash": {Context: 1_000_000, MaxOutput: 384_000},
-		"mimo-v2.5-pro":     {Context: 1_048_576, MaxOutput: 128_000},
-		"mimo-v2.5":         {Context: 1_000_000, MaxOutput: 128_000},
-		"hy3":               {Context: 256_000, MaxOutput: 64_000},
+		"glm-5.3":                      {Context: 1_000_000, MaxOutput: 131_072},
+		"glm-5.2":                      {Context: 1_000_000, MaxOutput: 131_072},
+		"glm-5.1":                      {Context: 202_752, MaxOutput: 32_768},
+		"kimi-k3":                      {Context: 1_048_576, MaxOutput: 131_072},
+		"kimi-k2.7-code":               {Context: 262_144, MaxOutput: 262_144},
+		"kimi-k2.6":                    {Context: 262_144, MaxOutput: 65_536},
+		"deepseek-v4-pro":              {Context: 1_000_000, MaxOutput: 384_000},
+		"deepseek-v4-flash":            {Context: 1_000_000, MaxOutput: 384_000},
+		"deepseek-v4-flash-vision-exp": {Context: 1_000_000, MaxOutput: 384_000},
+		"mimo-v2.5-pro":                {Context: 1_048_576, MaxOutput: 128_000},
+		"mimo-v2.5":                    {Context: 1_000_000, MaxOutput: 128_000},
+		"hy3":                          {Context: 256_000, MaxOutput: 64_000},
 	}
 }
 

--- a/internal/provider/opencode_go_test.go
+++ b/internal/provider/opencode_go_test.go
@@ -4,17 +4,18 @@ import "testing"
 
 func TestOpenCodeGoChatModelsMatchPinnedLimits(t *testing.T) {
 	want := map[string]OpenCodeGoModelLimits{
-		"glm-5.3":           {Context: 1_000_000, MaxOutput: 131_072},
-		"glm-5.2":           {Context: 1_000_000, MaxOutput: 131_072},
-		"glm-5.1":           {Context: 202_752, MaxOutput: 32_768},
-		"kimi-k3":           {Context: 1_048_576, MaxOutput: 131_072},
-		"kimi-k2.7-code":    {Context: 262_144, MaxOutput: 262_144},
-		"kimi-k2.6":         {Context: 262_144, MaxOutput: 65_536},
-		"deepseek-v4-pro":   {Context: 1_000_000, MaxOutput: 384_000},
-		"deepseek-v4-flash": {Context: 1_000_000, MaxOutput: 384_000},
-		"mimo-v2.5-pro":     {Context: 1_048_576, MaxOutput: 128_000},
-		"mimo-v2.5":         {Context: 1_000_000, MaxOutput: 128_000},
-		"hy3":               {Context: 256_000, MaxOutput: 64_000},
+		"glm-5.3":                      {Context: 1_000_000, MaxOutput: 131_072},
+		"glm-5.2":                      {Context: 1_000_000, MaxOutput: 131_072},
+		"glm-5.1":                      {Context: 202_752, MaxOutput: 32_768},
+		"kimi-k3":                      {Context: 1_048_576, MaxOutput: 131_072},
+		"kimi-k2.7-code":               {Context: 262_144, MaxOutput: 262_144},
+		"kimi-k2.6":                    {Context: 262_144, MaxOutput: 65_536},
+		"deepseek-v4-pro":              {Context: 1_000_000, MaxOutput: 384_000},
+		"deepseek-v4-flash":            {Context: 1_000_000, MaxOutput: 384_000},
+		"deepseek-v4-flash-vision-exp": {Context: 1_000_000, MaxOutput: 384_000},
+		"mimo-v2.5-pro":                {Context: 1_048_576, MaxOutput: 128_000},
+		"mimo-v2.5":                    {Context: 1_000_000, MaxOutput: 128_000},
+		"hy3":                          {Context: 256_000, MaxOutput: 64_000},
 	}
 	got := OpenCodeGoChatModels()
 	if len(got) != len(want) {


### PR DESCRIPTION
## Summary

- 修复 OpenCode Go 模型发现会过滤 `deepseek-v4-flash-vision-exp`，导致设置页无法搜索和选择该模型的问题。
- 将该 SKU 加入 Chat 路由能力表与普通/推荐预设，并补齐图片输入、1M 上下文、384K 上游输出上限及 `disabled/low/high/max` 推理档位。
- 仅迁移与旧官方预设完全一致的模型目录；保留自定义目录和显式关闭图片输入的选择。
- 更新中英文使用指南，说明 OpenCode Go Chat 的视觉模型能力。

## Issues

Fixes #9698

## Verification

- `go test ./...`
- `go test ./internal/provider ./internal/config`
- `make vet`
- `gofmt -l .`（无输出）
- `git diff --check`
- 实时核对 `https://opencode.ai/zen/go/v1/models` 与 `https://models.dev/api.json`：该 SKU 均存在，且 models.dev 标记 `attachment=true`、上下文 1,000,000、输出上限 384,000。

## Documentation impact

Documentation-impact: updated - 更新 `docs/GUIDE.md` 与 `docs/GUIDE.zh-CN.md` 中的 OpenCode Go Chat 视觉模型说明。

## Cache impact

Cache-impact: low - 仅新增可选择模型及其能力元数据；已有模型和既有会话的提示词前缀不变。
Cache-guard: `go test ./internal/provider ./internal/config` 覆盖路由过滤、预设能力与旧目录迁移。
System-prompt-review: N/A