### PR TITLE
fix(completioneval): disable thinking on the bounded verdict request / 补全验证请求按请求关闭 thinking，修复任务误停

### DIFF
--- a/desktop/metrics_app.go
+++ b/desktop/metrics_app.go
@@ -361,7 +361,7 @@ func (m *metricsAggregator) observeCompletionValidation(info event.CompletionVal
 		m.inc("completion_validation_attempt", "first")
 	}
 	if strings.TrimSpace(info.ErrorClass) != "" {
-		m.inc("completion_validation_error", knownBucket(info.ErrorClass, "timeout", "invalid_output", "unavailable", "over_budget", "error"))
+		m.inc("completion_validation_error", knownBucket(info.ErrorClass, "timeout", "empty_output", "invalid_output", "unavailable", "over_budget", "error"))
 	}
 }
 

--- a/docs/REASONING_PROVIDERS.md
+++ b/docs/REASONING_PROVIDERS.md
@@ -66,7 +66,9 @@ New official entries use this native Messages API path and enable provider-side
 `web_search`; existing explicit providers, including legacy
 `deepseek-anthropic` entries, keep their configured protocol. Reasonix emits
 `thinking.type=enabled|disabled` with `output_config.effort`, replays unsigned
-DeepSeek thinking blocks from historical tool-call turns, omits unsupported
+DeepSeek thinking blocks from every historical assistant turn that carries
+reasoning (tool-call turn or not, as DeepSeek's thinking mode requires when the
+request declares tools), omits unsupported
 images, and relies on DeepSeek's automatic prefix cache instead of ignored
 `cache_control` markers.
 

--- a/internal/agent/completion_validation.go
+++ b/internal/agent/completion_validation.go
@@ -175,6 +175,8 @@ func validatorErrorClass(err error) string {
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
 		return "timeout"
+	case errors.Is(err, completioneval.ErrEmptyOutput):
+		return "empty_output"
 	case errors.Is(err, completioneval.ErrInvalidOutput):
 		return "invalid_output"
 	case strings.Contains(err.Error(), "unavailable"):

--- a/internal/agent/completion_validation_test.go
+++ b/internal/agent/completion_validation_test.go
@@ -142,6 +142,12 @@ func TestCompletionValidatorFailureAndUncertainPause(t *testing.T) {
 			class: "invalid_output",
 		},
 		{
+			name:  "empty evaluator output",
+			eval:  &scriptedEvaluator{errs: []error{completioneval.ErrEmptyOutput}},
+			cause: CompletionUncertainValidatorFailed,
+			class: "empty_output",
+		},
+		{
 			name:  "evaluator timeout",
 			eval:  &scriptedEvaluator{errs: []error{context.DeadlineExceeded}},
 			cause: CompletionUncertainValidatorFailed,

--- a/internal/agent/reasoning_replay.go
+++ b/internal/agent/reasoning_replay.go
@@ -102,6 +102,33 @@ func (a *Agent) finishReasoningReplayRetry(retry streamedTurn, sink *deferredStr
 	return retry
 }
 
+// finishReasoningReplayOverflow terminates an attempt whose required reasoning
+// was truncated by the client limit: audit, finalize usage, and hand the turn
+// to the unreplayable-reasoning policy.
+func (a *Agent) finishReasoningReplayOverflow(result streamedTurn, sink *deferredStreamSink, issue ReasoningReplayFailure, billable *provider.Usage, attemptID string, attempt int) streamedTurn {
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningOverflowDetected})
+	result.usage = finalizeSamplingUsage(billable, result.usage)
+	terminal := a.finishUnreplayableReasoning(result, sink, issue)
+	a.emitReasoningReplayAttemptOutcome(attemptID, attempt, terminal.err)
+	return terminal
+}
+
+// suppressMissingReasoningRetry handles a missing-reasoning turn whose one
+// exact replay was already spent (or claimed cross-process): try the
+// provider-declared fallback, otherwise terminate through the
+// unreplayable-reasoning policy.
+func (a *Agent) suppressMissingReasoningRetry(ctx context.Context, turn int, frozen *samplingRequest, attemptID string, attempt int, sink *deferredStreamSink, result streamedTurn, issue ReasoningReplayFailure, billable *provider.Usage) streamedTurn {
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetrySuppressed})
+	if fallback, ok := a.runMissingReasoningFallback(ctx, turn, frozen, attemptID, attempt, billable, sink); ok {
+		return fallback
+	}
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
+	result.usage = finalizeSamplingUsage(billable, result.usage)
+	terminal := a.finishUnreplayableReasoning(result, sink, issue)
+	a.emitReasoningReplayAttemptOutcome(attemptID, attempt, terminal.err)
+	return terminal
+}
+
 func (a *Agent) finishUnreplayableReasoning(result streamedTurn, sink *deferredStreamSink, issue ReasoningReplayFailure) streamedTurn {
 	if issue == "" {
 		sink.Flush()

--- a/internal/agent/reasoning_replay_recovery.go
+++ b/internal/agent/reasoning_replay_recovery.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"reasonix/internal/event"
+	"reasonix/internal/i18n"
+	"reasonix/internal/provider"
+)
+
+// reasoningReplayRecoveryBudget bounds the thinking-400 catch-and-repair to one
+// retry per model round. It is independent from the context-recovery budget so
+// one overflow repair and one reasoning repair can never multiply requests.
+type reasoningReplayRecoveryBudget struct {
+	retries int
+}
+
+// recoverReasoningReplay400 applies the vendor-documented self-heal for a
+// provider that rejected replayed thinking history with HTTP 400: rebuild the
+// frozen request's messages through the strong projection (all assistant
+// reasoning stripped, unpaired tool activity dropped) and retry exactly once.
+// Everything except Messages stays byte-identical to the rejected request. A
+// history the projection cannot change is not worth a blind retry.
+func (a *Agent) recoverReasoningReplay400(frozen samplingRequest, err error, budget *reasoningReplayRecoveryBudget) (samplingRequest, bool) {
+	if a == nil || budget == nil || budget.retries > 0 {
+		return samplingRequest{}, false
+	}
+	if provider.AsReasoningReplayError(err) == nil {
+		return samplingRequest{}, false
+	}
+	repaired, changed := provider.ProjectReasoningStrippedMessages(a.svc.prov, frozen.req.Messages)
+	if !changed {
+		return samplingRequest{}, false
+	}
+	budget.retries++
+	next := frozen.req
+	next.Messages = repaired
+	return samplingRequest{req: next}, true
+}
+
+// activateReasoningReplayStrongProjection records that this conversation's
+// canonical history carries reasoning the provider rejects. Later rounds and
+// turns keep projecting through the strong projection instead of paying
+// another 400 plus repair retry per round.
+func (a *Agent) activateReasoningReplayStrongProjection() {
+	if a == nil {
+		return
+	}
+	a.sess.reasoningReplayStrongProjection = true
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Recovered})
+	a.emitReasoningReplayRepairNotice()
+}
+
+func (a *Agent) emitReasoningReplayRepairNotice() {
+	if a == nil || a.svc.sink == nil {
+		return
+	}
+	a.svc.sink.Emit(event.Event{
+		Kind:   event.Notice,
+		Level:  event.LevelWarn,
+		Code:   event.NoticeCodeReasoningReplayRepair,
+		Text:   i18n.M.ReasoningReplayRepair,
+		Detail: "provider rejected replayed thinking blocks (HTTP 400); retried once with reasoning stripped from the projected history",
+	})
+}

--- a/internal/agent/reasoning_replay_recovery.go
+++ b/internal/agent/reasoning_replay_recovery.go
@@ -36,6 +36,24 @@ func (a *Agent) recoverReasoningReplay400(frozen samplingRequest, err error, bud
 	return samplingRequest{req: next}, true
 }
 
+// tryRecoverReasoningReplay400 is the streamWithSamplingRecovery branch for a
+// thinking-400: the frozen history's replayed reasoning is stale for this
+// provider, so repair the projection once and retry; every other 400 falls
+// through to the terminal path. On a repair the speculative attempt's buffered
+// events are discarded and the attempt is audited before the caller replays.
+func (a *Agent) tryRecoverReasoningReplay400(streamSink *deferredStreamSink, frozen samplingRequest, attemptID string, attempt int, err error, budget *reasoningReplayRecoveryBudget) (samplingRequest, bool) {
+	next, ok := a.recoverReasoningReplay400(frozen, err, budget)
+	if !ok {
+		return samplingRequest{}, false
+	}
+	if streamSink != nil {
+		streamSink.Discard()
+	}
+	a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, "reasoning_replay_400", err)
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Detected})
+	return next, true
+}
+
 // activateReasoningReplayStrongProjection records that this conversation's
 // canonical history carries reasoning the provider rejects. Later rounds and
 // turns keep projecting through the strong projection instead of paying

--- a/internal/agent/reasoning_replay_recovery_test.go
+++ b/internal/agent/reasoning_replay_recovery_test.go
@@ -290,3 +290,143 @@ func TestStrictNoWarningReplayDoesNotLeakSpeculativeEvents(t *testing.T) {
 		}
 	}
 }
+
+func thinkingReplay400Error() error {
+	return provider.ParseReasoningReplayError(&provider.APIError{
+		Provider: "strict-replay", Status: 400,
+		Body: `{"error":{"message":"The ` + "`content[].thinking`" + ` in the thinking mode must be passed back to the API"}}`,
+	})
+}
+
+func reasoningReplaySeededSession() *Session {
+	session := NewSession("system")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "earlier"})
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "old answer", ReasoningContent: "stale thinking"})
+	return session
+}
+
+func TestReasoningReplay400RepairsProjectionAndRetriesOnce(t *testing.T) {
+	mp := testutil.NewMock("strict-replay",
+		testutil.ErrorTurn(thinkingReplay400Error()),
+		testutil.Turn{Text: "done"},
+		testutil.Turn{Text: "again done"},
+	)
+	sink := &recordSink{}
+	session := reasoningReplaySeededSession()
+	a := New(strictAssistantReasoningProvider{mp}, echoRegistry(), session, Options{}, sink)
+
+	if err := a.Run(withNoClosedLoop(context.Background()), "next"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := mp.CallCount(); got != 2 {
+		t.Fatalf("provider calls = %d, want rejected attempt plus one repair retry", got)
+	}
+	requests := mp.Requests()
+	var firstReasoning, secondReasoning int
+	for _, m := range requests[0].Messages {
+		if m.ReasoningContent != "" {
+			firstReasoning++
+		}
+	}
+	for _, m := range requests[1].Messages {
+		if m.ReasoningContent != "" {
+			secondReasoning++
+		}
+	}
+	if firstReasoning != 1 || secondReasoning != 0 {
+		t.Fatalf("reasoning in attempts = %d then %d, want the repair retry stripped", firstReasoning, secondReasoning)
+	}
+	// The frozen request may change only in Messages; everything else is
+	// byte-identical to the rejected attempt.
+	strippedTools := requests[1]
+	strippedTools.Messages = requests[0].Messages
+	if !reflect.DeepEqual(requests[0], strippedTools) {
+		t.Fatalf("repair retry changed more than Messages:\nfirst=%+v\nretry=%+v", requests[0], requests[1])
+	}
+	// Canonical history is never modified by the provider-visible projection.
+	for _, m := range session.Snapshot() {
+		if m.Role == provider.RoleAssistant && m.Content == "old answer" && m.ReasoningContent != "stale thinking" {
+			t.Fatalf("canonical history lost its reasoning: %+v", m)
+		}
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 1 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 1", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Recovered); got != 1 {
+		t.Fatalf("reasoning_replay_400_recovered audits = %d, want 1", got)
+	}
+	var repairNotices int
+	for _, e := range sink.kinds(event.Notice) {
+		if e.Code == event.NoticeCodeReasoningReplayRepair {
+			repairNotices++
+			if e.Level != event.LevelWarn {
+				t.Fatalf("repair notice level = %v, want warn", e.Level)
+			}
+		}
+	}
+	if repairNotices != 1 {
+		t.Fatalf("repair notices = %d, want 1", repairNotices)
+	}
+
+	// The strong projection stays active for the rest of the conversation.
+	if err := a.Run(withNoClosedLoop(context.Background()), "again"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if got := mp.CallCount(); got != 3 {
+		t.Fatalf("provider calls = %d, want no fresh 400 on the next run", got)
+	}
+	for _, m := range mp.Requests()[2].Messages {
+		if m.ReasoningContent != "" {
+			t.Fatalf("later request still carries reasoning under strong projection: %+v", m)
+		}
+	}
+}
+
+func TestReasoningReplay400RepairExhaustionStaysTerminal(t *testing.T) {
+	mp := testutil.NewMock("strict-replay",
+		testutil.ErrorTurn(thinkingReplay400Error()),
+		testutil.ErrorTurn(thinkingReplay400Error()),
+		testutil.Turn{Text: "unreachable"},
+	)
+	sink := &recordSink{}
+	a := New(strictAssistantReasoningProvider{mp}, echoRegistry(), reasoningReplaySeededSession(), Options{}, sink)
+
+	err := a.Run(withNoClosedLoop(context.Background()), "next")
+	var replayErr *provider.ReasoningReplayError
+	if !errors.As(err, &replayErr) {
+		t.Fatalf("Run error = %v, want ReasoningReplayError", err)
+	}
+	if got := mp.CallCount(); got != 2 {
+		t.Fatalf("provider calls = %d, want exactly one repair retry", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 1 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 1", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Recovered); got != 0 {
+		t.Fatalf("reasoning_replay_400_recovered audits = %d, want 0 after a failed repair", got)
+	}
+}
+
+func TestNonReplay400DoesNotTriggerReasoningRepair(t *testing.T) {
+	mp := testutil.NewMock("strict-replay",
+		testutil.ErrorTurn(&provider.APIError{Provider: "strict-replay", Status: 400, Body: `{"error":{"message":"invalid request: unknown tool"}}`}),
+		testutil.Turn{Text: "unreachable"},
+	)
+	sink := &recordSink{}
+	a := New(strictAssistantReasoningProvider{mp}, echoRegistry(), reasoningReplaySeededSession(), Options{}, sink)
+
+	err := a.Run(withNoClosedLoop(context.Background()), "next")
+	var apiErr *provider.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Run error = %v, want the raw APIError", err)
+	}
+	if replayErr := provider.AsReasoningReplayError(err); replayErr != nil {
+		t.Fatalf("unrelated 400 misclassified as reasoning replay: %v", replayErr)
+	}
+	if got := mp.CallCount(); got != 1 {
+		t.Fatalf("provider calls = %d, want no retry for an unrelated 400", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 0 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 0", got)
+	}
+}

--- a/internal/agent/retry_e2e_test.go
+++ b/internal/agent/retry_e2e_test.go
@@ -420,12 +420,12 @@ func TestDeepSeekAnthropicThinking400CatchAndRepair(t *testing.T) {
 	}
 	// The adopted answer streamed through and the canonical history keeps both
 	// turns' reasoning untouched by the provider-visible repair.
-	var answer string
+	var answer strings.Builder
 	for _, e := range sink.kinds(event.Text) {
-		answer += e.Text
+		answer.WriteString(e.Text)
 	}
-	if answer != "repaired answer" {
-		t.Fatalf("streamed answer = %q, want the repaired response", answer)
+	if answer.String() != "repaired answer" {
+		t.Fatalf("streamed answer = %q, want the repaired response", answer.String())
 	}
 
 	// The next run keeps the strong projection: no reasoning reaches the wire.

--- a/internal/agent/retry_e2e_test.go
+++ b/internal/agent/retry_e2e_test.go
@@ -3,10 +3,12 @@ package agent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,6 +17,7 @@ import (
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
+	"reasonix/internal/provider/anthropic"
 	"reasonix/internal/provider/openai"
 	"reasonix/internal/tool"
 )
@@ -320,5 +323,128 @@ func TestGLMReasoningOverflowFailsBeforeToolExecution(t *testing.T) {
 	}
 	if got := requests.Load(); got != 1 {
 		t.Fatalf("HTTP requests = %d, want no continuation after incomplete GLM reasoning", got)
+	}
+}
+
+// TestDeepSeekAnthropicThinking400CatchAndRepair drives the full self-heal
+// against the real Anthropic-adapter wire shape: the first request replays the
+// stored thinking block and the server rejects it with DeepSeek's documented
+// 400; the agent must repair the projection once (stripping all reasoning),
+// retry, and keep the strong projection for the following run.
+func TestDeepSeekAnthropicThinking400CatchAndRepair(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, append([]byte(nil), body...))
+		requestNo := len(bodies)
+		mu.Unlock()
+
+		if requestNo == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"The ` + "`content[].thinking`" + ` in the thinking mode must be passed back to the API","type":"invalid_request_error"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":20,\"output_tokens\":1}}}\n\n")
+		if requestNo == 2 {
+			_, _ = io.WriteString(w, "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n")
+			_, _ = io.WriteString(w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"fresh thinking\"}}\n\n")
+			_, _ = io.WriteString(w, "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
+		}
+		_, _ = io.WriteString(w, "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"repaired answer\"}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"content_block_stop\",\"index\":1}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"message_stop\"}\n\n")
+	}))
+	defer srv.Close()
+
+	prov, err := anthropic.New(provider.Config{
+		Name: "deepseek-anthropic", BaseURL: srv.URL, Model: "deepseek-v4-flash", APIKey: "k",
+		Extra: map[string]any{"reasoning_protocol": "deepseek", "thinking": "enabled"},
+	})
+	if err != nil {
+		t.Fatalf("New provider: %v", err)
+	}
+	session := NewSession("system")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "earlier"})
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "old answer", ReasoningContent: "stale thinking"})
+	sink := &recordSink{}
+	a := New(prov, echoRegistry(), session, Options{}, sink)
+
+	if err := a.Run(withNoClosedLoop(context.Background()), "next"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	gotBodies := append([][]byte(nil), bodies...)
+	mu.Unlock()
+	if len(gotBodies) != 2 {
+		t.Fatalf("HTTP requests = %d, want rejected attempt plus one repair retry", len(gotBodies))
+	}
+	if !bytes.Contains(gotBodies[0], []byte(`"type":"thinking"`)) || !bytes.Contains(gotBodies[0], []byte("stale thinking")) {
+		t.Fatalf("first request did not replay the stored thinking block: %s", gotBodies[0])
+	}
+	if bytes.Contains(gotBodies[1], []byte(`"type":"thinking"`)) || bytes.Contains(gotBodies[1], []byte("stale thinking")) {
+		t.Fatalf("repair retry still carries thinking blocks: %s", gotBodies[1])
+	}
+	if !bytes.Contains(gotBodies[1], []byte("old answer")) {
+		t.Fatalf("repair retry lost the visible assistant text: %s", gotBodies[1])
+	}
+	// Only Messages may change between the rejected request and its repair.
+	var first, second map[string]json.RawMessage
+	if err := json.Unmarshal(gotBodies[0], &first); err != nil || json.Unmarshal(gotBodies[1], &second) != nil {
+		t.Fatalf("decode request bodies: %v", err)
+	}
+	delete(first, "messages")
+	delete(second, "messages")
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("repair retry changed non-message fields:\nfirst=%s\nretry=%s", gotBodies[0], gotBodies[1])
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 1 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 1", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Recovered); got != 1 {
+		t.Fatalf("reasoning_replay_400_recovered audits = %d, want 1", got)
+	}
+	var repairNotices int
+	for _, e := range sink.kinds(event.Notice) {
+		if e.Code == event.NoticeCodeReasoningReplayRepair && e.Level == event.LevelWarn {
+			repairNotices++
+		}
+	}
+	if repairNotices != 1 {
+		t.Fatalf("repair notices = %d, want 1", repairNotices)
+	}
+	// The adopted answer streamed through and the canonical history keeps both
+	// turns' reasoning untouched by the provider-visible repair.
+	var answer string
+	for _, e := range sink.kinds(event.Text) {
+		answer += e.Text
+	}
+	if answer != "repaired answer" {
+		t.Fatalf("streamed answer = %q, want the repaired response", answer)
+	}
+
+	// The next run keeps the strong projection: no reasoning reaches the wire.
+	if err := a.Run(withNoClosedLoop(context.Background()), "again"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	mu.Lock()
+	third := append([]byte(nil), bodies[len(bodies)-1]...)
+	total := len(bodies)
+	mu.Unlock()
+	if total != 3 {
+		t.Fatalf("HTTP requests = %d, want one more for the follow-up run", total)
+	}
+	if bytes.Contains(third, []byte(`"type":"thinking"`)) || bytes.Contains(third, []byte("stale thinking")) || bytes.Contains(third, []byte("fresh thinking")) {
+		t.Fatalf("strong projection did not persist into the next run: %s", third)
+	}
+	for _, m := range session.Snapshot() {
+		if m.Role == provider.RoleAssistant && m.Content == "old answer" && m.ReasoningContent != "stale thinking" {
+			t.Fatalf("canonical history lost its reasoning: %+v", m)
+		}
 	}
 }

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -46,78 +46,6 @@ func (s streamedTurn) assistantMessage() provider.Message {
 	}
 }
 
-// deferredStreamSink keeps selected stream events local until the caller
-// chooses which provider response to adopt. On an ordinary healthy DeepSeek
-// turn, reasoning arrives before tool calls and unlocks live tool-card events.
-// On the rare malformed turn with no reasoning, only the speculative partial
-// tool cards remain buffered, so retrying does not flash duplicate cards in the
-// UI. A recovery attempt buffers everything because it may be discarded.
-type deferredStreamSink struct {
-	inner               event.Sink
-	deferAll            bool
-	waitingForReasoning bool
-	sawReasoning        bool
-	events              []event.Event
-}
-
-func newReasoningAwareStreamSink(inner event.Sink) *deferredStreamSink {
-	return &deferredStreamSink{inner: inner, waitingForReasoning: true}
-}
-
-func newDeferredStreamSink(inner event.Sink) *deferredStreamSink {
-	return &deferredStreamSink{inner: inner, deferAll: true}
-}
-
-func (s *deferredStreamSink) Emit(e event.Event) {
-	if s == nil {
-		return
-	}
-	if s.deferAll {
-		s.events = append(s.events, e)
-		return
-	}
-	if s.waitingForReasoning && e.Kind == event.Reasoning && strings.TrimSpace(e.Text) != "" {
-		s.sawReasoning = true
-		s.inner.Emit(e)
-		s.flushBuffered()
-		return
-	}
-	if s.waitingForReasoning && !s.sawReasoning {
-		switch e.Kind {
-		case event.ToolDispatch, event.ToolResult, event.Text, event.Message:
-			// Keep every user-visible speculative event private until reasoning
-			// proves the turn replayable. Healthy DeepSeek responses emit
-			// reasoning first, so their live-streaming fast path is unchanged.
-			s.events = append(s.events, e)
-			return
-		}
-	}
-	s.inner.Emit(e)
-}
-
-func (s *deferredStreamSink) flushBuffered() {
-	if s == nil {
-		return
-	}
-	for _, e := range s.events {
-		s.inner.Emit(e)
-	}
-	s.events = nil
-}
-
-func (s *deferredStreamSink) Flush() {
-	if s == nil {
-		return
-	}
-	s.flushBuffered()
-}
-
-func (s *deferredStreamSink) Discard() {
-	if s != nil {
-		s.events = nil
-	}
-}
-
 // beginRunTurn handles evidence scope, delivery classification, background-job
 // evidence re-lease, and the initial user-turn persistence. Callers still own
 // all Run-level defers (workspace lease, evidence commit, delivery checkpoint,
@@ -392,15 +320,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 				attempt = 0
 				continue
 			}
-			// A thinking-400 means the frozen history's replayed reasoning is
-			// stale for this provider. Repair the projection once and retry;
-			// every other 400 keeps falling through to the terminal path.
-			if next, retryReplay := a.recoverReasoningReplay400(frozen, result.err, &replayRecovery); retryReplay {
-				if streamSink != nil {
-					streamSink.Discard()
-				}
-				a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, "reasoning_replay_400", result.err)
-				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Detected})
+			if next, retryReplay := a.tryRecoverReasoningReplay400(streamSink, frozen, attemptID, attempt, result.err, &replayRecovery); retryReplay {
 				frozen = next
 				reasoningReplayRepaired = true
 				attempt = 0
@@ -431,11 +351,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 			a.observeMissingAssistantReasoning(result.assistantMessage(), result.reasoningComplete)
 		}
 		if issue == ReasoningReplayOverflow {
-			event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningOverflowDetected})
-			result.usage = finalizeSamplingUsage(billable, result.usage)
-			terminal := a.finishUnreplayableReasoning(result, streamSink, issue)
-			a.emitReasoningReplayAttemptOutcome(attemptID, attempt, terminal.err)
-			return terminal
+			return a.finishReasoningReplayOverflow(result, streamSink, issue, billable, attemptID, attempt)
 		}
 		if missing {
 			event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
@@ -475,15 +391,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 				return retry
 			}
 			if !shouldRetry {
-				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetrySuppressed})
-				if fallback, ok := a.runMissingReasoningFallback(ctx, turn, &frozen, attemptID, attempt, billable, streamSink); ok {
-					return fallback
-				}
-				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
-				result.usage = finalizeSamplingUsage(billable, result.usage)
-				terminal := a.finishUnreplayableReasoning(result, streamSink, issue)
-				a.emitReasoningReplayAttemptOutcome(attemptID, attempt, terminal.err)
-				return terminal
+				return a.suppressMissingReasoningRetry(ctx, turn, &frozen, attemptID, attempt, streamSink, result, issue, billable)
 			}
 		}
 
@@ -491,9 +399,6 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
 		result.usage = finalizeSamplingUsage(billable, result.usage)
 		if reasoningReplayRepaired {
-			// The repair retry proved the canonical history's stored reasoning is
-			// stale for this provider; keep the strong projection for the rest of
-			// the conversation so later rounds do not pay another 400.
 			a.activateReasoningReplayStrongProjection()
 		}
 		return result

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -363,6 +363,8 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 	// its delta so RequestCount equals real HTTP POSTs (no triangular growth).
 	ctx = provider.WithRequestAttemptCounter(ctx)
 	var contextRecovery contextRecoveryBudget
+	var replayRecovery reasoningReplayRecoveryBudget
+	reasoningReplayRepaired := false
 
 	var billable *provider.Usage
 	var last streamedTurn
@@ -387,6 +389,20 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 				}
 				a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, "context_limit", result.err)
 				frozen = next
+				attempt = 0
+				continue
+			}
+			// A thinking-400 means the frozen history's replayed reasoning is
+			// stale for this provider. Repair the projection once and retry;
+			// every other 400 keeps falling through to the terminal path.
+			if next, retryReplay := a.recoverReasoningReplay400(frozen, result.err, &replayRecovery); retryReplay {
+				if streamSink != nil {
+					streamSink.Discard()
+				}
+				a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, "reasoning_replay_400", result.err)
+				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Detected})
+				frozen = next
+				reasoningReplayRepaired = true
 				attempt = 0
 				continue
 			}
@@ -474,6 +490,12 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		streamSink.Flush()
 		a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
 		result.usage = finalizeSamplingUsage(billable, result.usage)
+		if reasoningReplayRepaired {
+			// The repair retry proved the canonical history's stored reasoning is
+			// stale for this provider; keep the strong projection for the rest of
+			// the conversation so later rounds do not pay another 400.
+			a.activateReasoningReplayStrongProjection()
+		}
 		return result
 	}
 	return last

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -165,7 +165,13 @@ func (a *Agent) providerProjectionMessages(msgs []provider.Message) []provider.M
 		// The provider-declared fallback owns this tool loop. Strict projection
 		// here would erase its completed tool round before adapter serialization.
 		if !a.sess.missingReasoning.fallbackActive || !provider.SupportsMissingReasoningFallback(a.svc.prov) {
-			if repaired, changed := provider.ProjectReplaySafeMessages(a.svc.prov, msgs); changed {
+			if a.sess.reasoningReplayStrongProjection {
+				// A repaired thinking-400 conversation keeps the stripped
+				// projection: its canonical reasoning is stale for this provider.
+				if repaired, changed := provider.ProjectReasoningStrippedMessages(a.svc.prov, msgs); changed {
+					msgs = repaired
+				}
+			} else if repaired, changed := provider.ProjectReplaySafeMessages(a.svc.prov, msgs); changed {
 				msgs = repaired
 			}
 		}

--- a/internal/agent/sessionstate.go
+++ b/internal/agent/sessionstate.go
@@ -25,10 +25,9 @@ type sessionRuntime struct {
 
 	missingReasoning missingReasoningWatch
 
-	// reasoningReplayStrongProjection is set once a thinking-400 catch-and-repair
-	// retry succeeds: the canonical history carries reasoning this provider
-	// rejects, so every later provider request in this conversation keeps using
-	// the stripped projection instead of paying another 400 per round.
+	// reasoningReplayStrongProjection is set once a thinking-400 repair retry
+	// succeeds: this conversation's stored reasoning is stale for the provider,
+	// so later requests keep using the stripped projection.
 	reasoningReplayStrongProjection bool
 
 	// compactionMu guards projection snapshots/install and the in-memory sidecar

--- a/internal/agent/sessionstate.go
+++ b/internal/agent/sessionstate.go
@@ -25,6 +25,12 @@ type sessionRuntime struct {
 
 	missingReasoning missingReasoningWatch
 
+	// reasoningReplayStrongProjection is set once a thinking-400 catch-and-repair
+	// retry succeeds: the canonical history carries reasoning this provider
+	// rejects, so every later provider request in this conversation keeps using
+	// the stripped projection instead of paying another 400 per round.
+	reasoningReplayStrongProjection bool
+
 	// compactionMu guards projection snapshots/install and the in-memory sidecar
 	// generation. Network summarization never runs while this lock is held.
 	compactionMu sync.Mutex
@@ -65,6 +71,7 @@ func (r *sessionRuntime) reset(s *Session) {
 	r.cacheMiss.Store(0)
 	r.output.reset()
 	r.missingReasoning = missingReasoningWatch{}
+	r.reasoningReplayStrongProjection = false
 	r.compactionMu.Lock()
 	r.compactionState = CompactionState{} // lineage change; disk reloaded on Resume
 	r.cacheState = CacheStateUnknown

--- a/internal/agent/sessionstate_test.go
+++ b/internal/agent/sessionstate_test.go
@@ -19,10 +19,13 @@ var sessionReset = map[string]bool{
 	"cacheHit":         true,
 	"cacheMiss":        true,
 	"missingReasoning": true,
-	"compactionMu":     true,
-	"compactionState":  true,
-	"cacheState":       true,
-	"compaction":       true,
+	// A strong-projection repair belongs to the corrupted conversation; a new
+	// conversation starts without it.
+	"reasoningReplayStrongProjection": true,
+	"compactionMu":                    true,
+	"compactionState":                 true,
+	"cacheState":                      true,
+	"compaction":                      true,
 }
 
 // sessionCarryOver names the fields reset deliberately leaves alone, each with

--- a/internal/agent/stream_sink.go
+++ b/internal/agent/stream_sink.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"strings"
+
+	"reasonix/internal/event"
+)
+
+// deferredStreamSink keeps selected stream events local until the caller
+// chooses which provider response to adopt. On an ordinary healthy DeepSeek
+// turn, reasoning arrives before tool calls and unlocks live tool-card events.
+// On the rare malformed turn with no reasoning, only the speculative partial
+// tool cards remain buffered, so retrying does not flash duplicate cards in the
+// UI. A recovery attempt buffers everything because it may be discarded.
+type deferredStreamSink struct {
+	inner               event.Sink
+	deferAll            bool
+	waitingForReasoning bool
+	sawReasoning        bool
+	events              []event.Event
+}
+
+func newReasoningAwareStreamSink(inner event.Sink) *deferredStreamSink {
+	return &deferredStreamSink{inner: inner, waitingForReasoning: true}
+}
+
+func newDeferredStreamSink(inner event.Sink) *deferredStreamSink {
+	return &deferredStreamSink{inner: inner, deferAll: true}
+}
+
+func (s *deferredStreamSink) Emit(e event.Event) {
+	if s == nil {
+		return
+	}
+	if s.deferAll {
+		s.events = append(s.events, e)
+		return
+	}
+	if s.waitingForReasoning && e.Kind == event.Reasoning && strings.TrimSpace(e.Text) != "" {
+		s.sawReasoning = true
+		s.inner.Emit(e)
+		s.flushBuffered()
+		return
+	}
+	if s.waitingForReasoning && !s.sawReasoning {
+		switch e.Kind {
+		case event.ToolDispatch, event.ToolResult, event.Text, event.Message:
+			// Keep every user-visible speculative event private until reasoning
+			// proves the turn replayable. Healthy DeepSeek responses emit
+			// reasoning first, so their live-streaming fast path is unchanged.
+			s.events = append(s.events, e)
+			return
+		}
+	}
+	s.inner.Emit(e)
+}
+
+func (s *deferredStreamSink) flushBuffered() {
+	if s == nil {
+		return
+	}
+	for _, e := range s.events {
+		s.inner.Emit(e)
+	}
+	s.events = nil
+}
+
+func (s *deferredStreamSink) Flush() {
+	if s == nil {
+		return
+	}
+	s.flushBuffered()
+}
+
+func (s *deferredStreamSink) Discard() {
+	if s != nil {
+		s.events = nil
+	}
+}

--- a/internal/boot/completion_effect_test.go
+++ b/internal/boot/completion_effect_test.go
@@ -122,6 +122,9 @@ func TestEffectCompletionValidatorEnforceDefaultReachesProvider(t *testing.T) {
 	if v.MaxTokens != completioneval.MaxTokens {
 		t.Fatalf("validator MaxTokens = %d, want %d", v.MaxTokens, completioneval.MaxTokens)
 	}
+	if v.EffortOverride != completioneval.EffortDisabled {
+		t.Fatalf("validator EffortOverride = %q, want %q so thinking cannot eat the verdict budget", v.EffortOverride, completioneval.EffortDisabled)
+	}
 	if !strings.Contains(v.Messages[1].Content, `"candidate_answer"`) {
 		t.Fatalf("validator evidence missing candidate answer: %s", v.Messages[1].Content)
 	}

--- a/internal/boundedllm/bounded.go
+++ b/internal/boundedllm/bounded.go
@@ -48,8 +48,9 @@ type Config struct {
 	Timeout time.Duration
 	// MaxTokens caps the completion. Zero uses DefaultMaxTokens.
 	MaxTokens int
-	// EffortOverride optionally requests a lower or higher reasoning depth for
-	// this independent call. Provider adapters ignore unsupported values.
+	// EffortOverride optionally requests a different reasoning depth for this
+	// independent call, or "disabled" to skip thinking — bounded reviewers
+	// replay no history. Provider adapters ignore unsupported values.
 	EffortOverride string
 	// MaxOutputBytes aborts the stream once exceeded. Zero uses DefaultMaxOutputBytes.
 	MaxOutputBytes int

--- a/internal/completioneval/evaluator_test.go
+++ b/internal/completioneval/evaluator_test.go
@@ -14,19 +14,21 @@ import (
 )
 
 type scriptedProvider struct {
-	turns   []string // one response per call, recycled
-	err     error    // stream-open error
-	timeout bool     // hang until ctx deadline
-	usage   *provider.Usage
-	mu      sync.Mutex
-	calls   int
+	turns    []string // one response per call, recycled
+	err      error    // stream-open error
+	timeout  bool     // hang until ctx deadline
+	usage    *provider.Usage
+	mu       sync.Mutex
+	calls    int
+	requests []provider.Request
 }
 
 func (s *scriptedProvider) Name() string { return "scripted" }
 
-func (s *scriptedProvider) Stream(ctx context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+func (s *scriptedProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
 	s.mu.Lock()
 	s.calls++
+	s.requests = append(s.requests, req)
 	i := s.calls - 1
 	if i >= len(s.turns) {
 		i = len(s.turns) - 1
@@ -115,6 +117,34 @@ func TestEvaluateFailClosedOnBadResponses(t *testing.T) {
 				t.Fatalf("Evaluate() error = nil, want fail-closed error for %q", tc.body)
 			}
 		})
+	}
+}
+
+func TestEvaluateDisablesThinkingPerRequest(t *testing.T) {
+	prov := &scriptedProvider{turns: []string{`{"outcome":"complete","reason":"done"}`}}
+	if _, err := evaluate(t, prov, Evidence{TaskText: "fix the parser"}); err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if len(prov.requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(prov.requests))
+	}
+	req := prov.requests[0]
+	if req.EffortOverride != EffortDisabled {
+		t.Fatalf("EffortOverride = %q, want %q so a thinking endpoint cannot burn the verdict budget on reasoning", req.EffortOverride, EffortDisabled)
+	}
+	if len(req.Tools) != 0 || len(req.Messages) != 2 {
+		t.Fatalf("request shape = %d tools/%d messages, want the stateless two-message call", len(req.Tools), len(req.Messages))
+	}
+}
+
+func TestEmptyResponseIsClassifiableApartFromInvalidOutput(t *testing.T) {
+	prov := &scriptedProvider{turns: []string{""}}
+	_, err := evaluate(t, prov, Evidence{})
+	if !errors.Is(err, ErrEmptyOutput) {
+		t.Fatalf("empty response error = %v, want ErrEmptyOutput", err)
+	}
+	if !errors.Is(err, ErrInvalidOutput) {
+		t.Fatalf("empty response error = %v, want it to keep matching ErrInvalidOutput", err)
 	}
 }
 

--- a/internal/completioneval/evidence.go
+++ b/internal/completioneval/evidence.go
@@ -10,6 +10,9 @@ import (
 const (
 	// MaxTokens caps the validator's completion.
 	MaxTokens = 256
+	// EffortDisabled turns thinking off for the verdict call; providers without
+	// a per-request thinking knob ignore it.
+	EffortDisabled = "disabled"
 	// Timeout bounds one evaluation call.
 	Timeout = 30 * time.Second
 	// MaxOutputBytes aborts the stream if the provider ignores MaxTokens.

--- a/internal/completioneval/live_deepseek_test.go
+++ b/internal/completioneval/live_deepseek_test.go
@@ -23,7 +23,7 @@ type liveCompletionScenario struct {
 }
 
 type liveCompletionResult struct {
-	model    string
+	variant  string
 	scenario string
 	outcome  Outcome
 	errClass string
@@ -36,24 +36,33 @@ func TestLiveDeepSeekCompletionValidationMatrix(t *testing.T) {
 	}
 	runs := completionLiveRuns
 	models := []string{"deepseek-v4-flash", "deepseek-v4-flash-vision-exp"}
+	// thinking=enabled mirrors the production desktop preset. The evaluator's
+	// per-request EffortOverride=disabled must neutralize it on the wire, so
+	// both thinking rows must score identically.
+	thinkings := []string{"disabled", "enabled"}
 	scenarios := liveCompletionScenarios()
 	providers := map[string]provider.Provider{}
+	var variants []string
 	for _, model := range models {
-		providers[model] = newLiveCompletionProvider(t, key, model)
+		for _, thinking := range thinkings {
+			variant := model + "/thinking-" + thinking
+			variants = append(variants, variant)
+			providers[variant] = newLiveCompletionProvider(t, key, model, thinking)
+		}
 	}
 
 	type job struct {
-		model    string
+		variant  string
 		scenario liveCompletionScenario
 	}
 	jobs := make(chan job)
-	results := make(chan liveCompletionResult, len(models)*len(scenarios)*runs)
+	results := make(chan liveCompletionResult, len(variants)*len(scenarios)*runs)
 	for range 4 {
 		go func() {
 			for job := range jobs {
-				session := NewSession(providers[job.model], nil, "deepseek/"+job.model, event.Discard)
+				session := NewSession(providers[job.variant], nil, "deepseek/"+job.variant, event.Discard)
 				verdict, err := session.Evaluate(context.Background(), job.scenario.evidence)
-				result := liveCompletionResult{model: job.model, scenario: job.scenario.name, outcome: verdict.Outcome}
+				result := liveCompletionResult{variant: job.variant, scenario: job.scenario.name, outcome: verdict.Outcome}
 				if err != nil {
 					result.errClass = liveCompletionErrorClass(err)
 				}
@@ -62,10 +71,10 @@ func TestLiveDeepSeekCompletionValidationMatrix(t *testing.T) {
 		}()
 	}
 	go func() {
-		for _, model := range models {
+		for _, variant := range variants {
 			for _, scenario := range scenarios {
 				for range runs {
-					jobs <- job{model: model, scenario: scenario}
+					jobs <- job{variant: variant, scenario: scenario}
 				}
 			}
 		}
@@ -77,9 +86,9 @@ func TestLiveDeepSeekCompletionValidationMatrix(t *testing.T) {
 		errors   map[string]int
 	}
 	all := map[string]*counts{}
-	for range len(models) * len(scenarios) * runs {
+	for range len(variants) * len(scenarios) * runs {
 		result := <-results
-		key := result.model + "/" + result.scenario
+		key := result.variant + "/" + result.scenario
 		if all[key] == nil {
 			all[key] = &counts{outcomes: map[Outcome]int{}, errors: map[string]int{}}
 		}
@@ -90,9 +99,9 @@ func TestLiveDeepSeekCompletionValidationMatrix(t *testing.T) {
 		}
 	}
 
-	for _, model := range models {
+	for _, variant := range variants {
 		for _, scenario := range scenarios {
-			key := model + "/" + scenario.name
+			key := variant + "/" + scenario.name
 			got := all[key]
 			t.Logf("%s outcomes=%v errors=%v", key, got.outcomes, got.errors)
 			if len(got.errors) != 0 {
@@ -117,14 +126,14 @@ func TestLiveDeepSeekCompletionValidationMatrix(t *testing.T) {
 	}
 }
 
-func newLiveCompletionProvider(t *testing.T, key, model string) provider.Provider {
+func newLiveCompletionProvider(t *testing.T, key, model, thinking string) provider.Provider {
 	t.Helper()
 	prov, err := anthropic.New(provider.Config{
-		Name: "deepseek-completion-live", BaseURL: "https://api.deepseek.com/anthropic", Model: model, APIKey: key,
-		Extra: map[string]any{"api_key_env": "DEEPSEEK_API_KEY", "thinking": "disabled", "effort": "high"},
+		Name: "deepseek-completion-live-" + thinking, BaseURL: "https://api.deepseek.com/anthropic", Model: model, APIKey: key,
+		Extra: map[string]any{"api_key_env": "DEEPSEEK_API_KEY", "thinking": thinking, "effort": "high"},
 	})
 	if err != nil {
-		t.Fatalf("build live provider for %s: %v", model, err)
+		t.Fatalf("build live provider for %s (thinking=%s): %v", model, thinking, err)
 	}
 	if closer, ok := prov.(interface{ CloseIdleConnections() }); ok {
 		t.Cleanup(closer.CloseIdleConnections)
@@ -194,6 +203,8 @@ func liveCompletionErrorClass(err error) string {
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
 		return "timeout"
+	case errors.Is(err, ErrEmptyOutput):
+		return "empty_output"
 	case errors.Is(err, ErrInvalidOutput):
 		return "invalid_output"
 	case strings.Contains(err.Error(), "exceed"):

--- a/internal/completioneval/session.go
+++ b/internal/completioneval/session.go
@@ -38,8 +38,10 @@ type Session struct {
 	mu sync.Mutex // serializes evaluations sharing this session's provider call path
 }
 
-// NewSession creates a completion validator with temperature 0 and MaxTokens
-// 256. prov is normally the same provider/model the working agent uses, so
+// NewSession creates a completion validator with temperature 0, MaxTokens
+// 256, and thinking disabled per request: the verdict call is a stateless
+// two-message exchange whose tiny completion budget reasoning would eat.
+// prov is normally the same provider/model the working agent uses, so
 // evidence never implicitly crosses to another model; modelRef labels emitted
 // usage. sink may be nil.
 func NewSession(prov provider.Provider, pricing *provider.Pricing, modelRef string, sink event.Sink) *Session {
@@ -75,6 +77,7 @@ func (s *Session) Evaluate(ctx context.Context, evidence Evidence) (Verdict, err
 		UsageSource:    event.UsageSourceCompletionEvaluator,
 		Timeout:        s.timeout,
 		MaxTokens:      MaxTokens,
+		EffortOverride: EffortDisabled,
 		MaxOutputBytes: MaxOutputBytes,
 		MaxSystemBytes: boundedllm.DefaultMaxSystemBytes,
 		MaxTotalBytes:  boundedllm.DefaultMaxTotalBytes,

--- a/internal/completioneval/verdict.go
+++ b/internal/completioneval/verdict.go
@@ -15,6 +15,12 @@ const MaxReasonBytes = 500
 // matching error strings.
 var ErrInvalidOutput = errors.New("invalid completion evaluator output")
 
+// ErrEmptyOutput marks the empty-response case: the stream ended without any
+// text, the signature of a thinking-enabled endpoint burning the whole
+// completion budget on reasoning. It wraps ErrInvalidOutput so existing
+// classifiers keep matching while hosts can bucket it apart.
+var ErrEmptyOutput = fmt.Errorf("%w: empty response", ErrInvalidOutput)
+
 // Outcome is the validator's structured verdict disposition.
 type Outcome string
 
@@ -48,7 +54,7 @@ type Verdict struct {
 func parseVerdict(text string) (Verdict, error) {
 	text = strings.TrimSpace(text)
 	if text == "" {
-		return Verdict{}, fmt.Errorf("%w: empty response", ErrInvalidOutput)
+		return Verdict{}, ErrEmptyOutput
 	}
 	if i := strings.Index(text, "{"); i >= 0 {
 		if j := strings.LastIndex(text, "}"); j > i {

--- a/internal/event/completion_validation.go
+++ b/internal/event/completion_validation.go
@@ -18,7 +18,7 @@ type CompletionValidationInfo struct {
 	Outcome    string // complete | continue | needs_user | blocked | uncertain | error
 	Attempt    int    // 1-based evaluation attempt within the run
 	DurationMs int64
-	ErrorClass string // timeout | invalid_output | unavailable | over_budget | error | ""; empty when Outcome is a verdict
+	ErrorClass string // timeout | empty_output | invalid_output | unavailable | over_budget | error | ""; empty when Outcome is a verdict
 }
 
 // CompletionValidationAuditSink receives host-only completion validation

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -673,6 +673,8 @@ const (
 	ProtocolRecoveryClientToolRejected              ProtocolRecoveryKind = "client_tool_rejected_unreplayable_reasoning"
 	ProtocolRecoveryServerSearchSalvaged            ProtocolRecoveryKind = "server_search_history_salvaged"
 	ProtocolRecoveryHistoryRepaired                 ProtocolRecoveryKind = "unreplayable_history_repaired"
+	ProtocolRecoveryReasoningReplay400Detected      ProtocolRecoveryKind = "reasoning_replay_400_detected"
+	ProtocolRecoveryReasoningReplay400Recovered     ProtocolRecoveryKind = "reasoning_replay_400_recovered"
 )
 
 type ProtocolRecoveryAudit struct {

--- a/internal/event/notice_codes.go
+++ b/internal/event/notice_codes.go
@@ -41,4 +41,5 @@ const (
 	NoticeCodeSessionTakenOver                                  = "session_taken_over"
 	NoticeCodeSessionReclaimRequested                           = "session_reclaim_requested"
 	NoticeCodeSessionReclaimed                                  = "session_reclaimed"
+	NoticeCodeReasoningReplayRepair                             = "reasoning_replay_repair"
 )

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -39,6 +39,7 @@ type Messages struct {
 	ReadinessContinuing    string // host is automatically finishing known readiness gaps
 	RecoveryPaused         string // controlled Auto retry pause; user can continue in the next message
 	CompletionUncertain    string // completion validator could not confirm the result; work is kept
+	ReasoningReplayRepair  string // provider rejected replayed thinking blocks; history repaired and retried once
 	ReceiptVerified        string // end-of-turn receipt, nothing unproven
 	ReceiptGapsHeader      string // end-of-turn receipt, header above the unproven list
 	ReceiptRisksHeader     string // end-of-turn receipt, header above declared risks

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -15,6 +15,7 @@ var English = Messages{
 	ReadinessContinuing:    "Reasonix is finishing the remaining task work or checks automatically.",
 	RecoveryPaused:         "Automatic retries paused. Reasonix stopped repeated attempts and kept completed work. Send “Continue” to start a fresh attempt, or add instructions to change direction.",
 	CompletionUncertain:    "Completion could not be confirmed. The current result and completed work are kept. Send \"continue\" to resume, or restate what should change.",
+	ReasoningReplayRepair:  "The model provider rejected this conversation's stored thinking blocks. Reasonix removed them from the provider-visible history and retried once.",
 	ReceiptVerified:        "nothing left unverified",
 	ReceiptGapsHeader:      "not verified:",
 	ReceiptRisksHeader:     "declared risks:",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -16,6 +16,7 @@ var Chinese = Messages{
 	ReadinessContinuing:    "Reasonix 正在自动完成剩余任务或检查。",
 	RecoveryPaused:         "已暂停自动重试。Reasonix 已停止重复尝试，并保留已完成的工作。发送“继续”即可开始新一轮，也可以补充要求来调整方向。",
 	CompletionUncertain:    "完成状态未确认。当前结果和已完成工作均已保留。发送“继续”可接着完成，也可以补充说明需要调整的内容。",
+	ReasoningReplayRepair:  "模型服务拒绝了本会话历史中的 thinking 块。Reasonix 已从发送给模型的历史中移除这些内容，并重试了一次。",
 	ReceiptVerified:        "没有未经验证的部分",
 	ReceiptGapsHeader:      "未验证:",
 	ReceiptRisksHeader:     "已申报的风险:",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -16,6 +16,7 @@ var ChineseTraditional = Messages{
 	ReadinessContinuing:    "Reasonix 正在自動完成剩餘任務或檢查。",
 	RecoveryPaused:         "已暫停自動重試。Reasonix 已停止重複嘗試，並保留已完成的工作。傳送「繼續」即可開始新一輪，也可以補充要求來調整方向。",
 	CompletionUncertain:    "完成狀態未確認。目前結果與已完成工作均已保留。傳送「繼續」可接著完成，也可以補充說明需要調整的內容。",
+	ReasoningReplayRepair:  "模型服務拒絕了本會話歷史中的 thinking 區塊。Reasonix 已從傳送給模型的歷史中移除這些內容，並重試了一次。",
 	ReceiptVerified:        "沒有未經驗證的部分",
 	ReceiptGapsHeader:      "未驗證:",
 	ReceiptRisksHeader:     "已申報的風險:",

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -349,12 +349,25 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 	recoveryWithoutThinking := c.missingReasoningFallback(ctx)
 
 	// appendBlocks adds blocks under role, merging into the previous message when
-	// it shares the role (keeps user/assistant strictly alternating).
+	// it shares the role (keeps user/assistant strictly alternating). A thinking
+	// block must lead its message, so when the appended blocks open with thinking
+	// and the merge target already has content, the thinking run moves to the
+	// front: after projection degrades a reasoning-less turn to plain text, a
+	// following healthy assistant turn merges into it and must stay
+	// [thinking, text, ...], never [text, thinking, ...].
 	appendBlocks := func(role string, blocks ...contentBlock) {
 		if len(blocks) == 0 {
 			return
 		}
 		if n := len(msgs); n > 0 && msgs[n-1].Role == role {
+			if head := leadingThinkingBlocks(blocks); head > 0 && len(msgs[n-1].Content) > 0 {
+				merged := make([]contentBlock, 0, len(msgs[n-1].Content)+len(blocks))
+				merged = append(merged, blocks[:head]...)
+				merged = append(merged, msgs[n-1].Content...)
+				merged = append(merged, blocks[head:]...)
+				msgs[n-1].Content = merged
+				return
+			}
 			msgs[n-1].Content = append(msgs[n-1].Content, blocks...)
 			return
 		}
@@ -459,6 +472,16 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 		}
 	}
 	return r
+}
+
+// leadingThinkingBlocks counts the thinking blocks at the head of blocks.
+// replayReasoningBlock emits at most one, so the run is normally 0 or 1.
+func leadingThinkingBlocks(blocks []contentBlock) int {
+	head := 0
+	for head < len(blocks) && blocks[head].Type == "thinking" {
+		head++
+	}
+	return head
 }
 
 // readStream parses the Messages API SSE stream into Chunks. Text deltas emit live;

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -349,26 +349,13 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 	recoveryWithoutThinking := c.missingReasoningFallback(ctx)
 
 	// appendBlocks adds blocks under role, merging into the previous message when
-	// it shares the role (keeps user/assistant strictly alternating). A thinking
-	// block must lead its message, so when the appended blocks open with thinking
-	// and the merge target already has content, the thinking run moves to the
-	// front: after projection degrades a reasoning-less turn to plain text, a
-	// following healthy assistant turn merges into it and must stay
-	// [thinking, text, ...], never [text, thinking, ...].
+	// it shares the role (keeps user/assistant strictly alternating).
 	appendBlocks := func(role string, blocks ...contentBlock) {
 		if len(blocks) == 0 {
 			return
 		}
 		if n := len(msgs); n > 0 && msgs[n-1].Role == role {
-			if head := leadingThinkingBlocks(blocks); head > 0 && len(msgs[n-1].Content) > 0 {
-				merged := make([]contentBlock, 0, len(msgs[n-1].Content)+len(blocks))
-				merged = append(merged, blocks[:head]...)
-				merged = append(merged, msgs[n-1].Content...)
-				merged = append(merged, blocks[head:]...)
-				msgs[n-1].Content = merged
-				return
-			}
-			msgs[n-1].Content = append(msgs[n-1].Content, blocks...)
+			msgs[n-1].Content = mergeThinkingFirst(msgs[n-1].Content, blocks)
 			return
 		}
 		msgs = append(msgs, anthMessage{Role: role, Content: blocks})
@@ -472,16 +459,6 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 		}
 	}
 	return r
-}
-
-// leadingThinkingBlocks counts the thinking blocks at the head of blocks.
-// replayReasoningBlock emits at most one, so the run is normally 0 or 1.
-func leadingThinkingBlocks(blocks []contentBlock) int {
-	head := 0
-	for head < len(blocks) && blocks[head].Type == "thinking" {
-		head++
-	}
-	return head
 }
 
 // readStream parses the Messages API SSE stream into Chunks. Text deltas emit live;

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -217,8 +217,18 @@ func (c *client) RequiresToolCallReasoning() bool {
 }
 
 func (c *client) RequiresAssistantReasoningReplay(m provider.Message) bool {
+	if c == nil || !c.deepseek {
+		return false
+	}
+	// A turn carrying provider-issued reasoning must replay it, tools or not:
+	// DeepSeek's thinking mode 400s when a stored thinking block is not passed
+	// back. Without stored reasoning there is nothing to replay — plain text
+	// turns stay out of projection so healthy histories keep their backing.
+	if strings.TrimSpace(m.ReasoningContent) != "" {
+		return true
+	}
 	activity := len(m.ToolCalls) > 0 || len(m.ServerSearch) > 0
-	return c != nil && c.deepseek && activity && (c.deepSeekThinkingEnabled() || strings.TrimSpace(m.ReasoningContent) != "")
+	return activity && c.deepSeekThinkingEnabled()
 }
 
 func (c *client) AllowsEmptyReasoningFallback() bool { return false }
@@ -383,11 +393,12 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 			appendBlocks("user", block)
 		case provider.RoleAssistant:
 			var blocks []contentBlock
-			// Replay provider reasoning before the tool_use it led to. DeepSeek uses
-			// unsigned thinking blocks and requires the reasoning from a tool-call
-			// turn in every subsequent request, even if the current request no longer
-			// declares tools or has since disabled thinking. Anthropic proper requires
-			// a signature, so reasoning without one cannot be replayed on that endpoint.
+			// Replay provider reasoning ahead of the content it led to. DeepSeek's
+			// thinking mode requires every historical assistant turn's thinking
+			// block back whenever the request declares tools — tool-call turn or
+			// not — even if the current request no longer declares tools or has
+			// since disabled thinking. Anthropic proper requires a signature, so
+			// reasoning without one cannot be replayed on that endpoint.
 			if block, ok := c.replayReasoningBlock(m, recoveryWithoutThinking); ok {
 				blocks = append(blocks, block)
 			}

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -702,7 +702,7 @@ func TestMissingToolCallReasoningWarningFingerprintTracksAnthropicConfiguration(
 	}
 }
 
-func TestBuildRequestDeepSeekReplaysOnlyToolCallReasoningFromHistory(t *testing.T) {
+func TestBuildRequestDeepSeekReplaysReasoningFromHistory(t *testing.T) {
 	toolTurn := []provider.Message{
 		{Role: provider.RoleUser, Content: "weather?"},
 		{Role: provider.RoleAssistant, ReasoningContent: "I should call the tool.",
@@ -733,17 +733,21 @@ func TestBuildRequestDeepSeekReplaysOnlyToolCallReasoningFromHistory(t *testing.
 		})
 	}
 
-	t.Run("reasoning without a tool call stays omitted", func(t *testing.T) {
+	t.Run("reasoning without a tool call is replayed", func(t *testing.T) {
+		// DeepSeek's thinking mode requires every historical assistant turn's
+		// thinking block back when the request declares tools, even for plain
+		// question-answer turns (api-docs.deepseek.com/guides/thinking_mode).
 		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
 		r := c.buildRequest(context.Background(), provider.Request{
 			Messages: []provider.Message{
 				{Role: provider.RoleUser, Content: "hello"},
-				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "private scratchpad"},
+				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "scratchpad"},
 			},
 			Tools: []provider.ToolSchema{{Name: "get_weather"}},
 		})
-		if len(r.Messages) != 2 || len(r.Messages[1].Content) != 1 || r.Messages[1].Content[0].Type != "text" {
-			t.Fatalf("non-tool assistant blocks = %+v, want visible text only", r.Messages)
+		blocks := r.Messages[1].Content
+		if len(r.Messages) != 2 || len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "scratchpad" || blocks[1].Type != "text" {
+			t.Fatalf("non-tool assistant blocks = %+v, want thinking before text", r.Messages)
 		}
 	})
 }
@@ -779,7 +783,7 @@ func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "disabled"}
 		r := c.buildRequest(context.Background(), provider.Request{
-			Messages: []provider.Message{{Role: provider.RoleAssistant, ReasoningContent: "do not replay"}},
+			Messages: []provider.Message{{Role: provider.RoleAssistant, ReasoningContent: "replay anyway"}},
 			Tools:    []provider.ToolSchema{{Name: "tool"}},
 		})
 		if r.Thinking == nil || r.Thinking.Type != "disabled" || r.OutputConfig != nil {
@@ -788,8 +792,11 @@ func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 		if provider.RequiresToolCallReasoning(c) || provider.RequiresReasoningRoundTrip(c) {
 			t.Fatal("disabled DeepSeek thinking must not retain reasoning for replay")
 		}
-		if len(r.Messages) != 0 {
-			t.Fatalf("reasoning-only assistant should be omitted when thinking is disabled: %+v", r.Messages)
+		// Historical thinking blocks are replayed even when the current request
+		// disables thinking, the same rule tool-call turns already follow.
+		if len(r.Messages) != 1 || len(r.Messages[0].Content) != 1 || r.Messages[0].Content[0].Type != "thinking" ||
+			r.Messages[0].Content[0].Thinking != "replay anyway" {
+			t.Fatalf("reasoning-only assistant under disabled thinking = %+v, want the thinking block replayed", r.Messages)
 		}
 	})
 }

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -702,56 +702,6 @@ func TestMissingToolCallReasoningWarningFingerprintTracksAnthropicConfiguration(
 	}
 }
 
-func TestBuildRequestDeepSeekReplaysReasoningFromHistory(t *testing.T) {
-	toolTurn := []provider.Message{
-		{Role: provider.RoleUser, Content: "weather?"},
-		{Role: provider.RoleAssistant, ReasoningContent: "I should call the tool.",
-			ToolCalls: []provider.ToolCall{{ID: "t1", Name: "get_weather", Arguments: `{"city":"Paris"}`}}},
-		{Role: provider.RoleTool, ToolCallID: "t1", Content: "sunny"},
-	}
-	for _, tc := range []struct {
-		name     string
-		thinking string
-		effort   string
-	}{
-		{name: "current request has no tools", thinking: "enabled", effort: "high"},
-		{name: "thinking disabled after tool call", thinking: "enabled", effort: "disabled"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: tc.thinking, effort: tc.effort}
-			r := c.buildRequest(context.Background(), provider.Request{Messages: toolTurn})
-			if len(r.Tools) != 0 {
-				t.Fatalf("current request tools = %+v, want none", r.Tools)
-			}
-			if len(r.Messages) != 3 {
-				t.Fatalf("messages = %+v, want user/assistant/user", r.Messages)
-			}
-			blocks := r.Messages[1].Content
-			if len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "I should call the tool." || blocks[1].Type != "tool_use" {
-				t.Fatalf("assistant blocks = %+v, want historical thinking before tool_use", blocks)
-			}
-		})
-	}
-
-	t.Run("reasoning without a tool call is replayed", func(t *testing.T) {
-		// DeepSeek's thinking mode requires every historical assistant turn's
-		// thinking block back when the request declares tools, even for plain
-		// question-answer turns (api-docs.deepseek.com/guides/thinking_mode).
-		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
-		r := c.buildRequest(context.Background(), provider.Request{
-			Messages: []provider.Message{
-				{Role: provider.RoleUser, Content: "hello"},
-				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "scratchpad"},
-			},
-			Tools: []provider.ToolSchema{{Name: "get_weather"}},
-		})
-		blocks := r.Messages[1].Content
-		if len(r.Messages) != 2 || len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "scratchpad" || blocks[1].Type != "text" {
-			t.Fatalf("non-tool assistant blocks = %+v, want thinking before text", r.Messages)
-		}
-	})
-}
-
 func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 	for _, tc := range []struct {
 		name, model, input, want string

--- a/internal/provider/anthropic/effort_override_test.go
+++ b/internal/provider/anthropic/effort_override_test.go
@@ -1,0 +1,80 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// Per-request EffortOverride on the DeepSeek Anthropic endpoint: a bounded
+// reviewer's stateless call can disable thinking or pick a depth without
+// touching the client-level configuration the main loop relies on.
+func TestBuildRequestDeepSeekEffortOverride(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		override   string
+		wantThink  string
+		wantEffort string // "" = no output_config
+	}{
+		{name: "no override keeps client defaults", override: "", wantThink: "enabled", wantEffort: "high"},
+		{name: "disabled turns thinking off", override: "disabled", wantThink: "disabled"},
+		{name: "disabled with surrounding space", override: " Disabled ", wantThink: "disabled"},
+		{name: "depth replaces configured effort", override: "low", wantThink: "enabled", wantEffort: "low"},
+		{name: "max is a valid depth", override: "max", wantThink: "enabled", wantEffort: "max"},
+		{name: "medium normalizes to high", override: "medium", wantThink: "enabled", wantEffort: "high"},
+		{name: "unknown value falls back", override: "extreme", wantThink: "enabled", wantEffort: "high"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
+			r := c.buildRequest(context.Background(), provider.Request{
+				Messages:       []provider.Message{{Role: provider.RoleUser, Content: "judge this"}},
+				EffortOverride: tc.override,
+			})
+			if r.Thinking == nil || r.Thinking.Type != tc.wantThink {
+				t.Fatalf("thinking = %+v, want type %q", r.Thinking, tc.wantThink)
+			}
+			var gotEffort string
+			if r.OutputConfig != nil {
+				gotEffort = r.OutputConfig.Effort
+			}
+			if gotEffort != tc.wantEffort {
+				t.Fatalf("output_config.effort = %q, want %q", gotEffort, tc.wantEffort)
+			}
+			if c.thinking != "enabled" || c.effort != "high" {
+				t.Fatalf("client config mutated: thinking=%q effort=%q", c.thinking, c.effort)
+			}
+		})
+	}
+}
+
+// A per-request override may only lower or disable thinking: with the client
+// configured thinking-off, no override re-enables it.
+func TestBuildRequestDeepSeekEffortOverrideCannotReenableThinking(t *testing.T) {
+	for _, c := range []*client{
+		{model: "deepseek-v4-flash", deepseek: true, thinking: "disabled"},
+		{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "disabled"},
+	} {
+		r := c.buildRequest(context.Background(), provider.Request{EffortOverride: "high"})
+		if r.Thinking == nil || r.Thinking.Type != "disabled" {
+			t.Fatalf("thinking = %+v, want disabled (client config wins over a depth override)", r.Thinking)
+		}
+		if r.OutputConfig != nil {
+			t.Fatalf("output_config = %+v, want omitted while thinking is off", r.OutputConfig)
+		}
+	}
+}
+
+// The missing-reasoning recovery already forces thinking off; a per-request
+// depth override must not re-enable it or emit output_config.
+func TestBuildRequestDeepSeekRecoveryIgnoresEffortOverride(t *testing.T) {
+	c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
+	ctx := provider.WithMissingReasoningFallback(context.Background())
+	r := c.buildRequest(ctx, provider.Request{
+		Messages:       []provider.Message{{Role: provider.RoleUser, Content: "do it"}},
+		EffortOverride: "max",
+	})
+	if r.Thinking == nil || r.Thinking.Type != "disabled" || r.OutputConfig != nil {
+		t.Fatalf("recovery with override: thinking = %+v output_config = %+v, want disabled/none", r.Thinking, r.OutputConfig)
+	}
+}

--- a/internal/provider/anthropic/missing_reasoning_fallback.go
+++ b/internal/provider/anthropic/missing_reasoning_fallback.go
@@ -37,6 +37,33 @@ func (c *client) replayReasoningBlock(m provider.Message, recoveryWithoutThinkin
 	return contentBlock{}, false
 }
 
+// mergeThinkingFirst merges appended blocks into an existing same-role
+// message's content. A thinking block must lead its message, so a leading
+// thinking run in the appended blocks moves to the front: after projection
+// degrades a reasoning-less turn to plain text, a following healthy assistant
+// turn merging into it must stay [thinking, text, ...], never [text, ...].
+func mergeThinkingFirst(existing, blocks []contentBlock) []contentBlock {
+	head := leadingThinkingBlocks(blocks)
+	if head == 0 || len(existing) == 0 {
+		return append(existing, blocks...)
+	}
+	merged := make([]contentBlock, 0, len(existing)+len(blocks))
+	merged = append(merged, blocks[:head]...)
+	merged = append(merged, existing...)
+	merged = append(merged, blocks[head:]...)
+	return merged
+}
+
+// leadingThinkingBlocks counts the thinking blocks at the head of blocks.
+// replayReasoningBlock emits at most one, so the run is normally 0 or 1.
+func leadingThinkingBlocks(blocks []contentBlock) int {
+	head := 0
+	for head < len(blocks) && blocks[head].Type == "thinking" {
+		head++
+	}
+	return head
+}
+
 func (c *client) applyDeepSeekThinking(r *anthRequest, req provider.Request, recoveryWithoutThinking bool) {
 	r.Temperature = req.Temperature
 	t := c.thinking

--- a/internal/provider/anthropic/missing_reasoning_fallback.go
+++ b/internal/provider/anthropic/missing_reasoning_fallback.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"context"
+	"strings"
 
 	"reasonix/internal/provider"
 )
@@ -75,11 +76,26 @@ func (c *client) applyDeepSeekThinking(r *anthRequest, req provider.Request, rec
 	if c.effort == "disabled" {
 		t = "disabled"
 	}
+	effort := normalizeDeepSeekAnthropicEffort(c.model, c.effort)
+	// A per-request override scopes to this call: "disabled" turns thinking
+	// off (bounded reviewers replay no history), a depth level replaces the
+	// configured effort. Recovery keeps its forced-off thinking either way.
+	if !recoveryWithoutThinking {
+		switch override := strings.ToLower(strings.TrimSpace(req.EffortOverride)); override {
+		case "":
+		case "disabled":
+			t = "disabled"
+		default:
+			if normalized := normalizeDeepSeekAnthropicEffort(c.model, override); normalized != "" {
+				effort = normalized
+			}
+		}
+	}
 	r.Thinking = &thinkingConfig{Type: t}
 	if t == "disabled" {
 		return
 	}
-	switch effort := normalizeDeepSeekAnthropicEffort(c.model, c.effort); effort {
+	switch effort {
 	case "low", "high", "max":
 		r.OutputConfig = &outputConfig{Effort: effort}
 	}

--- a/internal/provider/anthropic/missing_reasoning_fallback.go
+++ b/internal/provider/anthropic/missing_reasoning_fallback.go
@@ -25,8 +25,10 @@ func (c *client) replayMessages(messages []provider.Message, recoveryWithoutThin
 }
 
 func (c *client) replayReasoningBlock(m provider.Message, recoveryWithoutThinking bool) (contentBlock, bool) {
-	activity := len(m.ToolCalls) > 0 || len(m.ServerSearch) > 0
-	if c.deepseek && !recoveryWithoutThinking && activity && m.ReasoningContent != "" {
+	// DeepSeek's thinking mode requires every historical assistant turn's
+	// thinking block to be passed back whenever the request declares tools —
+	// including plain question-answer turns with no tool activity.
+	if c.deepseek && !recoveryWithoutThinking && m.ReasoningContent != "" {
 		return contentBlock{Type: "thinking", Thinking: m.ReasoningContent}, true
 	}
 	if !c.deepseek && c.thinking == "adaptive" && m.ReasoningContent != "" && m.ReasoningSignature != "" {

--- a/internal/provider/anthropic/replay_projection_test.go
+++ b/internal/provider/anthropic/replay_projection_test.go
@@ -89,3 +89,53 @@ func TestBuildRequestNativeAnthropicKeepsItsExistingValidationPath(t *testing.T)
 		t.Fatalf("native Anthropic history unexpectedly projected: %#v", r.Messages)
 	}
 }
+
+func TestBuildRequestDeepSeekReplaysReasoningFromHistory(t *testing.T) {
+	toolTurn := []provider.Message{
+		{Role: provider.RoleUser, Content: "weather?"},
+		{Role: provider.RoleAssistant, ReasoningContent: "I should call the tool.",
+			ToolCalls: []provider.ToolCall{{ID: "t1", Name: "get_weather", Arguments: `{"city":"Paris"}`}}},
+		{Role: provider.RoleTool, ToolCallID: "t1", Content: "sunny"},
+	}
+	for _, tc := range []struct {
+		name     string
+		thinking string
+		effort   string
+	}{
+		{name: "current request has no tools", thinking: "enabled", effort: "high"},
+		{name: "thinking disabled after tool call", thinking: "enabled", effort: "disabled"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: tc.thinking, effort: tc.effort}
+			r := c.buildRequest(context.Background(), provider.Request{Messages: toolTurn})
+			if len(r.Tools) != 0 {
+				t.Fatalf("current request tools = %+v, want none", r.Tools)
+			}
+			if len(r.Messages) != 3 {
+				t.Fatalf("messages = %+v, want user/assistant/user", r.Messages)
+			}
+			blocks := r.Messages[1].Content
+			if len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "I should call the tool." || blocks[1].Type != "tool_use" {
+				t.Fatalf("assistant blocks = %+v, want historical thinking before tool_use", blocks)
+			}
+		})
+	}
+
+	t.Run("reasoning without a tool call is replayed", func(t *testing.T) {
+		// DeepSeek's thinking mode requires every historical assistant turn's
+		// thinking block back when the request declares tools, even for plain
+		// question-answer turns (api-docs.deepseek.com/guides/thinking_mode).
+		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
+		r := c.buildRequest(context.Background(), provider.Request{
+			Messages: []provider.Message{
+				{Role: provider.RoleUser, Content: "hello"},
+				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "scratchpad"},
+			},
+			Tools: []provider.ToolSchema{{Name: "get_weather"}},
+		})
+		blocks := r.Messages[1].Content
+		if len(r.Messages) != 2 || len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "scratchpad" || blocks[1].Type != "text" {
+			t.Fatalf("non-tool assistant blocks = %+v, want thinking before text", r.Messages)
+		}
+	})
+}

--- a/internal/provider/anthropic/replay_projection_test.go
+++ b/internal/provider/anthropic/replay_projection_test.go
@@ -46,6 +46,38 @@ func TestDeepSeekReplayProjectionKeepsHealthyHistoryBacking(t *testing.T) {
 	}
 }
 
+func TestBuildRequestDeepSeekMergedAssistantTurnKeepsThinkingFirst(t *testing.T) {
+	c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled"}
+	r := c.buildRequest(context.Background(), provider.Request{Messages: []provider.Message{
+		{Role: provider.RoleUser, Content: "start"},
+		{
+			Role: provider.RoleAssistant, Content: "first answer",
+			ToolCalls: []provider.ToolCall{{ID: "t1", Name: "read_file", Arguments: `{}`}},
+		}, // reasoning lost: projection degrades this turn to plain text
+		{Role: provider.RoleTool, ToolCallID: "t1", Name: "read_file", Content: "data"},
+		{
+			Role: provider.RoleAssistant, Content: "second answer", ReasoningContent: "fresh thinking",
+			ToolCalls: []provider.ToolCall{{ID: "t2", Name: "read_file", Arguments: `{}`}},
+		},
+		{Role: provider.RoleTool, ToolCallID: "t2", Name: "read_file", Content: "more data"},
+		{Role: provider.RoleUser, Content: "continue"},
+	}})
+
+	// The degraded first turn and the healthy second turn merge into one
+	// assistant message; its thinking block must lead.
+	if len(r.Messages) != 3 {
+		t.Fatalf("messages = %#v, want user/merged-assistant/user", r.Messages)
+	}
+	blocks := r.Messages[1].Content
+	if len(blocks) != 4 ||
+		blocks[0].Type != "thinking" || blocks[0].Thinking != "fresh thinking" ||
+		blocks[1].Type != "text" || blocks[1].Text != "first answer" ||
+		blocks[2].Type != "text" || blocks[2].Text != "second answer" ||
+		blocks[3].Type != "tool_use" || blocks[3].ID != "t2" {
+		t.Fatalf("merged assistant blocks = %#v, want [thinking, text, text, tool_use]", blocks)
+	}
+}
+
 func TestBuildRequestNativeAnthropicKeepsItsExistingValidationPath(t *testing.T) {
 	c := &client{model: "claude-sonnet", thinking: "adaptive"}
 	r := c.buildRequest(context.Background(), provider.Request{Messages: []provider.Message{{

--- a/internal/provider/openai/effort.go
+++ b/internal/provider/openai/effort.go
@@ -84,6 +84,18 @@ func (c *client) requestEffort(req provider.Request) string {
 	return want
 }
 
+// deepSeekRequestThinking resolves the thinking toggle for one DeepSeek Chat
+// request: the configured knob, unless an explicit per-request override asks
+// to skip thinking. "disabled" is a toggle, not a depth, so vocabularies
+// strip it (depthOnly) and only this path may apply it — a stateless bounded
+// reviewer has no replay contract to protect, unlike the main loop.
+func (c *client) deepSeekRequestThinking(req provider.Request) string {
+	if c.thinkingType == "disabled" || strings.EqualFold(strings.TrimSpace(req.EffortOverride), "disabled") {
+		return "disabled"
+	}
+	return "enabled"
+}
+
 func supportsEffort(levels []string, want string) bool {
 	want = strings.ToLower(strings.TrimSpace(want))
 	for _, level := range levels {

--- a/internal/provider/openai/effort_override_test.go
+++ b/internal/provider/openai/effort_override_test.go
@@ -28,8 +28,10 @@ func TestEffortOverrideDeepSeekFlash(t *testing.T) {
 	if got := c.buildRequest(provider.Request{EffortOverride: "medium"}).ReasoningEffort; got != "high" {
 		t.Fatalf("override outside DeepSeek vocabulary must keep the default, got %q", got)
 	}
-	if got := c.buildRequest(provider.Request{EffortOverride: "disabled"}).ReasoningEffort; got != "high" {
-		t.Fatalf("override must never toggle thinking off, got %q", got)
+	out := c.buildRequest(provider.Request{EffortOverride: "disabled"})
+	if out.Thinking == nil || out.Thinking.Type != "disabled" || out.ReasoningEffort != "" {
+		t.Fatalf("per-request disabled = thinking %+v / effort %q, want thinking.type=disabled with the depth hint dropped",
+			out.Thinking, out.ReasoningEffort)
 	}
 }
 
@@ -62,8 +64,51 @@ func TestEffortOverrideHonorsSupportedEfforts(t *testing.T) {
 	if got := c.buildRequest(provider.Request{EffortOverride: "max"}).ReasoningEffort; got != "high" {
 		t.Fatalf("undeclared level must keep the default, got %q", got)
 	}
-	if got := c.buildRequest(provider.Request{EffortOverride: "disabled"}).ReasoningEffort; got != "high" {
-		t.Fatalf("disabled is a thinking toggle, not a depth; got %q", got)
+	out := c.buildRequest(provider.Request{EffortOverride: "disabled"})
+	if out.Thinking == nil || out.Thinking.Type != "disabled" || out.ReasoningEffort != "" {
+		t.Fatalf("disabled is a per-request thinking toggle, not a depth: thinking %+v / effort %q", out.Thinking, out.ReasoningEffort)
+	}
+}
+
+// A client already configured thinking-off is unaffected by overrides, and no
+// per-request value can turn thinking back on.
+func TestEffortOverrideCannotReenableThinking(t *testing.T) {
+	c := newTestClient(t, "deepseek-v4", map[string]any{"reasoning_protocol": "deepseek", "thinking": "disabled"})
+	for _, override := range []string{"", "low", "high", "enabled"} {
+		out := c.buildRequest(provider.Request{EffortOverride: override})
+		if out.Thinking == nil || out.Thinking.Type != "disabled" || out.ReasoningEffort != "" {
+			t.Fatalf("override %q: thinking %+v / effort %q, want thinking.type=disabled only", override, out.Thinking, out.ReasoningEffort)
+		}
+	}
+}
+
+// Outside DeepSeek the per-request toggle stays inert: binary-knob endpoints
+// keep their configured thinking state, so one request on a shared client can
+// never switch the main loop's thinking off there.
+func TestEffortOverrideDisabledInertOutsideDeepSeek(t *testing.T) {
+	for _, c := range []*client{
+		{model: "MiniMax-M3", minimax: true},
+		{model: "glm-4.5-air", zhipu: true},
+		{model: "LongCat-Flash", longcat: true},
+		{model: "some-model", thinkingType: "enabled"},
+	} {
+		out := c.buildRequest(provider.Request{EffortOverride: "disabled"})
+		if out.Thinking == nil || out.Thinking.Type == "disabled" {
+			t.Errorf("%s: thinking = %+v, want the configured state, not per-request disabled", c.model, out.Thinking)
+		}
+	}
+}
+
+// Endpoints with no per-request thinking knob on the wire leave the override
+// inert rather than inventing fields.
+func TestEffortOverrideDisabledInertWithoutThinkingKnob(t *testing.T) {
+	c := &client{model: "mimo-v2"}
+	out := c.buildRequest(provider.Request{EffortOverride: "disabled"})
+	if out.Thinking != nil {
+		t.Fatalf("thinking = %+v, want omitted on a knob-less endpoint", out.Thinking)
+	}
+	if out.ReasoningEffort != "" {
+		t.Fatalf("reasoning_effort = %q, want omitted", out.ReasoningEffort)
 	}
 }
 

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -797,13 +797,13 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		out.MaxCompletionTokens = maxOutputTokens
 	case c.deepseek:
 		// DeepSeek's CoT is controlled by `thinking` plus `reasoning_effort` for
-		// depth. Thinking is on by default but can be turned off via
-		// effort=disabled / thinking=disabled (credit @eghrhegpe, #5063).
-		if c.thinkingType == "disabled" {
-			out.Thinking = &thinkingMode{Type: "disabled"}
-		} else {
-			out.Thinking = &thinkingMode{Type: "enabled"}
+		// depth. Thinking is on by default; config (effort/thinking=disabled,
+		// #5063) or an explicit per-request override turns it off for one call.
+		t := c.deepSeekRequestThinking(req)
+		if t == "disabled" {
+			out.ReasoningEffort = ""
 		}
+		out.Thinking = &thinkingMode{Type: t}
 	case c.minimax:
 		// M3 uses a single `thinking.type` field with two valid values:
 		// "adaptive" (default, thinking on) and "disabled" (off). Reasoning

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -237,7 +237,7 @@ type Request struct {
 	// text.format.type=json_object). Nil omits the fieldentirely —
 	// thecommonpathmuststaybyte-stableforpromptcaching.
 	ResponseFormat *ResponseFormat `json:"ResponseFormat,omitempty"`
-	EffortOverride string          `json:"EffortOverride,omitempty"` // per-call reasoning-depth override; adapters apply it only when the endpoint's effort vocabulary accepts it
+	EffortOverride string          `json:"EffortOverride,omitempty"` // per-call reasoning-depth override, or "disabled" to skip thinking for one stateless call; adapters apply only values the endpoint can express
 	ToolSearch     *ToolSearch     `json:"-"`
 }
 

--- a/internal/provider/reasoning_replay.go
+++ b/internal/provider/reasoning_replay.go
@@ -82,6 +82,36 @@ func AllowsEmptyReasoningFallback(p Provider) bool {
 	return ok && policy.AllowsEmptyReasoningFallback()
 }
 
+// ProjectReasoningStrippedMessages is the catch-and-repair projection for a
+// provider that rejected replayed thinking/reasoning history with
+// ReasoningReplayError. It follows the vendor-documented self-heal recipe:
+// strip every assistant message's reasoning/thinking metadata from the
+// provider-visible projection, then drop the tool activity that can no longer
+// be paired with its thinking block. Canonical session messages are never
+// modified; a history with nothing to strip keeps its backing slice.
+func ProjectReasoningStrippedMessages(p Provider, msgs []Message) ([]Message, bool) {
+	work := msgs
+	stripped := false
+	for i, m := range msgs {
+		if m.Role != RoleAssistant {
+			continue
+		}
+		if m.ReasoningContent == "" && m.ReasoningSignature == "" && m.ReasoningID == "" && m.ReasoningStatus == "" {
+			continue
+		}
+		if !stripped {
+			work = append([]Message(nil), msgs...)
+			stripped = true
+		}
+		work[i].ReasoningContent = ""
+		work[i].ReasoningSignature = ""
+		work[i].ReasoningID = ""
+		work[i].ReasoningStatus = ""
+	}
+	projected, projectedChanged := ProjectReplaySafeMessages(p, work)
+	return projected, stripped || projectedChanged
+}
+
 // ProjectReplaySafeMessages returns the provider-visible projection for
 // histories that contain assistant activity without the reasoning required to
 // replay it. Canonical session messages are never modified. Healthy histories

--- a/internal/provider/reasoning_replay_error.go
+++ b/internal/provider/reasoning_replay_error.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// ReasoningReplayError is a trusted provider rejection of replayed
+// thinking/reasoning history: HTTP 400 whose body says the request's
+// thinking/reasoning blocks must be passed back. Unwrap returns the original
+// APIError so localization, trace IDs, and telemetry keep working. The body is
+// never persisted or replayed.
+type ReasoningReplayError struct {
+	APIError *APIError
+}
+
+func (e *ReasoningReplayError) Error() string {
+	if e == nil || e.APIError == nil {
+		return "reasoning replay rejected"
+	}
+	return e.APIError.Error()
+}
+
+func (e *ReasoningReplayError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.APIError
+}
+
+// ParseReasoningReplayError extracts a trusted thinking-replay rejection from
+// an APIError. The match is deliberately exact — DeepSeek's documented shape is
+// "The `content[].thinking` in the thinking mode must be passed back to the
+// API" — so only a 400 naming thinking/reasoning content AND the pass-back
+// obligation qualifies. Any other 400 (and every other status) returns nil so
+// the retry budget can never swallow an unrelated client error.
+func ParseReasoningReplayError(apiErr *APIError) *ReasoningReplayError {
+	if apiErr == nil || apiErr.Status != http.StatusBadRequest {
+		return nil
+	}
+	body := strings.ToLower(apiErr.Body)
+	namesReasoning := strings.Contains(body, "content[].thinking") || strings.Contains(body, "reasoning_content")
+	if !namesReasoning || !strings.Contains(body, "must be passed back") {
+		return nil
+	}
+	return &ReasoningReplayError{APIError: apiErr}
+}
+
+// AsReasoningReplayError unwraps err to a trusted thinking-replay rejection,
+// if any.
+func AsReasoningReplayError(err error) *ReasoningReplayError {
+	var replay *ReasoningReplayError
+	if err != nil && errors.As(err, &replay) {
+		return replay
+	}
+	return nil
+}

--- a/internal/provider/reasoning_replay_error_test.go
+++ b/internal/provider/reasoning_replay_error_test.go
@@ -1,0 +1,109 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestParseReasoningReplayError(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{
+			name:   "deepseek anthropic thinking 400",
+			status: 400,
+			body:   `{"error":{"message":"The ` + "`content[].thinking`" + ` in the thinking mode must be passed back to the API","type":"invalid_request_error"}}`,
+			want:   true,
+		},
+		{
+			name:   "openai-style reasoning_content 400",
+			status: 400,
+			body:   `{"error":{"message":"reasoning_content must be passed back to the API in thinking mode"}}`,
+			want:   true,
+		},
+		{
+			name:   "case-insensitive",
+			status: 400,
+			body:   `The CONTENT[].THINKING in the thinking mode MUST BE PASSED BACK to the API`,
+			want:   true,
+		},
+		{
+			name:   "400 without pass-back obligation",
+			status: 400,
+			body:   `{"error":{"message":"content[].thinking is not supported by this model"}}`,
+			want:   false,
+		},
+		{
+			name:   "400 pass-back without reasoning reference",
+			status: 400,
+			body:   `{"error":{"message":"the signed block must be passed back unchanged"}}`,
+			want:   false,
+		},
+		{
+			name:   "401 with the same body",
+			status: 401,
+			body:   `{"error":{"message":"The content[].thinking in the thinking mode must be passed back to the API"}}`,
+			want:   false,
+		},
+		{
+			name:   "422 with the same body",
+			status: 422,
+			body:   `{"error":{"message":"The content[].thinking in the thinking mode must be passed back to the API"}}`,
+			want:   false,
+		},
+		{
+			name:   "unrelated 400",
+			status: 400,
+			body:   `{"error":{"message":"invalid tool schema at index 2"}}`,
+			want:   false,
+		},
+		{
+			name:   "empty body",
+			status: 400,
+			body:   "",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseReasoningReplayError(&APIError{Provider: "p", Status: tc.status, Body: tc.body})
+			if (got != nil) != tc.want {
+				t.Fatalf("ParseReasoningReplayError = %v, want match=%v", got, tc.want)
+			}
+			if got != nil && got.APIError == nil {
+				t.Fatal("matched error lost the underlying APIError")
+			}
+		})
+	}
+	if ParseReasoningReplayError(nil) != nil {
+		t.Fatal("nil APIError must not match")
+	}
+}
+
+func TestAsReasoningReplayError(t *testing.T) {
+	apiErr := &APIError{Provider: "p", Status: 400, Body: "The `content[].thinking` in the thinking mode must be passed back to the API"}
+	replay := ParseReasoningReplayError(apiErr)
+	if replay == nil {
+		t.Fatal("fixture did not match")
+	}
+	if got := AsReasoningReplayError(fmt.Errorf("stream: %w", replay)); got != replay {
+		t.Fatalf("AsReasoningReplayError = %v, want the wrapped error", got)
+	}
+	if got := AsReasoningReplayError(apiErr); got != nil {
+		t.Fatalf("bare APIError must not unwrap as ReasoningReplayError: %v", got)
+	}
+	if got := AsReasoningReplayError(errors.New("other")); got != nil {
+		t.Fatalf("unrelated error = %v, want nil", got)
+	}
+	if got := AsReasoningReplayError(nil); got != nil {
+		t.Fatal("nil error must not match")
+	}
+	var base error = replay
+	if unwrapped := errors.Unwrap(base); unwrapped != apiErr {
+		t.Fatalf("Unwrap = %v, want the APIError", unwrapped)
+	}
+}

--- a/internal/provider/reasoning_replay_error_test.go
+++ b/internal/provider/reasoning_replay_error_test.go
@@ -102,8 +102,7 @@ func TestAsReasoningReplayError(t *testing.T) {
 	if got := AsReasoningReplayError(nil); got != nil {
 		t.Fatal("nil error must not match")
 	}
-	var base error = replay
-	if unwrapped := errors.Unwrap(base); unwrapped != apiErr {
-		t.Fatalf("Unwrap = %v, want the APIError", unwrapped)
+	if !errors.Is(replay, apiErr) {
+		t.Fatal("ReasoningReplayError must unwrap to the APIError")
 	}
 }

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -338,6 +338,9 @@ func SendWithRetry(ctx context.Context, httpClient *http.Client, opts SendOption
 			if limitErr := ParseContextLimitError(apiErr); limitErr != nil {
 				return nil, limitErr
 			}
+			if replayErr := ParseReasoningReplayError(apiErr); replayErr != nil {
+				return nil, replayErr
+			}
 			return nil, apiErr
 		}
 		lastErr = apiErr

--- a/internal/telemetry/sink.go
+++ b/internal/telemetry/sink.go
@@ -204,7 +204,7 @@ func completionValidationCounters(info event.CompletionValidationInfo) map[strin
 	}
 	add(counts, "completion_validation_attempt", attempt, 1)
 	if strings.TrimSpace(info.ErrorClass) != "" {
-		add(counts, "completion_validation_error", enumBucket(info.ErrorClass, "timeout", "invalid_output", "unavailable", "over_budget", "error"), 1)
+		add(counts, "completion_validation_error", enumBucket(info.ErrorClass, "timeout", "empty_output", "invalid_output", "unavailable", "over_budget", "error"), 1)
 	}
 	return counts
 }


### PR DESCRIPTION
## Summary

- The completion validator's bounded verdict request now sends `EffortOverride: "disabled"`, so the evaluator no longer burns its 256-token / 30s budget on model reasoning and then fails closed with an empty verdict — the mechanism that stopped in-progress tasks on thinking-enabled DeepSeek presets.
- The Anthropic-compatible provider now honors per-request `EffortOverride` (previously silently ignored): `"disabled"` takes the same request-scoped `thinking.type=disabled` path as recovery mode, depth values are normalized into `output_config.effort`, unknown values fall back to client config, and recovery mode keeps priority. Client-level thinking settings are immutable — an override can only lower/disable, never re-enable.
- The OpenAI-compatible provider applies an explicit per-request `"disabled"` on the DeepSeek chat branch (same wire shape as client-level disabled); the `depthOnly` vocabulary stays unchanged for client-level config and non-DeepSeek branches.
- New telemetry class `empty_output` (wrapping `ErrInvalidOutput`, so existing `errors.Is` consumers are unaffected) separates "validator returned no text" from generic invalid output, making thinking-budget failures observable instead of silently mis-stopping tasks.

Root cause: the evaluator follows the agent's provider (desktop default = DeepSeek Anthropic endpoint with thinking enabled), but its request was built with `max_tokens=256` / 30s and no effort control. Reasoning consumed the budget → empty text → `ErrInvalidOutput` → enforce mode → `CompletionUncertainError` → turn stopped after the answer was already produced.

Note: stacked on #9762 (touches the same provider package); the visible diff shrinks to this change alone once #9762 merges and this branch is rebased.

## Issues

Refs #9750

## Verification

- `go build ./...` (root and desktop modules)
- `go test -count=1 ./internal/completioneval/... ./internal/boundedllm/... ./internal/provider/... ./internal/agent/... ./internal/boot/... ./internal/telemetry/...`
- `go run ./tools/repolint` clean; `golangci-lint run --timeout=5m ./internal/...` 0 issues
- New deterministic coverage:
  - `internal/completioneval/evaluator_test.go` — the verdict request carries `EffortOverride: "disabled"`; empty output classifies apart from invalid output.
  - `internal/provider/anthropic/effort_override_test.go` (new) — disabled / depth / normalization / unknown-value fallback / client immutability / cannot-re-enable / recovery precedence.
  - `internal/provider/openai/effort_override_test.go` — per-request disabled wire shape on DeepSeek; inert outside DeepSeek.
  - `internal/boot/completion_effect_test.go` — end-to-end boot wiring asserts the validator request carries the override.
  - `internal/agent/completion_validation_test.go` — `empty_output` classification.
- `internal/completioneval/live_deepseek_test.go` matrix now covers thinking **enabled** (the production desktop preset) in addition to disabled; requires `DEEPSEEK_API_KEY` with `-tags live`, not run here (`go vet -tags live` clean). A live run showing the enabled rows green is the wire-level proof.

## Documentation impact

Documentation-impact: updated - docs/REASONING_PROVIDERS.md in the current diff view belongs to stacked base #9762 (documented there); this PR itself changes no user-visible documented surface.

## Cache impact

Cache-impact: low - the evaluator call is a stateless two-message request outside the agent's prompt-cache prefix; disabling thinking only shrinks it. One intentional side effect recorded in the commit body: the governor experiment's (`REASONIX_EXPERIMENT_GOVERNOR=1`) per-request `"low"` now actually reaches the DeepSeek Anthropic wire instead of being silently dropped by the adapter.
Cache-guard: `go test -count=1 ./internal/provider/anthropic/ -run EffortOverride` pins the per-request wire shape; main-loop history replay is untouched (client-level thinking config is immutable).
System-prompt-review: SivanCola reviewed - internal/boot/completion_effect_test.go (matched via internal/boot/*) is a wiring test asserting the evaluator request carries EffortOverride=disabled; no system prompt, memory prefix, output style, or skill index bytes change.

