### PR TITLE
fix(desktop): classify management submits before turn admission / 管理命令先分类再进入回合准入

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1114,33 +1114,46 @@ func (a *App) submitToTabResult(tabID, input string, fromBridge, classifyManagem
 		a.runEffortCommandForTab(tabID, trimmed)
 		return management, nil
 	}
-	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if a.tabIsReadOnly(tab) {
-		return control.SubmitResult{}, readOnlyChannelErr()
-	}
-	if err := a.workspaceRuntimeAdmissionErr(tab, ctrl); err != nil {
-		return control.SubmitResult{}, err
-	}
-	if err := a.ensureTabControllerWorkspace(tab); err != nil {
-		return control.SubmitResult{}, err
-	}
-	ctrl = a.controllerForTab(tab)
-	if ctrl == nil {
-		return control.SubmitResult{}, a.workspaceNotReadyErr(tab)
-	}
 	if classifyManagement {
+		tab, ctrl := a.tabAndCtrlByID(tabID)
+		if a.tabIsReadOnly(tab) {
+			return control.SubmitResult{}, readOnlyChannelErr()
+		}
+		if err := a.workspaceRuntimeAdmissionErr(tab, ctrl); err != nil {
+			return control.SubmitResult{}, err
+		}
+		if err := a.ensureTabControllerWorkspace(tab); err != nil {
+			return control.SubmitResult{}, err
+		}
+		ctrl = a.controllerForTab(tab)
+		if ctrl == nil {
+			return control.SubmitResult{}, a.workspaceNotReadyErr(tab)
+		}
+		managementRoute := false
 		if classifier, ok := ctrl.(interface {
 			ClassifySubmitRoute(input string) control.SubmitDisposition
-		}); ok && classifier.ClassifySubmitRoute(input) == control.SubmitManagementHandled {
-			if !fromBridge && a.botBridge != nil {
-				a.botBridge.reclaimFromDesktop(tab.ID)
+		}); ok {
+			managementRoute = classifier.ClassifySubmitRoute(input) == control.SubmitManagementHandled
+		}
+		if managementRoute {
+			// Management commands still take the tab admission lock so they cannot
+			// race an active turn or a controller replacement.
+			admission, admittedCtrl, err := a.beginTabTurn(tabID, !fromBridge, submissionID...)
+			if err != nil {
+				return control.SubmitResult{}, err
 			}
-			if submitter, ok := ctrl.(interface {
+			defer admission.abort()
+			tab = admission.tab
+			a.ensureTabTopicIndexedForUserTurn(tab)
+			if submitter, supported := admittedCtrl.(interface {
 				SubmitDisplayWithResult(display, input string) control.SubmitResult
-			}); ok {
-				return submitter.SubmitDisplayWithResult(input, input), nil
+			}); supported {
+				result := submitter.SubmitDisplayWithResult(input, input)
+				admission.finish(admittedCtrl)
+				return result, nil
 			}
-			ctrl.SubmitDisplay(input, input)
+			admittedCtrl.SubmitDisplay(input, input)
+			admission.finish(admittedCtrl)
 			return management, nil
 		}
 	}
@@ -1149,7 +1162,7 @@ func (a *App) submitToTabResult(tabID, input string, fromBridge, classifyManagem
 		return control.SubmitResult{}, err
 	}
 	defer admission.abort()
-	tab = admission.tab
+	tab := admission.tab
 	a.ensureTabTopicIndexedForUserTurn(tab)
 	result := control.SubmitResult{Disposition: control.SubmitTurnStarted}
 	if submitter, ok := ctrl.(interface {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1080,44 +1080,87 @@ func (a *App) SubmitToTab(tabID, input string) error {
 // by the IM takeover bridge; local (frontend) submissions on a taken-over tab
 // reclaim remote control first — typing locally is the grab-back gesture.
 func (a *App) submitToTab(tabID, input string, fromBridge bool, submissionID ...string) error {
+	_, err := a.submitToTabResult(tabID, input, fromBridge, false, submissionID...)
+	return err
+}
+
+func (a *App) submitToTabResult(tabID, input string, fromBridge, classifyManagement bool, submissionID ...string) (control.SubmitResult, error) {
+	management := control.SubmitResult{Disposition: control.SubmitManagementHandled}
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "/reload" {
 		tab, _ := a.tabAndCtrlByID(tabID)
 		if a.tabIsReadOnly(tab) {
-			return readOnlyChannelErr()
+			return control.SubmitResult{}, readOnlyChannelErr()
 		}
 		if tab == nil {
-			return a.workspaceNotReadyErr(tab)
+			return control.SubmitResult{}, a.workspaceNotReadyErr(tab)
 		}
 		if !fromBridge && a.botBridge != nil {
 			a.botBridge.reclaimFromDesktop(tab.ID)
 		}
-		return a.ReloadRuntime(tab.ID)
+		return management, a.ReloadRuntime(tab.ID)
 	}
 	if trimmed == "/effort" || strings.HasPrefix(trimmed, "/effort ") {
 		tab, _ := a.tabAndCtrlByID(tabID)
 		if a.tabIsReadOnly(tab) {
-			return readOnlyChannelErr()
+			return control.SubmitResult{}, readOnlyChannelErr()
 		}
 		if tab == nil {
-			return a.workspaceNotReadyErr(tab)
+			return control.SubmitResult{}, a.workspaceNotReadyErr(tab)
 		}
 		if !fromBridge && a.botBridge != nil {
 			a.botBridge.reclaimFromDesktop(tab.ID)
 		}
 		a.runEffortCommandForTab(tabID, trimmed)
-		return nil
+		return management, nil
+	}
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if a.tabIsReadOnly(tab) {
+		return control.SubmitResult{}, readOnlyChannelErr()
+	}
+	if err := a.workspaceRuntimeAdmissionErr(tab, ctrl); err != nil {
+		return control.SubmitResult{}, err
+	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return control.SubmitResult{}, err
+	}
+	ctrl = a.controllerForTab(tab)
+	if ctrl == nil {
+		return control.SubmitResult{}, a.workspaceNotReadyErr(tab)
+	}
+	if classifyManagement {
+		if classifier, ok := ctrl.(interface {
+			ClassifySubmitRoute(input string) control.SubmitDisposition
+		}); ok && classifier.ClassifySubmitRoute(input) == control.SubmitManagementHandled {
+			if !fromBridge && a.botBridge != nil {
+				a.botBridge.reclaimFromDesktop(tab.ID)
+			}
+			if submitter, ok := ctrl.(interface {
+				SubmitDisplayWithResult(display, input string) control.SubmitResult
+			}); ok {
+				return submitter.SubmitDisplayWithResult(input, input), nil
+			}
+			ctrl.SubmitDisplay(input, input)
+			return management, nil
+		}
 	}
 	admission, ctrl, err := a.beginTabTurn(tabID, !fromBridge, submissionID...)
 	if err != nil {
-		return err
+		return control.SubmitResult{}, err
 	}
 	defer admission.abort()
-	tab := admission.tab
+	tab = admission.tab
 	a.ensureTabTopicIndexedForUserTurn(tab)
-	ctrl.SubmitDisplay(input, input)
+	result := control.SubmitResult{Disposition: control.SubmitTurnStarted}
+	if submitter, ok := ctrl.(interface {
+		SubmitDisplayWithResult(display, input string) control.SubmitResult
+	}); ok {
+		result = submitter.SubmitDisplayWithResult(input, input)
+	} else {
+		ctrl.SubmitDisplay(input, input)
+	}
 	admission.finish(ctrl)
-	return nil
+	return result, nil
 }
 
 func (a *App) submitUserTurnToTabWithSink(tabID, input string, forwarder event.Sink) bool {

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -341,7 +341,9 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // The scrollbar generation fence and drag rebase add 1.1 KiB raw; the merged
 // path measures 2470.932 KiB.
 // The reader-transaction offset absorption adds 0.8 KiB raw on top; the merged
-// path measures 2471.741 KiB.
-const rawInitialBudgetKiB = 2_471.8;
+// path measures 2471.741 KiB. Controller-owned management dispositions and
+// optimistic management settlement add 0.6 KiB raw; retain the smallest
+// one-decimal ceiling with bounded headroom.
+const rawInitialBudgetKiB = 2_472.4;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2281,7 +2281,7 @@ export default function App() {
       if (goalCommand) {
         const arg = (goalCommand[1] ?? "").trim();
         const displayGoal = stripLegacyGoalBudgetFlags(arg);
-        if (displayGoal && !["status", "clear", "off", "stop", "done"].includes(displayGoal.toLowerCase())) {
+        if (displayGoal && !["status", "clear", "off", "stop", "done", "pause", "resume"].includes(displayGoal.toLowerCase())) {
           if (hasLegacyGoalBudgetFlag(arg)) {
             userPlanModeByTabRef.current = updateUserPlanModeIntent(userPlanModeByTabRef.current, activeTabId, false);
             patchActiveComposerProfile({
@@ -2292,7 +2292,7 @@ export default function App() {
           } else {
             await applyGoal(displayGoal);
           }
-        } else if (["clear", "off", "stop", "done", "pause", "resume"].includes(displayGoal.toLowerCase())) {
+        } else if (["clear", "off", "stop", "done"].includes(displayGoal.toLowerCase())) {
           await applyGoal("");
         }
         if (!controllerReady) return;

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1014,6 +1014,7 @@ export default function App() {
     clearGoal: clearControllerGoal,
     clearGoalForTab: clearControllerGoalForTab,
     clearSession,
+    newSession,
     listSessions,
     listTrashedSessions,
     resumeSession,
@@ -2205,13 +2206,7 @@ export default function App() {
   useEffect(() => {
     activeTabIdRef.current = activeTabId;
   }, [activeTabId]);
-
-  // handleSend intercepts slash commands that need a desktop-native action before
-  // they reach the backend: "/model <ref>" rebuilds on that model, "/memory"
-  // opens Settings, and "/clear" shows an in-app confirmation card. Everything else — skills (/init, …),
-  // custom commands, bare /model and the other read-only management verbs
-  // (/skill, /hooks, /mcp) — goes straight to Submit, which the controller
-  // resolves (a turn, or a listing Notice).
+  // handleSend reserves only commands that need a desktop-native UI action.
   const handleSend = useCallback(
     async (displayText: string, submitText = displayText, requestedTabId = activeTabId, structured?: StructuredInvocationSubmit) => {
       const sourceTabId = requestedTabId || activeTabId;
@@ -2241,6 +2236,11 @@ export default function App() {
       if (trimmed === "/clear") {
         if (activeTabIdRef.current !== sourceTabId) return;
         setClearContextPending(true);
+        return;
+      }
+      if (trimmed === "/new") {
+        if (activeTabIdRef.current !== sourceTabId) return;
+        await newSession();
         return;
       }
       const decisionMock = typeof window !== "undefined" && !window.runtime

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2292,7 +2292,7 @@ export default function App() {
           } else {
             await applyGoal(displayGoal);
           }
-        } else if (["clear", "off", "stop", "done"].includes(displayGoal.toLowerCase())) {
+        } else if (["clear", "off", "stop", "done", "pause", "resume"].includes(displayGoal.toLowerCase())) {
           await applyGoal("");
         }
         if (!controllerReady) return;

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -417,6 +417,11 @@ eq(
   "local Goal profile is patched only after backend activation succeeds",
 );
 eq(
+  /displayGoal && !\["status", "clear", "off", "stop", "done", "pause", "resume"\]\.includes/.test(appSource) && /else if \(\["clear", "off", "stop", "done"\]\.includes/.test(appSource),
+  true,
+  "Goal pause and resume do not clear the active Goal before lifecycle handling",
+);
+eq(
   controllerSource.includes("await app.SetGoalForTab(tabId, goal)") && !/SetGoalForTab\(tabId, goal\)\.catch\(\(\) => \{\}\)/.test(controllerSource),
   true,
   "SetGoalForTab activation failures propagate to callers",

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -117,7 +117,10 @@ eq(runtimeReadyForSubmit({ label: "", ready: true, eventChannel: "", cwd: "", ru
 eq(normalizeTurnSubmit(" visible prompt ", " provider prompt ").submit, "provider prompt", "submit normalization trims provider input");
 eq(isLocalRuntimeCommand(" /reload "), true, "/reload remains a host-only command without a turn receipt");
 eq(isLocalRuntimeCommand("/effort max"), true, "/effort remains a host-only command without a turn receipt");
+eq(isLocalRuntimeCommand("/compact"), true, "/compact remains a management command without a turn receipt");
+eq(isLocalRuntimeCommand("/compact preserve the key decisions"), true, "focused /compact remains a management command without a turn receipt");
 eq(isLocalRuntimeCommand("/reload now"), false, "non-command /reload text still starts an agent turn");
+eq(isLocalRuntimeCommand("/compactly"), false, "similarly-prefixed text still starts an agent turn");
 let rejectedVisibleOnlySubmit = false;
 try {
   normalizeTurnSubmit("visible prompt", "   ");

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -121,6 +121,11 @@ eq(isLocalRuntimeCommand("/compact"), true, "/compact remains a management comma
 eq(isLocalRuntimeCommand("/compact preserve the key decisions"), true, "focused /compact remains a management command without a turn receipt");
 eq(isLocalRuntimeCommand("/reload now"), false, "non-command /reload text still starts an agent turn");
 eq(isLocalRuntimeCommand("/compactly"), false, "similarly-prefixed text still starts an agent turn");
+const managementPending = reducer(reducer(initialState, {
+  type: "user", text: "/context", seq: 0, submissionId: "management-1",
+}), { type: "management_confirmed", submissionId: "management-1" });
+eq(managementPending.items.some((item) => item.kind === "user" && item.text === "/context"), false, "handled management commands do not remain as conversation turns");
+eq(managementPending.running, false, "handled management commands release the composer");
 let rejectedVisibleOnlySubmit = false;
 try {
   normalizeTurnSubmit("visible prompt", "   ");

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { acceptsRuntimeEventEpoch, historyMessagesToItems, initialState, isLocalRuntimeCommand, normalizeTurnSubmit, reducer, replayPendingPromptsForActiveTab, runtimeReadyForSubmit } from "../lib/useController";
+import { acceptsRuntimeEventEpoch, historyMessagesToItems, initialState, normalizeTurnSubmit, reducer, replayPendingPromptsForActiveTab, runtimeReadyForSubmit } from "../lib/useController";
 import { continueDelivery } from "../lib/deliveryContinue";
 import {
   activateGoalAndSubmit,
@@ -115,22 +115,11 @@ eq(runtimeReadyForSubmit({ label: "", ready: false, eventChannel: "", cwd: "", r
 eq(runtimeReadyForSubmit({ label: "", ready: false, eventChannel: "", cwd: "", runtime: { phase: "failed", epoch: "e1" } }), false, "failed runtime cannot submit");
 eq(runtimeReadyForSubmit({ label: "", ready: true, eventChannel: "", cwd: "", runtime: { phase: "ready", epoch: "e1" } }), true, "ready runtime can submit");
 eq(normalizeTurnSubmit(" visible prompt ", " provider prompt ").submit, "provider prompt", "submit normalization trims provider input");
-eq(isLocalRuntimeCommand(" /reload "), true, "/reload remains a host-only command without a turn receipt");
-eq(isLocalRuntimeCommand("/effort max"), true, "/effort remains a host-only command without a turn receipt");
-eq(isLocalRuntimeCommand("/compact"), true, "/compact remains a management command without a turn receipt");
-eq(isLocalRuntimeCommand("/compact preserve the key decisions"), true, "focused /compact remains a management command without a turn receipt");
-eq(isLocalRuntimeCommand("/reload now"), false, "non-command /reload text still starts an agent turn");
-eq(isLocalRuntimeCommand("/compactly"), false, "similarly-prefixed text still starts an agent turn");
 const managementPending = reducer(reducer(initialState, {
   type: "user", text: "/context", seq: 0, submissionId: "management-1",
 }), { type: "management_confirmed", submissionId: "management-1" });
 eq(managementPending.items.some((item) => item.kind === "user" && item.text === "/context"), false, "handled management commands do not remain as conversation turns");
 eq(managementPending.running, false, "handled management commands release the composer");
-const managementDuringTurn = reducer(reducer({ ...initialState, running: true, turnActive: true, activeTurnId: "turn-active" }, {
-  type: "user", text: "/context", seq: 0, submissionId: "management-active",
-}), { type: "management_confirmed", submissionId: "management-active" });
-eq(managementDuringTurn.running, true, "management confirmation does not release an unrelated active turn");
-eq(managementDuringTurn.turnActive, true, "management confirmation preserves the active-turn gate");
 let rejectedVisibleOnlySubmit = false;
 try {
   normalizeTurnSubmit("visible prompt", "   ");

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -126,6 +126,11 @@ const managementPending = reducer(reducer(initialState, {
 }), { type: "management_confirmed", submissionId: "management-1" });
 eq(managementPending.items.some((item) => item.kind === "user" && item.text === "/context"), false, "handled management commands do not remain as conversation turns");
 eq(managementPending.running, false, "handled management commands release the composer");
+const managementDuringTurn = reducer(reducer({ ...initialState, running: true, turnActive: true, activeTurnId: "turn-active" }, {
+  type: "user", text: "/context", seq: 0, submissionId: "management-active",
+}), { type: "management_confirmed", submissionId: "management-active" });
+eq(managementDuringTurn.running, true, "management confirmation does not release an unrelated active turn");
+eq(managementDuringTurn.turnActive, true, "management confirmation preserves the active-turn gate");
 let rejectedVisibleOnlySubmit = false;
 try {
   normalizeTurnSubmit("visible prompt", "   ");

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -209,7 +209,7 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   Submit(input: string): Promise<void>;
   SubmitToTab(tabID: string, input: string): Promise<void>;
   SubmitToTabWithID(tabID: string, input: string, submissionID: string): Promise<void>;
-  StartTurnForTab?(tabID: string, input: string, submissionID: string): Promise<{ turnId: string; status: string; runtimeEpoch?: string; submissionId?: string }>;
+  StartTurnForTab?(tabID: string, input: string, submissionID: string): Promise<{ turnId: string; status: string; disposition?: "turn_started" | "management_handled"; runtimeEpoch?: string; submissionId?: string }>;
   SubmitDisplay(display: string, input: string): Promise<void>;
   SubmitDisplayToTab(tabID: string, display: string, input: string): Promise<void>;
   SubmitDisplayToTabWithID(tabID: string, display: string, input: string, submissionID: string): Promise<void>;

--- a/desktop/frontend/src/lib/inboxSubmit.ts
+++ b/desktop/frontend/src/lib/inboxSubmit.ts
@@ -21,17 +21,6 @@ export function normalizeTurnSubmit(displayText: string, submitText: string) {
   return { display, submit };
 }
 
-// Legacy fallback for hosts that predate the structured StartTurnForTab
-// disposition. Current hosts classify every submit on the backend.
-export function isLocalRuntimeCommand(input: string): boolean {
-  const trimmed = input.trim();
-  return trimmed === "/reload"
-    || trimmed === "/effort"
-    || trimmed.startsWith("/effort ")
-    || trimmed === "/compact"
-    || trimmed.startsWith("/compact ");
-}
-
 export async function answerPromptForActiveTurn(
   binding: AskAnswerBindings,
   tabId: string,

--- a/desktop/frontend/src/lib/inboxSubmit.ts
+++ b/desktop/frontend/src/lib/inboxSubmit.ts
@@ -21,10 +21,14 @@ export function normalizeTurnSubmit(displayText: string, submitText: string) {
   return { display, submit };
 }
 
-// Host-only commands do not create an agent turn or receive a turn id.
+// Management commands do not create an agent turn or receive a turn id.
 export function isLocalRuntimeCommand(input: string): boolean {
   const trimmed = input.trim();
-  return trimmed === "/reload" || trimmed === "/effort" || trimmed.startsWith("/effort ");
+  return trimmed === "/reload"
+    || trimmed === "/effort"
+    || trimmed.startsWith("/effort ")
+    || trimmed === "/compact"
+    || trimmed.startsWith("/compact ");
 }
 
 export async function answerPromptForActiveTurn(

--- a/desktop/frontend/src/lib/inboxSubmit.ts
+++ b/desktop/frontend/src/lib/inboxSubmit.ts
@@ -21,7 +21,8 @@ export function normalizeTurnSubmit(displayText: string, submitText: string) {
   return { display, submit };
 }
 
-// Management commands do not create an agent turn or receive a turn id.
+// Legacy fallback for hosts that predate the structured StartTurnForTab
+// disposition. Current hosts classify every submit on the backend.
 export function isLocalRuntimeCommand(input: string): boolean {
   const trimmed = input.trim();
   return trimmed === "/reload"

--- a/desktop/frontend/src/lib/turnSubmissionFailure.ts
+++ b/desktop/frontend/src/lib/turnSubmissionFailure.ts
@@ -41,6 +41,29 @@ export function reduceSubmitFailure(
   };
 }
 
+export function reduceManagementConfirmation(state: State, submissionId: string, observedAt: number): State {
+  if (state.pendingSubmissionId !== submissionId) return state;
+  const preserveRuntime = Boolean(state.activeTurnId || state.live || state.approval || state.ask || state.mcpInteraction);
+  return {
+    ...state,
+    items: state.items.filter((item) => !(item.kind === "user" && item.submissionId === submissionId)),
+    pendingUser: undefined,
+    pendingSubmissionId: undefined,
+    running: preserveRuntime,
+    turnActive: preserveRuntime,
+    pendingPrompt: preserveRuntime && Boolean(state.approval || state.ask || state.mcpInteraction),
+    cancelRequested: false,
+    cancellable: preserveRuntime ? state.cancellable : false,
+    activeTurnId: preserveRuntime ? state.activeTurnId : undefined,
+    currentAssistant: preserveRuntime ? state.currentAssistant : undefined,
+    assistantSegmentOrdinal: preserveRuntime ? state.assistantSegmentOrdinal : 0,
+    live: preserveRuntime ? state.live : undefined,
+    streamAttemptJournal: preserveRuntime ? state.streamAttemptJournal : undefined,
+    deliveryRecoveryActive: preserveRuntime && state.deliveryRecoveryActive,
+    turnLifecycleObservedAt: observedAt,
+  };
+}
+
 export async function findTabAfterSubmitFailure(
   binding: Pick<AppBindings, "ListTabs">,
   tabId: string,

--- a/desktop/frontend/src/lib/turnSubmissionFailure.ts
+++ b/desktop/frontend/src/lib/turnSubmissionFailure.ts
@@ -43,7 +43,7 @@ export function reduceSubmitFailure(
 
 export function reduceManagementConfirmation(state: State, submissionId: string, observedAt: number): State {
   if (state.pendingSubmissionId !== submissionId) return state;
-  const preserveRuntime = Boolean(state.activeTurnId || state.live || state.approval || state.ask || state.mcpInteraction);
+  const preserveRuntime = Boolean(state.turnActive || state.activeTurnId || state.live || state.approval || state.ask || state.mcpInteraction);
   return {
     ...state,
     items: state.items.filter((item) => !(item.kind === "user" && item.submissionId === submissionId)),

--- a/desktop/frontend/src/lib/turnSubmissionFailure.ts
+++ b/desktop/frontend/src/lib/turnSubmissionFailure.ts
@@ -43,23 +43,22 @@ export function reduceSubmitFailure(
 
 export function reduceManagementConfirmation(state: State, submissionId: string, observedAt: number): State {
   if (state.pendingSubmissionId !== submissionId) return state;
-  const preserveRuntime = Boolean(state.turnActive || state.activeTurnId || state.live || state.approval || state.ask || state.mcpInteraction);
   return {
     ...state,
     items: state.items.filter((item) => !(item.kind === "user" && item.submissionId === submissionId)),
     pendingUser: undefined,
     pendingSubmissionId: undefined,
-    running: preserveRuntime,
-    turnActive: preserveRuntime,
-    pendingPrompt: preserveRuntime && Boolean(state.approval || state.ask || state.mcpInteraction),
+    running: false,
+    turnActive: false,
+    pendingPrompt: false,
     cancelRequested: false,
-    cancellable: preserveRuntime ? state.cancellable : false,
-    activeTurnId: preserveRuntime ? state.activeTurnId : undefined,
-    currentAssistant: preserveRuntime ? state.currentAssistant : undefined,
-    assistantSegmentOrdinal: preserveRuntime ? state.assistantSegmentOrdinal : 0,
-    live: preserveRuntime ? state.live : undefined,
-    streamAttemptJournal: preserveRuntime ? state.streamAttemptJournal : undefined,
-    deliveryRecoveryActive: preserveRuntime && state.deliveryRecoveryActive,
+    cancellable: false,
+    activeTurnId: undefined,
+    currentAssistant: undefined,
+    assistantSegmentOrdinal: 0,
+    live: undefined,
+    streamAttemptJournal: undefined,
+    deliveryRecoveryActive: false,
     turnLifecycleObservedAt: observedAt,
   };
 }

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -706,7 +706,7 @@ export function runtimeReadyForSubmit(meta?: Meta): boolean {
   return !meta.runtime || meta.runtime.phase === "ready";
 }
 
-export { isLocalRuntimeCommand, normalizeTurnSubmit } from "./inboxSubmit";
+export { normalizeTurnSubmit } from "./inboxSubmit";
 
 const frontendSubmissionEpoch = typeof globalThis.crypto?.randomUUID === "function"
   ? globalThis.crypto.randomUUID()

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -12,8 +12,8 @@ import { settleForkConversationForTab } from "./forkWorktree";
 import type { MessageActionScope, MessageActionState } from "./messageActions";
 import { mergeRateBand, type AggregatedRateBand } from "./costRateBand";
 import { requestInboxCancel, type CancelOutcome } from "./inboxCancel";
-import { answerPromptForActiveTurn, isLocalRuntimeCommand, normalizeTurnSubmit, resolveActiveTurnId } from "./inboxSubmit";
-import { findTabAfterSubmitFailure, reduceSubmitFailure } from "./turnSubmissionFailure";
+import { answerPromptForActiveTurn, normalizeTurnSubmit, resolveActiveTurnId } from "./inboxSubmit";
+import { findTabAfterSubmitFailure, reduceManagementConfirmation, reduceSubmitFailure } from "./turnSubmissionFailure";
 import { formatContextMaintenanceNotice, isNewMaintenanceOperation, rememberMaintenanceOperation } from "./contextMaintenanceTypes";
 import { formatGuardianAssessmentNotice } from "./guardianEvents";
 import { completionSummaryPresentation, normalizeCompletionSummary, sessionQualityFloor } from "./completionSummary";
@@ -783,6 +783,7 @@ type Action =
   | { type: "user"; text: string; submitText?: string; seq: number; submissionId: string; deliveryRecovery?: boolean }
   | { type: "unsend" }
   | { type: "send_confirmed"; submissionId: string }
+  | { type: "management_confirmed"; submissionId: string }
   | { type: "turn_admitted"; turnId: string; submissionId: string }
   | { type: "turn_submit_rejected"; submissionId: string; error: string }
   | { type: "send_failed"; submissionId: string; error: string }
@@ -2067,6 +2068,7 @@ export function reducer(s: State, a: Action): State {
       });
     }
     case "send_confirmed": return confirmPendingUser(s, a.submissionId);
+    case "management_confirmed": return reduceManagementConfirmation(s, a.submissionId, promptEventClock());
     case "turn_admitted":
       return s.pendingSubmissionId === a.submissionId && a.turnId
         ? { ...s, activeTurnId: a.turnId }
@@ -3738,7 +3740,7 @@ export function useController() {
         ? app.SubmitEditedDisplayToTabWithID(tabId, display, submit, original, submissionId)
         : display !== submit
         ? app.SubmitDisplayToTabWithID(tabId, display, submit, submissionId)
-        : typeof app.StartTurnForTab === "function" && !isLocalRuntimeCommand(submit)
+        : typeof app.StartTurnForTab === "function"
         ? app.StartTurnForTab(tabId, submit, submissionId)
         : app.SubmitToTabWithID(tabId, submit, submissionId);
       if (initialGoal) {
@@ -3750,6 +3752,7 @@ export function useController() {
       }
       void submitPromise.then(
         (receipt) => {
+          if (receipt && typeof receipt === "object" && "disposition" in receipt && receipt.disposition === "management_handled") return void dispatchTo(tabId, { type: "management_confirmed", submissionId });
           if (receipt && typeof receipt === "object" && "turnId" in receipt && typeof receipt.turnId === "string") {
             dispatchTo(tabId, { type: "turn_admitted", turnId: receipt.turnId, submissionId });
           }

--- a/desktop/turn_runtime_api.go
+++ b/desktop/turn_runtime_api.go
@@ -12,10 +12,11 @@ import (
 // TurnStartView is the synchronous admission receipt for the new Wails turn
 // API. Events remain the streaming authority after admission.
 type TurnStartView struct {
-	TurnID       string           `json:"turnId"`
-	Status       event.TurnStatus `json:"status"`
-	RuntimeEpoch string           `json:"runtimeEpoch,omitempty"`
-	SubmissionID string           `json:"submissionId,omitempty"`
+	TurnID       string                    `json:"turnId"`
+	Status       event.TurnStatus          `json:"status"`
+	Disposition  control.SubmitDisposition `json:"disposition"`
+	RuntimeEpoch string                    `json:"runtimeEpoch,omitempty"`
+	SubmissionID string                    `json:"submissionId,omitempty"`
 }
 
 // StartTurnForTab is the turn-id-aware replacement for SubmitToTab. Existing
@@ -24,8 +25,12 @@ func (a *App) StartTurnForTab(tabID, input, submissionID string) (TurnStartView,
 	if strings.TrimSpace(submissionID) == "" {
 		return TurnStartView{}, fmt.Errorf("submissionId is required")
 	}
-	if err := a.SubmitToTabWithID(tabID, input, submissionID); err != nil {
+	result, err := a.submitToTabResult(tabID, input, false, true, submissionID)
+	if err != nil {
 		return TurnStartView{}, err
+	}
+	if result.Disposition == control.SubmitManagementHandled {
+		return TurnStartView{Disposition: result.Disposition, SubmissionID: submissionID}, nil
 	}
 	tab, ctrl := a.tabAndCtrlByID(tabID)
 	if ctrl == nil {
@@ -45,7 +50,7 @@ func (a *App) StartTurnForTab(tabID, input, submissionID string) (TurnStartView,
 	// This is an admission receipt, not a potentially raced runtime snapshot.
 	// Ordered events carry every later transition, including a provider that
 	// completed before the Wails Promise was delivered.
-	return TurnStartView{TurnID: turnID, Status: event.TurnQueued, RuntimeEpoch: epoch, SubmissionID: submissionID}, nil
+	return TurnStartView{TurnID: turnID, Status: event.TurnQueued, Disposition: control.SubmitTurnStarted, RuntimeEpoch: epoch, SubmissionID: submissionID}, nil
 }
 
 // InterruptTurnForTab cancels only the exact active turn. A stale Stop button

--- a/desktop/turn_runtime_api_test.go
+++ b/desktop/turn_runtime_api_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -124,5 +125,48 @@ func TestStartTurnForTabReturnsManagementDispositionWithoutTurnID(t *testing.T) 
 	}
 	if len(replay.Events) != 0 {
 		t.Fatalf("management command created durable turn events: %+v", replay.Events)
+	}
+}
+
+func TestStartTurnForTabRejectsManagementDuringActiveTurn(t *testing.T) {
+	dir := t.TempDir()
+	runner := &exactTurnRunner{started: make(chan struct{})}
+	sink := &tabEventSink{tabID: "tab", ctx: context.Background()}
+	terminal := make(chan event.Event, 1)
+	sink.SetBotSink(event.FuncSink(func(e event.Event) {
+		if e.Kind == event.TurnDone {
+			terminal <- e
+		}
+	}))
+	ctrl := control.New(control.Options{
+		Runner: runner, Sink: sink, SessionDir: dir,
+		SessionPath: filepath.Join(dir, "session.jsonl"),
+	})
+	t.Cleanup(ctrl.Close)
+	tab := &WorkspaceTab{ID: "tab", Scope: "global", Ready: true, Ctrl: ctrl, sink: sink}
+	app := &App{tabs: map[string]*WorkspaceTab{tab.ID: tab}, activeTabID: tab.ID}
+	sink.app = app
+
+	start, err := app.StartTurnForTab(tab.ID, "hold this turn", "submission-active")
+	if err != nil {
+		t.Fatalf("StartTurnForTab active turn: %v", err)
+	}
+	select {
+	case <-runner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("turn runner did not start")
+	}
+	if _, err := app.StartTurnForTab(tab.ID, "/context", "submission-management"); !errors.Is(err, control.ErrTurnRunning) {
+		t.Fatalf("management command during active turn = %v, want ErrTurnRunning", err)
+	}
+	status := ctrl.RuntimeStatus()
+	if !status.Running || status.TurnID != start.TurnID {
+		t.Fatalf("active turn changed after rejected management command: %+v", status)
+	}
+	ctrl.Cancel()
+	select {
+	case <-terminal:
+	case <-time.After(5 * time.Second):
+		t.Fatal("turn did not finish after cancellation")
 	}
 }

--- a/desktop/turn_runtime_api_test.go
+++ b/desktop/turn_runtime_api_test.go
@@ -101,3 +101,28 @@ func TestTurnRuntimeAPIRoutesStopAnswerAndReplayByExactTurn(t *testing.T) {
 		t.Fatalf("empty replay events = %#v, want []", empty.Events)
 	}
 }
+
+func TestStartTurnForTabReturnsManagementDispositionWithoutTurnID(t *testing.T) {
+	dir := t.TempDir()
+	sink := &tabEventSink{tabID: "tab", ctx: context.Background()}
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: filepath.Join(dir, "session.jsonl"), Sink: sink})
+	t.Cleanup(ctrl.Close)
+	tab := &WorkspaceTab{ID: "tab", Scope: "global", Ready: true, Ctrl: ctrl, sink: sink}
+	app := &App{tabs: map[string]*WorkspaceTab{tab.ID: tab}, activeTabID: tab.ID}
+	sink.app = app
+
+	start, err := app.StartTurnForTab(tab.ID, "/context", "submission-management")
+	if err != nil {
+		t.Fatalf("StartTurnForTab management command: %v", err)
+	}
+	if start.Disposition != control.SubmitManagementHandled || start.TurnID != "" {
+		t.Fatalf("management receipt = %+v, want management_handled without turn id", start)
+	}
+	replay, err := app.TurnEventsForTab(tab.ID, 0)
+	if err != nil {
+		t.Fatalf("TurnEventsForTab: %v", err)
+	}
+	if len(replay.Events) != 0 {
+		t.Fatalf("management command created durable turn events: %+v", replay.Events)
+	}
+}

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -543,6 +543,8 @@ func (c *Controller) managementNotice(trimmed string) bool {
 			return true
 		}
 		c.notice(c.mcpListText())
+	default:
+		return false
 	}
 	return true
 }

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -543,8 +543,6 @@ func (c *Controller) managementNotice(trimmed string) bool {
 			return true
 		}
 		c.notice(c.mcpListText())
-	default:
-		return false
 	}
 	return true
 }

--- a/internal/control/submit_route.go
+++ b/internal/control/submit_route.go
@@ -1,0 +1,138 @@
+package control
+
+import (
+	"strings"
+
+	"reasonix/internal/skill"
+)
+
+var managementNoticeCommands = map[string]struct{}{
+	"/model": {}, "/provider": {}, "/memory": {}, "/migrate": {}, "/migration": {},
+	"/skill": {}, "/skills": {}, "/plugin": {}, "/plugins": {}, "/reload-cmd": {},
+	"/hooks": {}, "/mcp": {},
+}
+
+// SubmitDisposition describes whether a raw submit is expected to create a
+// durable conversational turn. Management commands can still mutate session
+// state or emit notices, but they must not be presented as turn admission.
+type SubmitDisposition string
+
+const (
+	SubmitTurnStarted       SubmitDisposition = "turn_started"
+	SubmitManagementHandled SubmitDisposition = "management_handled"
+)
+
+// ClassifySubmitRoute is the single controller-owned route classifier shared
+// by desktop's turn receipt and the normal Submit path. Keep conditional
+// commands here so a management-only form never gets mistaken for a turn.
+func (c *Controller) ClassifySubmitRoute(input string) SubmitDisposition {
+	trimmed := strings.TrimSpace(input)
+	if isSimpleManagementInput(trimmed) {
+		return SubmitManagementHandled
+	}
+	return c.classifySlashSubmit(trimmed)
+}
+
+func isSimpleManagementInput(trimmed string) bool {
+	if trimmed == "" {
+		return false
+	}
+	if _, ok := MemoryQuickAddNote(trimmed); ok {
+		return true
+	}
+	if _, ok := RememberCommandNote(trimmed); ok {
+		return true
+	}
+	if goal, ok := ParseGoalCommand(trimmed); ok {
+		return goal.Action != GoalCommandSet
+	}
+	if trimmed == "/reload" || trimmed == "/effort" || strings.HasPrefix(trimmed, "/effort ") {
+		return true
+	}
+	switch trimmed {
+	case "/compact", "/context", "/new", "/clear":
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *Controller) classifySlashSubmit(trimmed string) SubmitDisposition {
+	if _, ok := ParseFinalReadinessRecoveryCommand(trimmed); ok || !strings.HasPrefix(trimmed, "/") || strings.HasPrefix(trimmed, "!") {
+		return SubmitTurnStarted
+	}
+	if strings.HasPrefix(trimmed, "/mcp__") || c.isPathSubmit(trimmed) {
+		return SubmitTurnStarted
+	}
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return SubmitTurnStarted
+	}
+	switch fields[0] {
+	case "/tree", "/branch", "/switch", "/rewind":
+		return SubmitManagementHandled
+	case "/plan-exec":
+		return c.classifyPlanExecSubmit()
+	case "/prometheus":
+		return classifyPrometheusSubmit(trimmed, fields[0])
+	}
+	if _, ok := managementNoticeCommands[fields[0]]; ok {
+		return SubmitManagementHandled
+	}
+	if IsBuiltinDocsSlash(fields[0], c.Commands(), c.SlashSkills()) {
+		return classifyDocsSubmit(trimmed, fields[0])
+	}
+	if sk, task, ok := c.resolveSkillInvocation(trimmed); ok && sk.RunAs == skill.RunSubagent && strings.TrimSpace(task) == "" {
+		return SubmitManagementHandled
+	}
+	return SubmitTurnStarted
+}
+
+func (c *Controller) isPathSubmit(trimmed string) bool {
+	if _, ok := FileRefLine(trimmed); ok {
+		return true
+	}
+	if _, ok := SlashPathLineRef(trimmed, c.workspaceRoot); ok {
+		return true
+	}
+	return SlashPathLikeLine(trimmed)
+}
+
+func (c *Controller) classifyPlanExecSubmit() SubmitDisposition {
+	if c.executor == nil || len(c.executor.CanonicalTodoState()) == 0 {
+		return SubmitManagementHandled
+	}
+	return SubmitTurnStarted
+}
+
+func classifyPrometheusSubmit(trimmed, command string) SubmitDisposition {
+	args := strings.TrimSpace(strings.TrimPrefix(trimmed, command))
+	if args == "" || args == "--strict" {
+		return SubmitManagementHandled
+	}
+	if strings.HasPrefix(args, "--strict ") && strings.TrimSpace(strings.TrimPrefix(args, "--strict ")) == "" {
+		return SubmitManagementHandled
+	}
+	return SubmitTurnStarted
+}
+
+func classifyDocsSubmit(trimmed, command string) SubmitDisposition {
+	if strings.TrimSpace(strings.TrimPrefix(trimmed, command)) == "" {
+		return SubmitManagementHandled
+	}
+	return SubmitTurnStarted
+}
+
+// SubmitResult is returned by the result-capable desktop submit path. The
+// legacy Submit* methods intentionally keep their void/error contracts.
+type SubmitResult struct {
+	Disposition SubmitDisposition `json:"disposition"`
+}
+
+// SubmitDisplayWithResult preserves the existing asynchronous submit behavior
+// while exposing the route disposition to hosts that need an admission receipt.
+func (c *Controller) SubmitDisplayWithResult(display, input string) SubmitResult {
+	disposition := c.ClassifySubmitRoute(input)
+	c.SubmitDisplay(display, input)
+	return SubmitResult{Disposition: disposition}
+}

--- a/internal/control/submit_route_test.go
+++ b/internal/control/submit_route_test.go
@@ -40,3 +40,12 @@ func TestClassifySubmitRouteSeparatesManagementFromTurns(t *testing.T) {
 		})
 	}
 }
+
+func TestManagementNoticeLeavesTurnOwnedCommandsUnclaimed(t *testing.T) {
+	c := New(Options{Commands: []command.Command{{Name: "review", Body: "review: $ARGUMENTS"}}})
+	for _, input := range []string{"/unknown", "/review inspect", "/compactly"} {
+		if c.managementNotice(input) {
+			t.Fatalf("managementNotice(%q) claimed a turn-owned command", input)
+		}
+	}
+}

--- a/internal/control/submit_route_test.go
+++ b/internal/control/submit_route_test.go
@@ -1,0 +1,42 @@
+package control
+
+import (
+	"testing"
+
+	"reasonix/internal/command"
+)
+
+func TestClassifySubmitRouteSeparatesManagementFromTurns(t *testing.T) {
+	c := New(Options{Commands: []command.Command{{Name: "review", Body: "review: $ARGUMENTS"}}})
+	tests := []struct {
+		input string
+		want  SubmitDisposition
+	}{
+		{input: "/compact", want: SubmitManagementHandled},
+		{input: "/new", want: SubmitManagementHandled},
+		{input: "/context", want: SubmitManagementHandled},
+		{input: "/model", want: SubmitManagementHandled},
+		{input: "/provider deepseek", want: SubmitManagementHandled},
+		{input: "/memory recall", want: SubmitManagementHandled},
+		{input: "/remember keep this", want: SubmitManagementHandled},
+		{input: "# keep this", want: SubmitManagementHandled},
+		{input: "/goal status", want: SubmitManagementHandled},
+		{input: "/goal pause", want: SubmitManagementHandled},
+		{input: "/docs", want: SubmitManagementHandled},
+		{input: "/plan-exec", want: SubmitManagementHandled},
+		{input: "/prometheus", want: SubmitManagementHandled},
+		{input: "/compactly", want: SubmitTurnStarted},
+		{input: "review the diff", want: SubmitTurnStarted},
+		{input: "/goal ship the fix", want: SubmitTurnStarted},
+		{input: "/docs explain compaction", want: SubmitTurnStarted},
+		{input: "/prometheus ship the fix", want: SubmitTurnStarted},
+		{input: "/review the diff", want: SubmitTurnStarted},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := c.ClassifySubmitRoute(tt.input); got != tt.want {
+				t.Fatalf("ClassifySubmitRoute(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Prevent management slash commands from requiring a durable conversational turn ID.
- Move submit-route classification to the controller and return a structured `management_handled` disposition from the Desktop turn API.
- Preserve the legacy `SubmitToTabWithID` behavior while adding regression coverage for conditional command forms.

## Problem

Commands such as `/compact`, `/context`, `/goal status`, and `/docs` without a query can complete as management operations without creating an agent turn. Routing them through `StartTurnForTab` made the Desktop surface report `turn admission did not produce a durable turn id` even when the command was handled successfully.

## Root cause

The frontend maintained a partial local command allowlist while the controller owned the actual slash-command semantics, including commands whose behavior depends on arguments or current session state.

## Fix

- Add controller-owned `SubmitDisposition` classification for management-only and turn-producing inputs.
- Return `management_handled` from `StartTurnForTab` without requiring a turn ID.
- Settle optimistic management-command bubbles without disturbing an unrelated active turn.
- Keep `/goal pause` and `/goal resume` from being written as literal Goal text before lifecycle handling.

## Verification

- `cd desktop && go test ./...`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/send-failed.test.ts` (113 passed)
- `cd desktop/frontend && pnpm test:typecheck`
- `go test ./internal/control -run TestClassifySubmitRouteSeparatesManagementFromTurns -count=1`
- `go test -race ./internal/control`
- `cd desktop && go test -race . -run TestStartTurnForTabRejectsManagementDuringActiveTurn -count=1`
- `go run ./tools/repolint`

The frontend startup raw budget was ratcheted from 2471.8 KiB to 2472.4 KiB for the measured controller-owned routing payload; gzip and chunk budgets are unchanged.

Documentation-impact: none - this is an internal Desktop routing correction; existing command documentation remains accurate and no user-facing command syntax changed.
