### PR TITLE
feat(desktop): add optional periodic full-session snapshot

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -128,6 +128,9 @@ type App struct {
 	ctx          context.Context
 	workspaceHub *workspaceChangeHub
 	topicState   *topicStateManager
+	// periodicSnapshot drives scheduled full-session snapshots as a safety net
+	// for the TurnDone-only autosave. Nil when the feature is disabled by env.
+	periodicSnapshot *periodicSnapshotter
 	// topicTitleMutationMu keeps the authoritative title commit and its Tab /
 	// session-sidecar publication in the same order for manual and automatic
 	// renames. It is never held by generic topic-state reads or other metadata.
@@ -534,6 +537,11 @@ func (a *App) startup(ctx context.Context) {
 	// After restoreOrBuildTabs is launched: the GC's first sweep waits on
 	// tabsRestored so it never observes the pre-restore empty tab map.
 	a.startRecoveryGC()
+	// Periodic full-session snapshot is a safety net for the TurnDone-only
+	// autosave. Opt-in via REASONIX_ENABLE_PERIODIC_SNAPSHOT=1; no-op when
+	// disabled so default behaviour is unchanged.
+	a.periodicSnapshot = newPeriodicSnapshotter(a)
+	a.periodicSnapshot.Start()
 }
 
 func (a *App) beforeClose(ctx context.Context) bool {

--- a/desktop/persistence_enhancer.go
+++ b/desktop/persistence_enhancer.go
@@ -1,0 +1,192 @@
+// Periodic snapshot engine — scheduled full-session persistence that complements
+// the existing TurnDone-driven autosave.
+//
+// Reasonix currently persists sessions only when a turn completes (event.TurnDone
+// → scheduleTabSnapshot). A long in-flight turn, a crash before TurnDone, or a
+// version-update migration can therefore lose data that never reached disk. This
+// engine adds a safety-net ticker that calls the existing snapshotAllTabs() on a
+// configurable interval, so a force-kill loses at most interval seconds of work
+// instead of an entire in-flight turn.
+//
+// Design goals:
+//   - Zero behaviour change by default. The engine is opt-in via
+//     REASONIX_ENABLE_PERIODIC_SNAPSHOT=1 so existing users, tests, and
+//     cache-sensitive paths are unaffected.
+//   - No new persistence mechanism. It reuses snapshotAllTabs() / snapshotTab(),
+//     the same code path shutdown and tab-switch already rely on.
+//   - No config-system changes. Interval is read from an env var so the feature
+//     can ship without touching the TOML schema, migration, or UI.
+//   - Deterministic shutdown. Stop() blocks until the in-flight tick (if any)
+//     finishes, so close-time ordering with controller teardown stays well-defined.
+
+package main
+
+import (
+	"log/slog"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	// periodicSnapshotEnvEnable gates the engine. Empty or "0" / "false" / "off"
+	// keeps it disabled, matching the historical behaviour.
+	periodicSnapshotEnvEnable = "REASONIX_ENABLE_PERIODIC_SNAPSHOT"
+	// periodicSnapshotEnvInterval overrides the default tick interval in seconds.
+	periodicSnapshotEnvInterval = "REASONIX_PERIODIC_SNAPSHOT_INTERVAL"
+	// periodicSnapshotDefaultInterval is the tick used when the env var is absent
+	// or unparseable. 30s is a conservative balance: long enough to avoid visible
+	// disk thrash on large transcripts, short enough that a forced kill loses at
+	// most half a minute of in-flight work.
+	periodicSnapshotDefaultInterval = 30 * time.Second
+	// periodicSnapshotMinInterval guards against pathological configs that would
+	// snapshot on every few hundred milliseconds and starve the UI goroutine.
+	periodicSnapshotMinInterval = 5 * time.Second
+)
+
+// periodicSnapshotter drives scheduled full-session snapshots.
+//
+// The zero value is not usable; construct with newPeriodicSnapshotter. Start()
+// and Stop() are idempotent and safe to call from any goroutine.
+type periodicSnapshotter struct {
+	app      *App
+	interval time.Duration
+
+	mu      sync.Mutex
+	stop    chan struct{}
+	stopped chan struct{}
+	running bool
+}
+
+// newPeriodicSnapshotter builds a snapshotter for the given app. It does not start
+// the background goroutine; call Start().
+//
+// If the feature is disabled by environment, interval is zero and Start() is a
+// no-op so callers can unconditionally wire it into app lifecycle without a
+// feature flag at every call site.
+func newPeriodicSnapshotter(app *App) *periodicSnapshotter {
+	return &periodicSnapshotter{
+		app:      app,
+		interval: resolvePeriodicSnapshotInterval(),
+	}
+}
+
+// enabled reports whether the engine should run. It is derived once at construction
+// time so toggling the env var after startup does not race with the ticker.
+func (p *periodicSnapshotter) enabled() bool {
+	return p.interval > 0
+}
+
+// Start launches the background ticker. It is a no-op when the feature is disabled
+// or already running. Safe to call multiple times.
+func (p *periodicSnapshotter) Start() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.enabled() || p.running {
+		return
+	}
+
+	p.running = true
+	p.stop = make(chan struct{})
+	p.stopped = make(chan struct{})
+
+	go p.loop()
+
+	slog.Info("desktop: periodic session snapshot enabled",
+		"interval", p.interval.String())
+}
+
+// Stop shuts down the ticker and waits for any in-flight snapshot to finish. It is
+// a no-op when the feature is disabled or not running. Safe to call multiple times.
+//
+// Callers should invoke Stop() before controller teardown in shutdownBody so the
+// final snapshot completes while controllers are still alive.
+func (p *periodicSnapshotter) Stop() {
+	p.mu.Lock()
+	if !p.running {
+		p.mu.Unlock()
+		return
+	}
+	p.running = false
+	close(p.stop)
+	stopped := p.stopped
+	p.mu.Unlock()
+
+	<-stopped
+}
+
+// loop is the background goroutine. It ticks at the configured interval and calls
+// snapshotAllTabs. A long snapshot does not pile up: the ticker fires while a
+// snapshot is in flight, the in-flight call is allowed to finish, and the next
+// tick starts a fresh one — the single-flight nature of snapshotTab (via
+// tab.saveMu) prevents concurrent writes to the same session file.
+func (p *periodicSnapshotter) loop() {
+	defer close(p.stopped)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.stop:
+			return
+		case <-ticker.C:
+			p.snapshotOnce()
+		}
+	}
+}
+
+// snapshotOnce runs one full snapshot cycle. Recovered to a warn log so a panic in
+// one tick cannot kill the background goroutine (the next tick would then never
+// fire).
+func (p *periodicSnapshotter) snapshotOnce() {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Warn("desktop: periodic snapshot panicked", "panic", r)
+		}
+	}()
+
+	p.app.snapshotAllTabs()
+}
+
+// resolvePeriodicSnapshotInterval reads the interval from the environment. Returns
+// 0 when the feature is disabled, otherwise a duration clamped to
+// [periodicSnapshotMinInterval, +∞).
+func resolvePeriodicSnapshotInterval() time.Duration {
+	if !periodicSnapshotEnabledFromEnv() {
+		return 0
+	}
+
+	interval := periodicSnapshotDefaultInterval
+	if raw := os.Getenv(periodicSnapshotEnvInterval); raw != "" {
+		if seconds, err := strconv.Atoi(raw); err == nil && seconds > 0 {
+			interval = time.Duration(seconds) * time.Second
+		} else {
+			slog.Warn("desktop: invalid periodic snapshot interval, using default",
+				"raw", raw, "default", periodicSnapshotDefaultInterval.String())
+		}
+	}
+
+	if interval < periodicSnapshotMinInterval {
+		slog.Warn("desktop: periodic snapshot interval below minimum, clamped",
+			"requested", interval.String(), "min", periodicSnapshotMinInterval.String())
+		interval = periodicSnapshotMinInterval
+	}
+
+	return interval
+}
+
+// periodicSnapshotEnabledFromEnv parses the enable flag. Accepts "1", "true",
+// "yes", "on" (case-insensitive) as enabled; everything else (including absent)
+// is disabled.
+func periodicSnapshotEnabledFromEnv() bool {
+	raw := os.Getenv(periodicSnapshotEnvEnable)
+	switch raw {
+	case "1", "true", "TRUE", "True", "yes", "YES", "Yes", "on", "ON", "On":
+		return true
+	default:
+		return false
+	}
+}

--- a/desktop/persistence_enhancer_test.go
+++ b/desktop/persistence_enhancer_test.go
@@ -1,0 +1,204 @@
+// Tests for the periodic session snapshot engine.
+//
+// These tests cover env-var parsing, interval clamping, and the Start/Stop
+// lifecycle. They do not assert on real snapshot timing — the engine reuses
+// snapshotAllTabs(), whose behaviour is covered by app_autosave_test.go.
+
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// ── Enable-flag parsing ────────────────────────────────────────────────────
+
+func TestPeriodicSnapshotEnabledFromEnv(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"absent", "", false},
+		{"zero", "0", false},
+		{"false", "false", false},
+		{"FALSE", "FALSE", false},
+		{"off", "off", false},
+		{"no", "no", false},
+		{"one", "1", true},
+		{"true", "true", true},
+		{"TRUE", "TRUE", true},
+		{"True", "True", true},
+		{"yes", "yes", true},
+		{"on", "on", true},
+		{"ON", "ON", true},
+		{"garbage", "maybe", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.value == "" {
+				os.Unsetenv(periodicSnapshotEnvEnable)
+			} else {
+				t.Setenv(periodicSnapshotEnvEnable, tc.value)
+			}
+			if got := periodicSnapshotEnabledFromEnv(); got != tc.want {
+				t.Fatalf("enabled = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// ── Interval resolution ─────────────────────────────────────────────────────
+
+func TestResolvePeriodicSnapshotIntervalDisabled(t *testing.T) {
+	os.Unsetenv(periodicSnapshotEnvEnable)
+	os.Unsetenv(periodicSnapshotEnvInterval)
+	if got := resolvePeriodicSnapshotInterval(); got != 0 {
+		t.Fatalf("interval = %v when disabled, want 0", got)
+	}
+}
+
+func TestResolvePeriodicSnapshotIntervalDefault(t *testing.T) {
+	t.Setenv(periodicSnapshotEnvEnable, "1")
+	os.Unsetenv(periodicSnapshotEnvInterval)
+	if got := resolvePeriodicSnapshotInterval(); got != periodicSnapshotDefaultInterval {
+		t.Fatalf("interval = %v, want default %v", got, periodicSnapshotDefaultInterval)
+	}
+}
+
+func TestResolvePeriodicSnapshotIntervalCustom(t *testing.T) {
+	t.Setenv(periodicSnapshotEnvEnable, "1")
+	t.Setenv(periodicSnapshotEnvInterval, "120")
+	want := 120 * time.Second
+	if got := resolvePeriodicSnapshotInterval(); got != want {
+		t.Fatalf("interval = %v, want %v", got, want)
+	}
+}
+
+func TestResolvePeriodicSnapshotIntervalClampedToMinimum(t *testing.T) {
+	t.Setenv(periodicSnapshotEnvEnable, "1")
+	t.Setenv(periodicSnapshotEnvInterval, "1")
+	if got := resolvePeriodicSnapshotInterval(); got != periodicSnapshotMinInterval {
+		t.Fatalf("interval = %v, want clamped minimum %v", got, periodicSnapshotMinInterval)
+	}
+}
+
+func TestResolvePeriodicSnapshotIntervalInvalidFallsBackToDefault(t *testing.T) {
+	t.Setenv(periodicSnapshotEnvEnable, "1")
+	t.Setenv(periodicSnapshotEnvInterval, "not-a-number")
+	if got := resolvePeriodicSnapshotInterval(); got != periodicSnapshotDefaultInterval {
+		t.Fatalf("interval = %v after invalid value, want default %v", got, periodicSnapshotDefaultInterval)
+	}
+}
+
+func TestResolvePeriodicSnapshotIntervalZeroFallsBackToDefault(t *testing.T) {
+	t.Setenv(periodicSnapshotEnvEnable, "1")
+	t.Setenv(periodicSnapshotEnvInterval, "0")
+	if got := resolvePeriodicSnapshotInterval(); got != periodicSnapshotDefaultInterval {
+		t.Fatalf("interval = %v after zero value, want default %v", got, periodicSnapshotDefaultInterval)
+	}
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+
+func TestPeriodicSnapshotterDisabledStartIsNoOp(t *testing.T) {
+	os.Unsetenv(periodicSnapshotEnvEnable)
+	os.Unsetenv(periodicSnapshotEnvInterval)
+
+	a := &App{}
+	p := newPeriodicSnapshotter(a)
+	if p.enabled() {
+		t.Fatal("snapshotter should be disabled by default")
+	}
+
+	// Start must not launch a goroutine or panic.
+	p.Start()
+	p.Start() // idempotent
+
+	// Stop must be safe to call on a never-started engine.
+	p.Stop()
+	p.Stop() // idempotent
+}
+
+func TestPeriodicSnapshotterEnabledStartStop(t *testing.T) {
+	t.Setenv(periodicSnapshotEnvEnable, "1")
+	// Use a short interval so the ticker fires at least once, but not so short
+	// that it thrashes. The test only asserts lifecycle correctness, not timing.
+	t.Setenv(periodicSnapshotEnvInterval, "5")
+
+	a := &App{
+		tabs: map[string]*WorkspaceTab{},
+	}
+	p := newPeriodicSnapshotter(a)
+	if !p.enabled() {
+		t.Fatal("snapshotter should be enabled")
+	}
+
+	p.Start()
+	p.Start() // idempotent — must not spawn a second goroutine
+
+	// Let the ticker fire at least once.
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop blocks until the in-flight tick (if any) finishes.
+	done := make(chan struct{})
+	go func() {
+		p.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not return within 5s — ticker goroutine leaked")
+	}
+
+	// Second Stop is a no-op and must not block.
+	p.Stop()
+}
+
+func TestPeriodicSnapshotterStopBeforeStartIsSafe(t *testing.T) {
+	t.Setenv(periodicSnapshotEnvEnable, "1")
+	t.Setenv(periodicSnapshotEnvInterval, "30")
+
+	a := &App{}
+	p := newPeriodicSnapshotter(a)
+
+	// Stop before Start must not panic or block.
+	done := make(chan struct{})
+	go func() {
+		p.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+		// ok
+	case <-time.After(time.Second):
+		t.Fatal("Stop before Start blocked")
+	}
+}
+
+// ── Construction ────────────────────────────────────────────────────────────
+
+func TestNewPeriodicSnapshotterReadsEnvOnce(t *testing.T) {
+	t.Setenv(periodicSnapshotEnvEnable, "1")
+	t.Setenv(periodicSnapshotEnvInterval, "45")
+
+	a := &App{}
+	p := newPeriodicSnapshotter(a)
+
+	want := 45 * time.Second
+	if p.interval != want {
+		t.Fatalf("interval = %v, want %v", p.interval, want)
+	}
+
+	// Changing the env after construction must not affect the running interval —
+	// the snapshotter reads env once at construction time to avoid races with the
+	// ticker.
+	t.Setenv(periodicSnapshotEnvInterval, "999")
+	if p.interval != want {
+		t.Fatalf("interval changed after construction: %v, want %v", p.interval, want)
+	}
+}

--- a/desktop/shutdown.go
+++ b/desktop/shutdown.go
@@ -22,6 +22,11 @@ func completeDesktopShutdown(tracker *desktopLifecycleTracker, body func()) {
 }
 
 func (a *App) shutdownBody() {
+	// Stop the periodic snapshotter before controller teardown so its final
+	// in-flight snapshot completes while controllers are still alive.
+	if a.periodicSnapshot != nil {
+		a.periodicSnapshot.Stop()
+	}
 	if a.topicState != nil {
 		defer a.topicState.close()
 	}


### PR DESCRIPTION
## Summary
Add an **opt‑in periodic full‑session snapshot** engine for the desktop app, as a safety net for the existing TurnDone‑only autosave.
Currently, sessions are persisted only when `event.TurnDone` fires (`tabEventSink.Emit` → `scheduleTabSnapshot` → `tabSnapshotLoop`). A long in‑flight turn, a crash before TurnDone, or a version‑upgrade migration can therefore lose data that never reached disk. This PR adds a configurable ticker that calls the existing `snapshotAllTabs()` on an interval, so a force‑kill loses at most `interval` seconds of work instead of an entire in‑flight turn.
**Default behaviour is unchanged**: the engine is disabled unless `REASONIX_ENABLE_PERIODIC_SNAPSHOT=1` is set. No config‑system, migration, or UI changes.
## Issues
Addresses the data‑loss class of issues where in‑flight turns are lost on crash or before the TurnDone event persists the session. This PR lays the groundwork for later pre‑update snapshots and JSON export (both out of scope here).
## Verification
- Run unit tests:
  ```bash
  cd desktop
  go test -run "TestPeriodicSnapshot|TestResolvePeriodic" -v ./...
  go vet ./...
  ```

- Enable the feature and observe periodic snapshots:
    
    - On Windows: `set REASONIX_ENABLE_PERIODIC_SNAPSHOT=1 && reasonix-desktop.exe`
        
    - Verify logs or disk writes occur at the configured interval (default 30s, clamped to 5s min).
        
- Ensure existing tests pass unchanged when the env var is absent (no‑op behaviour).
    

## Documentation impact

Documentation-impact: none - This feature is opt-in and disabled by default; it only adds two environment variables, so no configuration file schema, migration, or UI changes are required.

## Cache impact

Cache-impact: none - This change does not touch system prompt construction, memory prefix, output styles, skill index, tool schemas, provider request serialization, compaction, or MCP/tool registration. It only schedules calls to the existing `snapshotAllTabs()` path.

Cache-guard: Existing autosave tests in `app_autosave_test.go` cover the snapshot path; this PR adds `persistence_enhancer_test.go` with test cases covering env‑var parsing, interval clamping, and lifecycle (Start/Stop idempotency, stop‑before‑start safety). The engine is disabled by default, so no existing cache‑sensitive test path is affected.

System-prompt-review: N/A