### PR TITLE
Fix Ask session activation race / 修复 Ask 会话首次切换失败

### DIFF
--- a/desktop/frontend/src/__tests__/topic-activation.test.tsx
+++ b/desktop/frontend/src/__tests__/topic-activation.test.tsx
@@ -135,8 +135,9 @@ const tabA = tabMeta("tab-a", { active: true });
 const tabB = tabMeta("tab-b");
 const tabC = tabMeta("tab-c");
 const tabR = tabMeta("tab-r", { running: true, cancellable: true });
+const tabAsk = tabMeta("tab-ask", { workspaceRoot: "/work/ask", topicId: "topic-ask", sessionPath: "/sessions/ask.jsonl" });
 let backendActiveId = "tab-a";
-const tabsById = new Map([tabA, tabB, tabC, tabR].map((tab) => [tab.id, tab]));
+const tabsById = new Map([tabA, tabB, tabC, tabR, tabAsk].map((tab) => [tab.id, tab]));
 const eventHandlers: Array<(e: WireEvent) => void> = [];
 const readyHandlers: Array<(tabId?: string) => void> = [];
 const topicActivationHandlers: Array<(e: TopicActivationEvent) => void> = [];
@@ -147,6 +148,7 @@ const requestIdByTab = new Map<string, string>();
 // ticket (exercises the terminal-event stash path).
 let eagerActivationEvents = false;
 let failedHistoryTabId = "";
+const transientHistoryFailures = new Map<string, { remaining: number; beforeThrow?: () => Promise<void> }>();
 let failSetActiveTabId = "";
 let restoredTabSeq = 0;
 
@@ -188,6 +190,12 @@ window.go = {
       HistoryForTab: async (tabID: string) => historyFor(tabID),
       HistorySliceForTab: async (tabID: string, req: HistorySliceRequest) => {
         if (tabID === failedHistoryTabId) throw new Error(`/private/${tabID}/history.jsonl could not be read`);
+        const transientFailure = transientHistoryFailures.get(tabID);
+        if (transientFailure && transientFailure.remaining > 0) {
+          transientFailure.remaining -= 1;
+          await transientFailure.beforeThrow?.();
+          throw new Error("session runtime is still publishing its history");
+        }
         return historySliceFromMessages(tabID, historyFor(tabID), req);
       },
       HistoryCheckpointTurnsForTab: async () => [],
@@ -389,6 +397,49 @@ await waitFor("switch-back restores the thinking transcript", () =>
 eq(controller?.state.running, true, "switch-back keeps the composer in the live turn");
 eq(controller?.state.items.some((item) => item.kind === "user" && item.text === "history tab-b") ?? false, false, "switch-back does not keep the other session as the visible transcript");
 eq(controller?.state.hydratePlaceholderItems?.length ?? 0, 0, "switch-back clears the foreign placeholder after live history lands");
+
+// A ready Ask runtime can race the first history read while its session is
+// being published. One transient read failure must recover in the same click
+// instead of restoring the source and making the user click B again.
+tabsById.set(tabAsk.id, { ...tabAsk, running: true, pendingPrompt: true, cancellable: true });
+let markHistoryStarted: (() => void) | undefined;
+const historyStarted = new Promise<void>((resolve) => { markHistoryStarted = resolve; });
+let releaseHistoryFailure: (() => void) | undefined;
+const historyFailureGate = new Promise<void>((resolve) => { releaseHistoryFailure = resolve; });
+transientHistoryFailures.set(tabAsk.id, {
+  remaining: 1,
+  beforeThrow: async () => { markHistoryStarted?.(); await historyFailureGate; },
+});
+await act(async () => {
+  await controller?.activateTopic("project", tabAsk.workspaceRoot, tabAsk.topicId ?? "");
+  for (const handler of eventHandlers) {
+    handler({
+      kind: "ask_request",
+      tabId: tabAsk.id,
+      ask: { id: "ask-tab-ask", questions: [{ id: "choice", prompt: "Choose a repair", options: [] }] },
+    });
+  }
+  await flushPromises();
+});
+eq(controller?.state.ask?.id, "ask-tab-ask", "Ask is visible before activation history hydrates");
+await act(async () => {
+  // Production emits agent:ready before topic:activation ready. Hold the
+  // startup hydration open so activation-ready must supersede it without
+  // resetting the live Ask.
+  for (const handler of readyHandlers) handler(tabAsk.id);
+  await historyStarted;
+  emitActivation({ requestId: requestIdByTab.get(tabAsk.id) ?? "", tabId: tabAsk.id, phase: "ready" });
+  releaseHistoryFailure?.();
+  await flushPromises();
+});
+for (let attempt = 0; attempt < 10; attempt += 1) {
+  await act(async () => { await flushPromises(); });
+}
+eq(controller?.activeTabId, tabAsk.id, "transient Ask history failure stays on the selected session");
+ok(hasHistory(tabAsk.id), "transient Ask history failure retries without a second click");
+eq(controller?.state.pendingPrompt, true, "transient Ask history retry remains blocked on user input");
+eq(controller?.state.running, true, "transient Ask history retry remains running");
+eq(controller?.state.ask?.id, "ask-tab-ask", "transient Ask history retry preserves the decision card");
 
 await act(async () => {
   root.unmount();

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -247,7 +247,6 @@ type PendingTopicActivation = {
   navigationSeq: number;
   tabId?: string;
   placeholderItems?: Item[];
-  surfacePolicy: HydrateSurfacePolicy;
   /** Terminal event that arrived before the ticket resolved. */
   terminal?: TopicActivationEvent;
 };
@@ -3447,7 +3446,9 @@ export function useController() {
     }
     noteActivationSettled(event.requestId, "ready");
     ensureTranscriptSubscription(tabId);
-    void loadSessionDataForTab(tabId, true, "open-topic", { placeholderItems: pending.placeholderItems, surfacePolicy: pending.surfacePolicy })
+    // The ticket already prepared the target. Preserve any Ask that raced
+    // ready while reset=true supersedes the earlier agent-ready history read.
+    void loadSessionDataForTab(tabId, true, "open-topic", { placeholderItems: pending.placeholderItems })
       .then(() => {
         if (!isNavigationIntentCurrent(pending.navigationSeq) || activeTabIdRef.current !== tabId) return;
         const hydrated = statesRef.current.get(tabId);
@@ -4830,11 +4831,7 @@ export function useController() {
     // in the background and report through "topic:activation". Register the
     // pending ticket before the call so synchronously-emitted events match.
     topicActivationSeqRef.current += 1;
-    const pending: PendingTopicActivation = {
-      requestId: `fe-act-${Date.now()}-${topicActivationSeqRef.current}`,
-      navigationSeq,
-      surfacePolicy: "replace-surface",
-    };
+    const pending: PendingTopicActivation = { requestId: `fe-act-${Date.now()}-${topicActivationSeqRef.current}`, navigationSeq };
     pendingTopicActivationRef.current = pending;
     noteActivationRequested(pending.requestId);
     const ticket = await app.StartTopicActivation({
@@ -4865,7 +4862,7 @@ export function useController() {
     const previousSurface = activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current) : undefined;
     const sameSession = sameSessionHydrateIdentity(meta, previousSurface?.meta);
     const prevItems = sameSessionPlaceholderItems(meta, previousSurface);
-    pending.placeholderItems = prevItems; pending.surfacePolicy = sameSession ? "preserve-current" : "replace-surface";
+    pending.placeholderItems = prevItems;
     setActiveTabId(meta.id);
     activeTabIdRef.current = meta.id;
     confirmBackendActiveTab(meta.id);


### PR DESCRIPTION
## Summary

- preserve an Ask prompt that arrives between topic activation ticketing and terminal readiness
- let terminal topic readiness supersede a transient earlier `agent:ready` history projection in the same click
- keep persistent history failures on the existing sanitized source-restore path

## Root cause

Ticketed topic activation prepared the target surface once, but terminal readiness performed another replace-surface reset. That second logical reset could erase a live Ask. The diagnostic ordering also showed `agent:ready` starting a history projection while the runtime was still publishing the session, before terminal topic readiness supplied the authoritative fresh projection.

## Concurrency contract

- the activation ticket remains the single immediate surface-reset point
- terminal topic readiness keeps `reset=true`, so its fresh projection supersedes and generation-fences the earlier `agent:ready` read
- the default preserve-current policy defers that logical reset, and a foreground Ask prevents it from clearing live runtime state
- navigation and session-generation guards remain authoritative before projection commit
- no new history request is added relative to the existing ticketed activation flow

## Verification

- `pnpm exec tsx src/__tests__/topic-activation.test.tsx` — 31 passed
- related activation, stale-prompt, and tab-hydration suites — 209 passed
- `pnpm test:all` — 249 discovered suites plus remote and performance checks passed
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint:hooks`
- `go run ./tools/repolint`
- `git diff --check`

## Related work

#9385 and #9469 touch adjacent resident and paged-history paths without changing this activation-ready failure contract. #9650 has landed; this PR is rebased on top of its navigation-intent fencing and keeps those guards intact. #9416 overlaps the activation-ready hunk by replaying runtime state after a replace-surface reset; if it is revived, retain its unrelated scroll work but resolve that hunk with this PR's preserve-current terminal hydrate so late Ask state is not erased.

Cache-impact: none — no provider-visible prompt, tool schema, request serialization, memory, compaction, or reasoning bytes changed.

Documentation-impact: none - existing user documentation remains accurate; this only fixes an internal activation race.
