### PR TITLE
fix(frontend): omit empty fenced Markdown blocks / 去掉空代码围栏产生的空白卡片

### DIFF
--- a/desktop/frontend/src/__tests__/markdown-pipeline.test.tsx
+++ b/desktop/frontend/src/__tests__/markdown-pipeline.test.tsx
@@ -111,6 +111,21 @@ for (const [name, text] of Object.entries(fixtures)) {
   eq(sliced, expected, `${name}: sliced blocks render identically (${blocks.length} blocks)`);
 }
 
+// Empty fenced blocks are formatting placeholders. They must not create a
+// bordered CodeViewer, while comment-only and whitespace-adjacent blocks stay
+// visible as real code content.
+{
+  const emptyFences = "Before\n\n```\n\n```\n\nAfter\n\n```ts\n   \n```";
+  const html = renderCurrent(emptyFences);
+  ok(!html.includes("code-block"), "empty fenced blocks do not render phantom code cards");
+  ok(html.includes("Before") && html.includes("After"), "text around empty fenced blocks remains visible");
+
+  const comments = "```ts\n// keep this comment\nconst stable = true;\n```";
+  const commentHtml = renderCurrent(comments);
+  ok(commentHtml.includes("keep this comment"), "non-empty comment code blocks remain visible");
+  ok(commentHtml.includes("code-block"), "non-empty comment code keeps its code-block surface");
+}
+
 // Block keys are stable top-level indexes.
 {
   const blocks = parseMarkdownToBlocks("one\n\ntwo\n\nthree");

--- a/desktop/frontend/src/components/markdownComponents.tsx
+++ b/desktop/frontend/src/components/markdownComponents.tsx
@@ -59,6 +59,7 @@ function splitPlainBlock(text: string): { preText: string; statusItems: string[]
 }
 
 function PlainMarkdownBlock({ text }: { text: string }) {
+  if (text.trim() === "") return null;
   const { preText, statusItems } = splitPlainBlock(text);
   const asList = statusItems.length >= 2;
   return (
@@ -97,6 +98,9 @@ export function createComponents(plainStatusBlocks: boolean): Components {
       const isBlock = match !== null || text.includes("\n");
       if (isBlock) {
         const value = text.replace(/\n$/, "");
+        // An empty fence is a formatting placeholder; a bordered one-line
+        // CodeViewer would otherwise become a phantom row in every surface.
+        if (value.trim() === "") return null;
         if (lang === "mermaid") {
           return (
             <Suspense fallback={<CodeViewer value={value} language="mermaid" scrollMode="bounded" maxHeight="min(60vh, 28rem)" />}>


### PR DESCRIPTION
## Summary

Fenced code blocks with no content rendered as bordered one-line `CodeViewer` cards. The #9711 capture shows them as empty boxes between paragraphs; each one also adds phantom height to its transcript row.

## Change

`createComponents()` returns `null` for a fenced block whose trimmed value is empty, and `PlainMarkdownBlock` does the same for whitespace-only plain blocks. Comment-only and any other non-empty code keeps its `code-block` surface.

## Verification

- `markdown-pipeline.test.tsx`: four new assertions (empty fences render nothing, surrounding text survives, comment-only blocks keep their surface). They fail against the previous component.
- `typecheck`, `lint:hooks`, `transcript-selection-rendering`, `transcript-virtualization`, `markdown-table-virtual`, `transcript-row-geometry`, `vite build`, bundle budgets: pass. No budget change needed.

## Relationship to #9754

Extracted verbatim (minus a shortened comment) from #9754 so the display fix can land now, independently of the scroll-ownership changes that still need rework.

Documentation-impact: none - removes a rendering artifact; no documented Markdown behavior changes.
