### PR TITLE
fix(desktop): guard late transcript range commits / 防止延迟范围提交导致会话回跳

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -325,6 +325,9 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // Session takeover banners and #9703/#9711's provisional-selection handoff
 // combine with Sticky Context's pinned-file state at 2469.125 KiB raw on the
 // merged stable path. Retain only the next one-decimal ceiling.
-const rawInitialBudgetKiB = 2_469.2;
+// The passive reader-anchor lease for delayed WebView2 range commits measures
+// 2469.347 KiB raw (+0.222 KiB, +0.009%). Retain only the next one-decimal
+// ceiling; gzip and largest-chunk budgets remain unchanged.
+const rawInitialBudgetKiB = 2_469.4;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/__tests__/transcript-anchor-compensation-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-anchor-compensation-race.test.tsx
@@ -305,6 +305,43 @@ check(
   "user scroll intent cancels a pending anchor compensation",
 );
 
+// WebView2 may commit a delayed Virtuoso range immediately after the active
+// reader transaction ends. Keep the reader's last logical anchor passive so
+// that commit cannot become a new (already-jumped) resting position.
+await act(async () => arbiter?.reset());
+scrollExtent = 20_000;
+scrollElement.scrollTop = 8_000;
+rowElement.getBoundingClientRect = () => rectAt(20 + (Number.parseFloat(
+  scrollElement.style.getPropertyValue("--transcript-reader-visual-offset"),
+) || 0));
+await act(async () => arbiter?.deliverScroll());
+await act(async () => arbiter?.setMode("manual", "test-passive-reader-anchor"));
+await act(async () => arbiter?.onWheelIntent({
+  ctrlKey: false,
+  deltaX: 0,
+  deltaY: 120,
+  target: scrollElement,
+} as React.WheelEvent<HTMLElement>));
+scrollElement.scrollTop = 8_120;
+await act(async () => arbiter?.deliverScroll());
+clockNow += 1_201;
+for (let frame = 0; frame < 6; frame += 1) await flushFrames();
+check(arbiter?.readerTransactionActive === true, "reader anchor lease remains passive after active transaction end");
+scrollWrites.length = 0;
+// Delayed range replacement parks the native scroller above the user's
+// position while the logical row moves down by the same amount.
+scrollElement.scrollTop = 7_620;
+rowElement.getBoundingClientRect = () => rectAt(520 + (Number.parseFloat(
+  scrollElement.style.getPropertyValue("--transcript-reader-visual-offset"),
+) || 0));
+await act(async () => arbiter?.deliverScroll());
+await flushFrames();
+check(
+  scrollWrites.some((write) => write.owner === "anchor-compensation" && !write.rejectedReason),
+  "late range replacement is corrected against the passive reader anchor",
+);
+check(scrollElement.scrollTop === 8_120, "late range replacement restores the pre-commit reader offset");
+
 await act(async () => root.unmount());
 Date.now = originalDateNow;
 dom.window.setTimeout = originalSetTimeout;

--- a/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
@@ -501,6 +501,45 @@ check(scrollElement.dataset.transcriptReaderIntent === "false",
   "the reader writer transaction ends after the bounded quiet window");
 check(arbiter?.readerTransactionActive === true,
   "manual ownership retains the layout-only mount corridor after the writer transaction ends");
+
+// WebView2 may commit a delayed Virtuoso range immediately after the active
+// reader transaction ends. Keep the reader's last logical anchor passive so
+// that commit cannot become a new (already-jumped) resting position.
+await act(async () => arbiter?.reset());
+scrollExtent = 20_000;
+scrollElement.scrollTop = 8_000;
+rowElement.getBoundingClientRect = () => rectAt(20 + (Number.parseFloat(
+  scrollElement.style.getPropertyValue("--transcript-reader-visual-offset"),
+) || 0));
+await act(async () => arbiter?.deliverScroll());
+await act(async () => arbiter?.setMode("manual", "test-passive-reader-anchor"));
+await act(async () => arbiter?.onWheelIntent({
+  ctrlKey: false,
+  deltaMode: 0,
+  deltaX: 0,
+  deltaY: 120,
+  target: scrollElement,
+} as React.WheelEvent<HTMLElement>));
+scrollElement.scrollTop = 8_120;
+await act(async () => arbiter?.deliverScroll());
+fakeNow += 1_201;
+for (let frame = 0; frame < 6; frame += 1) await flushFrames();
+check(arbiter?.readerTransactionActive === true, "reader anchor lease remains passive after active transaction end");
+scrollWrites.length = 0;
+// Delayed range replacement parks the native scroller above the user's
+// position while the logical row moves down by the same amount.
+scrollElement.scrollTop = 7_620;
+rowElement.getBoundingClientRect = () => rectAt(520 + (Number.parseFloat(
+  scrollElement.style.getPropertyValue("--transcript-reader-visual-offset"),
+) || 0));
+await act(async () => arbiter?.deliverScroll());
+await flushFrames();
+check(
+  scrollWrites.some((write) => write.owner === "anchor-compensation" && !write.rejectedReason),
+  "late range replacement is corrected against the passive reader anchor",
+);
+check(scrollElement.scrollTop === 8_120, "late range replacement restores the pre-commit reader offset");
+
 await act(async () => arbiter?.setMode("selection", "test-manual-layout-lease-release"));
 check(arbiter?.readerTransactionActive === false,
   "an explicit owner releases the idle manual layout lease");

--- a/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
@@ -502,44 +502,6 @@ check(scrollElement.dataset.transcriptReaderIntent === "false",
 check(arbiter?.readerTransactionActive === true,
   "manual ownership retains the layout-only mount corridor after the writer transaction ends");
 
-// WebView2 may commit a delayed Virtuoso range immediately after the active
-// reader transaction ends. Keep the reader's last logical anchor passive so
-// that commit cannot become a new (already-jumped) resting position.
-await act(async () => arbiter?.reset());
-scrollExtent = 20_000;
-scrollElement.scrollTop = 8_000;
-rowElement.getBoundingClientRect = () => rectAt(20 + (Number.parseFloat(
-  scrollElement.style.getPropertyValue("--transcript-reader-visual-offset"),
-) || 0));
-await act(async () => arbiter?.deliverScroll());
-await act(async () => arbiter?.setMode("manual", "test-passive-reader-anchor"));
-await act(async () => arbiter?.onWheelIntent({
-  ctrlKey: false,
-  deltaMode: 0,
-  deltaX: 0,
-  deltaY: 120,
-  target: scrollElement,
-} as React.WheelEvent<HTMLElement>));
-scrollElement.scrollTop = 8_120;
-await act(async () => arbiter?.deliverScroll());
-fakeNow += 1_201;
-for (let frame = 0; frame < 6; frame += 1) await flushFrames();
-check(arbiter?.readerTransactionActive === true, "reader anchor lease remains passive after active transaction end");
-scrollWrites.length = 0;
-// Delayed range replacement parks the native scroller above the user's
-// position while the logical row moves down by the same amount.
-scrollElement.scrollTop = 7_620;
-rowElement.getBoundingClientRect = () => rectAt(520 + (Number.parseFloat(
-  scrollElement.style.getPropertyValue("--transcript-reader-visual-offset"),
-) || 0));
-await act(async () => arbiter?.deliverScroll());
-await flushFrames();
-check(
-  scrollWrites.some((write) => write.owner === "anchor-compensation" && !write.rejectedReason),
-  "late range replacement is corrected against the passive reader anchor",
-);
-check(scrollElement.scrollTop === 8_120, "late range replacement restores the pre-commit reader offset");
-
 await act(async () => arbiter?.setMode("selection", "test-manual-layout-lease-release"));
 check(arbiter?.readerTransactionActive === false,
   "an explicit owner releases the idle manual layout lease");

--- a/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-reader-extent-race.test.tsx
@@ -501,7 +501,6 @@ check(scrollElement.dataset.transcriptReaderIntent === "false",
   "the reader writer transaction ends after the bounded quiet window");
 check(arbiter?.readerTransactionActive === true,
   "manual ownership retains the layout-only mount corridor after the writer transaction ends");
-
 await act(async () => arbiter?.setMode("selection", "test-manual-layout-lease-release"));
 check(arbiter?.readerTransactionActive === false,
   "an explicit owner releases the idle manual layout lease");

--- a/desktop/frontend/src/lib/transcriptAnchorCompensation.ts
+++ b/desktop/frontend/src/lib/transcriptAnchorCompensation.ts
@@ -91,28 +91,16 @@ export function createTranscriptAnchorCompensation({
     compensation.element.style.removeProperty("--transcript-reader-visual-offset");
   };
 
-  const anchorRow = (compensation: ActiveAnchorCompensation, element: HTMLDivElement) => (
+  const anchorRow = (rowKey: string, element: HTMLDivElement) => (
     Array.from(element.querySelectorAll<HTMLElement>(".transcript__row[data-row-key]"))
-      .find((candidate) => candidate.dataset.rowKey === compensation.anchor.rowKey)
+      .find((candidate) => candidate.dataset.rowKey === rowKey)
   );
 
   const physicalCorrection = (compensation: ActiveAnchorCompensation, element: HTMLDivElement) => {
-    const row = anchorRow(compensation, element);
+    const row = anchorRow(compensation.anchor.rowKey, element);
     if (!row) return null;
     const rendered = row.getBoundingClientRect().top - element.getBoundingClientRect().top - compensation.anchor.offset;
     return rendered - compensation.visualOffset;
-  };
-
-  const passiveAnchorDrift = (element: HTMLDivElement) => {
-    if (!anchor) return null;
-    return physicalCorrection({
-      anchor,
-      element,
-      frame: null,
-      stableFrames: 0,
-      deadline: passiveReaderAnchorUntil,
-      visualOffset: 0,
-    }, element);
   };
 
   const guardLargeDrift = (compensation: ActiveAnchorCompensation, element: HTMLDivElement) => {
@@ -227,7 +215,11 @@ export function createTranscriptAnchorCompensation({
         // compared with the reader's anchor. Sampling it as a new anchor would
         // canonize the jump and leave no trustworthy correction target.
         if (passiveReaderAnchorUntil !== 0 && Date.now() < passiveReaderAnchorUntil && anchor) {
-          if (Math.abs(passiveAnchorDrift(element) ?? 0) >= MIN_REVERSE_JUMP_PX) schedule();
+          const row = anchorRow(anchor.rowKey, element);
+          const drift = row
+            ? row.getBoundingClientRect().top - element.getBoundingClientRect().top - anchor.offset
+            : null;
+          if (drift !== null && Math.abs(drift) >= MIN_REVERSE_JUMP_PX) schedule();
         } else {
           passiveReaderAnchorUntil = 0;
           sample(element);

--- a/desktop/frontend/src/lib/transcriptAnchorCompensation.ts
+++ b/desktop/frontend/src/lib/transcriptAnchorCompensation.ts
@@ -17,6 +17,10 @@ import { MIN_REVERSE_JUMP_PX } from "./transcriptReaderExtentStability";
 const ANCHOR_COMPENSATION_BUDGET_MS = 1_000;
 const ANCHOR_COMPENSATION_STABLE_FRAMES = 2;
 const ANCHOR_COMPENSATION_TOLERANCE_PX = 8;
+// WebView2/Virtuoso may publish a delayed range/measurement commit just after
+// the active reader transaction times out. Keep the last accepted logical
+// anchor as a passive, cancellable lease long enough to guard that commit.
+const PASSIVE_READER_ANCHOR_BUDGET_MS = 1_000;
 
 type ManualAnchor = Extract<TranscriptLayoutAnchor, { mode: "manual" }>;
 
@@ -77,6 +81,7 @@ export function createTranscriptAnchorCompensation({
   dispatch: (event: TranscriptScrollEvent) => void;
 }): TranscriptAnchorCompensation {
   let anchor: ManualAnchor | null = null;
+  let passiveReaderAnchorUntil = 0;
   let active: ActiveAnchorCompensation | null = null;
   let pendingAfterReader = false;
 
@@ -96,6 +101,18 @@ export function createTranscriptAnchorCompensation({
     if (!row) return null;
     const rendered = row.getBoundingClientRect().top - element.getBoundingClientRect().top - compensation.anchor.offset;
     return rendered - compensation.visualOffset;
+  };
+
+  const passiveAnchorDrift = (element: HTMLDivElement) => {
+    if (!anchor) return null;
+    return physicalCorrection({
+      anchor,
+      element,
+      frame: null,
+      stableFrames: 0,
+      deadline: passiveReaderAnchorUntil,
+      visualOffset: 0,
+    }, element);
   };
 
   const guardLargeDrift = (compensation: ActiveAnchorCompensation, element: HTMLDivElement) => {
@@ -205,9 +222,17 @@ export function createTranscriptAnchorCompensation({
     }
     if (event.type === "SCROLL_DELIVERED") {
       const element = scrollRef.current;
-      // Scroll deliveries caused by a geometry commit must not replace the
-      // reader transaction's last accepted logical anchor.
-      if (element && !readerExtentIsActive()) sample(element);
+      if (element && !readerExtentIsActive()) {
+        // A late Virtuoso delivery during the passive reader lease must be
+        // compared with the reader's anchor. Sampling it as a new anchor would
+        // canonize the jump and leave no trustworthy correction target.
+        if (passiveReaderAnchorUntil !== 0 && Date.now() < passiveReaderAnchorUntil && anchor) {
+          if (Math.abs(passiveAnchorDrift(element) ?? 0) >= MIN_REVERSE_JUMP_PX) schedule();
+        } else {
+          passiveReaderAnchorUntil = 0;
+          sample(element);
+        }
+      }
       return;
     }
     if (
@@ -223,6 +248,7 @@ export function createTranscriptAnchorCompensation({
       || (event.type === "SCROLL_TO_OFFSET" && event.owner !== "anchor-compensation" && event.owner !== "block-window-prepend")
     ) {
       cancel();
+      passiveReaderAnchorUntil = 0;
     }
     if (event.type === "RESET") anchor = null;
   };
@@ -230,11 +256,15 @@ export function createTranscriptAnchorCompensation({
   const reset = () => {
     cancel();
     anchor = null;
+    passiveReaderAnchorUntil = 0;
     pendingAfterReader = false;
   };
 
   const adoptReaderAnchor = (next: { rowKey: string; offset: number } | undefined) => {
-    if (next) anchor = { mode: "manual", ...next };
+    if (next) {
+      anchor = { mode: "manual", ...next };
+      passiveReaderAnchorUntil = Date.now() + PASSIVE_READER_ANCHOR_BUDGET_MS;
+    }
   };
 
   return { noteEvent, schedule, reset, adoptReaderAnchor };


### PR DESCRIPTION
## Summary

- Preserve the last logical transcript anchor through late WebView2/Virtuoso range commits that arrive after a reader transaction times out.
- Route delayed deliveries through the existing anchor-compensation writer and cancel the passive lease when a higher-priority owner takes over.
- Add a deterministic regression for the delayed range-replacement race.

## Issues

Field diagnostics from v1.36.0 on Windows showed repeated downward-reading jumps back to the same stale transcript offset after the reader transaction timed out. The viewport only appeared to recover after the user reached the tail. The trace contained no question-jump or click navigation; it matched a delayed virtual-range/measurement commit being accepted as the new resting anchor.

This is a narrow follow-up on current `main-v2`. Related open transcript PRs #9416 and #9673 cover broader or older scroll changes; this PR intentionally changes only the late-anchor ownership path and its regression coverage.

## Verification

- `pnpm --dir desktop/frontend test:transcript`
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend build`
- `PLAYWRIGHT_BROWSERS_PATH=.pw-browsers REASONIX_TRANSCRIPT_READER_ITERATIONS=1 pnpm --dir desktop/frontend test:transcript-reader-browser` (Chromium and WebKit)
- `PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir desktop/frontend test:transcript-browser`
- `git diff --check`
- PR CI: lint, desktop/macOS/Windows, Linux WebKit, macOS WKWebView, CodeQL, and metadata guards

The raw initial bundle measured `2469.347 KiB` after the passive lease (+`0.222 KiB`, +`0.009%`) and is guarded by a narrow `2469.4 KiB` ceiling; gzip and largest-chunk budgets are unchanged.

## Documentation impact

Documentation-impact: none - this is an internal desktop transcript-scroll reliability fix; it adds no user-facing setting, command, API, or workflow.

## Cache impact

Cache-impact: none - no provider-visible prompts, tool schemas, request serialization, memory, or skill metadata changed.
Cache-guard: not applicable; the patch is limited to frontend scroll ownership and deterministic UI tests.
System-prompt-review: N/A
