### PR TITLE
fix(desktop): reduce idle polling and checkpoint turns

### DIFF
--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -103,19 +103,31 @@ func TestTurnDonePersistsSession(t *testing.T) {
 	waitForAutosaveIdle(t, tab)
 }
 
-// TestNonTurnDoneDoesNotPersist confirms only TurnDone triggers a save, so the
-// per-token event storm doesn't thrash the disk.
-func TestNonTurnDoneDoesNotPersist(t *testing.T) {
+// TestStreamingDeltasDoNotPersist confirms per-token events stay out of the
+// autosave path, while durable lifecycle events checkpoint the session.
+func TestStreamingDeltasDoNotPersist(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	a, tab := appWithTab(t, path)
 	_ = a
 
 	tab.sink.Emit(event.Event{Kind: event.Text, Text: "tok"})
+	tab.sink.Emit(event.Event{Kind: event.Reasoning, Text: "think"})
+	tab.sink.Emit(event.Event{Kind: event.ToolProgress, Text: "progress"})
 
 	time.Sleep(50 * time.Millisecond)
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Fatalf("a non-TurnDone event wrote the session file (err=%v)", err)
+		t.Fatalf("a streaming event wrote the session file (err=%v)", err)
 	}
+}
+
+func TestTurnStartedCheckpointsSession(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	_, tab := appWithTab(t, path)
+
+	tab.sink.Emit(event.Event{Kind: event.TurnStarted})
+
+	waitForFile(t, path, "remember this turn")
+	waitForAutosaveIdle(t, tab)
 }
 
 // TestScheduleSnapshotCoalesces hammers the scheduler concurrently to prove the

--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -103,6 +103,26 @@ func TestTurnDonePersistsSession(t *testing.T) {
 	waitForAutosaveIdle(t, tab)
 }
 
+// TestTurnDoneWaitBlocksUntilSnapshotWritten is the persistence-barrier
+// regression test: when Emit(TurnDone) returns, the session snapshot must
+// already be on disk, not merely scheduled. A process exit right after a turn
+// completes can otherwise lose the final transcript.
+func TestTurnDoneWaitBlocksUntilSnapshotWritten(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	_, tab := appWithTab(t, path)
+
+	tab.sink.Emit(event.Event{Kind: event.TurnDone})
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read session file immediately after TurnDone: %v", err)
+	}
+	if !strings.Contains(string(b), "remember this turn") {
+		t.Fatalf("session file after TurnDone = %q, want the turn transcript", string(b))
+	}
+	waitForAutosaveIdle(t, tab)
+}
+
 // TestStreamingDeltasDoNotPersist confirms per-token events stay out of the
 // autosave path, while durable lifecycle events checkpoint the session.
 func TestStreamingDeltasDoNotPersist(t *testing.T) {

--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -120,11 +120,13 @@ func TestStreamingDeltasDoNotPersist(t *testing.T) {
 	}
 }
 
-func TestTurnStartedCheckpointsSession(t *testing.T) {
+func TestCommittedTurnPhaseCheckpointsSession(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	_, tab := appWithTab(t, path)
 
-	tab.sink.Emit(event.Event{Kind: event.TurnStarted})
+	// TurnPhaseWorking is emitted only after the controller has appended the
+	// user message; TurnStarted alone must not race a snapshot ahead of it.
+	tab.sink.Emit(event.Event{Kind: event.TurnPhase, PhaseName: event.TurnPhaseWorking})
 
 	waitForFile(t, path, "remember this turn")
 	waitForAutosaveIdle(t, tab)

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import { useGoalActionHandler } from "./lib/goalAction";
 import { useWailsResizeFix } from "./lib/useWailsResizeFix";
 import { asArray } from "./lib/array";
 import { activeLeaseBlockedTab, createBoundedRefreshCoordinator, sameTabMetaLists, seedActiveTabMetaList, shouldRefreshTabMetaForEvent, TAB_META_MAX_IN_FLIGHT } from "./lib/tabMetaRefresh";
+import { createBackgroundRuntimeRefreshCoordinator, sameBackgroundRuntimeLists } from "./lib/backgroundRuntimeRefresh";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, t, useI18n, useT, type Translator } from "./lib/i18n";
 import { useActiveRemoteSession } from "./lib/useRemoteSession";
 import { useRemoteTabOpened } from "./lib/useRemoteTabOpened";
@@ -1268,6 +1269,7 @@ export default function App() {
   const [sidebarTogglePressed, setSidebarTogglePressed] = useState(false);
   const [clearContextPending, setClearContextPending] = useState(false);
   const [backgroundRuntimes, setBackgroundRuntimes] = useState<BackgroundRuntimeView[]>([]);
+  const backgroundRuntimeRefreshRef = useRef<ReturnType<typeof createBackgroundRuntimeRefreshCoordinator> | null>(null);
   const [workspaceConflict, setWorkspaceConflict] = useState<WorkspaceConflictView | null>(null);
   const [pendingClose, setPendingClose] = useState<{ tabId: string; work: ActiveWorkView; stopping: boolean } | null>(null);
   const [worktreeMergeTabId, setWorktreeMergeTabId] = useState<string | null>(null);
@@ -1288,9 +1290,9 @@ export default function App() {
     document.documentElement.setAttribute("data-platform", desktopPlatform);
   }, [desktopPlatform]);
 
-  const refreshBackgroundRuntimes = useCallback(async () => {
+  const refreshBackgroundRuntimes = useCallback(async (afterMutation = false) => {
     try {
-      setBackgroundRuntimes(await app.BackgroundRuntimes());
+      await backgroundRuntimeRefreshRef.current?.refresh(afterMutation ? { afterMutation: true } : undefined);
     } catch {
       // The global recovery entry is supplementary; the active-tab job list
       // remains available even when the detached-runtime list is unavailable.
@@ -1298,16 +1300,17 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    let disposed = false;
-    const refresh = async () => {
-      if (disposed) return;
-      await refreshBackgroundRuntimes();
-    };
-    void refresh();
-    const timer = window.setInterval(() => void refresh(), 1000);
+    const coordinator = createBackgroundRuntimeRefreshCoordinator(
+      () => app.BackgroundRuntimes(),
+      (runtimes) => setBackgroundRuntimes((current) => (
+        sameBackgroundRuntimeLists(current, runtimes) ? current : runtimes
+      )),
+    );
+    backgroundRuntimeRefreshRef.current = coordinator;
+    void refreshBackgroundRuntimes();
     return () => {
-      disposed = true;
-      window.clearInterval(timer);
+      coordinator.dispose();
+      if (backgroundRuntimeRefreshRef.current === coordinator) backgroundRuntimeRefreshRef.current = null;
     };
   }, [refreshBackgroundRuntimes]);
 
@@ -1961,7 +1964,7 @@ export default function App() {
   const cancelRuntimeJob = useCallback(async (tabId: string, jobId: string): Promise<boolean> => {
     try {
       const cancelled = await app.CancelJobForTab(tabId, jobId);
-      await refreshBackgroundRuntimes();
+      await refreshBackgroundRuntimes(true);
       return cancelled;
     } catch (err) {
       showToast(err instanceof Error ? err.message : String(err), "error");
@@ -2444,6 +2447,7 @@ export default function App() {
     const unsub = onEvent((e) => {
       if (shouldRefreshTabMetaForEvent(e.kind)) {
         void refreshTabMetas(undefined, { afterMutation: true });
+        void refreshBackgroundRuntimes(true);
       }
       if (e.kind !== "turn_done") return;
       const turnTabId = resolvePlanRestoreTabId(e.tabId, activeTabIdRef.current);
@@ -2473,7 +2477,7 @@ export default function App() {
       }, 250);
     });
     return unsub;
-  }, [refreshTabMetas, setControllerCollaborationMode]);
+  }, [refreshBackgroundRuntimes, refreshTabMetas, setControllerCollaborationMode]);
 
   const blankSessionTarget = useCallback(() => {
     const activeWorkspaceRoot = activeTab?.scope === "project" ? activeTab.workspaceRoot || "" : "";
@@ -3251,7 +3255,7 @@ export default function App() {
       return remaining.map((tab) => ({ ...tab, active: tab.id === nextActiveId }));
     });
     await refreshTabMetas(undefined, { afterMutation: true });
-    await refreshBackgroundRuntimes();
+    await refreshBackgroundRuntimes(true);
     setTabRevealSignal((signal) => signal + 1);
     return true;
   }, [activeTabId, closeTab, closeTransientOverlays, refreshBackgroundRuntimes, refreshTabMetas, showToast, t]);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1320,16 +1320,21 @@ export default function App() {
       return;
     }
     let disposed = false;
+    let inFlight = false;
     const inspect = async () => {
+      if (disposed || inFlight) return;
+      inFlight = true;
       try {
         const conflict = await app.WorkspaceConflictForTab(activeTabId);
         if (!disposed) setWorkspaceConflict(conflict.state === "none" ? null : conflict);
       } catch {
         if (!disposed) setWorkspaceConflict(null);
+      } finally {
+        inFlight = false;
       }
     };
     void inspect();
-    const timer = window.setInterval(() => void inspect(), 500);
+    const timer = window.setInterval(() => void inspect(), 1_500);
     return () => {
       disposed = true;
       window.clearInterval(timer);

--- a/desktop/frontend/src/__tests__/background-runtime-refresh.test.ts
+++ b/desktop/frontend/src/__tests__/background-runtime-refresh.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import {
+  BACKGROUND_RUNTIME_ACTIVE_REFRESH_MS,
+  createBackgroundRuntimeRefreshCoordinator,
+  sameBackgroundRuntimeLists,
+} from "../lib/backgroundRuntimeRefresh";
+import type { BackgroundRuntimeView } from "../lib/types";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+const flushPromises = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+const runtime = (overrides: Partial<BackgroundRuntimeView> = {}): BackgroundRuntimeView => ({
+  tabId: "tab-1",
+  title: "Run",
+  detached: false,
+  running: true,
+  pendingPrompt: false,
+  jobs: [],
+  ...overrides,
+});
+
+assert.equal(BACKGROUND_RUNTIME_ACTIVE_REFRESH_MS, 5_000);
+assert.equal(sameBackgroundRuntimeLists([runtime()], [runtime()]), true);
+assert.equal(sameBackgroundRuntimeLists([runtime()], [runtime({ running: false })]), false);
+
+{
+  let loads = 0;
+  const scheduled: Array<() => void> = [];
+  const coordinator = createBackgroundRuntimeRefreshCoordinator(
+    async () => { loads += 1; return []; },
+    () => undefined,
+    (callback) => { scheduled.push(callback); return scheduled.length; },
+    () => undefined,
+  );
+  await coordinator.refresh();
+  assert.equal(loads, 1);
+  assert.equal(scheduled.length, 0, "an idle runtime list must not keep polling");
+}
+
+{
+  let loads = 0;
+  const scheduled: Array<() => void> = [];
+  const coordinator = createBackgroundRuntimeRefreshCoordinator(
+    async () => { loads += 1; return loads === 1 ? [runtime()] : []; },
+    () => undefined,
+    (callback) => { scheduled.push(callback); return scheduled.length; },
+    () => undefined,
+  );
+  await coordinator.refresh();
+  assert.equal(scheduled.length, 1, "active work schedules a bounded fallback refresh");
+  scheduled[0]();
+  await flushPromises();
+  assert.equal(loads, 2);
+}
+
+{
+  const first = deferred<BackgroundRuntimeView[]>();
+  let loads = 0;
+  const coordinator = createBackgroundRuntimeRefreshCoordinator(
+    () => { loads += 1; return loads === 1 ? first.promise : Promise.resolve([]); },
+    () => undefined,
+    () => 1,
+    () => undefined,
+  );
+  const initial = coordinator.refresh();
+  const joined = coordinator.refresh();
+  await Promise.resolve();
+  assert.equal(loads, 1, "concurrent observations share one bridge request");
+  first.resolve([runtime()]);
+  await Promise.all([initial, joined]);
+}
+
+{
+  const first = deferred<BackgroundRuntimeView[]>();
+  let loads = 0;
+  const coordinator = createBackgroundRuntimeRefreshCoordinator(
+    () => { loads += 1; return loads === 1 ? first.promise : Promise.resolve([]); },
+    () => undefined,
+    () => 1,
+    () => undefined,
+  );
+  const initial = coordinator.refresh();
+  void coordinator.refresh({ afterMutation: true });
+  await Promise.resolve();
+  assert.equal(loads, 1);
+  first.resolve([runtime()]);
+  await initial;
+  await flushPromises();
+  assert.equal(loads, 2, "a mutation queues one authoritative trailing refresh");
+}
+
+console.log("background runtime refresh tests passed");

--- a/desktop/frontend/src/__tests__/background-runtime-refresh.test.ts
+++ b/desktop/frontend/src/__tests__/background-runtime-refresh.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   BACKGROUND_RUNTIME_ACTIVE_REFRESH_MS,
+  BACKGROUND_RUNTIME_ERROR_RETRY_BASE_MS,
   createBackgroundRuntimeRefreshCoordinator,
   sameBackgroundRuntimeLists,
 } from "../lib/backgroundRuntimeRefresh";
@@ -25,6 +26,7 @@ const runtime = (overrides: Partial<BackgroundRuntimeView> = {}): BackgroundRunt
 });
 
 assert.equal(BACKGROUND_RUNTIME_ACTIVE_REFRESH_MS, 5_000);
+assert.equal(BACKGROUND_RUNTIME_ERROR_RETRY_BASE_MS, 5_000);
 assert.equal(sameBackgroundRuntimeLists([runtime()], [runtime()]), true);
 assert.equal(sameBackgroundRuntimeLists([runtime()], [runtime({ running: false })]), false);
 
@@ -95,22 +97,41 @@ assert.equal(sameBackgroundRuntimeLists([runtime()], [runtime({ running: false }
 }
 
 {
-  const pending = deferred<BackgroundRuntimeView[]>();
-  let applied = 0;
-  let scheduled = 0;
+  let calls = 0;
+  const scheduled: Array<{ callback: () => void; delayMs: number }> = [];
   const coordinator = createBackgroundRuntimeRefreshCoordinator(
-    () => pending.promise,
-    () => { applied += 1; },
-    () => { scheduled += 1; return scheduled; },
+    async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("temporary bridge failure");
+      return [];
+    },
+    () => undefined,
+    (callback, delayMs) => { scheduled.push({ callback, delayMs }); return scheduled.length; },
     () => undefined,
   );
-  const request = coordinator.refresh();
-  coordinator.dispose();
+  await assert.rejects(coordinator.refresh());
+  assert.equal(scheduled.length, 1, "a failed active refresh must schedule a retry");
+  assert.equal(scheduled[0].delayMs, BACKGROUND_RUNTIME_ERROR_RETRY_BASE_MS);
+  scheduled[0].callback();
+  await flushPromises();
+  assert.equal(calls, 2);
+
+  const pending = deferred<BackgroundRuntimeView[]>();
+  let applied = 0;
+  let disposedSchedules = 0;
+  const disposedCoordinator = createBackgroundRuntimeRefreshCoordinator(
+    () => pending.promise,
+    () => { applied += 1; },
+    () => { disposedSchedules += 1; return disposedSchedules; },
+    () => undefined,
+  );
+  const request = disposedCoordinator.refresh();
+  disposedCoordinator.dispose();
   pending.resolve([runtime()]);
   await request;
   await flushPromises();
   assert.equal(applied, 0, "disposed coordinators must ignore late bridge results");
-  assert.equal(scheduled, 0, "disposed coordinators must not schedule fallback polling");
+  assert.equal(disposedSchedules, 0, "disposed coordinators must not schedule fallback polling");
 }
 
 console.log("background runtime refresh tests passed");

--- a/desktop/frontend/src/__tests__/background-runtime-refresh.test.ts
+++ b/desktop/frontend/src/__tests__/background-runtime-refresh.test.ts
@@ -28,6 +28,13 @@ const runtime = (overrides: Partial<BackgroundRuntimeView> = {}): BackgroundRunt
 assert.equal(BACKGROUND_RUNTIME_ACTIVE_REFRESH_MS, 5_000);
 assert.equal(BACKGROUND_RUNTIME_ERROR_RETRY_BASE_MS, 5_000);
 assert.equal(sameBackgroundRuntimeLists([runtime()], [runtime()]), true);
+assert.equal(
+  sameBackgroundRuntimeLists(
+    [runtime({ tabId: "tab-a" }), runtime({ tabId: "tab-b" })],
+    [runtime({ tabId: "tab-b" }), runtime({ tabId: "tab-a" })],
+  ),
+  true,
+);
 assert.equal(sameBackgroundRuntimeLists([runtime()], [runtime({ running: false })]), false);
 
 {

--- a/desktop/frontend/src/__tests__/background-runtime-refresh.test.ts
+++ b/desktop/frontend/src/__tests__/background-runtime-refresh.test.ts
@@ -94,4 +94,23 @@ assert.equal(sameBackgroundRuntimeLists([runtime()], [runtime({ running: false }
   assert.equal(loads, 2, "a mutation queues one authoritative trailing refresh");
 }
 
+{
+  const pending = deferred<BackgroundRuntimeView[]>();
+  let applied = 0;
+  let scheduled = 0;
+  const coordinator = createBackgroundRuntimeRefreshCoordinator(
+    () => pending.promise,
+    () => { applied += 1; },
+    () => { scheduled += 1; return scheduled; },
+    () => undefined,
+  );
+  const request = coordinator.refresh();
+  coordinator.dispose();
+  pending.resolve([runtime()]);
+  await request;
+  await flushPromises();
+  assert.equal(applied, 0, "disposed coordinators must ignore late bridge results");
+  assert.equal(scheduled, 0, "disposed coordinators must not schedule fallback polling");
+}
+
 console.log("background runtime refresh tests passed");

--- a/desktop/frontend/src/lib/backgroundRuntimeRefresh.ts
+++ b/desktop/frontend/src/lib/backgroundRuntimeRefresh.ts
@@ -1,6 +1,8 @@
 import type { BackgroundRuntimeView } from "./types";
 
 export const BACKGROUND_RUNTIME_ACTIVE_REFRESH_MS = 5_000;
+export const BACKGROUND_RUNTIME_ERROR_RETRY_BASE_MS = 5_000;
+export const BACKGROUND_RUNTIME_ERROR_RETRY_MAX_MS = 60_000;
 
 export function sameBackgroundRuntimeLists(
   current: readonly BackgroundRuntimeView[],
@@ -26,6 +28,7 @@ export function createBackgroundRuntimeRefreshCoordinator(
   let inFlight: Promise<BackgroundRuntimeView[]> | null = null;
   let trailing = false;
   let timer: number | null = null;
+  let failureStreak = 0;
 
   const clearTimer = () => {
     if (timer === null) return;
@@ -33,25 +36,30 @@ export function createBackgroundRuntimeRefreshCoordinator(
     timer = null;
   };
 
-  const scheduleNext = (active: boolean) => {
+  const scheduleNext = (active: boolean, retry = false) => {
     clearTimer();
-    if (disposed || !active) return;
+    if (disposed || (!active && !retry)) return;
+    const delay = retry
+      ? Math.min(BACKGROUND_RUNTIME_ERROR_RETRY_MAX_MS, BACKGROUND_RUNTIME_ERROR_RETRY_BASE_MS * 2 ** Math.min(failureStreak - 1, 3))
+      : BACKGROUND_RUNTIME_ACTIVE_REFRESH_MS;
     timer = schedule(() => {
       timer = null;
-      void refresh();
-    }, BACKGROUND_RUNTIME_ACTIVE_REFRESH_MS);
+      void refresh().catch(() => undefined);
+    }, delay);
   };
 
   const start = (): Promise<BackgroundRuntimeView[]> => {
     const request = Promise.resolve().then(load);
     const settled = request.then(
       (runtimes) => {
+        failureStreak = 0;
         if (!disposed) apply(runtimes);
         scheduleNext(runtimes.length > 0);
         return runtimes;
       },
       (reason) => {
-        scheduleNext(false);
+        failureStreak += 1;
+        scheduleNext(false, true);
         throw reason;
       },
     ).finally(() => {
@@ -59,7 +67,7 @@ export function createBackgroundRuntimeRefreshCoordinator(
       if (!disposed && trailing) {
         trailing = false;
         clearTimer();
-        void start();
+        void start().catch(() => undefined);
       }
     });
     inFlight = settled;

--- a/desktop/frontend/src/lib/backgroundRuntimeRefresh.ts
+++ b/desktop/frontend/src/lib/backgroundRuntimeRefresh.ts
@@ -10,8 +10,12 @@ export function sameBackgroundRuntimeLists(
 ): boolean {
   if (current === next) return true;
   if (current.length !== next.length) return false;
-  for (let index = 0; index < current.length; index += 1) {
-    if (JSON.stringify(current[index]) !== JSON.stringify(next[index])) return false;
+  const sortByTabId = (left: BackgroundRuntimeView, right: BackgroundRuntimeView) =>
+    left.tabId.localeCompare(right.tabId);
+  const currentByTab = [...current].sort(sortByTabId);
+  const nextByTab = [...next].sort(sortByTabId);
+  for (let index = 0; index < currentByTab.length; index += 1) {
+    if (JSON.stringify(currentByTab[index]) !== JSON.stringify(nextByTab[index])) return false;
   }
   return true;
 }

--- a/desktop/frontend/src/lib/backgroundRuntimeRefresh.ts
+++ b/desktop/frontend/src/lib/backgroundRuntimeRefresh.ts
@@ -1,0 +1,87 @@
+import type { BackgroundRuntimeView } from "./types";
+
+export const BACKGROUND_RUNTIME_ACTIVE_REFRESH_MS = 5_000;
+
+export function sameBackgroundRuntimeLists(
+  current: readonly BackgroundRuntimeView[],
+  next: readonly BackgroundRuntimeView[],
+): boolean {
+  if (current === next) return true;
+  if (current.length !== next.length) return false;
+  for (let index = 0; index < current.length; index += 1) {
+    if (JSON.stringify(current[index]) !== JSON.stringify(next[index])) return false;
+  }
+  return true;
+}
+
+type RefreshOptions = { afterMutation?: boolean };
+
+export function createBackgroundRuntimeRefreshCoordinator(
+  load: () => Promise<BackgroundRuntimeView[]>,
+  apply: (runtimes: BackgroundRuntimeView[]) => void,
+  schedule: (callback: () => void, delayMs: number) => number = window.setTimeout,
+  clear: (timer: number) => void = window.clearTimeout,
+) {
+  let disposed = false;
+  let inFlight: Promise<BackgroundRuntimeView[]> | null = null;
+  let trailing = false;
+  let timer: number | null = null;
+
+  const clearTimer = () => {
+    if (timer === null) return;
+    clear(timer);
+    timer = null;
+  };
+
+  const scheduleNext = (active: boolean) => {
+    clearTimer();
+    if (disposed || !active) return;
+    timer = schedule(() => {
+      timer = null;
+      void refresh();
+    }, BACKGROUND_RUNTIME_ACTIVE_REFRESH_MS);
+  };
+
+  const start = (): Promise<BackgroundRuntimeView[]> => {
+    const request = Promise.resolve().then(load);
+    const settled = request.then(
+      (runtimes) => {
+        if (!disposed) apply(runtimes);
+        scheduleNext(runtimes.length > 0);
+        return runtimes;
+      },
+      (reason) => {
+        scheduleNext(false);
+        throw reason;
+      },
+    ).finally(() => {
+      if (inFlight === settled) inFlight = null;
+      if (!disposed && trailing) {
+        trailing = false;
+        clearTimer();
+        void start();
+      }
+    });
+    inFlight = settled;
+    return settled;
+  };
+
+  const refresh = (options?: RefreshOptions): Promise<BackgroundRuntimeView[]> => {
+    if (disposed) return Promise.resolve([]);
+    clearTimer();
+    if (inFlight) {
+      if (options?.afterMutation) trailing = true;
+      return inFlight;
+    }
+    return start();
+  };
+
+  return {
+    refresh,
+    dispose() {
+      disposed = true;
+      trailing = false;
+      clearTimer();
+    },
+  };
+}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1763,9 +1763,16 @@ func (s *tabEventSink) Emit(e event.Event) {
 	if app != nil {
 		s.recordDisplay(e)
 	}
-	// Persist after each turn so a force-kill loses at most the in-flight prompt.
-	if e.Kind == event.TurnDone && app != nil {
-		app.scheduleTabSnapshot(tabID)
+	// Checkpoint durable transcript transitions while a turn is in flight. Stream
+	// deltas intentionally stay out of this path so a long answer does not cause
+	// one disk write per token; TurnDone remains the final forced flush.
+	if app != nil {
+		switch e.Kind {
+		case event.TurnStarted, event.Message, event.ToolResult, event.ApprovalRequest, event.AskRequest, event.CompactionDone:
+			app.scheduleTabSnapshot(tabID)
+		case event.TurnDone:
+			app.scheduleTabSnapshot(tabID)
+		}
 	}
 	// Forward event to bot channels when a bot forwarder is attached.
 	// Read the sink under the read lock so SetBotSink can safely swap it

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -47,6 +47,7 @@ type tabDisplayState struct {
 	executor       displayTurnBuffer
 	pendingWrites  []*pendingDisplayWrite
 	persistRunning bool
+	persistCond    *sync.Cond
 }
 
 const displayPersistRetryLimit = 4
@@ -1573,6 +1574,9 @@ func enqueuePendingDisplayWrite(state *tabDisplayState, write *pendingDisplayWri
 		return
 	}
 	state.mu.Lock()
+	if state.persistCond == nil {
+		state.persistCond = sync.NewCond(&state.mu)
+	}
 	state.pendingWrites = append(state.pendingWrites, write)
 	if state.persistRunning {
 		state.mu.Unlock()
@@ -1608,12 +1612,29 @@ func persistOrEnqueueDisplayWrite(state *tabDisplayState, write *pendingDisplayW
 	return true
 }
 
+func waitForPendingDisplayWrites(state *tabDisplayState) {
+	if state == nil {
+		return
+	}
+	state.mu.Lock()
+	if state.persistCond == nil {
+		state.persistCond = sync.NewCond(&state.mu)
+	}
+	for state.persistRunning {
+		state.persistCond.Wait()
+	}
+	state.mu.Unlock()
+}
+
 func retryPendingDisplayWrites(state *tabDisplayState) {
 	failures := 0
 	for {
 		state.mu.Lock()
 		if len(state.pendingWrites) == 0 {
 			state.persistRunning = false
+			if state.persistCond != nil {
+				state.persistCond.Broadcast()
+			}
 			state.mu.Unlock()
 			return
 		}
@@ -1633,6 +1654,9 @@ func retryPendingDisplayWrites(state *tabDisplayState) {
 			}
 			state.mu.Lock()
 			state.persistRunning = false
+			if state.persistCond != nil {
+				state.persistCond.Broadcast()
+			}
 			state.mu.Unlock()
 			slog.Warn("desktop: display-only turn history remains pending after retries", "err", err)
 			return
@@ -1772,6 +1796,18 @@ func (s *tabEventSink) Emit(e event.Event) {
 			app.scheduleTabSnapshot(tabID)
 		case event.TurnDone:
 			app.scheduleTabSnapshot(tabID)
+			// Persistence barrier for turn completion: wait until the final
+			// session snapshot (and any queued saveAgain pass) is written, and
+			// until the flushed display-only text finishes its current persist
+			// attempt including bounded retries. Without this, an immediate
+			// process exit after TurnDone could lose the last turn.
+			app.mu.RLock()
+			tab := app.tabByEventSinkIDLocked(tabID)
+			app.mu.RUnlock()
+			app.waitForTabSnapshot(tab)
+			if tab != nil {
+				waitForPendingDisplayWrites(tab.displayBufferState())
+			}
 		}
 	}
 	// Forward event to bot channels when a bot forwarder is attached.
@@ -4660,6 +4696,29 @@ func (a *App) scheduleTabSnapshot(tabID string) {
 	go a.tabSnapshotLoop(tab)
 }
 
+// waitForTabSnapshot blocks until the tab's autosave loop is idle: the current
+// write has finished and no queued saveAgain work remains. TurnDone uses this to
+// give the caller a persistence barrier — a process exit immediately after the
+// turn completes can no longer lose the final transcript. Deferred snapshots
+// queued by later events after the wait returns are not included by design.
+func (a *App) waitForTabSnapshot(tab *WorkspaceTab) {
+	if a == nil || tab == nil {
+		return
+	}
+	tab.saveMu.Lock()
+	if tab.saveCond == nil && !tab.saving {
+		tab.saveMu.Unlock()
+		return
+	}
+	if tab.saveCond == nil {
+		tab.saveCond = sync.NewCond(&tab.saveMu)
+	}
+	for tab.saving || tab.saveAgain {
+		tab.saveCond.Wait()
+	}
+	tab.saveMu.Unlock()
+}
+
 // quiesceTabAutosave marks the tab as closing and blocks until any in-flight
 // tabSnapshotLoop has finished its current (and final) write. After it returns,
 // no background goroutine can call Snapshot on this tab's controller again, so
@@ -4726,6 +4785,9 @@ func (a *App) tabSnapshotLoop(tab *WorkspaceTab) {
 		}
 		if tab.saveAgain {
 			tab.saveAgain = false
+			// Waiting waiters care about the queued write too; the loop will
+			// broadcast again when that pass completes.
+			tab.saveCond.Broadcast()
 			tab.saveMu.Unlock()
 			if snapshotErr != nil {
 				slog.Warn("desktop: session autosave failed; newer snapshot queued", "tab", tab.ID, "err", snapshotErr)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1768,7 +1768,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 	// one disk write per token; TurnDone remains the final forced flush.
 	if app != nil {
 		switch e.Kind {
-		case event.TurnStarted, event.Message, event.ToolResult, event.ApprovalRequest, event.AskRequest, event.CompactionDone:
+		case event.ToolResult, event.ApprovalRequest, event.AskRequest, event.CompactionDone, event.TurnPhase:
 			app.scheduleTabSnapshot(tabID)
 		case event.TurnDone:
 			app.scheduleTabSnapshot(tabID)

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -136,8 +136,7 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string, pinned pinnedRev
 	providerInput = withInterruptedRecovery(providerInput, a.pendingInterruptedRecovery())
 	a.task.prepareScope(scoped, scope.ID)
 	a.svc.sink.Emit(event.Event{Kind: event.TurnStarted})
-		a.emitTurnPhase(event.TurnPhaseWorking)
-		input = a.prepareProviderTurn(ctx, providerInput)
+	input = a.prepareProviderTurn(ctx, providerInput)
 
 	userCreatedAt := time.Now().UnixMilli()
 	a.activeTurnCreatedAt.Store(userCreatedAt)
@@ -149,11 +148,10 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string, pinned pinnedRev
 		Role: provider.RoleUser, Origin: inputMessageOrigin(ctx), Content: input, RawContent: rawContent,
 		Images: userImages(ctx), VisionSummary: VisionSummaryFromContext(ctx), CreatedAt: userCreatedAt,
 	}
-		a.appendPinnedRevisionAndUser(ctx, pinned, userMessage)
-		// TurnPhaseWorking is emitted after the user message is in the session, so
-		// desktop hosts can checkpoint the transcript without racing the append.
-		a.emitTurnPhase(event.TurnPhaseWorking)
-
+	a.appendPinnedRevisionAndUser(ctx, pinned, userMessage)
+	// TurnPhaseWorking is emitted after the user message is in the session, so
+	// desktop hosts can checkpoint the transcript without racing the append.
+	a.emitTurnPhase(event.TurnPhaseWorking)
 
 	// The loop fields join the classification computed above rather than
 	// opening a second object: one turn, one turnRuntime. The zero values the

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -136,8 +136,9 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string, pinned pinnedRev
 	providerInput = withInterruptedRecovery(providerInput, a.pendingInterruptedRecovery())
 	a.task.prepareScope(scoped, scope.ID)
 	a.svc.sink.Emit(event.Event{Kind: event.TurnStarted})
-	a.emitTurnPhase(event.TurnPhaseWorking)
-	input = a.prepareProviderTurn(ctx, providerInput)
+		a.emitTurnPhase(event.TurnPhaseWorking)
+		input = a.prepareProviderTurn(ctx, providerInput)
+
 	userCreatedAt := time.Now().UnixMilli()
 	a.activeTurnCreatedAt.Store(userCreatedAt)
 	rawContent := rawInput
@@ -148,7 +149,11 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string, pinned pinnedRev
 		Role: provider.RoleUser, Origin: inputMessageOrigin(ctx), Content: input, RawContent: rawContent,
 		Images: userImages(ctx), VisionSummary: VisionSummaryFromContext(ctx), CreatedAt: userCreatedAt,
 	}
-	a.appendPinnedRevisionAndUser(ctx, pinned, userMessage)
+		a.appendPinnedRevisionAndUser(ctx, pinned, userMessage)
+		// TurnPhaseWorking is emitted after the user message is in the session, so
+		// desktop hosts can checkpoint the transcript without racing the append.
+		a.emitTurnPhase(event.TurnPhaseWorking)
+
 
 	// The loop fields join the classification computed above rather than
 	// opening a second object: one turn, one turnRuntime. The zero values the

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -162,10 +162,9 @@ func (o *turnOrchestrator) runSubagentSkillTurns(ctx context.Context, skills []s
 	if c.executor == nil {
 		return fmt.Errorf("subagent slash invocation requires an active session")
 	}
-		c.executor.AppendTurnContextAndUser(ctx, persistedUserTurn(input, firstNonEmpty(raw, task), images, time.Now().UnixMilli()))
-		// Hosts checkpoint only after the user message is present in the session.
-		c.sink.Emit(event.Event{Kind: event.TurnPhase, PhaseName: event.TurnPhaseWorking})
-
+	c.executor.AppendTurnContextAndUser(ctx, persistedUserTurn(input, firstNonEmpty(raw, task), images, time.Now().UnixMilli()))
+	// Hosts checkpoint only after the user message is present in the session.
+	c.sink.Emit(event.Event{Kind: event.TurnPhase, PhaseName: event.TurnPhaseWorking})
 
 	for _, sk := range skills {
 		sk = c.skills.prepare(sk)

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -162,7 +162,10 @@ func (o *turnOrchestrator) runSubagentSkillTurns(ctx context.Context, skills []s
 	if c.executor == nil {
 		return fmt.Errorf("subagent slash invocation requires an active session")
 	}
-	c.executor.AppendTurnContextAndUser(ctx, persistedUserTurn(input, firstNonEmpty(raw, task), images, time.Now().UnixMilli()))
+		c.executor.AppendTurnContextAndUser(ctx, persistedUserTurn(input, firstNonEmpty(raw, task), images, time.Now().UnixMilli()))
+		// Hosts checkpoint only after the user message is present in the session.
+		c.sink.Emit(event.Event{Kind: event.TurnPhase, PhaseName: event.TurnPhaseWorking})
+
 
 	for _, sk := range skills {
 		sk = c.skills.prepare(sk)


### PR DESCRIPTION
## Summary

Improve two desktop reliability paths:

- Closes #9719: checkpoint durable transcript state after the user message is actually appended, instead of using `TurnStarted` as an unsafe proxy, and make `TurnDone` a real persistence barrier.
- Refs #9539: reduce redundant `BackgroundRuntimes` bridge polling and prevent overlapping requests. The session-catalog repair-loop CPU root cause is handled separately by merged PR #9697; this PR does not claim to fix that loop itself.

## Changes

- Keep `TurnStarted` as a lifecycle signal, then emit `turn_phase=working` only after the user message is in the session; desktop autosave checkpoints that post-append boundary.
- Keep streaming deltas out of autosave while checkpointing tool results, prompts, compaction completion, committed user-turn state, and `TurnDone`.
- **TurnDone persistence barrier**: `Emit(TurnDone)` now waits until (a) the autosave loop drains its current write plus any queued `saveAgain` pass (`waitForTabSnapshot`), and (b) the flushed display-only text finishes its current persist attempt including bounded retries (`waitForPendingDisplayWrites`). A process exit immediately after a completed turn can no longer lose the final transcript. Mid-turn checkpoint events stay asynchronous — no per-token disk writes.
- Add a single-flight background runtime refresh coordinator.
- Stop fallback polling when no background runtime is active; use a 5-second fallback while work remains.
- Retry transient bridge failures with bounded exponential backoff and handle internal Promise rejections.
- **Order-insensitive runtime comparison**: the backend builds `BackgroundRuntimes` from Go maps whose iteration order is unstable, so `sameBackgroundRuntimeLists` now compares by `tabId` instead of by array position; identical runtimes no longer trigger redundant React state updates.
- Prevent overlapping `WorkspaceConflictForTab` requests and lower its fallback cadence to 1.5 seconds.
- Ignore late results after coordinator disposal and avoid redundant React state updates.
- Add regression tests: session content is readable from disk immediately after `Emit(TurnDone)` returns (`TestTurnDoneWaitBlocksUntilSnapshotWritten`), and reordered identical runtime lists compare equal.

## Verification

- `go test ./internal/agent ./internal/control -count=1` passed (after rebase onto `upstream/main-v2@c01ec347b`).
- Focused desktop autosave tests passed, including the new persistence-barrier regression test, `TestScheduleSnapshotCoalesces`, `TestCloseTabNoResurrectionFromAutosave`, and the cannot-persist guard tests.
- `background-runtime-refresh.test.ts` passed (including the new order-insensitivity assertion).
- `tsc --noEmit` passed after regenerating the local (gitignored) Wails bindings for this branch — earlier failures came from stale generated bindings left behind by the #9659 work, not from PR code.
- ESLint passed for changed frontend files. `git diff --check` passed.

Documentation-impact: none - this change affects internal desktop polling and persistence behavior; existing user-facing documentation does not describe these implementation details.

Cache-impact: none - no provider prompt, tool schema, or cache-prefix behavior changes.

Cache-guard: `go test ./internal/agent ./internal/control -count=1`, the focused desktop autosave tests (including the new `TestTurnDoneWaitBlocksUntilSnapshotWritten` barrier regression), and `background-runtime-refresh.test.ts` cover checkpoint ordering, the TurnDone persistence barrier, order-insensitive runtime comparison, refresh coalescing, retry behavior, and disposal.

System-prompt-review: no system-prompt or agent-instruction templates are touched; all changes are desktop event-sink persistence, autosave scheduling, and frontend refresh coordination.
