### PR TITLE
fix(crash): prevent 1101 on high-volume group detail / 修复高量分组详情 1101

### DIFF
--- a/workers/crash-report/migrate-dashboard-indexes.sql
+++ b/workers/crash-report/migrate-dashboard-indexes.sql
@@ -8,6 +8,7 @@ CREATE INDEX IF NOT EXISTS groups_source ON groups (source);
 CREATE INDEX IF NOT EXISTS groups_last_version ON groups (last_version);
 CREATE INDEX IF NOT EXISTS groups_last_os ON groups (last_os);
 CREATE INDEX IF NOT EXISTS groups_first_version ON groups (first_version);
+CREATE INDEX IF NOT EXISTS reports_fingerprint_id ON reports (fingerprint, id DESC);
 CREATE INDEX IF NOT EXISTS report_daily_fingerprint_date
   ON report_daily (fingerprint, date);
 CREATE INDEX IF NOT EXISTS firebase_crash_outbox_fingerprint

--- a/workers/crash-report/schema.sql
+++ b/workers/crash-report/schema.sql
@@ -53,6 +53,7 @@ CREATE TABLE IF NOT EXISTS reports (
 );
 
 CREATE INDEX IF NOT EXISTS reports_fingerprint ON reports (fingerprint);
+CREATE INDEX IF NOT EXISTS reports_fingerprint_id ON reports (fingerprint, id DESC);
 
 -- Firebase Spark delivery is coordinated through D1 so an unavailable or
 -- quota-limited Realtime Database never loses a sanitized report. The payload

--- a/workers/crash-report/src/diagnostics_v2.test.ts
+++ b/workers/crash-report/src/diagnostics_v2.test.ts
@@ -519,5 +519,51 @@ describe("diagnostics v2 storage consistency", () => {
     await groupDiagnosticSummary({ DB: db } as unknown as Env, "b".repeat(64));
     expect(distributionSQL).toContain("WITH window AS MATERIALIZED");
     expect(distributionSQL.match(/FROM report_event_dimensions/g)).toHaveLength(1);
+    expect(distributionSQL).toContain("ROW_NUMBER() OVER (PARTITION BY facet");
+    expect(distributionSQL).toContain("WHERE rank <= 20");
+  });
+
+  it("bounds each group facet and reads totals from the daily rollups", async () => {
+    const sqlite = new DatabaseSync(":memory:");
+    sqlite.exec(freshSchemaSQL);
+    const fingerprint = "c".repeat(64);
+    sqlite.prepare(
+      `INSERT INTO report_daily (date, fingerprint, events, identified_events)
+       VALUES (date('now'), ?1, 40, 40)`,
+    ).run(fingerprint);
+    sqlite.prepare(
+      `INSERT INTO report_installations (date, fingerprint, install_id, version, os, arch)
+       VALUES (date('now'), ?1, 'install-1', 'v1.0.0', 'windows', 'amd64')`,
+    ).run(fingerprint);
+    const fact = sqlite.prepare(
+      `INSERT INTO report_event_dimensions
+       (date, fingerprint, install_id, version, os, arch, os_build, os_revision,
+        distro_id, distro_version, kernel_version, session_type, channel,
+        runtime_engine, runtime_version, failure_kind, failure_reason, exit_code, recovery, gpu_mode, events)
+       VALUES (date('now'), ?1, ?2, 'v1.0.0', 'windows', 'amd64', 1, 1, '', '', '', '', 'stable',
+               'webview2', ?3, 'browser_process_exited', 'unexpected', '1', '', 'unknown', 1)`,
+    );
+    for (let i = 0; i < 40; i++) fact.run(fingerprint, `install-${i}`, `runtime-${i}`);
+    const db = {
+      prepare(sql: string) {
+        const statement = sqlite.prepare(sql);
+        const wrapper: any = {
+          values: [] as unknown[],
+          bind(...values: unknown[]) { wrapper.values = values; return wrapper; },
+          async first() { return statement.get(...wrapper.values); },
+          async all() { return { results: statement.all(...wrapper.values) }; },
+        };
+        return wrapper;
+      },
+    } as unknown as D1Database;
+    try {
+      const result = await groupDiagnosticSummary({ DB: db } as unknown as Env, fingerprint);
+      expect(result).toMatchObject({ windowEvents: 40, identifiedEvents: 40, affectedInstalls: 1 });
+      const byFacet = new Map<string, number>();
+      for (const row of result.distributions) byFacet.set(row.facet, (byFacet.get(row.facet) ?? 0) + 1);
+      expect(Math.max(...byFacet.values())).toBeLessThanOrEqual(20);
+    } finally {
+      sqlite.close();
+    }
   });
 });

--- a/workers/crash-report/src/diagnostics_v2.ts
+++ b/workers/crash-report/src/diagnostics_v2.ts
@@ -460,10 +460,17 @@ export async function groupDiagnosticSummary(
   const [totals, distributions] = await Promise.all([
     observedFirst<{ window_events: number; identified_events: number; affected_installs: number }>(env.DB.prepare(
       `SELECT
-         COALESCE(SUM(events), 0) AS window_events,
-         COALESCE(SUM(CASE WHEN install_id <> '' THEN events ELSE 0 END), 0) AS identified_events,
-         COUNT(DISTINCT NULLIF(install_id, '')) AS affected_installs
-       FROM report_event_dimensions WHERE fingerprint = ?1 AND date >= date('now', '-29 day')`,
+         COALESCE(daily.window_events, 0) AS window_events,
+         COALESCE(daily.identified_events, 0) AS identified_events,
+         COALESCE(installs.affected_installs, 0) AS affected_installs
+       FROM (
+         SELECT SUM(events) AS window_events, SUM(identified_events) AS identified_events
+         FROM report_daily WHERE fingerprint = ?1 AND date >= date('now', '-29 day')
+       ) daily
+       CROSS JOIN (
+         SELECT COUNT(DISTINCT install_id) AS affected_installs
+         FROM report_installations WHERE fingerprint = ?1 AND date >= date('now', '-29 day')
+       ) installs`,
     ).bind(fingerprint), "group_diagnostic_totals", observe),
     observedAll<{ facet: string; value: string; installs: number; events: number }>(env.DB.prepare(
       `WITH window AS MATERIALIZED (
@@ -487,9 +494,16 @@ export async function groupDiagnosticSummary(
          UNION ALL SELECT 'exitCode', exit_code, install_id, events FROM window
          UNION ALL SELECT 'gpu', gpu_mode, install_id, events FROM window
          UNION ALL SELECT 'recovery', recovery, install_id, events FROM window WHERE recovery <> ''
+       ), grouped AS (
+         SELECT facet, value, COUNT(DISTINCT NULLIF(install_id, '')) AS installs, SUM(events) AS events
+         FROM facts GROUP BY facet, value
+       ), ranked AS (
+         SELECT facet, value, installs, events,
+                ROW_NUMBER() OVER (PARTITION BY facet ORDER BY installs DESC, events DESC, value) AS rank
+         FROM grouped
        )
-       SELECT facet, value, COUNT(DISTINCT NULLIF(install_id, '')) AS installs, SUM(events) AS events
-       FROM facts GROUP BY facet, value ORDER BY facet, installs DESC`,
+       SELECT facet, value, installs, events
+       FROM ranked WHERE rank <= 20 ORDER BY facet, rank`,
     ).bind(fingerprint), "group_diagnostic_distributions", observe),
   ]);
   return {

--- a/workers/crash-report/src/group.ts
+++ b/workers/crash-report/src/group.ts
@@ -140,7 +140,7 @@ ${webRuntime ? `<details class="sample-nested"><summary>Web Runtime</summary><pr
 </div></details>`;
 }
 
-function sampleReports(reports: ReportSample[], options: { limit?: number } = {}): string {
+function sampleReports(reports: ReportSample[], options: { limit?: number; truncated?: boolean } = {}): string {
   if (!reports.length) return `<div class="empty">${i18n("No raw samples stored for this group", "这个分组没有保存原始样本")}</div>`;
   const limit = options.limit ?? 10;
   const visible = reports.slice(0, limit);
@@ -150,7 +150,10 @@ function sampleReports(reports: ReportSample[], options: { limit?: number } = {}
   const history = hidden.length > 0
     ? `<details class="sample-more"><summary>${i18nHTML(`Historical samples ${hidden.length}`, `历史样本 ${hidden.length}`)}</summary><div class="sample-more-list">${hiddenSamples}</div></details>`
     : "";
-  return `<div class="sample-list">${visibleSamples}${history}</div>`;
+  const boundary = options.truncated
+    ? `<p class="group-note sample-boundary">${i18n("Showing the first retained sample and the latest 5 samples; older raw samples are omitted to keep this page responsive.", "当前展示首个保留样本和最近 5 个样本；更早的原始样本已省略，以保证页面稳定。")}</p>`
+    : "";
+  return `${boundary}<div class="sample-list">${visibleSamples}${history}</div>`;
 }
 
 export function renderGroup(
@@ -159,8 +162,9 @@ export function renderGroup(
   user: User,
   diagnostics?: GroupDiagnosticSummary,
   lifecycle?: { state: "active" | "compacted" | "archiving" | "archived"; epoch: number },
+  warnings: { samplesUnavailable?: boolean; diagnosticsUnavailable?: boolean } = {},
 ): string {
-  const samples = sampleReports(reports);
+  const samples = sampleReports(reports, { truncated: group.count > reports.length });
   const platform = [group.last_os, group.last_arch].filter(Boolean).join("/");
   const status = statusPill(group.status) || `<span class="pill open">${i18n("open", "未处理")}</span>`;
   const tags = [
@@ -199,6 +203,15 @@ export function renderGroup(
         : lifecycle && lifecycle.epoch > 1
           ? `<div class="card full"><p>${i18nHTML(`Samples belong to retained cycle ${lifecycle.epoch}; Lifetime First Seen remains the D1 value above.`, `样本属于第 ${lifecycle.epoch} 个保留周期；Lifetime First Seen 仍以上方 D1 值为准。`)}</p></div>`
           : "";
+  const englishDetails = [warnings.samplesUnavailable && "raw samples", warnings.diagnosticsUnavailable && "technical distributions"]
+    .filter(Boolean)
+    .join(", ");
+  const chineseDetails = [warnings.samplesUnavailable && "原始样本", warnings.diagnosticsUnavailable && "技术分布"]
+    .filter(Boolean)
+    .join("、");
+  const degradedNotice = englishDetails
+    ? `<div class="card full notice warn"><p>${i18nHTML(`Some ${englishDetails} could not be loaded. Core group aggregates remain available.`, `部分${chineseDetails}暂时无法加载，分组核心汇总仍可用。`)}</p></div>`
+    : "";
   return page(
     `Reasonix · ${group.fingerprint.slice(0, 8)}`,
     `stats / ${group.fingerprint.slice(0, 8)}`,
@@ -208,6 +221,7 @@ ${group.title ? `<p class="summary group-summary">${esc(group.title)}</p>` : ""}
 <div class="group-tags">${tags}</div>
 <div class="group-metrics">${metrics}</div>
 ${group.note ? `<p class="group-note">${i18n("Note", "备注")}: ${esc(group.note)}</p>` : ""}</section>
+${degradedNotice}
 ${lifecycleNotice}
 <div class="card full sample-card"><h2>${i18nHTML("Samples <b>— newest first, retained-cycle first plus latest 5 kept</b>", "样本 <b>— 最新优先，保留当前周期首个样本和最近 5 个</b>")}</h2>${samples}</div>
 ${distributions}

--- a/workers/crash-report/src/group_queries.test.ts
+++ b/workers/crash-report/src/group_queries.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error Node 22+ provides node:sqlite; Worker production code does not import it.
+import { DatabaseSync } from "node:sqlite";
+import { groupReportsStatement, loadD1GroupReports, loadGroupDiagnostics } from "./group_queries";
+import { renderGroup, type Group } from "./group";
+import freshSchemaSQL from "../schema.sql?raw";
+
+describe("group report query bounds", () => {
+  it("returns only the first retained sample and the latest five reports", async () => {
+    const sqlite = new DatabaseSync(":memory:");
+    sqlite.exec(freshSchemaSQL);
+    const fingerprint = "a".repeat(64);
+    for (let id = 1; id <= 35_000; id++) {
+      sqlite.prepare(
+        `INSERT INTO reports (fingerprint, kind, version, arch, os, message, created_at)
+         VALUES (?1, 'crash', 'v1.0.0', 'amd64', 'windows', ?2, ?3)`,
+      ).run(fingerprint, `sample-${id}`, `2026-09-03T00:00:${String(id).padStart(5, "0")}Z`);
+    }
+    sqlite.prepare(
+      `INSERT INTO reports (fingerprint, kind, version, arch, os, message, created_at)
+       VALUES (?1, 'crash', 'v1.0.0', 'amd64', 'windows', 'other-group', '2026-09-30T00:00:00.000Z')`,
+    ).run("b".repeat(64));
+
+    const db = {
+      prepare(sql: string) {
+        const statement = sqlite.prepare(sql);
+        const wrapper: any = {
+          values: [] as unknown[],
+          bind(...values: unknown[]) { wrapper.values = values; return wrapper; },
+          async all() { return { results: statement.all(...wrapper.values) }; },
+        };
+        return wrapper;
+      },
+    } as unknown as D1Database;
+    try {
+      const rows = await groupReportsStatement(db, fingerprint, 5).all();
+      expect(rows.results.map((row) => String((row as { message: string }).message))).toEqual([
+        "sample-35000", "sample-34999", "sample-34998", "sample-34997", "sample-34996", "sample-1",
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("renders a graceful notice when a detail query is unavailable", () => {
+    const group: Group = {
+      fingerprint: "c".repeat(64), kind: "crash", count: 35_000,
+      first_seen: "2026-01-01T00:00:00.000Z", last_seen: "2026-09-03T00:00:00.000Z",
+      first_version: "v1.0.0", last_version: "v1.36.0", status: "open", note: "",
+      title: "worker failure", source: "native.lifecycle", label: "", error_type: "Error", severity: "high",
+      top_frame: "", last_os: "windows", last_arch: "amd64", last_build_commit: "",
+      last_channel: "stable", resolved_in: "", resolved_at: "", regressed_at: "",
+    };
+    const html = renderGroup(
+      group,
+      [],
+      { id: 1, email: "admin@example.com", role: "admin", created_at: "", approved_at: null },
+      undefined,
+      undefined,
+      { samplesUnavailable: true, diagnosticsUnavailable: true },
+    );
+    expect(html).toContain("原始样本");
+    expect(html).toContain("技术分布");
+    expect(html).toContain("分组核心汇总仍可用");
+  });
+
+  it("turns D1 detail failures into bounded degradation instead of throwing", async () => {
+    const db = { prepare() { throw new Error("simulated D1 failure"); } } as unknown as D1Database;
+    const env = { DB: db } as any;
+    const observe = () => {};
+    await expect(loadD1GroupReports(env, "a".repeat(64), 5, observe)).resolves.toEqual({ reports: [], unavailable: true });
+    await expect(loadGroupDiagnostics(env, "a".repeat(64), observe)).resolves.toEqual({ unavailable: true });
+  });
+});

--- a/workers/crash-report/src/group_queries.ts
+++ b/workers/crash-report/src/group_queries.ts
@@ -1,0 +1,63 @@
+import type { Env } from "./env";
+import type { ReportSample } from "./group";
+import {
+  groupDiagnosticSummary,
+  type DiagnosticsQueryObserver,
+  type GroupDiagnosticSummary,
+} from "./diagnostics_v2";
+
+const REPORT_COLUMNS = `
+  id, version, os, arch, message, device, created_at, source, label, error_type, error_message,
+  top_frame, build_commit, channel, language, view, breadcrumbs, component_stack, stack,
+  occurred_at, webview2, web_runtime`;
+
+// Keep the detail page bounded even when a group has a large lifetime count.
+// The first retained sample preserves the earliest context; the latest samples
+// show the current failure shape. UNION removes the duplicate when a group has
+// fewer rows than the requested latest sample window.
+export function groupReportsStatement(db: D1Database, fingerprint: string, latestSamples: number): D1PreparedStatement {
+  return db.prepare(
+    `WITH first_sample AS (
+       SELECT ${REPORT_COLUMNS}
+       FROM reports INDEXED BY reports_fingerprint_id WHERE fingerprint = ?1 ORDER BY id ASC LIMIT 1
+     ), latest_samples AS (
+       SELECT ${REPORT_COLUMNS}
+       FROM reports INDEXED BY reports_fingerprint_id WHERE fingerprint = ?1 ORDER BY id DESC LIMIT ?2
+     ), retained AS (
+       SELECT * FROM first_sample
+       UNION
+       SELECT * FROM latest_samples
+     )
+     SELECT ${REPORT_COLUMNS} FROM retained ORDER BY id DESC`,
+  ).bind(fingerprint, latestSamples);
+}
+
+export async function loadD1GroupReports(
+  env: Env,
+  fingerprint: string,
+  latestSamples: number,
+  observe: DiagnosticsQueryObserver,
+): Promise<{ reports: ReportSample[]; unavailable: boolean }> {
+  try {
+    const started = performance.now();
+    const stored = await groupReportsStatement(env.DB, fingerprint, latestSamples).all<ReportSample>();
+    observe("group_samples", performance.now() - started, stored.results?.length ?? 0);
+    return { reports: stored.results, unavailable: false };
+  } catch (error) {
+    console.error("group raw sample query failed", error);
+    return { reports: [], unavailable: true };
+  }
+}
+
+export async function loadGroupDiagnostics(
+  env: Env,
+  fingerprint: string,
+  observe: DiagnosticsQueryObserver,
+): Promise<{ summary?: GroupDiagnosticSummary; unavailable: boolean }> {
+  try {
+    return { summary: await groupDiagnosticSummary(env, fingerprint, observe), unavailable: false };
+  } catch (error) {
+    console.error("group diagnostic summary query failed", error);
+    return { unavailable: true };
+  }
+}

--- a/workers/crash-report/src/index.test.ts
+++ b/workers/crash-report/src/index.test.ts
@@ -460,4 +460,83 @@ describe("diagnostics dashboard lanes", () => {
     expect(html).toContain('href="/stats"');
   });
 
+  it("makes triage priorities scannable with labeled metrics and explicit status", () => {
+    type StatsData = Parameters<typeof renderStats>[0];
+    const row = {
+      fingerprint: "a".repeat(64),
+      kind: "crash",
+      count: 102373,
+      first_version: "v1.24.0",
+      last_version: "v1.36.0",
+      seen: "2026-09-03",
+      status: "open",
+      title: "A long lifecycle failure summary that should remain available to assistive technology",
+      source: "native.lifecycle",
+      label: "",
+      error_type: "Error",
+      top_frame: "at render",
+      severity: "high",
+      last_os: "windows",
+      last_arch: "amd64",
+      last_channel: "stable",
+      regressed_at: "",
+      affected_installs: 16406,
+      window_events: 34941,
+      identified_events: 34941,
+      identity_coverage: 1,
+      dimension_coverage: 1,
+      impact_rate: 0.137,
+    };
+    const data: StatsData = {
+      daily: [],
+      versions: [],
+      platforms: [],
+      crashes: [row, { ...row, fingerprint: "b".repeat(64), status: "resolved" }, { ...row, fingerprint: "c".repeat(64), status: "ignored" }],
+      metrics: [],
+      previousMetrics: [],
+      sources: [],
+      overview: { latestAdoptionPct: null, openReports: 3, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 0 },
+      latestVersion: "v1.36.0",
+      filters: {
+        surface: "desktop",
+        status: "",
+        source: "",
+        version: "",
+        os: "",
+        platform: "",
+        newLatest: false,
+        regressed: false,
+        windowDays: 30,
+      },
+    };
+
+    const html = renderStats(
+      data,
+      { id: 1, email: "admin@example.com", role: "admin", created_at: "", approved_at: "" },
+      "diagnostics",
+    );
+
+    expect(html).toContain("Past 30 days");
+    expect(html).toContain("ranked by affected installs");
+    expect(html).toContain("受影响安装");
+    expect(html).toContain("受影响安装（30天）");
+    expect(html).toContain("影响率");
+    expect(html).toContain("窗口事件");
+    expect(html).toContain("身份覆盖率");
+    expect(html).toContain("累计");
+    expect(html).toContain('aria-label="A long lifecycle failure summary that should remain available to assistive technology"');
+    expect(html).toContain("status-open");
+    expect(html).toContain("status-resolved");
+    expect(html).toContain("status-ignored");
+    expect(html).toContain(":focus-visible");
+
+    const sevenDayHtml = renderStats(
+      { ...data, filters: { ...data.filters, windowDays: 7 } },
+      { id: 1, email: "admin@example.com", role: "admin", created_at: "", approved_at: "" },
+      "diagnostics",
+    );
+    expect(sevenDayHtml).toContain("受影响安装（7天）");
+    expect(sevenDayHtml).not.toContain("受影响安装（30天）");
+  });
+
 });

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -45,6 +45,7 @@ import {
   type DiagnosticFacets,
 } from "./diagnostics_v2";
 import { statsQueryObserver } from "./stats_timing";
+import { loadD1GroupReports, loadGroupDiagnostics } from "./group_queries";
 import { Report, WebRuntimeDiagnostic, type ReportPayload } from "./report_schema";
 import { statsFilters, type StatsFilters } from "./stats_filters";
 import {
@@ -1130,7 +1131,7 @@ async function handleGroup(env: Env, fingerprint: string, user: User): Promise<R
   if (!group) return new Response("not found", { status: 404 });
   group.severity = effectiveGroupSeverity(group);
   const state = crashStorageMode(env) === "d1" ? null : await firebaseGroupState(env, fingerprint);
-  let reports: ReportSample[];
+  let reports: ReportSample[] = [], samplesUnavailable = false;
   if (crashStorageMode(env) === "firebase") {
     if (state?.sample_state === "archived") {
       reports = [];
@@ -1143,16 +1144,15 @@ async function handleGroup(env: Env, fingerprint: string, user: User): Promise<R
       }
     }
   } else {
-    const stored = await env.DB.prepare(
-      `SELECT version, os, arch, message, device, created_at, source, label, error_type, error_message,
-        top_frame, build_commit, channel, language, view, breadcrumbs, component_stack, stack, occurred_at, webview2, web_runtime
-       FROM reports WHERE fingerprint = ?1 ORDER BY id DESC`,
-    ).bind(fingerprint).all<ReportSample>();
-    reports = stored.results;
+    const loaded = await loadD1GroupReports(env, fingerprint, LATEST_SAMPLES_PER_GROUP, statsQueryObserver("/stats/group"));
+    reports = loaded.reports;
+    samplesUnavailable = loaded.unavailable;
   }
+  const loadedDiagnostics = await loadGroupDiagnostics(env, fingerprint, statsQueryObserver("/stats/group"));
   return html(renderGroup(
-    group, reports, user, await groupDiagnosticSummary(env, fingerprint, statsQueryObserver("/stats/group")),
+    group, reports, user, loadedDiagnostics.summary,
     state ? { state: state.sample_state, epoch: Number(state.sample_epoch) } : undefined,
+    { samplesUnavailable, diagnosticsUnavailable: loadedDiagnostics.unavailable },
   ));
 }
 

--- a/workers/crash-report/src/performance_migration.test.ts
+++ b/workers/crash-report/src/performance_migration.test.ts
@@ -15,6 +15,7 @@ describe("crash and registry performance migrations", () => {
     for (const sql of [schema, migration]) {
       expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS report_daily_fingerprint_date\s+ON report_daily \(fingerprint, date\)/);
       expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS firebase_crash_outbox_fingerprint\s+ON firebase_crash_outbox \(fingerprint\)/);
+      expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS reports_fingerprint_id\s+ON reports \(fingerprint, id DESC\)/);
     }
   });
 
@@ -44,8 +45,12 @@ describe("crash and registry performance migrations", () => {
       const outboxPlan = db.prepare(
         "EXPLAIN QUERY PLAN SELECT event_id FROM firebase_crash_outbox WHERE fingerprint = 'x' LIMIT 1",
       ).all().map((row: Record<string, unknown>) => String(row.detail)).join(" ");
+      const reportPlan = db.prepare(
+        "EXPLAIN QUERY PLAN SELECT id FROM reports INDEXED BY reports_fingerprint_id WHERE fingerprint = 'x' ORDER BY id DESC LIMIT 5",
+      ).all().map((row: Record<string, unknown>) => String(row.detail)).join(" ");
       expect(dailyPlan).toContain("USING INDEX report_daily_fingerprint_date");
       expect(outboxPlan).toContain("USING INDEX firebase_crash_outbox_fingerprint");
+      expect(reportPlan).toContain("USING COVERING INDEX reports_fingerprint_id");
     } finally {
       db.close();
     }

--- a/workers/crash-report/src/shell.ts
+++ b/workers/crash-report/src/shell.ts
@@ -113,11 +113,15 @@ td.summary{max-width:480px;white-space:nowrap;overflow:hidden;text-overflow:elli
 p.summary{font-family:var(--mono);font-size:14px;margin:2px 0 6px;word-break:break-word}
 a.fp{font-family:var(--mono);font-size:13px;color:var(--accent);text-decoration:none}
 a.fp:hover{text-decoration:underline}
+a:focus-visible,button:focus-visible,summary:focus-visible{outline:3px solid color-mix(in oklch,var(--accent) 72%,white);outline-offset:3px}
 .pill{display:inline-block;font-size:12px;font-weight:500;padding:2px 10px;border-radius:999px;background:var(--accent-soft);color:var(--accent)}
 .pill.crash{background:oklch(0.95 0.03 25);color:oklch(0.55 0.18 25)}
 .pill.open{background:oklch(0.96 0.025 250);color:var(--ink-2)}
+.pill.status-open{background:oklch(0.96 0.025 250);color:var(--ink-2)}
 .pill.resolved{background:oklch(0.95 0.05 150);color:oklch(0.48 0.13 150)}
+.pill.status-resolved{background:oklch(0.95 0.05 150);color:oklch(0.48 0.13 150)}
 .pill.ignored{background:var(--bg-soft);color:var(--ink-3)}
+.pill.status-ignored{background:var(--bg-soft);color:var(--ink-3)}
 .back{display:inline-block;margin:18px 0 0;color:var(--accent);text-decoration:none;font-size:14px}
 .report{margin-top:20px}
 .report .meta{display:flex;flex-wrap:wrap;gap:8px 18px;font-size:13px;color:var(--ink-2);margin-bottom:10px}
@@ -183,7 +187,7 @@ padding:6px 9px;border:1px solid var(--line);border-radius:11px;background:#fff;
 .filter-empty{font-size:13px;color:var(--ink-3)}
 .crash-card{overflow:hidden}
 .crash-list{display:flex;flex-direction:column;gap:2px}
-.crash-head,.crash-item{display:grid;grid-template-columns:minmax(300px,1fr) minmax(185px,.55fr) 150px 62px;gap:16px;align-items:center}
+.crash-head,.crash-item{display:grid;grid-template-columns:minmax(280px,1.35fr) minmax(170px,.72fr) minmax(130px,.55fr) minmax(250px,1.15fr);gap:16px;align-items:center}
 .crash-head{padding:0 12px 9px;color:var(--ink-3);font-size:12.5px;font-weight:600;border-bottom:1px solid var(--line)}
 .crash-item{margin:0 -12px;padding:14px 12px;border-radius:14px;color:var(--ink);text-decoration:none;border-bottom:1px solid var(--line)}
 .crash-item:hover{background:var(--bg-soft)}
@@ -191,12 +195,25 @@ padding:6px 9px;border:1px solid var(--line);border-radius:11px;background:#fff;
 .crash-fingerprint b{font-family:var(--mono);font-size:13px;color:var(--accent);font-weight:700}
 .crash-fingerprint small,.crash-scope small{font-family:var(--mono);font-size:11.5px;color:var(--ink-3);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .crash-summary{display:flex;flex-direction:column;gap:5px;min-width:0}
-.crash-summary>span{font-family:var(--mono);font-size:12.8px;line-height:1.45;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.crash-summary>span{display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;font-family:var(--mono);font-size:12.8px;line-height:1.45;overflow:hidden;white-space:normal;overflow-wrap:anywhere}
 .crash-summary small{font-family:var(--mono);font-size:11.5px;color:var(--ink-3);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .crash-summary em{font-size:12px;font-style:normal;color:oklch(0.55 0.18 25)}
 .crash-scope{display:flex;flex-direction:column;gap:4px;min-width:0}
+.crash-meta{display:flex;gap:6px;min-width:0;line-height:1.35;white-space:normal}
+.crash-meta b{flex:0 0 auto;font-family:var(--sans);font-size:10.5px;font-weight:700;color:var(--ink-3)}
+.crash-meta span{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .crash-health{display:flex;flex-wrap:wrap;gap:6px;align-items:center}
-.crash-count{font-family:var(--mono);font-size:14px;font-weight:700;color:var(--ink);text-align:right}
+.crash-count{font-family:var(--mono);font-size:14px;font-weight:700;color:var(--ink);text-align:right;min-width:0}
+.crash-metrics{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:7px 12px;text-align:left}
+.crash-metric{display:flex;flex-direction:column;gap:2px;min-width:0}
+.crash-metric b{font-family:var(--mono);font-size:14px;line-height:1.1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.crash-metric small{font-family:var(--sans);font-size:11px;font-weight:600;line-height:1.2;color:var(--ink-3);white-space:normal}
+.crash-metric.primary b{font-size:18px;color:var(--accent)}
+.crash-metric.full{grid-column:1/-1;flex-direction:row;align-items:baseline;gap:6px}
+.crash-metric.full b{font-size:12.5px}
+.panel-title{display:flex;align-items:baseline;justify-content:space-between;gap:12px;flex-wrap:wrap}
+.panel-title h3{margin-bottom:0}
+.panel-context{font-size:12px;font-weight:600;color:var(--ink-3)}
 .group-hero{padding:28px 0 22px}
 .group-nav{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px}
 .group-nav .back{margin:0}
@@ -206,8 +223,8 @@ padding:6px 9px;border:1px solid var(--line);border-radius:11px;background:#fff;
 .group-tags{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 18px}
 .group-tags span{display:inline-flex;align-items:center;gap:6px;border:1px solid var(--line);border-radius:11px;background:#fff;padding:6px 9px;font-size:13px;color:var(--ink-2)}
 .group-tags b{font-size:12px;color:var(--ink-3);font-weight:600}
-.crash-list.compact .crash-head{display:none}
-.crash-list.compact .crash-item{padding:12px;margin:0 -12px;grid-template-columns:minmax(260px,1fr) minmax(160px,.5fr) 140px 52px}
+.crash-list.compact .crash-head{display:grid}
+.crash-list.compact .crash-item{padding:12px;margin:0 -12px;grid-template-columns:minmax(280px,1.35fr) minmax(170px,.72fr) minmax(130px,.55fr) minmax(250px,1.15fr)}
 .group-metrics{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}
 .group-metrics div{border:1px solid var(--line);border-radius:14px;background:var(--bg-soft);padding:12px 13px;min-width:0}
 .group-metrics span{display:block;font-size:12px;color:var(--ink-3);margin-bottom:5px}
@@ -279,8 +296,8 @@ td select{width:auto;padding:6px 10px;border-radius:10px}
 .note-edit{margin-top:12px;display:flex;gap:8px;max-width:560px}
 .note-edit input{flex:1}
 @media(max-width:1100px){.overview-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.module-nav{grid-template-columns:repeat(2,minmax(0,1fr))}.health-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.module-split,.module-split.wide,.preference-compare{grid-template-columns:1fr}}
-@media(max-width:900px){.hero-line{flex-direction:column}.facet-grid{grid-template-columns:1fr}.crash-head{display:none}.crash-item,.crash-list.compact .crash-item{grid-template-columns:1fr;gap:10px}
-.crash-health{justify-content:flex-start}.crash-count{text-align:left}.filter-head,.module-head{align-items:flex-start;flex-direction:column;gap:8px}.module-actions{justify-content:flex-start}
+@media(max-width:900px){.hero-line{flex-direction:column}.facet-grid{grid-template-columns:1fr}.crash-list.compact .crash-head,.crash-list:not(.compact) .crash-head{display:none}.crash-item,.crash-list.compact .crash-item{grid-template-columns:1fr;gap:10px}
+.crash-health{justify-content:flex-start}.crash-count{text-align:left}.crash-metrics{max-width:360px}.filter-head,.module-head{align-items:flex-start;flex-direction:column;gap:8px}.module-actions{justify-content:flex-start}
 .group-metrics{grid-template-columns:1fr 1fr}.sample summary{grid-template-columns:1fr}.sample-time{text-align:left}.manage-head{flex-direction:column}.manage-actions{justify-content:flex-start}.manage-grid{grid-template-columns:1fr}.manage-form.wide{grid-column:auto}}
 @media(max-width:760px){header{height:auto;min-height:68px;flex-wrap:wrap;padding:14px 0}.lang-switch{margin-left:0}.nav{width:100%;flex-wrap:wrap;gap:8px}.site-nav{overflow-x:auto;padding-bottom:2px}.site-nav a{white-space:nowrap}.chip{min-width:0;max-width:100%;overflow:hidden;text-overflow:ellipsis}.grid{grid-template-columns:1fr}.overview-grid,.module-nav,.health-grid{grid-template-columns:1fr}.metrics,.pref-metrics{grid-template-columns:1fr}.row{grid-template-columns:minmax(0,1fr) minmax(70px,.8fr) 3.2em}.card-title-row{align-items:flex-start;flex-direction:column}.filter-card{position:static}.wrap{padding:0 16px 48px}}
 `;

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -1,5 +1,7 @@
 import { esc, page } from "./shell";
 import { type User, userNav } from "./auth";
+import { clip, reportGroups, statusPill, type CrashRow } from "./stats_reports";
+export { clip, statusPill } from "./stats_reports";
 
 type Daily = { date: string; users: number; opens: number };
 type MetricRow = { signal: string; bucket: string; total: number };
@@ -489,43 +491,6 @@ ${healthCard(
 </div>`;
 }
 
-export function statusPill(status: string): string {
-  if (status === "resolved") return `<span class="pill resolved">resolved</span>`;
-  if (status === "ignored") return `<span class="pill ignored">ignored</span>`;
-  return "";
-}
-
-type CrashRow = {
-  fingerprint: string;
-  kind: string;
-  count: number;
-  first_version: string;
-  last_version: string;
-  seen: string;
-  status: string;
-  title: string;
-  source: string;
-  label: string;
-  error_type: string;
-  top_frame: string;
-  severity: string;
-  last_os: string;
-  last_arch: string;
-  last_channel: string;
-  regressed_at: string;
-  development?: boolean;
-  affected_installs?: number;
-  window_events?: number;
-  identified_events?: number;
-  identity_coverage?: number;
-  dimension_coverage?: number;
-  impact_rate?: number | null;
-};
-
-export function clip(s: string, n: number): string {
-  return s.length > n ? `${s.slice(0, n - 1)}…` : s;
-}
-
 function filterTab(label: string, zhLabel: string, href: string, active: boolean): string {
   return `<a class="filter-tab${active ? " active" : ""}" href="${esc(href)}">${i18n(label, zhLabel)}</a>`;
 }
@@ -565,25 +530,6 @@ function topSeverityTone(openReports: number, regressedReports: number, critical
 
 function navLink(href: string, label: { en: string; zh: string }, active = false): string {
   return `<a${active ? ` class="active" aria-current="page"` : ""} href="${esc(href)}">${i18n(label.en, label.zh)}</a>`;
-}
-
-function reportGroups(rows: CrashRow[], compact = false): string {
-  if (!rows.length) return `<div class="empty">${i18n("No diagnostic reports yet — that's the good kind of empty", "还没有诊断报告，这是好消息")}</div>`;
-  return `<div class="crash-list${compact ? " compact" : ""}"><div class="crash-head"><span>${i18n("summary", "摘要")}</span><span>${i18n("scope", "范围")}</span><span>${i18n("health", "状态")}</span><span title="${i18n("Window events and affected installs; lifetime count remains visible for historical context", "窗口事件数和受影响安装数；同时保留全生命周期累计次数")}">${i18n("window / lifetime", "窗口 / 累计")}</span></div>${rows
-    .map((c) => {
-      const platform = [c.last_os, c.last_arch].filter(Boolean).join("/");
-      const versions = `${c.first_version || "?"} → ${c.last_version || "?"}`;
-      const title = c.title || c.error_type || c.top_frame || c.fingerprint;
-      return `<a class="crash-item" href="/stats/group/${esc(c.fingerprint)}" title="${esc(title)}">
-<span class="crash-summary"><span>${c.title ? esc(clip(c.title, compact ? 88 : 120)) : `<span class="muted">${i18n("No summary captured", "暂无摘要")}</span>`}</span><small>${esc(c.fingerprint.slice(0, 8))} · ${esc(c.seen)}</small>${
-        c.regressed_at ? `<em>${i18nHTML(`regressed ${esc(c.regressed_at.slice(0, 10))}`, `回归 ${esc(c.regressed_at.slice(0, 10))}`)}</em>` : ""
-      }</span>
-<span class="crash-scope"><small>${esc(c.source || "legacy")}</small><small>${esc(versions)}</small><small>${platform ? esc(platform) : "unknown platform"}</small>${c.last_channel && c.last_channel !== "stable" ? `<small>${esc(c.last_channel)}</small>` : ""}</span>
-<span class="crash-health"><span class="pill">${esc(c.severity || "medium")}</span><span class="pill ${c.kind === "crash" ? "crash" : ""}">${esc(c.kind)}</span>${statusPill(c.status)}</span>
-<span class="crash-count"><b>${Number(c.affected_installs ?? 0)} ${i18n("installs", "安装")}</b><small>${Number(c.window_events ?? 0)} ${i18n("events", "事件")} · ${Number(c.identity_coverage ?? 0) >= 0.9 && Number(c.dimension_coverage ?? 1) >= 0.9 ? `${Math.round(Number(c.identity_coverage) * 100)}% ${i18n("identified", "已关联")}${c.impact_rate !== null && c.impact_rate !== undefined ? ` · ${(c.impact_rate * 100).toFixed(1)}% ${i18n("impact", "影响率")}` : ""}` : i18n("sample incomplete", "样本不完整")}</small><small>${c.count} ${i18n("lifetime", "累计")}</small></span>
-</a>`;
-    })
-    .join("")}</div>`;
 }
 
 export function renderStats(
@@ -806,11 +752,11 @@ ${anyPing ? dailyChart(days) : `<div class="empty">${i18n("No pings yet — data
   const diagnosticsModule = `<section id="diagnostics" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Diagnostic triage", "诊断分诊")}</h2></div><a class="module-action" href="#top">${i18n("Back to overview", "回到概览")}</a></div>
 <p class="sub">${i18n("Installation-linked data is available only from the diagnostics-v2 deployment date; historical device counts are not backfilled.", "可关联安装的数据仅从 diagnostics-v2 部署日起提供；历史设备数不回填。")}</p>
 ${firebaseStorage}
-<section class="module-panel"><h3>${i18nHTML("Needs attention <b>— top 10 release crashes and exceptions</b>", "优先处理 <b>— 正式版崩溃与异常 Top 10</b>")}</h3>${reportGroups(releaseCrashes.slice(0, 10), true)}</section>
-${performanceDiagnostics.length ? `<section class="module-panel"><h3>${i18nHTML("Performance signals <b>— tracked separately from crashes</b>", "性能信号 <b>— 与崩溃分开统计</b>")}</h3>${reportGroups(performanceDiagnostics.slice(0, 5), true)}</section>` : ""}
-${developmentDiagnostics.length ? `<section class="module-panel"><h3>${i18nHTML("Development diagnostics <b>— excluded from release priority</b>", "开发版诊断 <b>— 不计入正式版优先级</b>")}</h3>${reportGroups(developmentDiagnostics.slice(0, 5), true)}</section>` : ""}
+<section class="module-panel"><div class="panel-title"><h3>${i18nHTML("Needs attention <b>— top 10 release crashes and exceptions</b>", "优先处理 <b>— 正式版崩溃与异常 Top 10</b>")}</h3><span class="panel-context">${i18n(`Past ${range} days · ranked by affected installs`, `过去${range}天 · 按受影响安装降序`)}</span></div>${reportGroups(releaseCrashes.slice(0, 10), true, range)}</section>
+${performanceDiagnostics.length ? `<section class="module-panel"><div class="panel-title"><h3>${i18nHTML("Performance signals <b>— tracked separately from crashes</b>", "性能信号 <b>— 与崩溃分开统计</b>")}</h3><span class="panel-context">${i18n(`Past ${range} days · ranked by affected installs`, `过去${range}天 · 按受影响安装降序`)}</span></div>${reportGroups(performanceDiagnostics.slice(0, 5), true, range)}</section>` : ""}
+${developmentDiagnostics.length ? `<section class="module-panel"><div class="panel-title"><h3>${i18nHTML("Development diagnostics <b>— excluded from release priority</b>", "开发版诊断 <b>— 不计入正式版优先级</b>")}</h3><span class="panel-context">${i18n(`Past ${range} days · ranked by affected installs`, `过去${range}天 · 按受影响安装降序`)}</span></div>${reportGroups(developmentDiagnostics.slice(0, 5), true, range)}</section>` : ""}
 ${filters}
-<section class="module-panel"><h3>${i18nHTML("All report groups <b>— open, regression, severity, count, recency</b>", "全部诊断分组 <b>— 未处理、回归、严重性、次数和最近出现</b>")}</h3>${reportGroups(data.crashes)}</section>
+<section class="module-panel"><h3>${i18nHTML("All report groups <b>— open, regression, severity, count, recency</b>", "全部诊断分组 <b>— 未处理、回归、严重性、次数和最近出现</b>")}</h3>${reportGroups(data.crashes, false, range)}</section>
 </section>`;
   const preferencesModule = `<section id="preferences" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Settings preferences", "设置偏好")}</h2></div></div>
 <section class="module-panel"><h3>${i18nHTML(`Launch/open snapshots <b>— ${rangeText}</b>`, `启动/开启快照 <b>— ${rangeText}</b>`)}</h3>${settingsDashboard(settingsMetrics, { collapseSections: true })}</section></section>`;

--- a/workers/crash-report/src/stats_reports.ts
+++ b/workers/crash-report/src/stats_reports.ts
@@ -1,0 +1,71 @@
+import { esc } from "./shell";
+
+export function i18n(en: string, zh: string): string {
+  return `<span data-i18n="en">${esc(en)}</span><span data-i18n="zh">${esc(zh)}</span>`;
+}
+
+export function i18nHTML(en: string, zh: string): string {
+  return `<span data-i18n="en">${en}</span><span data-i18n="zh">${zh}</span>`;
+}
+
+export type CrashRow = {
+  fingerprint: string;
+  kind: string;
+  count: number;
+  first_version: string;
+  last_version: string;
+  seen: string;
+  status: string;
+  title: string;
+  source: string;
+  label: string;
+  error_type: string;
+  top_frame: string;
+  severity: string;
+  last_os: string;
+  last_arch: string;
+  last_channel: string;
+  regressed_at: string;
+  development?: boolean;
+  affected_installs?: number;
+  window_events?: number;
+  identified_events?: number;
+  identity_coverage?: number;
+  dimension_coverage?: number;
+  impact_rate?: number | null;
+};
+
+export function clip(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s;
+}
+
+export function statusPill(status: string): string {
+  if (status === "resolved") return `<span class="pill status-resolved">${i18n("Resolved", "已解决")}</span>`;
+  if (status === "ignored") return `<span class="pill status-ignored">${i18n("Ignored", "已忽略")}</span>`;
+  return `<span class="pill status-open open">${i18n("Open", "未处理")}</span>`;
+}
+
+function crashMetric(en: string, zh: string, value: string | number, className = ""): string {
+  return `<span class="crash-metric${className ? ` ${className}` : ""}"><b>${esc(value)}</b><small>${i18n(en, zh)}</small></span>`;
+}
+
+export function reportGroups(rows: CrashRow[], compact = false, windowDays: 7 | 30 = 30): string {
+  if (!rows.length) return `<div class="empty">${i18n("No diagnostic reports yet — that's the good kind of empty", "还没有诊断报告，这是好消息")}</div>`;
+  return `<div class="crash-list${compact ? " compact" : ""}"><div class="crash-head"><span>${i18n("summary", "摘要")}</span><span>${i18n("scope", "范围")}</span><span>${i18n("health", "状态")}</span><span title="${i18n("Window events, impact rate, identity coverage, and lifetime count", "窗口事件、影响率、身份覆盖率和累计事件")}">${i18n("triage metrics", "分诊指标")}</span></div>${rows
+    .map((c) => {
+      const platform = [c.last_os, c.last_arch].filter(Boolean).join("/");
+      const versions = `${c.first_version || "?"} → ${c.last_version || "?"}`;
+      const title = c.title || c.error_type || c.top_frame || c.fingerprint;
+      const identityCoverage = Number(c.identity_coverage ?? 0) >= 0.9 && Number(c.dimension_coverage ?? 1) >= 0.9;
+      const impactRate = c.impact_rate !== null && c.impact_rate !== undefined ? `${(Number(c.impact_rate) * 100).toFixed(1)}%` : "—";
+      return `<a class="crash-item" href="/stats/group/${esc(c.fingerprint)}" title="${esc(title)}">
+<span class="crash-summary" aria-label="${esc(title)}"><span>${c.title ? esc(clip(c.title, compact ? 150 : 180)) : `<span class="muted">${i18n("No summary captured", "暂无摘要")}</span>`}</span><small>${esc(c.fingerprint.slice(0, 8))} · ${esc(c.seen)}</small>${
+        c.regressed_at ? `<em>${i18nHTML(`regressed ${esc(c.regressed_at.slice(0, 10))}`, `回归 ${esc(c.regressed_at.slice(0, 10))}`)}</em>` : ""
+      }</span>
+<span class="crash-scope"><span class="crash-meta"><b>${i18n("Source", "来源")}</b><span>${esc(c.source || "legacy")}</span></span><span class="crash-meta"><b>${i18n("Versions", "版本")}</b><span>${esc(versions)}</span></span><span class="crash-meta"><b>${i18n("Platform", "平台")}</b><span>${platform ? esc(platform) : "unknown platform"}</span></span>${c.last_channel && c.last_channel !== "stable" ? `<span class="crash-meta"><b>${i18n("Channel", "渠道")}</b><span>${esc(c.last_channel)}</span></span>` : ""}</span>
+<span class="crash-health"><span class="pill">${esc(c.severity || "medium")}</span><span class="pill ${c.kind === "crash" ? "crash" : ""}">${esc(c.kind)}</span>${statusPill(c.status)}</span>
+<span class="crash-count"><span class="crash-metrics">${crashMetric(`Affected installs (${windowDays}d)`, `受影响安装（${windowDays}天）`, Number(c.affected_installs ?? 0), "primary")}${crashMetric("Impact rate", "影响率", impactRate)}${crashMetric("Window events", "窗口事件", Number(c.window_events ?? 0))}${crashMetric("Identity coverage", "身份覆盖率", identityCoverage ? `${Math.round(Number(c.identity_coverage) * 100)}%` : "sample incomplete / 样本不完整")}${crashMetric("Lifetime events", "累计事件", Number(c.count), "full")}</span></span>
+</a>`;
+    })
+    .join("")}</div>`;
+}


### PR DESCRIPTION
## Summary\n\n- Bound D1 group-detail sample reads to the first retained sample plus the latest five rows, with a fingerprint/id index.\n- Compute group totals from 30-day rollups and cap each technical facet at its top 20 values.\n- Gracefully degrade to the core group page when optional sample or distribution queries fail instead of propagating a Worker 1101.\n- Preserve the diagnostics triage readability improvements from the preceding merged PR: labeled metrics, explicit status, ranking context, and responsive rows.\n\n## Issues\n\nRefs #9752\n\n## Verification\n\n- cd workers/crash-report && npm test — 130 tests passed.\n- npm run typecheck, npx wrangler deploy --dry-run, go run ./tools/repolint, and git diff --check passed.\n- SQLite regression fixture with 35,000 reports returns only the first retained sample plus five latest samples.\n- D1 failure fixture confirms optional detail reads degrade without throwing.\n- Cloudflare D1 supports SQLite semantics; the bounded query avoids unbounded execution/result serialization on the Worker path.\n\n## Documentation impact\n\nDocumentation-impact: none - this is an internal admin diagnostics reliability fix; existing runbooks and user-facing behavior remain accurate.\n\n## Cache impact\n\nCache-impact: none - no provider prompts, memory prefixes, tool schemas, or model-visible bytes changed.\nCache-guard: N/A - the change is confined to the Crash Worker D1 read path and admin HTML rendering.\nSystem-prompt-review: N/A