### PR TITLE
test: stabilize Windows release gates / 稳定 Windows 发布门禁

### DIFF
--- a/.github/workflows/e2e-bot.yml
+++ b/.github/workflows/e2e-bot.yml
@@ -164,7 +164,9 @@ jobs:
           else
             # The current five-task baseline can exceed 400k after only three
             # successful tasks. Keep bounded headroom so every scenario is graded.
-            "$RUNNER_TEMP/e2ebench" -bin "${{ steps.agent.outputs.bin }}" -suite "$RUNNER_TEMP/suite" -model e2e -out report.md -json report.json -budget 800000
+            "$RUNNER_TEMP/e2ebench" -bin "${{ steps.agent.outputs.bin }}" -suite "$RUNNER_TEMP/suite" \
+              -task "compaction,fix-add-bug,fizzbuzz,palindrome,subagent-delegation" \
+              -model e2e -out report.md -json report.json -budget 800000
             node -e '
               const results = require("./report.json");
               const unsuccessful = results.filter((result) => !result.Passed || result.Skipped);

--- a/internal/agent/session_listing_repair_lock_test.go
+++ b/internal/agent/session_listing_repair_lock_test.go
@@ -19,13 +19,18 @@ func TestRepairSessionListingProjectionDoesNotWaitForMetaLock(t *testing.T) {
 	}
 	defer unlockMeta()
 
-	started := time.Now()
-	_, err = RepairSessionListingProjection(context.Background(), path)
+	repairResult := make(chan error, 1)
+	go func() {
+		_, repairErr := RepairSessionListingProjection(context.Background(), path)
+		repairResult <- repairErr
+	}()
+	select {
+	case err = <-repairResult:
+	case <-time.After(5 * time.Second):
+		t.Fatal("meta-busy repair did not yield to the foreground owner")
+	}
 	if !errors.Is(err, ErrSessionListingRepairBusy) {
 		t.Fatalf("repair err = %v, want busy", err)
-	}
-	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
-		t.Fatalf("meta-busy repair waited %v", elapsed)
 	}
 
 	unlockSave, ok := tryLockSessionSavePath(path)

--- a/internal/serve/serve_lease_test.go
+++ b/internal/serve/serve_lease_test.go
@@ -177,6 +177,8 @@ func waitServeLeaseResult(t *testing.T, ch <-chan error, what string, timeout ti
 	}
 }
 
+const concurrentServeLeaseTimeout = 60 * time.Second
+
 // TestConcurrentResumesKeepControllerAndLeaseAligned hammers POST /resume from
 // two goroutines bouncing between different targets and asserts the invariant
 // this PR exists for: whatever session the controller ends up writing is the
@@ -239,7 +241,7 @@ func TestConcurrentResumesKeepControllerAndLeaseAligned(t *testing.T) {
 		close(done)
 		close(errs)
 	}()
-	waitServeLeaseDone(t, done, "concurrent resume posts", 20*time.Second)
+	waitServeLeaseDone(t, done, "concurrent resume posts", concurrentServeLeaseTimeout)
 	for err := range errs {
 		if err != nil {
 			t.Fatal(err)
@@ -311,7 +313,7 @@ func TestConcurrentResumeAndForkKeepAlignment(t *testing.T) {
 		close(done)
 		close(errs)
 	}()
-	waitServeLeaseDone(t, done, "concurrent resume/fork posts", 20*time.Second)
+	waitServeLeaseDone(t, done, "concurrent resume/fork posts", concurrentServeLeaseTimeout)
 	for err := range errs {
 		if err != nil {
 			t.Fatal(err)

--- a/internal/worktree/merge_test.go
+++ b/internal/worktree/merge_test.go
@@ -223,7 +223,10 @@ func TestMergeBackReportsRecoveryRequiredWhenPreparedSourceDrifts(t *testing.T) 
 	inspection := inspectMergeTest(t, created.WorkspaceRoot, managed)
 	mergeStepHook = func(step string) {
 		if step == "after_merge_prepare" {
-			gitTest(t, repo, "merge", "--abort")
+			// Preserve the prepared index and worktree while clearing merge
+			// metadata so switching branches deterministically simulates source
+			// identity drift on every supported Git platform.
+			gitTest(t, repo, "merge", "--quit")
 			gitTest(t, repo, "switch", "-c", "prepared-drift")
 		}
 	}

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -1596,6 +1596,7 @@ e2e_workflow="$repo_root/.github/workflows/e2e-bot.yml"
 grep -Fq 'REASONIX_HOME: ${{ runner.temp }}/reasonix-e2e-home' "$e2e_workflow"
 grep -Fq 'cp /tmp/reasonix-e2e.toml "$REASONIX_HOME/config.toml"' "$e2e_workflow"
 grep -Fq "printf 'DEEPSEEK_API_KEY=%s\\n' \"\$DEEPSEEK_API_KEY\" > \"\$REASONIX_HOME/.env\"" "$e2e_workflow"
+grep -Fq -- '-task "compaction,fix-add-bug,fizzbuzz,palindrome,subagent-delegation"' "$e2e_workflow"
 grep -Fq 'const unsuccessful = results.filter((result) => !result.Passed || result.Skipped);' "$e2e_workflow"
 grep -Fq "if: always() && hashFiles('report.md') != ''" "$e2e_workflow"
 if grep -A2 -F 'missing DEEPSEEK_API_KEY secret' "$e2e_workflow" | grep -Fq 'exit 0'; then


### PR DESCRIPTION
## Problem

The exact v1.36 candidate failed the Windows full-suite gate twice. The trusted real-provider benchmark also could not complete its documented fixed suite: it traversed all 73 corpus tasks, exhausted the 800k-token cap, marked the remainder skipped, and then rejected every skipped result.

## Root cause

- The prepared-source drift test used `git merge --abort`, which intermittently refuses to reset the prepared index on Windows.
- Two concurrency tests encoded loaded-runner tail latency as 100 ms and 20 s correctness requirements instead of asserting the intended event with a generous outer watchdog.
- The E2E workflow described and budgeted a historical five-task baseline but omitted the harness `-task` filter after the corpus expanded.

## Fix

- Clear merge metadata with `git merge --quit`, preserve the prepared tree, and then change the source branch identity deterministically.
- Assert the meta-lock Busy result through a result channel with a 5-second outer watchdog, retaining the existing foreground-lock release checks.
- Keep the original concurrency load and widen only its suite-level watchdog to 60 seconds.
- Pin the trusted E2E release baseline to the five tasks used when its 800k budget was calibrated, and lock that list in the release workflow contract test.

## Verification

- `go test ./... -count=1`
- `go test -race ./internal/worktree ./internal/agent ./internal/serve -count=1`
- Worktree drift test: 20 consecutive passes
- Meta-lock test: 50 consecutive passes
- Concurrent resume/fork tests: 5 consecutive passes each
- `go test ./cmd/e2ebench -count=5`
- `go vet ./...`
- `bash scripts/release-workflows.test.sh`
- `go run ./tools/repolint`
- `git diff --check`

The failing provider run that exposed the missing filter is [Actions run 33640608076](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/33640608076). The fixed five-task list is the same corpus documented when the budget was calibrated in #7307.

## Compatibility and cache impact

This PR changes tests and trusted CI wiring only. It does not alter product runtime behavior, persisted formats, provider-visible messages, tool schemas, release artifacts, credential handling, or prompt-cache ordering.