### PR TITLE
fix(provider,agent): replay DeepSeek thinking on all turns and self-heal stale-thinking 400 / DeepSeek thinking 全轮回传与 400 自愈修复

### DIFF
--- a/docs/REASONING_PROVIDERS.md
+++ b/docs/REASONING_PROVIDERS.md
@@ -66,7 +66,9 @@ New official entries use this native Messages API path and enable provider-side
 `web_search`; existing explicit providers, including legacy
 `deepseek-anthropic` entries, keep their configured protocol. Reasonix emits
 `thinking.type=enabled|disabled` with `output_config.effort`, replays unsigned
-DeepSeek thinking blocks from historical tool-call turns, omits unsupported
+DeepSeek thinking blocks from every historical assistant turn that carries
+reasoning (tool-call turn or not, as DeepSeek's thinking mode requires when the
+request declares tools), omits unsupported
 images, and relies on DeepSeek's automatic prefix cache instead of ignored
 `cache_control` markers.
 

--- a/internal/agent/reasoning_replay.go
+++ b/internal/agent/reasoning_replay.go
@@ -102,6 +102,33 @@ func (a *Agent) finishReasoningReplayRetry(retry streamedTurn, sink *deferredStr
 	return retry
 }
 
+// finishReasoningReplayOverflow terminates an attempt whose required reasoning
+// was truncated by the client limit: audit, finalize usage, and hand the turn
+// to the unreplayable-reasoning policy.
+func (a *Agent) finishReasoningReplayOverflow(result streamedTurn, sink *deferredStreamSink, issue ReasoningReplayFailure, billable *provider.Usage, attemptID string, attempt int) streamedTurn {
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningOverflowDetected})
+	result.usage = finalizeSamplingUsage(billable, result.usage)
+	terminal := a.finishUnreplayableReasoning(result, sink, issue)
+	a.emitReasoningReplayAttemptOutcome(attemptID, attempt, terminal.err)
+	return terminal
+}
+
+// suppressMissingReasoningRetry handles a missing-reasoning turn whose one
+// exact replay was already spent (or claimed cross-process): try the
+// provider-declared fallback, otherwise terminate through the
+// unreplayable-reasoning policy.
+func (a *Agent) suppressMissingReasoningRetry(ctx context.Context, turn int, frozen *samplingRequest, attemptID string, attempt int, sink *deferredStreamSink, result streamedTurn, issue ReasoningReplayFailure, billable *provider.Usage) streamedTurn {
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetrySuppressed})
+	if fallback, ok := a.runMissingReasoningFallback(ctx, turn, frozen, attemptID, attempt, billable, sink); ok {
+		return fallback
+	}
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
+	result.usage = finalizeSamplingUsage(billable, result.usage)
+	terminal := a.finishUnreplayableReasoning(result, sink, issue)
+	a.emitReasoningReplayAttemptOutcome(attemptID, attempt, terminal.err)
+	return terminal
+}
+
 func (a *Agent) finishUnreplayableReasoning(result streamedTurn, sink *deferredStreamSink, issue ReasoningReplayFailure) streamedTurn {
 	if issue == "" {
 		sink.Flush()

--- a/internal/agent/reasoning_replay_recovery.go
+++ b/internal/agent/reasoning_replay_recovery.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"reasonix/internal/event"
+	"reasonix/internal/i18n"
+	"reasonix/internal/provider"
+)
+
+// reasoningReplayRecoveryBudget bounds the thinking-400 catch-and-repair to one
+// retry per model round. It is independent from the context-recovery budget so
+// one overflow repair and one reasoning repair can never multiply requests.
+type reasoningReplayRecoveryBudget struct {
+	retries int
+}
+
+// recoverReasoningReplay400 applies the vendor-documented self-heal for a
+// provider that rejected replayed thinking history with HTTP 400: rebuild the
+// frozen request's messages through the strong projection (all assistant
+// reasoning stripped, unpaired tool activity dropped) and retry exactly once.
+// Everything except Messages stays byte-identical to the rejected request. A
+// history the projection cannot change is not worth a blind retry.
+func (a *Agent) recoverReasoningReplay400(frozen samplingRequest, err error, budget *reasoningReplayRecoveryBudget) (samplingRequest, bool) {
+	if a == nil || budget == nil || budget.retries > 0 {
+		return samplingRequest{}, false
+	}
+	if provider.AsReasoningReplayError(err) == nil {
+		return samplingRequest{}, false
+	}
+	repaired, changed := provider.ProjectReasoningStrippedMessages(a.svc.prov, frozen.req.Messages)
+	if !changed {
+		return samplingRequest{}, false
+	}
+	budget.retries++
+	next := frozen.req
+	next.Messages = repaired
+	return samplingRequest{req: next}, true
+}
+
+// activateReasoningReplayStrongProjection records that this conversation's
+// canonical history carries reasoning the provider rejects. Later rounds and
+// turns keep projecting through the strong projection instead of paying
+// another 400 plus repair retry per round.
+func (a *Agent) activateReasoningReplayStrongProjection() {
+	if a == nil {
+		return
+	}
+	a.sess.reasoningReplayStrongProjection = true
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Recovered})
+	a.emitReasoningReplayRepairNotice()
+}
+
+func (a *Agent) emitReasoningReplayRepairNotice() {
+	if a == nil || a.svc.sink == nil {
+		return
+	}
+	a.svc.sink.Emit(event.Event{
+		Kind:   event.Notice,
+		Level:  event.LevelWarn,
+		Code:   event.NoticeCodeReasoningReplayRepair,
+		Text:   i18n.M.ReasoningReplayRepair,
+		Detail: "provider rejected replayed thinking blocks (HTTP 400); retried once with reasoning stripped from the projected history",
+	})
+}

--- a/internal/agent/reasoning_replay_recovery.go
+++ b/internal/agent/reasoning_replay_recovery.go
@@ -36,6 +36,24 @@ func (a *Agent) recoverReasoningReplay400(frozen samplingRequest, err error, bud
 	return samplingRequest{req: next}, true
 }
 
+// tryRecoverReasoningReplay400 is the streamWithSamplingRecovery branch for a
+// thinking-400: the frozen history's replayed reasoning is stale for this
+// provider, so repair the projection once and retry; every other 400 falls
+// through to the terminal path. On a repair the speculative attempt's buffered
+// events are discarded and the attempt is audited before the caller replays.
+func (a *Agent) tryRecoverReasoningReplay400(streamSink *deferredStreamSink, frozen samplingRequest, attemptID string, attempt int, err error, budget *reasoningReplayRecoveryBudget) (samplingRequest, bool) {
+	next, ok := a.recoverReasoningReplay400(frozen, err, budget)
+	if !ok {
+		return samplingRequest{}, false
+	}
+	if streamSink != nil {
+		streamSink.Discard()
+	}
+	a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, "reasoning_replay_400", err)
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Detected})
+	return next, true
+}
+
 // activateReasoningReplayStrongProjection records that this conversation's
 // canonical history carries reasoning the provider rejects. Later rounds and
 // turns keep projecting through the strong projection instead of paying

--- a/internal/agent/reasoning_replay_recovery_test.go
+++ b/internal/agent/reasoning_replay_recovery_test.go
@@ -290,3 +290,143 @@ func TestStrictNoWarningReplayDoesNotLeakSpeculativeEvents(t *testing.T) {
 		}
 	}
 }
+
+func thinkingReplay400Error() error {
+	return provider.ParseReasoningReplayError(&provider.APIError{
+		Provider: "strict-replay", Status: 400,
+		Body: `{"error":{"message":"The ` + "`content[].thinking`" + ` in the thinking mode must be passed back to the API"}}`,
+	})
+}
+
+func reasoningReplaySeededSession() *Session {
+	session := NewSession("system")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "earlier"})
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "old answer", ReasoningContent: "stale thinking"})
+	return session
+}
+
+func TestReasoningReplay400RepairsProjectionAndRetriesOnce(t *testing.T) {
+	mp := testutil.NewMock("strict-replay",
+		testutil.ErrorTurn(thinkingReplay400Error()),
+		testutil.Turn{Text: "done"},
+		testutil.Turn{Text: "again done"},
+	)
+	sink := &recordSink{}
+	session := reasoningReplaySeededSession()
+	a := New(strictAssistantReasoningProvider{mp}, echoRegistry(), session, Options{}, sink)
+
+	if err := a.Run(withNoClosedLoop(context.Background()), "next"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := mp.CallCount(); got != 2 {
+		t.Fatalf("provider calls = %d, want rejected attempt plus one repair retry", got)
+	}
+	requests := mp.Requests()
+	var firstReasoning, secondReasoning int
+	for _, m := range requests[0].Messages {
+		if m.ReasoningContent != "" {
+			firstReasoning++
+		}
+	}
+	for _, m := range requests[1].Messages {
+		if m.ReasoningContent != "" {
+			secondReasoning++
+		}
+	}
+	if firstReasoning != 1 || secondReasoning != 0 {
+		t.Fatalf("reasoning in attempts = %d then %d, want the repair retry stripped", firstReasoning, secondReasoning)
+	}
+	// The frozen request may change only in Messages; everything else is
+	// byte-identical to the rejected attempt.
+	strippedTools := requests[1]
+	strippedTools.Messages = requests[0].Messages
+	if !reflect.DeepEqual(requests[0], strippedTools) {
+		t.Fatalf("repair retry changed more than Messages:\nfirst=%+v\nretry=%+v", requests[0], requests[1])
+	}
+	// Canonical history is never modified by the provider-visible projection.
+	for _, m := range session.Snapshot() {
+		if m.Role == provider.RoleAssistant && m.Content == "old answer" && m.ReasoningContent != "stale thinking" {
+			t.Fatalf("canonical history lost its reasoning: %+v", m)
+		}
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 1 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 1", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Recovered); got != 1 {
+		t.Fatalf("reasoning_replay_400_recovered audits = %d, want 1", got)
+	}
+	var repairNotices int
+	for _, e := range sink.kinds(event.Notice) {
+		if e.Code == event.NoticeCodeReasoningReplayRepair {
+			repairNotices++
+			if e.Level != event.LevelWarn {
+				t.Fatalf("repair notice level = %v, want warn", e.Level)
+			}
+		}
+	}
+	if repairNotices != 1 {
+		t.Fatalf("repair notices = %d, want 1", repairNotices)
+	}
+
+	// The strong projection stays active for the rest of the conversation.
+	if err := a.Run(withNoClosedLoop(context.Background()), "again"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if got := mp.CallCount(); got != 3 {
+		t.Fatalf("provider calls = %d, want no fresh 400 on the next run", got)
+	}
+	for _, m := range mp.Requests()[2].Messages {
+		if m.ReasoningContent != "" {
+			t.Fatalf("later request still carries reasoning under strong projection: %+v", m)
+		}
+	}
+}
+
+func TestReasoningReplay400RepairExhaustionStaysTerminal(t *testing.T) {
+	mp := testutil.NewMock("strict-replay",
+		testutil.ErrorTurn(thinkingReplay400Error()),
+		testutil.ErrorTurn(thinkingReplay400Error()),
+		testutil.Turn{Text: "unreachable"},
+	)
+	sink := &recordSink{}
+	a := New(strictAssistantReasoningProvider{mp}, echoRegistry(), reasoningReplaySeededSession(), Options{}, sink)
+
+	err := a.Run(withNoClosedLoop(context.Background()), "next")
+	var replayErr *provider.ReasoningReplayError
+	if !errors.As(err, &replayErr) {
+		t.Fatalf("Run error = %v, want ReasoningReplayError", err)
+	}
+	if got := mp.CallCount(); got != 2 {
+		t.Fatalf("provider calls = %d, want exactly one repair retry", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 1 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 1", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Recovered); got != 0 {
+		t.Fatalf("reasoning_replay_400_recovered audits = %d, want 0 after a failed repair", got)
+	}
+}
+
+func TestNonReplay400DoesNotTriggerReasoningRepair(t *testing.T) {
+	mp := testutil.NewMock("strict-replay",
+		testutil.ErrorTurn(&provider.APIError{Provider: "strict-replay", Status: 400, Body: `{"error":{"message":"invalid request: unknown tool"}}`}),
+		testutil.Turn{Text: "unreachable"},
+	)
+	sink := &recordSink{}
+	a := New(strictAssistantReasoningProvider{mp}, echoRegistry(), reasoningReplaySeededSession(), Options{}, sink)
+
+	err := a.Run(withNoClosedLoop(context.Background()), "next")
+	var apiErr *provider.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Run error = %v, want the raw APIError", err)
+	}
+	if replayErr := provider.AsReasoningReplayError(err); replayErr != nil {
+		t.Fatalf("unrelated 400 misclassified as reasoning replay: %v", replayErr)
+	}
+	if got := mp.CallCount(); got != 1 {
+		t.Fatalf("provider calls = %d, want no retry for an unrelated 400", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 0 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 0", got)
+	}
+}

--- a/internal/agent/retry_e2e_test.go
+++ b/internal/agent/retry_e2e_test.go
@@ -420,12 +420,12 @@ func TestDeepSeekAnthropicThinking400CatchAndRepair(t *testing.T) {
 	}
 	// The adopted answer streamed through and the canonical history keeps both
 	// turns' reasoning untouched by the provider-visible repair.
-	var answer string
+	var answer strings.Builder
 	for _, e := range sink.kinds(event.Text) {
-		answer += e.Text
+		answer.WriteString(e.Text)
 	}
-	if answer != "repaired answer" {
-		t.Fatalf("streamed answer = %q, want the repaired response", answer)
+	if answer.String() != "repaired answer" {
+		t.Fatalf("streamed answer = %q, want the repaired response", answer.String())
 	}
 
 	// The next run keeps the strong projection: no reasoning reaches the wire.

--- a/internal/agent/retry_e2e_test.go
+++ b/internal/agent/retry_e2e_test.go
@@ -3,10 +3,12 @@ package agent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,6 +17,7 @@ import (
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
+	"reasonix/internal/provider/anthropic"
 	"reasonix/internal/provider/openai"
 	"reasonix/internal/tool"
 )
@@ -320,5 +323,128 @@ func TestGLMReasoningOverflowFailsBeforeToolExecution(t *testing.T) {
 	}
 	if got := requests.Load(); got != 1 {
 		t.Fatalf("HTTP requests = %d, want no continuation after incomplete GLM reasoning", got)
+	}
+}
+
+// TestDeepSeekAnthropicThinking400CatchAndRepair drives the full self-heal
+// against the real Anthropic-adapter wire shape: the first request replays the
+// stored thinking block and the server rejects it with DeepSeek's documented
+// 400; the agent must repair the projection once (stripping all reasoning),
+// retry, and keep the strong projection for the following run.
+func TestDeepSeekAnthropicThinking400CatchAndRepair(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, append([]byte(nil), body...))
+		requestNo := len(bodies)
+		mu.Unlock()
+
+		if requestNo == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"The ` + "`content[].thinking`" + ` in the thinking mode must be passed back to the API","type":"invalid_request_error"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":20,\"output_tokens\":1}}}\n\n")
+		if requestNo == 2 {
+			_, _ = io.WriteString(w, "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n")
+			_, _ = io.WriteString(w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"fresh thinking\"}}\n\n")
+			_, _ = io.WriteString(w, "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
+		}
+		_, _ = io.WriteString(w, "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"repaired answer\"}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"content_block_stop\",\"index\":1}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"message_stop\"}\n\n")
+	}))
+	defer srv.Close()
+
+	prov, err := anthropic.New(provider.Config{
+		Name: "deepseek-anthropic", BaseURL: srv.URL, Model: "deepseek-v4-flash", APIKey: "k",
+		Extra: map[string]any{"reasoning_protocol": "deepseek", "thinking": "enabled"},
+	})
+	if err != nil {
+		t.Fatalf("New provider: %v", err)
+	}
+	session := NewSession("system")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "earlier"})
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "old answer", ReasoningContent: "stale thinking"})
+	sink := &recordSink{}
+	a := New(prov, echoRegistry(), session, Options{}, sink)
+
+	if err := a.Run(withNoClosedLoop(context.Background()), "next"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	gotBodies := append([][]byte(nil), bodies...)
+	mu.Unlock()
+	if len(gotBodies) != 2 {
+		t.Fatalf("HTTP requests = %d, want rejected attempt plus one repair retry", len(gotBodies))
+	}
+	if !bytes.Contains(gotBodies[0], []byte(`"type":"thinking"`)) || !bytes.Contains(gotBodies[0], []byte("stale thinking")) {
+		t.Fatalf("first request did not replay the stored thinking block: %s", gotBodies[0])
+	}
+	if bytes.Contains(gotBodies[1], []byte(`"type":"thinking"`)) || bytes.Contains(gotBodies[1], []byte("stale thinking")) {
+		t.Fatalf("repair retry still carries thinking blocks: %s", gotBodies[1])
+	}
+	if !bytes.Contains(gotBodies[1], []byte("old answer")) {
+		t.Fatalf("repair retry lost the visible assistant text: %s", gotBodies[1])
+	}
+	// Only Messages may change between the rejected request and its repair.
+	var first, second map[string]json.RawMessage
+	if err := json.Unmarshal(gotBodies[0], &first); err != nil || json.Unmarshal(gotBodies[1], &second) != nil {
+		t.Fatalf("decode request bodies: %v", err)
+	}
+	delete(first, "messages")
+	delete(second, "messages")
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("repair retry changed non-message fields:\nfirst=%s\nretry=%s", gotBodies[0], gotBodies[1])
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 1 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 1", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Recovered); got != 1 {
+		t.Fatalf("reasoning_replay_400_recovered audits = %d, want 1", got)
+	}
+	var repairNotices int
+	for _, e := range sink.kinds(event.Notice) {
+		if e.Code == event.NoticeCodeReasoningReplayRepair && e.Level == event.LevelWarn {
+			repairNotices++
+		}
+	}
+	if repairNotices != 1 {
+		t.Fatalf("repair notices = %d, want 1", repairNotices)
+	}
+	// The adopted answer streamed through and the canonical history keeps both
+	// turns' reasoning untouched by the provider-visible repair.
+	var answer string
+	for _, e := range sink.kinds(event.Text) {
+		answer += e.Text
+	}
+	if answer != "repaired answer" {
+		t.Fatalf("streamed answer = %q, want the repaired response", answer)
+	}
+
+	// The next run keeps the strong projection: no reasoning reaches the wire.
+	if err := a.Run(withNoClosedLoop(context.Background()), "again"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	mu.Lock()
+	third := append([]byte(nil), bodies[len(bodies)-1]...)
+	total := len(bodies)
+	mu.Unlock()
+	if total != 3 {
+		t.Fatalf("HTTP requests = %d, want one more for the follow-up run", total)
+	}
+	if bytes.Contains(third, []byte(`"type":"thinking"`)) || bytes.Contains(third, []byte("stale thinking")) || bytes.Contains(third, []byte("fresh thinking")) {
+		t.Fatalf("strong projection did not persist into the next run: %s", third)
+	}
+	for _, m := range session.Snapshot() {
+		if m.Role == provider.RoleAssistant && m.Content == "old answer" && m.ReasoningContent != "stale thinking" {
+			t.Fatalf("canonical history lost its reasoning: %+v", m)
+		}
 	}
 }

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -46,78 +46,6 @@ func (s streamedTurn) assistantMessage() provider.Message {
 	}
 }
 
-// deferredStreamSink keeps selected stream events local until the caller
-// chooses which provider response to adopt. On an ordinary healthy DeepSeek
-// turn, reasoning arrives before tool calls and unlocks live tool-card events.
-// On the rare malformed turn with no reasoning, only the speculative partial
-// tool cards remain buffered, so retrying does not flash duplicate cards in the
-// UI. A recovery attempt buffers everything because it may be discarded.
-type deferredStreamSink struct {
-	inner               event.Sink
-	deferAll            bool
-	waitingForReasoning bool
-	sawReasoning        bool
-	events              []event.Event
-}
-
-func newReasoningAwareStreamSink(inner event.Sink) *deferredStreamSink {
-	return &deferredStreamSink{inner: inner, waitingForReasoning: true}
-}
-
-func newDeferredStreamSink(inner event.Sink) *deferredStreamSink {
-	return &deferredStreamSink{inner: inner, deferAll: true}
-}
-
-func (s *deferredStreamSink) Emit(e event.Event) {
-	if s == nil {
-		return
-	}
-	if s.deferAll {
-		s.events = append(s.events, e)
-		return
-	}
-	if s.waitingForReasoning && e.Kind == event.Reasoning && strings.TrimSpace(e.Text) != "" {
-		s.sawReasoning = true
-		s.inner.Emit(e)
-		s.flushBuffered()
-		return
-	}
-	if s.waitingForReasoning && !s.sawReasoning {
-		switch e.Kind {
-		case event.ToolDispatch, event.ToolResult, event.Text, event.Message:
-			// Keep every user-visible speculative event private until reasoning
-			// proves the turn replayable. Healthy DeepSeek responses emit
-			// reasoning first, so their live-streaming fast path is unchanged.
-			s.events = append(s.events, e)
-			return
-		}
-	}
-	s.inner.Emit(e)
-}
-
-func (s *deferredStreamSink) flushBuffered() {
-	if s == nil {
-		return
-	}
-	for _, e := range s.events {
-		s.inner.Emit(e)
-	}
-	s.events = nil
-}
-
-func (s *deferredStreamSink) Flush() {
-	if s == nil {
-		return
-	}
-	s.flushBuffered()
-}
-
-func (s *deferredStreamSink) Discard() {
-	if s != nil {
-		s.events = nil
-	}
-}
-
 // beginRunTurn handles evidence scope, delivery classification, background-job
 // evidence re-lease, and the initial user-turn persistence. Callers still own
 // all Run-level defers (workspace lease, evidence commit, delivery checkpoint,
@@ -392,15 +320,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 				attempt = 0
 				continue
 			}
-			// A thinking-400 means the frozen history's replayed reasoning is
-			// stale for this provider. Repair the projection once and retry;
-			// every other 400 keeps falling through to the terminal path.
-			if next, retryReplay := a.recoverReasoningReplay400(frozen, result.err, &replayRecovery); retryReplay {
-				if streamSink != nil {
-					streamSink.Discard()
-				}
-				a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, "reasoning_replay_400", result.err)
-				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Detected})
+			if next, retryReplay := a.tryRecoverReasoningReplay400(streamSink, frozen, attemptID, attempt, result.err, &replayRecovery); retryReplay {
 				frozen = next
 				reasoningReplayRepaired = true
 				attempt = 0
@@ -431,11 +351,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 			a.observeMissingAssistantReasoning(result.assistantMessage(), result.reasoningComplete)
 		}
 		if issue == ReasoningReplayOverflow {
-			event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningOverflowDetected})
-			result.usage = finalizeSamplingUsage(billable, result.usage)
-			terminal := a.finishUnreplayableReasoning(result, streamSink, issue)
-			a.emitReasoningReplayAttemptOutcome(attemptID, attempt, terminal.err)
-			return terminal
+			return a.finishReasoningReplayOverflow(result, streamSink, issue, billable, attemptID, attempt)
 		}
 		if missing {
 			event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
@@ -475,15 +391,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 				return retry
 			}
 			if !shouldRetry {
-				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetrySuppressed})
-				if fallback, ok := a.runMissingReasoningFallback(ctx, turn, &frozen, attemptID, attempt, billable, streamSink); ok {
-					return fallback
-				}
-				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
-				result.usage = finalizeSamplingUsage(billable, result.usage)
-				terminal := a.finishUnreplayableReasoning(result, streamSink, issue)
-				a.emitReasoningReplayAttemptOutcome(attemptID, attempt, terminal.err)
-				return terminal
+				return a.suppressMissingReasoningRetry(ctx, turn, &frozen, attemptID, attempt, streamSink, result, issue, billable)
 			}
 		}
 
@@ -491,9 +399,6 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
 		result.usage = finalizeSamplingUsage(billable, result.usage)
 		if reasoningReplayRepaired {
-			// The repair retry proved the canonical history's stored reasoning is
-			// stale for this provider; keep the strong projection for the rest of
-			// the conversation so later rounds do not pay another 400.
 			a.activateReasoningReplayStrongProjection()
 		}
 		return result

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -363,6 +363,8 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 	// its delta so RequestCount equals real HTTP POSTs (no triangular growth).
 	ctx = provider.WithRequestAttemptCounter(ctx)
 	var contextRecovery contextRecoveryBudget
+	var replayRecovery reasoningReplayRecoveryBudget
+	reasoningReplayRepaired := false
 
 	var billable *provider.Usage
 	var last streamedTurn
@@ -387,6 +389,20 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 				}
 				a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, "context_limit", result.err)
 				frozen = next
+				attempt = 0
+				continue
+			}
+			// A thinking-400 means the frozen history's replayed reasoning is
+			// stale for this provider. Repair the projection once and retry;
+			// every other 400 keeps falling through to the terminal path.
+			if next, retryReplay := a.recoverReasoningReplay400(frozen, result.err, &replayRecovery); retryReplay {
+				if streamSink != nil {
+					streamSink.Discard()
+				}
+				a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, "reasoning_replay_400", result.err)
+				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Detected})
+				frozen = next
+				reasoningReplayRepaired = true
 				attempt = 0
 				continue
 			}
@@ -474,6 +490,12 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		streamSink.Flush()
 		a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
 		result.usage = finalizeSamplingUsage(billable, result.usage)
+		if reasoningReplayRepaired {
+			// The repair retry proved the canonical history's stored reasoning is
+			// stale for this provider; keep the strong projection for the rest of
+			// the conversation so later rounds do not pay another 400.
+			a.activateReasoningReplayStrongProjection()
+		}
 		return result
 	}
 	return last

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -165,7 +165,13 @@ func (a *Agent) providerProjectionMessages(msgs []provider.Message) []provider.M
 		// The provider-declared fallback owns this tool loop. Strict projection
 		// here would erase its completed tool round before adapter serialization.
 		if !a.sess.missingReasoning.fallbackActive || !provider.SupportsMissingReasoningFallback(a.svc.prov) {
-			if repaired, changed := provider.ProjectReplaySafeMessages(a.svc.prov, msgs); changed {
+			if a.sess.reasoningReplayStrongProjection {
+				// A repaired thinking-400 conversation keeps the stripped
+				// projection: its canonical reasoning is stale for this provider.
+				if repaired, changed := provider.ProjectReasoningStrippedMessages(a.svc.prov, msgs); changed {
+					msgs = repaired
+				}
+			} else if repaired, changed := provider.ProjectReplaySafeMessages(a.svc.prov, msgs); changed {
 				msgs = repaired
 			}
 		}

--- a/internal/agent/sessionstate.go
+++ b/internal/agent/sessionstate.go
@@ -25,10 +25,9 @@ type sessionRuntime struct {
 
 	missingReasoning missingReasoningWatch
 
-	// reasoningReplayStrongProjection is set once a thinking-400 catch-and-repair
-	// retry succeeds: the canonical history carries reasoning this provider
-	// rejects, so every later provider request in this conversation keeps using
-	// the stripped projection instead of paying another 400 per round.
+	// reasoningReplayStrongProjection is set once a thinking-400 repair retry
+	// succeeds: this conversation's stored reasoning is stale for the provider,
+	// so later requests keep using the stripped projection.
 	reasoningReplayStrongProjection bool
 
 	// compactionMu guards projection snapshots/install and the in-memory sidecar

--- a/internal/agent/sessionstate.go
+++ b/internal/agent/sessionstate.go
@@ -25,6 +25,12 @@ type sessionRuntime struct {
 
 	missingReasoning missingReasoningWatch
 
+	// reasoningReplayStrongProjection is set once a thinking-400 catch-and-repair
+	// retry succeeds: the canonical history carries reasoning this provider
+	// rejects, so every later provider request in this conversation keeps using
+	// the stripped projection instead of paying another 400 per round.
+	reasoningReplayStrongProjection bool
+
 	// compactionMu guards projection snapshots/install and the in-memory sidecar
 	// generation. Network summarization never runs while this lock is held.
 	compactionMu sync.Mutex
@@ -65,6 +71,7 @@ func (r *sessionRuntime) reset(s *Session) {
 	r.cacheMiss.Store(0)
 	r.output.reset()
 	r.missingReasoning = missingReasoningWatch{}
+	r.reasoningReplayStrongProjection = false
 	r.compactionMu.Lock()
 	r.compactionState = CompactionState{} // lineage change; disk reloaded on Resume
 	r.cacheState = CacheStateUnknown

--- a/internal/agent/sessionstate_test.go
+++ b/internal/agent/sessionstate_test.go
@@ -19,10 +19,13 @@ var sessionReset = map[string]bool{
 	"cacheHit":         true,
 	"cacheMiss":        true,
 	"missingReasoning": true,
-	"compactionMu":     true,
-	"compactionState":  true,
-	"cacheState":       true,
-	"compaction":       true,
+	// A strong-projection repair belongs to the corrupted conversation; a new
+	// conversation starts without it.
+	"reasoningReplayStrongProjection": true,
+	"compactionMu":                    true,
+	"compactionState":                 true,
+	"cacheState":                      true,
+	"compaction":                      true,
 }
 
 // sessionCarryOver names the fields reset deliberately leaves alone, each with

--- a/internal/agent/stream_sink.go
+++ b/internal/agent/stream_sink.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"strings"
+
+	"reasonix/internal/event"
+)
+
+// deferredStreamSink keeps selected stream events local until the caller
+// chooses which provider response to adopt. On an ordinary healthy DeepSeek
+// turn, reasoning arrives before tool calls and unlocks live tool-card events.
+// On the rare malformed turn with no reasoning, only the speculative partial
+// tool cards remain buffered, so retrying does not flash duplicate cards in the
+// UI. A recovery attempt buffers everything because it may be discarded.
+type deferredStreamSink struct {
+	inner               event.Sink
+	deferAll            bool
+	waitingForReasoning bool
+	sawReasoning        bool
+	events              []event.Event
+}
+
+func newReasoningAwareStreamSink(inner event.Sink) *deferredStreamSink {
+	return &deferredStreamSink{inner: inner, waitingForReasoning: true}
+}
+
+func newDeferredStreamSink(inner event.Sink) *deferredStreamSink {
+	return &deferredStreamSink{inner: inner, deferAll: true}
+}
+
+func (s *deferredStreamSink) Emit(e event.Event) {
+	if s == nil {
+		return
+	}
+	if s.deferAll {
+		s.events = append(s.events, e)
+		return
+	}
+	if s.waitingForReasoning && e.Kind == event.Reasoning && strings.TrimSpace(e.Text) != "" {
+		s.sawReasoning = true
+		s.inner.Emit(e)
+		s.flushBuffered()
+		return
+	}
+	if s.waitingForReasoning && !s.sawReasoning {
+		switch e.Kind {
+		case event.ToolDispatch, event.ToolResult, event.Text, event.Message:
+			// Keep every user-visible speculative event private until reasoning
+			// proves the turn replayable. Healthy DeepSeek responses emit
+			// reasoning first, so their live-streaming fast path is unchanged.
+			s.events = append(s.events, e)
+			return
+		}
+	}
+	s.inner.Emit(e)
+}
+
+func (s *deferredStreamSink) flushBuffered() {
+	if s == nil {
+		return
+	}
+	for _, e := range s.events {
+		s.inner.Emit(e)
+	}
+	s.events = nil
+}
+
+func (s *deferredStreamSink) Flush() {
+	if s == nil {
+		return
+	}
+	s.flushBuffered()
+}
+
+func (s *deferredStreamSink) Discard() {
+	if s != nil {
+		s.events = nil
+	}
+}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -673,6 +673,8 @@ const (
 	ProtocolRecoveryClientToolRejected              ProtocolRecoveryKind = "client_tool_rejected_unreplayable_reasoning"
 	ProtocolRecoveryServerSearchSalvaged            ProtocolRecoveryKind = "server_search_history_salvaged"
 	ProtocolRecoveryHistoryRepaired                 ProtocolRecoveryKind = "unreplayable_history_repaired"
+	ProtocolRecoveryReasoningReplay400Detected      ProtocolRecoveryKind = "reasoning_replay_400_detected"
+	ProtocolRecoveryReasoningReplay400Recovered     ProtocolRecoveryKind = "reasoning_replay_400_recovered"
 )
 
 type ProtocolRecoveryAudit struct {

--- a/internal/event/notice_codes.go
+++ b/internal/event/notice_codes.go
@@ -41,4 +41,5 @@ const (
 	NoticeCodeSessionTakenOver                                  = "session_taken_over"
 	NoticeCodeSessionReclaimRequested                           = "session_reclaim_requested"
 	NoticeCodeSessionReclaimed                                  = "session_reclaimed"
+	NoticeCodeReasoningReplayRepair                             = "reasoning_replay_repair"
 )

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -39,6 +39,7 @@ type Messages struct {
 	ReadinessContinuing    string // host is automatically finishing known readiness gaps
 	RecoveryPaused         string // controlled Auto retry pause; user can continue in the next message
 	CompletionUncertain    string // completion validator could not confirm the result; work is kept
+	ReasoningReplayRepair  string // provider rejected replayed thinking blocks; history repaired and retried once
 	ReceiptVerified        string // end-of-turn receipt, nothing unproven
 	ReceiptGapsHeader      string // end-of-turn receipt, header above the unproven list
 	ReceiptRisksHeader     string // end-of-turn receipt, header above declared risks

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -15,6 +15,7 @@ var English = Messages{
 	ReadinessContinuing:    "Reasonix is finishing the remaining task work or checks automatically.",
 	RecoveryPaused:         "Automatic retries paused. Reasonix stopped repeated attempts and kept completed work. Send “Continue” to start a fresh attempt, or add instructions to change direction.",
 	CompletionUncertain:    "Completion could not be confirmed. The current result and completed work are kept. Send \"continue\" to resume, or restate what should change.",
+	ReasoningReplayRepair:  "The model provider rejected this conversation's stored thinking blocks. Reasonix removed them from the provider-visible history and retried once.",
 	ReceiptVerified:        "nothing left unverified",
 	ReceiptGapsHeader:      "not verified:",
 	ReceiptRisksHeader:     "declared risks:",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -16,6 +16,7 @@ var Chinese = Messages{
 	ReadinessContinuing:    "Reasonix 正在自动完成剩余任务或检查。",
 	RecoveryPaused:         "已暂停自动重试。Reasonix 已停止重复尝试，并保留已完成的工作。发送“继续”即可开始新一轮，也可以补充要求来调整方向。",
 	CompletionUncertain:    "完成状态未确认。当前结果和已完成工作均已保留。发送“继续”可接着完成，也可以补充说明需要调整的内容。",
+	ReasoningReplayRepair:  "模型服务拒绝了本会话历史中的 thinking 块。Reasonix 已从发送给模型的历史中移除这些内容，并重试了一次。",
 	ReceiptVerified:        "没有未经验证的部分",
 	ReceiptGapsHeader:      "未验证:",
 	ReceiptRisksHeader:     "已申报的风险:",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -16,6 +16,7 @@ var ChineseTraditional = Messages{
 	ReadinessContinuing:    "Reasonix 正在自動完成剩餘任務或檢查。",
 	RecoveryPaused:         "已暫停自動重試。Reasonix 已停止重複嘗試，並保留已完成的工作。傳送「繼續」即可開始新一輪，也可以補充要求來調整方向。",
 	CompletionUncertain:    "完成狀態未確認。目前結果與已完成工作均已保留。傳送「繼續」可接著完成，也可以補充說明需要調整的內容。",
+	ReasoningReplayRepair:  "模型服務拒絕了本會話歷史中的 thinking 區塊。Reasonix 已從傳送給模型的歷史中移除這些內容，並重試了一次。",
 	ReceiptVerified:        "沒有未經驗證的部分",
 	ReceiptGapsHeader:      "未驗證:",
 	ReceiptRisksHeader:     "已申報的風險:",

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -349,12 +349,25 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 	recoveryWithoutThinking := c.missingReasoningFallback(ctx)
 
 	// appendBlocks adds blocks under role, merging into the previous message when
-	// it shares the role (keeps user/assistant strictly alternating).
+	// it shares the role (keeps user/assistant strictly alternating). A thinking
+	// block must lead its message, so when the appended blocks open with thinking
+	// and the merge target already has content, the thinking run moves to the
+	// front: after projection degrades a reasoning-less turn to plain text, a
+	// following healthy assistant turn merges into it and must stay
+	// [thinking, text, ...], never [text, thinking, ...].
 	appendBlocks := func(role string, blocks ...contentBlock) {
 		if len(blocks) == 0 {
 			return
 		}
 		if n := len(msgs); n > 0 && msgs[n-1].Role == role {
+			if head := leadingThinkingBlocks(blocks); head > 0 && len(msgs[n-1].Content) > 0 {
+				merged := make([]contentBlock, 0, len(msgs[n-1].Content)+len(blocks))
+				merged = append(merged, blocks[:head]...)
+				merged = append(merged, msgs[n-1].Content...)
+				merged = append(merged, blocks[head:]...)
+				msgs[n-1].Content = merged
+				return
+			}
 			msgs[n-1].Content = append(msgs[n-1].Content, blocks...)
 			return
 		}
@@ -459,6 +472,16 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 		}
 	}
 	return r
+}
+
+// leadingThinkingBlocks counts the thinking blocks at the head of blocks.
+// replayReasoningBlock emits at most one, so the run is normally 0 or 1.
+func leadingThinkingBlocks(blocks []contentBlock) int {
+	head := 0
+	for head < len(blocks) && blocks[head].Type == "thinking" {
+		head++
+	}
+	return head
 }
 
 // readStream parses the Messages API SSE stream into Chunks. Text deltas emit live;

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -349,26 +349,13 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 	recoveryWithoutThinking := c.missingReasoningFallback(ctx)
 
 	// appendBlocks adds blocks under role, merging into the previous message when
-	// it shares the role (keeps user/assistant strictly alternating). A thinking
-	// block must lead its message, so when the appended blocks open with thinking
-	// and the merge target already has content, the thinking run moves to the
-	// front: after projection degrades a reasoning-less turn to plain text, a
-	// following healthy assistant turn merges into it and must stay
-	// [thinking, text, ...], never [text, thinking, ...].
+	// it shares the role (keeps user/assistant strictly alternating).
 	appendBlocks := func(role string, blocks ...contentBlock) {
 		if len(blocks) == 0 {
 			return
 		}
 		if n := len(msgs); n > 0 && msgs[n-1].Role == role {
-			if head := leadingThinkingBlocks(blocks); head > 0 && len(msgs[n-1].Content) > 0 {
-				merged := make([]contentBlock, 0, len(msgs[n-1].Content)+len(blocks))
-				merged = append(merged, blocks[:head]...)
-				merged = append(merged, msgs[n-1].Content...)
-				merged = append(merged, blocks[head:]...)
-				msgs[n-1].Content = merged
-				return
-			}
-			msgs[n-1].Content = append(msgs[n-1].Content, blocks...)
+			msgs[n-1].Content = mergeThinkingFirst(msgs[n-1].Content, blocks)
 			return
 		}
 		msgs = append(msgs, anthMessage{Role: role, Content: blocks})
@@ -472,16 +459,6 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 		}
 	}
 	return r
-}
-
-// leadingThinkingBlocks counts the thinking blocks at the head of blocks.
-// replayReasoningBlock emits at most one, so the run is normally 0 or 1.
-func leadingThinkingBlocks(blocks []contentBlock) int {
-	head := 0
-	for head < len(blocks) && blocks[head].Type == "thinking" {
-		head++
-	}
-	return head
 }
 
 // readStream parses the Messages API SSE stream into Chunks. Text deltas emit live;

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -217,8 +217,18 @@ func (c *client) RequiresToolCallReasoning() bool {
 }
 
 func (c *client) RequiresAssistantReasoningReplay(m provider.Message) bool {
+	if c == nil || !c.deepseek {
+		return false
+	}
+	// A turn carrying provider-issued reasoning must replay it, tools or not:
+	// DeepSeek's thinking mode 400s when a stored thinking block is not passed
+	// back. Without stored reasoning there is nothing to replay — plain text
+	// turns stay out of projection so healthy histories keep their backing.
+	if strings.TrimSpace(m.ReasoningContent) != "" {
+		return true
+	}
 	activity := len(m.ToolCalls) > 0 || len(m.ServerSearch) > 0
-	return c != nil && c.deepseek && activity && (c.deepSeekThinkingEnabled() || strings.TrimSpace(m.ReasoningContent) != "")
+	return activity && c.deepSeekThinkingEnabled()
 }
 
 func (c *client) AllowsEmptyReasoningFallback() bool { return false }
@@ -383,11 +393,12 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 			appendBlocks("user", block)
 		case provider.RoleAssistant:
 			var blocks []contentBlock
-			// Replay provider reasoning before the tool_use it led to. DeepSeek uses
-			// unsigned thinking blocks and requires the reasoning from a tool-call
-			// turn in every subsequent request, even if the current request no longer
-			// declares tools or has since disabled thinking. Anthropic proper requires
-			// a signature, so reasoning without one cannot be replayed on that endpoint.
+			// Replay provider reasoning ahead of the content it led to. DeepSeek's
+			// thinking mode requires every historical assistant turn's thinking
+			// block back whenever the request declares tools — tool-call turn or
+			// not — even if the current request no longer declares tools or has
+			// since disabled thinking. Anthropic proper requires a signature, so
+			// reasoning without one cannot be replayed on that endpoint.
 			if block, ok := c.replayReasoningBlock(m, recoveryWithoutThinking); ok {
 				blocks = append(blocks, block)
 			}

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -702,7 +702,7 @@ func TestMissingToolCallReasoningWarningFingerprintTracksAnthropicConfiguration(
 	}
 }
 
-func TestBuildRequestDeepSeekReplaysOnlyToolCallReasoningFromHistory(t *testing.T) {
+func TestBuildRequestDeepSeekReplaysReasoningFromHistory(t *testing.T) {
 	toolTurn := []provider.Message{
 		{Role: provider.RoleUser, Content: "weather?"},
 		{Role: provider.RoleAssistant, ReasoningContent: "I should call the tool.",
@@ -733,17 +733,21 @@ func TestBuildRequestDeepSeekReplaysOnlyToolCallReasoningFromHistory(t *testing.
 		})
 	}
 
-	t.Run("reasoning without a tool call stays omitted", func(t *testing.T) {
+	t.Run("reasoning without a tool call is replayed", func(t *testing.T) {
+		// DeepSeek's thinking mode requires every historical assistant turn's
+		// thinking block back when the request declares tools, even for plain
+		// question-answer turns (api-docs.deepseek.com/guides/thinking_mode).
 		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
 		r := c.buildRequest(context.Background(), provider.Request{
 			Messages: []provider.Message{
 				{Role: provider.RoleUser, Content: "hello"},
-				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "private scratchpad"},
+				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "scratchpad"},
 			},
 			Tools: []provider.ToolSchema{{Name: "get_weather"}},
 		})
-		if len(r.Messages) != 2 || len(r.Messages[1].Content) != 1 || r.Messages[1].Content[0].Type != "text" {
-			t.Fatalf("non-tool assistant blocks = %+v, want visible text only", r.Messages)
+		blocks := r.Messages[1].Content
+		if len(r.Messages) != 2 || len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "scratchpad" || blocks[1].Type != "text" {
+			t.Fatalf("non-tool assistant blocks = %+v, want thinking before text", r.Messages)
 		}
 	})
 }
@@ -779,7 +783,7 @@ func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "disabled"}
 		r := c.buildRequest(context.Background(), provider.Request{
-			Messages: []provider.Message{{Role: provider.RoleAssistant, ReasoningContent: "do not replay"}},
+			Messages: []provider.Message{{Role: provider.RoleAssistant, ReasoningContent: "replay anyway"}},
 			Tools:    []provider.ToolSchema{{Name: "tool"}},
 		})
 		if r.Thinking == nil || r.Thinking.Type != "disabled" || r.OutputConfig != nil {
@@ -788,8 +792,11 @@ func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 		if provider.RequiresToolCallReasoning(c) || provider.RequiresReasoningRoundTrip(c) {
 			t.Fatal("disabled DeepSeek thinking must not retain reasoning for replay")
 		}
-		if len(r.Messages) != 0 {
-			t.Fatalf("reasoning-only assistant should be omitted when thinking is disabled: %+v", r.Messages)
+		// Historical thinking blocks are replayed even when the current request
+		// disables thinking, the same rule tool-call turns already follow.
+		if len(r.Messages) != 1 || len(r.Messages[0].Content) != 1 || r.Messages[0].Content[0].Type != "thinking" ||
+			r.Messages[0].Content[0].Thinking != "replay anyway" {
+			t.Fatalf("reasoning-only assistant under disabled thinking = %+v, want the thinking block replayed", r.Messages)
 		}
 	})
 }

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -702,56 +702,6 @@ func TestMissingToolCallReasoningWarningFingerprintTracksAnthropicConfiguration(
 	}
 }
 
-func TestBuildRequestDeepSeekReplaysReasoningFromHistory(t *testing.T) {
-	toolTurn := []provider.Message{
-		{Role: provider.RoleUser, Content: "weather?"},
-		{Role: provider.RoleAssistant, ReasoningContent: "I should call the tool.",
-			ToolCalls: []provider.ToolCall{{ID: "t1", Name: "get_weather", Arguments: `{"city":"Paris"}`}}},
-		{Role: provider.RoleTool, ToolCallID: "t1", Content: "sunny"},
-	}
-	for _, tc := range []struct {
-		name     string
-		thinking string
-		effort   string
-	}{
-		{name: "current request has no tools", thinking: "enabled", effort: "high"},
-		{name: "thinking disabled after tool call", thinking: "enabled", effort: "disabled"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: tc.thinking, effort: tc.effort}
-			r := c.buildRequest(context.Background(), provider.Request{Messages: toolTurn})
-			if len(r.Tools) != 0 {
-				t.Fatalf("current request tools = %+v, want none", r.Tools)
-			}
-			if len(r.Messages) != 3 {
-				t.Fatalf("messages = %+v, want user/assistant/user", r.Messages)
-			}
-			blocks := r.Messages[1].Content
-			if len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "I should call the tool." || blocks[1].Type != "tool_use" {
-				t.Fatalf("assistant blocks = %+v, want historical thinking before tool_use", blocks)
-			}
-		})
-	}
-
-	t.Run("reasoning without a tool call is replayed", func(t *testing.T) {
-		// DeepSeek's thinking mode requires every historical assistant turn's
-		// thinking block back when the request declares tools, even for plain
-		// question-answer turns (api-docs.deepseek.com/guides/thinking_mode).
-		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
-		r := c.buildRequest(context.Background(), provider.Request{
-			Messages: []provider.Message{
-				{Role: provider.RoleUser, Content: "hello"},
-				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "scratchpad"},
-			},
-			Tools: []provider.ToolSchema{{Name: "get_weather"}},
-		})
-		blocks := r.Messages[1].Content
-		if len(r.Messages) != 2 || len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "scratchpad" || blocks[1].Type != "text" {
-			t.Fatalf("non-tool assistant blocks = %+v, want thinking before text", r.Messages)
-		}
-	})
-}
-
 func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 	for _, tc := range []struct {
 		name, model, input, want string

--- a/internal/provider/anthropic/missing_reasoning_fallback.go
+++ b/internal/provider/anthropic/missing_reasoning_fallback.go
@@ -37,6 +37,33 @@ func (c *client) replayReasoningBlock(m provider.Message, recoveryWithoutThinkin
 	return contentBlock{}, false
 }
 
+// mergeThinkingFirst merges appended blocks into an existing same-role
+// message's content. A thinking block must lead its message, so a leading
+// thinking run in the appended blocks moves to the front: after projection
+// degrades a reasoning-less turn to plain text, a following healthy assistant
+// turn merging into it must stay [thinking, text, ...], never [text, ...].
+func mergeThinkingFirst(existing, blocks []contentBlock) []contentBlock {
+	head := leadingThinkingBlocks(blocks)
+	if head == 0 || len(existing) == 0 {
+		return append(existing, blocks...)
+	}
+	merged := make([]contentBlock, 0, len(existing)+len(blocks))
+	merged = append(merged, blocks[:head]...)
+	merged = append(merged, existing...)
+	merged = append(merged, blocks[head:]...)
+	return merged
+}
+
+// leadingThinkingBlocks counts the thinking blocks at the head of blocks.
+// replayReasoningBlock emits at most one, so the run is normally 0 or 1.
+func leadingThinkingBlocks(blocks []contentBlock) int {
+	head := 0
+	for head < len(blocks) && blocks[head].Type == "thinking" {
+		head++
+	}
+	return head
+}
+
 func (c *client) applyDeepSeekThinking(r *anthRequest, req provider.Request, recoveryWithoutThinking bool) {
 	r.Temperature = req.Temperature
 	t := c.thinking

--- a/internal/provider/anthropic/missing_reasoning_fallback.go
+++ b/internal/provider/anthropic/missing_reasoning_fallback.go
@@ -25,8 +25,10 @@ func (c *client) replayMessages(messages []provider.Message, recoveryWithoutThin
 }
 
 func (c *client) replayReasoningBlock(m provider.Message, recoveryWithoutThinking bool) (contentBlock, bool) {
-	activity := len(m.ToolCalls) > 0 || len(m.ServerSearch) > 0
-	if c.deepseek && !recoveryWithoutThinking && activity && m.ReasoningContent != "" {
+	// DeepSeek's thinking mode requires every historical assistant turn's
+	// thinking block to be passed back whenever the request declares tools —
+	// including plain question-answer turns with no tool activity.
+	if c.deepseek && !recoveryWithoutThinking && m.ReasoningContent != "" {
 		return contentBlock{Type: "thinking", Thinking: m.ReasoningContent}, true
 	}
 	if !c.deepseek && c.thinking == "adaptive" && m.ReasoningContent != "" && m.ReasoningSignature != "" {

--- a/internal/provider/anthropic/replay_projection_test.go
+++ b/internal/provider/anthropic/replay_projection_test.go
@@ -89,3 +89,53 @@ func TestBuildRequestNativeAnthropicKeepsItsExistingValidationPath(t *testing.T)
 		t.Fatalf("native Anthropic history unexpectedly projected: %#v", r.Messages)
 	}
 }
+
+func TestBuildRequestDeepSeekReplaysReasoningFromHistory(t *testing.T) {
+	toolTurn := []provider.Message{
+		{Role: provider.RoleUser, Content: "weather?"},
+		{Role: provider.RoleAssistant, ReasoningContent: "I should call the tool.",
+			ToolCalls: []provider.ToolCall{{ID: "t1", Name: "get_weather", Arguments: `{"city":"Paris"}`}}},
+		{Role: provider.RoleTool, ToolCallID: "t1", Content: "sunny"},
+	}
+	for _, tc := range []struct {
+		name     string
+		thinking string
+		effort   string
+	}{
+		{name: "current request has no tools", thinking: "enabled", effort: "high"},
+		{name: "thinking disabled after tool call", thinking: "enabled", effort: "disabled"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: tc.thinking, effort: tc.effort}
+			r := c.buildRequest(context.Background(), provider.Request{Messages: toolTurn})
+			if len(r.Tools) != 0 {
+				t.Fatalf("current request tools = %+v, want none", r.Tools)
+			}
+			if len(r.Messages) != 3 {
+				t.Fatalf("messages = %+v, want user/assistant/user", r.Messages)
+			}
+			blocks := r.Messages[1].Content
+			if len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "I should call the tool." || blocks[1].Type != "tool_use" {
+				t.Fatalf("assistant blocks = %+v, want historical thinking before tool_use", blocks)
+			}
+		})
+	}
+
+	t.Run("reasoning without a tool call is replayed", func(t *testing.T) {
+		// DeepSeek's thinking mode requires every historical assistant turn's
+		// thinking block back when the request declares tools, even for plain
+		// question-answer turns (api-docs.deepseek.com/guides/thinking_mode).
+		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
+		r := c.buildRequest(context.Background(), provider.Request{
+			Messages: []provider.Message{
+				{Role: provider.RoleUser, Content: "hello"},
+				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "scratchpad"},
+			},
+			Tools: []provider.ToolSchema{{Name: "get_weather"}},
+		})
+		blocks := r.Messages[1].Content
+		if len(r.Messages) != 2 || len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "scratchpad" || blocks[1].Type != "text" {
+			t.Fatalf("non-tool assistant blocks = %+v, want thinking before text", r.Messages)
+		}
+	})
+}

--- a/internal/provider/anthropic/replay_projection_test.go
+++ b/internal/provider/anthropic/replay_projection_test.go
@@ -46,6 +46,38 @@ func TestDeepSeekReplayProjectionKeepsHealthyHistoryBacking(t *testing.T) {
 	}
 }
 
+func TestBuildRequestDeepSeekMergedAssistantTurnKeepsThinkingFirst(t *testing.T) {
+	c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled"}
+	r := c.buildRequest(context.Background(), provider.Request{Messages: []provider.Message{
+		{Role: provider.RoleUser, Content: "start"},
+		{
+			Role: provider.RoleAssistant, Content: "first answer",
+			ToolCalls: []provider.ToolCall{{ID: "t1", Name: "read_file", Arguments: `{}`}},
+		}, // reasoning lost: projection degrades this turn to plain text
+		{Role: provider.RoleTool, ToolCallID: "t1", Name: "read_file", Content: "data"},
+		{
+			Role: provider.RoleAssistant, Content: "second answer", ReasoningContent: "fresh thinking",
+			ToolCalls: []provider.ToolCall{{ID: "t2", Name: "read_file", Arguments: `{}`}},
+		},
+		{Role: provider.RoleTool, ToolCallID: "t2", Name: "read_file", Content: "more data"},
+		{Role: provider.RoleUser, Content: "continue"},
+	}})
+
+	// The degraded first turn and the healthy second turn merge into one
+	// assistant message; its thinking block must lead.
+	if len(r.Messages) != 3 {
+		t.Fatalf("messages = %#v, want user/merged-assistant/user", r.Messages)
+	}
+	blocks := r.Messages[1].Content
+	if len(blocks) != 4 ||
+		blocks[0].Type != "thinking" || blocks[0].Thinking != "fresh thinking" ||
+		blocks[1].Type != "text" || blocks[1].Text != "first answer" ||
+		blocks[2].Type != "text" || blocks[2].Text != "second answer" ||
+		blocks[3].Type != "tool_use" || blocks[3].ID != "t2" {
+		t.Fatalf("merged assistant blocks = %#v, want [thinking, text, text, tool_use]", blocks)
+	}
+}
+
 func TestBuildRequestNativeAnthropicKeepsItsExistingValidationPath(t *testing.T) {
 	c := &client{model: "claude-sonnet", thinking: "adaptive"}
 	r := c.buildRequest(context.Background(), provider.Request{Messages: []provider.Message{{

--- a/internal/provider/reasoning_replay.go
+++ b/internal/provider/reasoning_replay.go
@@ -82,6 +82,36 @@ func AllowsEmptyReasoningFallback(p Provider) bool {
 	return ok && policy.AllowsEmptyReasoningFallback()
 }
 
+// ProjectReasoningStrippedMessages is the catch-and-repair projection for a
+// provider that rejected replayed thinking/reasoning history with
+// ReasoningReplayError. It follows the vendor-documented self-heal recipe:
+// strip every assistant message's reasoning/thinking metadata from the
+// provider-visible projection, then drop the tool activity that can no longer
+// be paired with its thinking block. Canonical session messages are never
+// modified; a history with nothing to strip keeps its backing slice.
+func ProjectReasoningStrippedMessages(p Provider, msgs []Message) ([]Message, bool) {
+	work := msgs
+	stripped := false
+	for i, m := range msgs {
+		if m.Role != RoleAssistant {
+			continue
+		}
+		if m.ReasoningContent == "" && m.ReasoningSignature == "" && m.ReasoningID == "" && m.ReasoningStatus == "" {
+			continue
+		}
+		if !stripped {
+			work = append([]Message(nil), msgs...)
+			stripped = true
+		}
+		work[i].ReasoningContent = ""
+		work[i].ReasoningSignature = ""
+		work[i].ReasoningID = ""
+		work[i].ReasoningStatus = ""
+	}
+	projected, projectedChanged := ProjectReplaySafeMessages(p, work)
+	return projected, stripped || projectedChanged
+}
+
 // ProjectReplaySafeMessages returns the provider-visible projection for
 // histories that contain assistant activity without the reasoning required to
 // replay it. Canonical session messages are never modified. Healthy histories

--- a/internal/provider/reasoning_replay_error.go
+++ b/internal/provider/reasoning_replay_error.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// ReasoningReplayError is a trusted provider rejection of replayed
+// thinking/reasoning history: HTTP 400 whose body says the request's
+// thinking/reasoning blocks must be passed back. Unwrap returns the original
+// APIError so localization, trace IDs, and telemetry keep working. The body is
+// never persisted or replayed.
+type ReasoningReplayError struct {
+	APIError *APIError
+}
+
+func (e *ReasoningReplayError) Error() string {
+	if e == nil || e.APIError == nil {
+		return "reasoning replay rejected"
+	}
+	return e.APIError.Error()
+}
+
+func (e *ReasoningReplayError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.APIError
+}
+
+// ParseReasoningReplayError extracts a trusted thinking-replay rejection from
+// an APIError. The match is deliberately exact — DeepSeek's documented shape is
+// "The `content[].thinking` in the thinking mode must be passed back to the
+// API" — so only a 400 naming thinking/reasoning content AND the pass-back
+// obligation qualifies. Any other 400 (and every other status) returns nil so
+// the retry budget can never swallow an unrelated client error.
+func ParseReasoningReplayError(apiErr *APIError) *ReasoningReplayError {
+	if apiErr == nil || apiErr.Status != http.StatusBadRequest {
+		return nil
+	}
+	body := strings.ToLower(apiErr.Body)
+	namesReasoning := strings.Contains(body, "content[].thinking") || strings.Contains(body, "reasoning_content")
+	if !namesReasoning || !strings.Contains(body, "must be passed back") {
+		return nil
+	}
+	return &ReasoningReplayError{APIError: apiErr}
+}
+
+// AsReasoningReplayError unwraps err to a trusted thinking-replay rejection,
+// if any.
+func AsReasoningReplayError(err error) *ReasoningReplayError {
+	var replay *ReasoningReplayError
+	if err != nil && errors.As(err, &replay) {
+		return replay
+	}
+	return nil
+}

--- a/internal/provider/reasoning_replay_error_test.go
+++ b/internal/provider/reasoning_replay_error_test.go
@@ -1,0 +1,109 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestParseReasoningReplayError(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{
+			name:   "deepseek anthropic thinking 400",
+			status: 400,
+			body:   `{"error":{"message":"The ` + "`content[].thinking`" + ` in the thinking mode must be passed back to the API","type":"invalid_request_error"}}`,
+			want:   true,
+		},
+		{
+			name:   "openai-style reasoning_content 400",
+			status: 400,
+			body:   `{"error":{"message":"reasoning_content must be passed back to the API in thinking mode"}}`,
+			want:   true,
+		},
+		{
+			name:   "case-insensitive",
+			status: 400,
+			body:   `The CONTENT[].THINKING in the thinking mode MUST BE PASSED BACK to the API`,
+			want:   true,
+		},
+		{
+			name:   "400 without pass-back obligation",
+			status: 400,
+			body:   `{"error":{"message":"content[].thinking is not supported by this model"}}`,
+			want:   false,
+		},
+		{
+			name:   "400 pass-back without reasoning reference",
+			status: 400,
+			body:   `{"error":{"message":"the signed block must be passed back unchanged"}}`,
+			want:   false,
+		},
+		{
+			name:   "401 with the same body",
+			status: 401,
+			body:   `{"error":{"message":"The content[].thinking in the thinking mode must be passed back to the API"}}`,
+			want:   false,
+		},
+		{
+			name:   "422 with the same body",
+			status: 422,
+			body:   `{"error":{"message":"The content[].thinking in the thinking mode must be passed back to the API"}}`,
+			want:   false,
+		},
+		{
+			name:   "unrelated 400",
+			status: 400,
+			body:   `{"error":{"message":"invalid tool schema at index 2"}}`,
+			want:   false,
+		},
+		{
+			name:   "empty body",
+			status: 400,
+			body:   "",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseReasoningReplayError(&APIError{Provider: "p", Status: tc.status, Body: tc.body})
+			if (got != nil) != tc.want {
+				t.Fatalf("ParseReasoningReplayError = %v, want match=%v", got, tc.want)
+			}
+			if got != nil && got.APIError == nil {
+				t.Fatal("matched error lost the underlying APIError")
+			}
+		})
+	}
+	if ParseReasoningReplayError(nil) != nil {
+		t.Fatal("nil APIError must not match")
+	}
+}
+
+func TestAsReasoningReplayError(t *testing.T) {
+	apiErr := &APIError{Provider: "p", Status: 400, Body: "The `content[].thinking` in the thinking mode must be passed back to the API"}
+	replay := ParseReasoningReplayError(apiErr)
+	if replay == nil {
+		t.Fatal("fixture did not match")
+	}
+	if got := AsReasoningReplayError(fmt.Errorf("stream: %w", replay)); got != replay {
+		t.Fatalf("AsReasoningReplayError = %v, want the wrapped error", got)
+	}
+	if got := AsReasoningReplayError(apiErr); got != nil {
+		t.Fatalf("bare APIError must not unwrap as ReasoningReplayError: %v", got)
+	}
+	if got := AsReasoningReplayError(errors.New("other")); got != nil {
+		t.Fatalf("unrelated error = %v, want nil", got)
+	}
+	if got := AsReasoningReplayError(nil); got != nil {
+		t.Fatal("nil error must not match")
+	}
+	var base error = replay
+	if unwrapped := errors.Unwrap(base); unwrapped != apiErr {
+		t.Fatalf("Unwrap = %v, want the APIError", unwrapped)
+	}
+}

--- a/internal/provider/reasoning_replay_error_test.go
+++ b/internal/provider/reasoning_replay_error_test.go
@@ -102,8 +102,7 @@ func TestAsReasoningReplayError(t *testing.T) {
 	if got := AsReasoningReplayError(nil); got != nil {
 		t.Fatal("nil error must not match")
 	}
-	var base error = replay
-	if unwrapped := errors.Unwrap(base); unwrapped != apiErr {
-		t.Fatalf("Unwrap = %v, want the APIError", unwrapped)
+	if !errors.Is(replay, apiErr) {
+		t.Fatal("ReasoningReplayError must unwrap to the APIError")
 	}
 }

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -338,6 +338,9 @@ func SendWithRetry(ctx context.Context, httpClient *http.Client, opts SendOption
 			if limitErr := ParseContextLimitError(apiErr); limitErr != nil {
 				return nil, limitErr
 			}
+			if replayErr := ParseReasoningReplayError(apiErr); replayErr != nil {
+				return nil, replayErr
+			}
 			return nil, apiErr
 		}
 		lastErr = apiErr


### PR DESCRIPTION
## Summary

- Replay DeepSeek thinking blocks for **every** assistant turn that carries stored reasoning — DeepSeek's thinking mode requires `reasoning_content` back on all historical turns whenever the request declares tools, not only tool-call turns ([official doc](https://api-docs.deepseek.com/guides/thinking_mode)).
- Keep `thinking` first when merged assistant messages combine a projection-degraded plain-text turn with a following healthy turn (`[thinking, text, …]`, never `[text, thinking, …]`).
- Add a one-shot catch-and-repair for the `content[].thinking … must be passed back` HTTP 400: strip all assistant reasoning from the provider-visible projection (vendor-documented self-heal), retry exactly once, and pin the conversation to the strong projection so later rounds do not pay another 400. Canonical session history is never modified; unrelated 400s stay terminal.

Root cause of the report: histories containing plain question-answer assistant turns (reasoning stored, no tool calls) were replayed without their thinking blocks, so the next tool-carrying request was rejected, and the turn stopped with no recovery.

## Issues

Refs #9750

## Verification

- `go build ./...`
- `go test -count=1 ./internal/provider/... ./internal/agent/...`
- `go test -race -count=1 ./internal/agent/ -run 'Replay|Reasoning|Retry'`
- New deterministic coverage:
  - `internal/provider/reasoning_replay_error_test.go` — matcher accepts only the exact 400 thinking-replay shape (10 cases: non-matching 400/401/422/empty body all rejected).
  - `internal/provider/anthropic/replay_projection_test.go` — merged assistant turns keep thinking first after projection.
  - `internal/agent/reasoning_replay_recovery_test.go` — repair retry succeeds with only `Messages` changed in the frozen request; a second 400 terminates as before; retry budget is exactly one; unrelated 400 untouched.
  - `internal/agent/retry_e2e_test.go` — end-to-end against a stub Anthropic endpoint: first request 400 → repaired retry succeeds → later rounds keep the strong projection.
- Two pre-existing assertions were updated because they encoded the old "tool-call turns only" replay decision that conflicts with DeepSeek's documented contract (`anthropic_test.go`): reasoning on plain-text turns is now replayed, matching the long-standing "thinking disabled after tool call" behavior.

## Documentation impact

Documentation-impact: updated - `docs/REASONING_PROVIDERS.md` now describes replaying reasoning for every assistant turn carrying it.

## Cache impact

Cache-impact: medium - provider-visible history bytes change once for in-flight sessions (stored thinking blocks are now replayed on plain-text assistant turns; required by the DeepSeek API contract). Steady-state behavior stays append-only; healthy histories keep their backing slices (zero-copy projection unchanged). The 400-repair strong projection only activates on conversations that already hit the 400, i.e. ones that were failing anyway.
Cache-guard: `go test -count=1 ./internal/provider/ -run 'ReplaySafe|ReasoningStripped'` plus `internal/agent/retry_e2e_test.go` byte-equality assertion on the frozen request (only `Messages` may change).
System-prompt-review: N/A - system prompt, memory prefix, output style, and skill index are untouched; only assistant-history reasoning replay on the DeepSeek Anthropic endpoint changes.
