### PR TITLE
Preserve and recover subagent outcomes / 系统化修复子代理结果交付与恢复

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1114,33 +1114,46 @@ func (a *App) submitToTabResult(tabID, input string, fromBridge, classifyManagem
 		a.runEffortCommandForTab(tabID, trimmed)
 		return management, nil
 	}
-	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if a.tabIsReadOnly(tab) {
-		return control.SubmitResult{}, readOnlyChannelErr()
-	}
-	if err := a.workspaceRuntimeAdmissionErr(tab, ctrl); err != nil {
-		return control.SubmitResult{}, err
-	}
-	if err := a.ensureTabControllerWorkspace(tab); err != nil {
-		return control.SubmitResult{}, err
-	}
-	ctrl = a.controllerForTab(tab)
-	if ctrl == nil {
-		return control.SubmitResult{}, a.workspaceNotReadyErr(tab)
-	}
 	if classifyManagement {
+		tab, ctrl := a.tabAndCtrlByID(tabID)
+		if a.tabIsReadOnly(tab) {
+			return control.SubmitResult{}, readOnlyChannelErr()
+		}
+		if err := a.workspaceRuntimeAdmissionErr(tab, ctrl); err != nil {
+			return control.SubmitResult{}, err
+		}
+		if err := a.ensureTabControllerWorkspace(tab); err != nil {
+			return control.SubmitResult{}, err
+		}
+		ctrl = a.controllerForTab(tab)
+		if ctrl == nil {
+			return control.SubmitResult{}, a.workspaceNotReadyErr(tab)
+		}
+		managementRoute := false
 		if classifier, ok := ctrl.(interface {
 			ClassifySubmitRoute(input string) control.SubmitDisposition
-		}); ok && classifier.ClassifySubmitRoute(input) == control.SubmitManagementHandled {
-			if !fromBridge && a.botBridge != nil {
-				a.botBridge.reclaimFromDesktop(tab.ID)
+		}); ok {
+			managementRoute = classifier.ClassifySubmitRoute(input) == control.SubmitManagementHandled
+		}
+		if managementRoute {
+			// Management commands still take the tab admission lock so they cannot
+			// race an active turn or a controller replacement.
+			admission, admittedCtrl, err := a.beginTabTurn(tabID, !fromBridge, submissionID...)
+			if err != nil {
+				return control.SubmitResult{}, err
 			}
-			if submitter, ok := ctrl.(interface {
+			defer admission.abort()
+			tab = admission.tab
+			a.ensureTabTopicIndexedForUserTurn(tab)
+			if submitter, supported := admittedCtrl.(interface {
 				SubmitDisplayWithResult(display, input string) control.SubmitResult
-			}); ok {
-				return submitter.SubmitDisplayWithResult(input, input), nil
+			}); supported {
+				result := submitter.SubmitDisplayWithResult(input, input)
+				admission.finish(admittedCtrl)
+				return result, nil
 			}
-			ctrl.SubmitDisplay(input, input)
+			admittedCtrl.SubmitDisplay(input, input)
+			admission.finish(admittedCtrl)
 			return management, nil
 		}
 	}
@@ -1149,7 +1162,7 @@ func (a *App) submitToTabResult(tabID, input string, fromBridge, classifyManagem
 		return control.SubmitResult{}, err
 	}
 	defer admission.abort()
-	tab = admission.tab
+	tab := admission.tab
 	a.ensureTabTopicIndexedForUserTurn(tab)
 	result := control.SubmitResult{Disposition: control.SubmitTurnStarted}
 	if submitter, ok := ctrl.(interface {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1080,44 +1080,87 @@ func (a *App) SubmitToTab(tabID, input string) error {
 // by the IM takeover bridge; local (frontend) submissions on a taken-over tab
 // reclaim remote control first — typing locally is the grab-back gesture.
 func (a *App) submitToTab(tabID, input string, fromBridge bool, submissionID ...string) error {
+	_, err := a.submitToTabResult(tabID, input, fromBridge, false, submissionID...)
+	return err
+}
+
+func (a *App) submitToTabResult(tabID, input string, fromBridge, classifyManagement bool, submissionID ...string) (control.SubmitResult, error) {
+	management := control.SubmitResult{Disposition: control.SubmitManagementHandled}
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "/reload" {
 		tab, _ := a.tabAndCtrlByID(tabID)
 		if a.tabIsReadOnly(tab) {
-			return readOnlyChannelErr()
+			return control.SubmitResult{}, readOnlyChannelErr()
 		}
 		if tab == nil {
-			return a.workspaceNotReadyErr(tab)
+			return control.SubmitResult{}, a.workspaceNotReadyErr(tab)
 		}
 		if !fromBridge && a.botBridge != nil {
 			a.botBridge.reclaimFromDesktop(tab.ID)
 		}
-		return a.ReloadRuntime(tab.ID)
+		return management, a.ReloadRuntime(tab.ID)
 	}
 	if trimmed == "/effort" || strings.HasPrefix(trimmed, "/effort ") {
 		tab, _ := a.tabAndCtrlByID(tabID)
 		if a.tabIsReadOnly(tab) {
-			return readOnlyChannelErr()
+			return control.SubmitResult{}, readOnlyChannelErr()
 		}
 		if tab == nil {
-			return a.workspaceNotReadyErr(tab)
+			return control.SubmitResult{}, a.workspaceNotReadyErr(tab)
 		}
 		if !fromBridge && a.botBridge != nil {
 			a.botBridge.reclaimFromDesktop(tab.ID)
 		}
 		a.runEffortCommandForTab(tabID, trimmed)
-		return nil
+		return management, nil
+	}
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if a.tabIsReadOnly(tab) {
+		return control.SubmitResult{}, readOnlyChannelErr()
+	}
+	if err := a.workspaceRuntimeAdmissionErr(tab, ctrl); err != nil {
+		return control.SubmitResult{}, err
+	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return control.SubmitResult{}, err
+	}
+	ctrl = a.controllerForTab(tab)
+	if ctrl == nil {
+		return control.SubmitResult{}, a.workspaceNotReadyErr(tab)
+	}
+	if classifyManagement {
+		if classifier, ok := ctrl.(interface {
+			ClassifySubmitRoute(input string) control.SubmitDisposition
+		}); ok && classifier.ClassifySubmitRoute(input) == control.SubmitManagementHandled {
+			if !fromBridge && a.botBridge != nil {
+				a.botBridge.reclaimFromDesktop(tab.ID)
+			}
+			if submitter, ok := ctrl.(interface {
+				SubmitDisplayWithResult(display, input string) control.SubmitResult
+			}); ok {
+				return submitter.SubmitDisplayWithResult(input, input), nil
+			}
+			ctrl.SubmitDisplay(input, input)
+			return management, nil
+		}
 	}
 	admission, ctrl, err := a.beginTabTurn(tabID, !fromBridge, submissionID...)
 	if err != nil {
-		return err
+		return control.SubmitResult{}, err
 	}
 	defer admission.abort()
-	tab := admission.tab
+	tab = admission.tab
 	a.ensureTabTopicIndexedForUserTurn(tab)
-	ctrl.SubmitDisplay(input, input)
+	result := control.SubmitResult{Disposition: control.SubmitTurnStarted}
+	if submitter, ok := ctrl.(interface {
+		SubmitDisplayWithResult(display, input string) control.SubmitResult
+	}); ok {
+		result = submitter.SubmitDisplayWithResult(input, input)
+	} else {
+		ctrl.SubmitDisplay(input, input)
+	}
 	admission.finish(ctrl)
-	return nil
+	return result, nil
 }
 
 func (a *App) submitUserTurnToTabWithSink(tabID, input string, forwarder event.Sink) bool {

--- a/desktop/completion_validation_audit.go
+++ b/desktop/completion_validation_audit.go
@@ -19,3 +19,20 @@ func (s *tabEventSink) RecordCompletionValidation(info event.CompletionValidatio
 		metrics.persist()
 	}
 }
+
+// RecordSubagentLifecycle consumes content-free child lifecycle telemetry.
+// ToolResult already carries the live card metadata; this side channel only
+// contributes scrubbed status/error buckets to anonymous desktop diagnostics.
+func (s *tabEventSink) RecordSubagentLifecycle(info event.SubagentLifecycleInfo) {
+	if s == nil {
+		return
+	}
+	_, app := s.binding()
+	if app == nil {
+		return
+	}
+	if metrics := app.metrics.Load(); metrics != nil {
+		metrics.observeSubagentLifecycle(info)
+		metrics.persist()
+	}
+}

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -348,6 +348,9 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // path measures 2470.932 KiB.
 // The reader-transaction offset absorption adds 0.8 KiB raw on top; the merged
 // path measures 2471.741 KiB.
-const rawInitialBudgetKiB = 2_471.8;
+// The outcome card and history hydration add 2.3 KiB raw on the initial path
+// (2474.0 KiB measured in CI). Keep this narrowly attributable ratchet rather
+// than removing persisted-result visibility or changing chunk ownership.
+const rawInitialBudgetKiB = 2_474.0;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -257,7 +257,10 @@ for (const path of localeChunks) {
   // reclaim), while Sticky Context adds file-state and limit diagnostics. The
   // merged stable chunks measure 60.395 KiB zh and 61.232 KiB zh-TW; retain
   // only the next one-decimal ceiling for each dialect.
-  const budget = name.startsWith("zh-TW-") ? 61.3 * 1024 : 60.4 * 1024;
+  // The outcome card adds one short localized status label per dialect. CI's
+  // Windows zlib measured zh at 60.4 KiB exactly; retain the next decimal
+  // ceiling so platform compression variance does not fail the product build.
+  const budget = name.startsWith("zh-TW-") ? 61.3 * 1024 : 60.5 * 1024;
   assertBudget(`${name} gzip`, gzipBytes(path), budget);
 }
 

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -190,7 +190,10 @@ console.log("\nbundle budgets");
 // Absorbing content-preserving block-window prepends into the active reader
 // transaction adds 0.2 KiB gzip on top; the merged path measures 463.292 KiB,
 // 8 bytes under the next decimal. Retain one cross-platform decimal step.
-const initialJSBudgetKiB = 463.4;
+// The subagent outcome envelope, partial-state card, and history hydration add
+// 0.5 KiB gzip on the initial path (463.8 KiB measured in CI). Keep this narrow
+// ratchet explicit rather than removing the recovery UI or widening a chunk.
+const initialJSBudgetKiB = 463.8;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -350,6 +350,11 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // path measures 2471.741 KiB. Controller-owned management dispositions and
 // optimistic management settlement add 0.6 KiB raw; retain the smallest
 // one-decimal ceiling with bounded headroom.
-const rawInitialBudgetKiB = 2_472.4;
+// The outcome card and history hydration add 2.3 KiB raw on the initial path
+// (2474.0 KiB measured in CI). Keep this narrowly attributable ratchet rather
+// than removing persisted-result visibility or changing chunk ownership.
+// On the current main-v2 base, the combined measured path is 2474.6 KiB;
+// retain 0.1 KiB of bounded cross-platform headroom.
+const rawInitialBudgetKiB = 2_474.7;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -191,9 +191,10 @@ console.log("\nbundle budgets");
 // transaction adds 0.2 KiB gzip on top; the merged path measures 463.292 KiB,
 // 8 bytes under the next decimal. Retain one cross-platform decimal step.
 // The subagent outcome envelope, partial-state card, and history hydration add
-// 0.5 KiB gzip on the initial path (463.8 KiB measured in CI). Keep this narrow
-// ratchet explicit rather than removing the recovery UI or widening a chunk.
-const initialJSBudgetKiB = 463.8;
+// 0.5 KiB gzip on the initial path. Current cross-platform CI measures 463.9
+// KiB; keep this narrow ratchet explicit rather than removing recovery UI or
+// widening a chunk.
+const initialJSBudgetKiB = 463.9;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -341,7 +341,9 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // The scrollbar generation fence and drag rebase add 1.1 KiB raw; the merged
 // path measures 2470.932 KiB.
 // The reader-transaction offset absorption adds 0.8 KiB raw on top; the merged
-// path measures 2471.741 KiB.
-const rawInitialBudgetKiB = 2_471.8;
+// path measures 2471.741 KiB. Controller-owned management dispositions and
+// optimistic management settlement add 0.6 KiB raw; retain the smallest
+// one-decimal ceiling with bounded headroom.
+const rawInitialBudgetKiB = 2_472.4;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2281,7 +2281,7 @@ export default function App() {
       if (goalCommand) {
         const arg = (goalCommand[1] ?? "").trim();
         const displayGoal = stripLegacyGoalBudgetFlags(arg);
-        if (displayGoal && !["status", "clear", "off", "stop", "done"].includes(displayGoal.toLowerCase())) {
+        if (displayGoal && !["status", "clear", "off", "stop", "done", "pause", "resume"].includes(displayGoal.toLowerCase())) {
           if (hasLegacyGoalBudgetFlag(arg)) {
             userPlanModeByTabRef.current = updateUserPlanModeIntent(userPlanModeByTabRef.current, activeTabId, false);
             patchActiveComposerProfile({
@@ -2292,7 +2292,7 @@ export default function App() {
           } else {
             await applyGoal(displayGoal);
           }
-        } else if (["clear", "off", "stop", "done", "pause", "resume"].includes(displayGoal.toLowerCase())) {
+        } else if (["clear", "off", "stop", "done"].includes(displayGoal.toLowerCase())) {
           await applyGoal("");
         }
         if (!controllerReady) return;

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1014,6 +1014,7 @@ export default function App() {
     clearGoal: clearControllerGoal,
     clearGoalForTab: clearControllerGoalForTab,
     clearSession,
+    newSession,
     listSessions,
     listTrashedSessions,
     resumeSession,
@@ -2205,13 +2206,7 @@ export default function App() {
   useEffect(() => {
     activeTabIdRef.current = activeTabId;
   }, [activeTabId]);
-
-  // handleSend intercepts slash commands that need a desktop-native action before
-  // they reach the backend: "/model <ref>" rebuilds on that model, "/memory"
-  // opens Settings, and "/clear" shows an in-app confirmation card. Everything else — skills (/init, …),
-  // custom commands, bare /model and the other read-only management verbs
-  // (/skill, /hooks, /mcp) — goes straight to Submit, which the controller
-  // resolves (a turn, or a listing Notice).
+  // handleSend reserves only commands that need a desktop-native UI action.
   const handleSend = useCallback(
     async (displayText: string, submitText = displayText, requestedTabId = activeTabId, structured?: StructuredInvocationSubmit) => {
       const sourceTabId = requestedTabId || activeTabId;
@@ -2241,6 +2236,11 @@ export default function App() {
       if (trimmed === "/clear") {
         if (activeTabIdRef.current !== sourceTabId) return;
         setClearContextPending(true);
+        return;
+      }
+      if (trimmed === "/new") {
+        if (activeTabIdRef.current !== sourceTabId) return;
+        await newSession();
         return;
       }
       const decisionMock = typeof window !== "undefined" && !window.runtime

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2292,7 +2292,7 @@ export default function App() {
           } else {
             await applyGoal(displayGoal);
           }
-        } else if (["clear", "off", "stop", "done"].includes(displayGoal.toLowerCase())) {
+        } else if (["clear", "off", "stop", "done", "pause", "resume"].includes(displayGoal.toLowerCase())) {
           await applyGoal("");
         }
         if (!controllerReady) return;

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -417,6 +417,11 @@ eq(
   "local Goal profile is patched only after backend activation succeeds",
 );
 eq(
+  /displayGoal && !\["status", "clear", "off", "stop", "done", "pause", "resume"\]\.includes/.test(appSource) && /else if \(\["clear", "off", "stop", "done"\]\.includes/.test(appSource),
+  true,
+  "Goal pause and resume do not clear the active Goal before lifecycle handling",
+);
+eq(
   controllerSource.includes("await app.SetGoalForTab(tabId, goal)") && !/SetGoalForTab\(tabId, goal\)\.catch\(\(\) => \{\}\)/.test(controllerSource),
   true,
   "SetGoalForTab activation failures propagate to callers",

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -117,7 +117,10 @@ eq(runtimeReadyForSubmit({ label: "", ready: true, eventChannel: "", cwd: "", ru
 eq(normalizeTurnSubmit(" visible prompt ", " provider prompt ").submit, "provider prompt", "submit normalization trims provider input");
 eq(isLocalRuntimeCommand(" /reload "), true, "/reload remains a host-only command without a turn receipt");
 eq(isLocalRuntimeCommand("/effort max"), true, "/effort remains a host-only command without a turn receipt");
+eq(isLocalRuntimeCommand("/compact"), true, "/compact remains a management command without a turn receipt");
+eq(isLocalRuntimeCommand("/compact preserve the key decisions"), true, "focused /compact remains a management command without a turn receipt");
 eq(isLocalRuntimeCommand("/reload now"), false, "non-command /reload text still starts an agent turn");
+eq(isLocalRuntimeCommand("/compactly"), false, "similarly-prefixed text still starts an agent turn");
 let rejectedVisibleOnlySubmit = false;
 try {
   normalizeTurnSubmit("visible prompt", "   ");

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -121,6 +121,11 @@ eq(isLocalRuntimeCommand("/compact"), true, "/compact remains a management comma
 eq(isLocalRuntimeCommand("/compact preserve the key decisions"), true, "focused /compact remains a management command without a turn receipt");
 eq(isLocalRuntimeCommand("/reload now"), false, "non-command /reload text still starts an agent turn");
 eq(isLocalRuntimeCommand("/compactly"), false, "similarly-prefixed text still starts an agent turn");
+const managementPending = reducer(reducer(initialState, {
+  type: "user", text: "/context", seq: 0, submissionId: "management-1",
+}), { type: "management_confirmed", submissionId: "management-1" });
+eq(managementPending.items.some((item) => item.kind === "user" && item.text === "/context"), false, "handled management commands do not remain as conversation turns");
+eq(managementPending.running, false, "handled management commands release the composer");
 let rejectedVisibleOnlySubmit = false;
 try {
   normalizeTurnSubmit("visible prompt", "   ");

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { acceptsRuntimeEventEpoch, historyMessagesToItems, initialState, isLocalRuntimeCommand, normalizeTurnSubmit, reducer, replayPendingPromptsForActiveTab, runtimeReadyForSubmit } from "../lib/useController";
+import { acceptsRuntimeEventEpoch, historyMessagesToItems, initialState, normalizeTurnSubmit, reducer, replayPendingPromptsForActiveTab, runtimeReadyForSubmit } from "../lib/useController";
 import { continueDelivery } from "../lib/deliveryContinue";
 import {
   activateGoalAndSubmit,
@@ -115,22 +115,11 @@ eq(runtimeReadyForSubmit({ label: "", ready: false, eventChannel: "", cwd: "", r
 eq(runtimeReadyForSubmit({ label: "", ready: false, eventChannel: "", cwd: "", runtime: { phase: "failed", epoch: "e1" } }), false, "failed runtime cannot submit");
 eq(runtimeReadyForSubmit({ label: "", ready: true, eventChannel: "", cwd: "", runtime: { phase: "ready", epoch: "e1" } }), true, "ready runtime can submit");
 eq(normalizeTurnSubmit(" visible prompt ", " provider prompt ").submit, "provider prompt", "submit normalization trims provider input");
-eq(isLocalRuntimeCommand(" /reload "), true, "/reload remains a host-only command without a turn receipt");
-eq(isLocalRuntimeCommand("/effort max"), true, "/effort remains a host-only command without a turn receipt");
-eq(isLocalRuntimeCommand("/compact"), true, "/compact remains a management command without a turn receipt");
-eq(isLocalRuntimeCommand("/compact preserve the key decisions"), true, "focused /compact remains a management command without a turn receipt");
-eq(isLocalRuntimeCommand("/reload now"), false, "non-command /reload text still starts an agent turn");
-eq(isLocalRuntimeCommand("/compactly"), false, "similarly-prefixed text still starts an agent turn");
 const managementPending = reducer(reducer(initialState, {
   type: "user", text: "/context", seq: 0, submissionId: "management-1",
 }), { type: "management_confirmed", submissionId: "management-1" });
 eq(managementPending.items.some((item) => item.kind === "user" && item.text === "/context"), false, "handled management commands do not remain as conversation turns");
 eq(managementPending.running, false, "handled management commands release the composer");
-const managementDuringTurn = reducer(reducer({ ...initialState, running: true, turnActive: true, activeTurnId: "turn-active" }, {
-  type: "user", text: "/context", seq: 0, submissionId: "management-active",
-}), { type: "management_confirmed", submissionId: "management-active" });
-eq(managementDuringTurn.running, true, "management confirmation does not release an unrelated active turn");
-eq(managementDuringTurn.turnActive, true, "management confirmation preserves the active-turn gate");
 let rejectedVisibleOnlySubmit = false;
 try {
   normalizeTurnSubmit("visible prompt", "   ");

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -126,6 +126,11 @@ const managementPending = reducer(reducer(initialState, {
 }), { type: "management_confirmed", submissionId: "management-1" });
 eq(managementPending.items.some((item) => item.kind === "user" && item.text === "/context"), false, "handled management commands do not remain as conversation turns");
 eq(managementPending.running, false, "handled management commands release the composer");
+const managementDuringTurn = reducer(reducer({ ...initialState, running: true, turnActive: true, activeTurnId: "turn-active" }, {
+  type: "user", text: "/context", seq: 0, submissionId: "management-active",
+}), { type: "management_confirmed", submissionId: "management-active" });
+eq(managementDuringTurn.running, true, "management confirmation does not release an unrelated active turn");
+eq(managementDuringTurn.turnActive, true, "management confirmation preserves the active-turn gate");
 let rejectedVisibleOnlySubmit = false;
 try {
   normalizeTurnSubmit("visible prompt", "   ");

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -60,8 +60,19 @@ function subagentPhaseLabel(t: Translator, phase: SubagentPhase): string {
     case "tool": return t("subagent.phase.tool");
     case "retrying": return t("subagent.phase.retrying");
     case "completed": return t("subagent.phase.completed");
+    case "partial": return t("subagent.phase.partial");
     case "failed": return t("subagent.phase.failed");
     case "cancelled": return t("subagent.phase.cancelled");
+  }
+}
+
+function subagentOutcomeLabel(t: Translator, status: string): string {
+  switch (status) {
+    case "completed": return t("subagent.outcome.completed");
+    case "partial": return t("subagent.outcome.partial");
+    case "failed": return t("subagent.outcome.failed");
+    case "cancelled": return t("subagent.outcome.cancelled");
+    default: return status;
   }
 }
 
@@ -341,7 +352,8 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId, displayN
   const shellOutput = isShellCard && displayOutput ? displayOutput : null;
   const shellPreview = shellOutput ? splitPreview(shellOutput, SHELL_PREVIEW_LINES) : null;
   const hasStderrDetails = Boolean(execution?.outputTail && execution.outputTail.trim());
-  const hasBody = Boolean(previewDiff || diffs.length || hasNested || shellPreview || (!shellPreview && hasArgsOrOutput) || item.error || hasSubagentPreview || hasStderrDetails || riskLabel || verificationLabel);
+  const hasSubagentOutcome = Boolean(item.subagentStatus || item.subagentRef);
+  const hasBody = Boolean(previewDiff || diffs.length || hasNested || shellPreview || (!shellPreview && hasArgsOrOutput) || item.error || hasSubagentPreview || hasSubagentOutcome || hasStderrDetails || riskLabel || verificationLabel);
   const errorText = item.error ? normalizeErrorText(item.error) : "";
   const errorSummary = errorText ? summarizeToolError(errorText, t("tool.errorReceiptMismatch")) : "";
   const hasErrorDetails = errorText ? errorNeedsDetails(errorText, errorSummary) : false;
@@ -505,6 +517,16 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId, displayN
               </div>
             )}
             {sp.truncated && <div className="tool__note">{t("subagent.preview.truncated")}</div>}
+          </div>
+        )}
+
+        {open && hasSubagentOutcome && (
+          <div className="tool__subagent-outcome">
+            <div className="tool__subagent-outcome-status">
+              {t("subagent.outcome.label")} {subagentOutcomeLabel(t, item.subagentStatus ?? "unknown")}{item.subagentRetryable ? ` · ${t("subagent.outcome.retryable")}` : ""}
+            </div>
+            {item.subagentRef && <code>{item.subagentRef}</code>}
+            {item.subagentErrorCode && <div className="tool__note">{item.subagentErrorCode}</div>}
           </div>
         )}
 

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -209,7 +209,7 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   Submit(input: string): Promise<void>;
   SubmitToTab(tabID: string, input: string): Promise<void>;
   SubmitToTabWithID(tabID: string, input: string, submissionID: string): Promise<void>;
-  StartTurnForTab?(tabID: string, input: string, submissionID: string): Promise<{ turnId: string; status: string; runtimeEpoch?: string; submissionId?: string }>;
+  StartTurnForTab?(tabID: string, input: string, submissionID: string): Promise<{ turnId: string; status: string; disposition?: "turn_started" | "management_handled"; runtimeEpoch?: string; submissionId?: string }>;
   SubmitDisplay(display: string, input: string): Promise<void>;
   SubmitDisplayToTab(tabID: string, display: string, input: string): Promise<void>;
   SubmitDisplayToTabWithID(tabID: string, display: string, input: string, submissionID: string): Promise<void>;

--- a/desktop/frontend/src/lib/inboxSubmit.ts
+++ b/desktop/frontend/src/lib/inboxSubmit.ts
@@ -21,17 +21,6 @@ export function normalizeTurnSubmit(displayText: string, submitText: string) {
   return { display, submit };
 }
 
-// Legacy fallback for hosts that predate the structured StartTurnForTab
-// disposition. Current hosts classify every submit on the backend.
-export function isLocalRuntimeCommand(input: string): boolean {
-  const trimmed = input.trim();
-  return trimmed === "/reload"
-    || trimmed === "/effort"
-    || trimmed.startsWith("/effort ")
-    || trimmed === "/compact"
-    || trimmed.startsWith("/compact ");
-}
-
 export async function answerPromptForActiveTurn(
   binding: AskAnswerBindings,
   tabId: string,

--- a/desktop/frontend/src/lib/inboxSubmit.ts
+++ b/desktop/frontend/src/lib/inboxSubmit.ts
@@ -21,10 +21,14 @@ export function normalizeTurnSubmit(displayText: string, submitText: string) {
   return { display, submit };
 }
 
-// Host-only commands do not create an agent turn or receive a turn id.
+// Management commands do not create an agent turn or receive a turn id.
 export function isLocalRuntimeCommand(input: string): boolean {
   const trimmed = input.trim();
-  return trimmed === "/reload" || trimmed === "/effort" || trimmed.startsWith("/effort ");
+  return trimmed === "/reload"
+    || trimmed === "/effort"
+    || trimmed.startsWith("/effort ")
+    || trimmed === "/compact"
+    || trimmed.startsWith("/compact ");
 }
 
 export async function answerPromptForActiveTurn(

--- a/desktop/frontend/src/lib/inboxSubmit.ts
+++ b/desktop/frontend/src/lib/inboxSubmit.ts
@@ -21,7 +21,8 @@ export function normalizeTurnSubmit(displayText: string, submitText: string) {
   return { display, submit };
 }
 
-// Management commands do not create an agent turn or receive a turn id.
+// Legacy fallback for hosts that predate the structured StartTurnForTab
+// disposition. Current hosts classify every submit on the backend.
 export function isLocalRuntimeCommand(input: string): boolean {
   const trimmed = input.trim();
   return trimmed === "/reload"

--- a/desktop/frontend/src/lib/subagentOutcome.ts
+++ b/desktop/frontend/src/lib/subagentOutcome.ts
@@ -1,0 +1,20 @@
+export type SubagentOutcomeFields = {
+  subagentRef?: string;
+  subagentStatus?: string;
+  subagentErrorCode?: string;
+  subagentRetryable?: boolean;
+};
+
+export function parseSubagentOutcomeText(text?: string): SubagentOutcomeFields {
+  if (!text) return {};
+  const head = text.slice(0, 1024);
+  const ref = head.match(/^Subagent reference(?: \(failed\))?: ([^\n]+)/m)?.[1]?.trim();
+  const match = head.match(/^Subagent outcome: status=([^\s]+) retryable=(true|false)(?: error_code=([^\s]+))?/m);
+  if (!ref || !match) return {};
+  return {
+    subagentRef: ref,
+    subagentStatus: match[1],
+    subagentRetryable: match[2] === "true",
+    subagentErrorCode: match[3],
+  };
+}

--- a/desktop/frontend/src/lib/turnSubmissionFailure.ts
+++ b/desktop/frontend/src/lib/turnSubmissionFailure.ts
@@ -41,6 +41,29 @@ export function reduceSubmitFailure(
   };
 }
 
+export function reduceManagementConfirmation(state: State, submissionId: string, observedAt: number): State {
+  if (state.pendingSubmissionId !== submissionId) return state;
+  const preserveRuntime = Boolean(state.activeTurnId || state.live || state.approval || state.ask || state.mcpInteraction);
+  return {
+    ...state,
+    items: state.items.filter((item) => !(item.kind === "user" && item.submissionId === submissionId)),
+    pendingUser: undefined,
+    pendingSubmissionId: undefined,
+    running: preserveRuntime,
+    turnActive: preserveRuntime,
+    pendingPrompt: preserveRuntime && Boolean(state.approval || state.ask || state.mcpInteraction),
+    cancelRequested: false,
+    cancellable: preserveRuntime ? state.cancellable : false,
+    activeTurnId: preserveRuntime ? state.activeTurnId : undefined,
+    currentAssistant: preserveRuntime ? state.currentAssistant : undefined,
+    assistantSegmentOrdinal: preserveRuntime ? state.assistantSegmentOrdinal : 0,
+    live: preserveRuntime ? state.live : undefined,
+    streamAttemptJournal: preserveRuntime ? state.streamAttemptJournal : undefined,
+    deliveryRecoveryActive: preserveRuntime && state.deliveryRecoveryActive,
+    turnLifecycleObservedAt: observedAt,
+  };
+}
+
 export async function findTabAfterSubmitFailure(
   binding: Pick<AppBindings, "ListTabs">,
   tabId: string,

--- a/desktop/frontend/src/lib/turnSubmissionFailure.ts
+++ b/desktop/frontend/src/lib/turnSubmissionFailure.ts
@@ -43,7 +43,7 @@ export function reduceSubmitFailure(
 
 export function reduceManagementConfirmation(state: State, submissionId: string, observedAt: number): State {
   if (state.pendingSubmissionId !== submissionId) return state;
-  const preserveRuntime = Boolean(state.activeTurnId || state.live || state.approval || state.ask || state.mcpInteraction);
+  const preserveRuntime = Boolean(state.turnActive || state.activeTurnId || state.live || state.approval || state.ask || state.mcpInteraction);
   return {
     ...state,
     items: state.items.filter((item) => !(item.kind === "user" && item.submissionId === submissionId)),

--- a/desktop/frontend/src/lib/turnSubmissionFailure.ts
+++ b/desktop/frontend/src/lib/turnSubmissionFailure.ts
@@ -43,23 +43,22 @@ export function reduceSubmitFailure(
 
 export function reduceManagementConfirmation(state: State, submissionId: string, observedAt: number): State {
   if (state.pendingSubmissionId !== submissionId) return state;
-  const preserveRuntime = Boolean(state.turnActive || state.activeTurnId || state.live || state.approval || state.ask || state.mcpInteraction);
   return {
     ...state,
     items: state.items.filter((item) => !(item.kind === "user" && item.submissionId === submissionId)),
     pendingUser: undefined,
     pendingSubmissionId: undefined,
-    running: preserveRuntime,
-    turnActive: preserveRuntime,
-    pendingPrompt: preserveRuntime && Boolean(state.approval || state.ask || state.mcpInteraction),
+    running: false,
+    turnActive: false,
+    pendingPrompt: false,
     cancelRequested: false,
-    cancellable: preserveRuntime ? state.cancellable : false,
-    activeTurnId: preserveRuntime ? state.activeTurnId : undefined,
-    currentAssistant: preserveRuntime ? state.currentAssistant : undefined,
-    assistantSegmentOrdinal: preserveRuntime ? state.assistantSegmentOrdinal : 0,
-    live: preserveRuntime ? state.live : undefined,
-    streamAttemptJournal: preserveRuntime ? state.streamAttemptJournal : undefined,
-    deliveryRecoveryActive: preserveRuntime && state.deliveryRecoveryActive,
+    cancellable: false,
+    activeTurnId: undefined,
+    currentAssistant: undefined,
+    assistantSegmentOrdinal: 0,
+    live: undefined,
+    streamAttemptJournal: undefined,
+    deliveryRecoveryActive: false,
     turnLifecycleObservedAt: observedAt,
   };
 }

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -112,12 +112,12 @@ export interface WireTool {
   partial?: boolean; // an early dispatch (name only) — a full one with args follows
   argChars?: number; // partial only: cumulative argument chars streamed so far
   refreshed?: boolean; // same-ID full dispatch with a preview recomputed after an earlier write
-  parentId?: string; // set on a sub-agent's calls — the parent `task` call's id
+	parentId?: string; // set on a sub-agent's calls — the parent `task` call's id
   /** Host-local stream_attempt id for speculative parent partials only. */
   attemptId?: string;
   diff?: string;
   added?: number;
-  removed?: number;
+  removed?: number; subagentRef?: string; subagentStatus?: string; subagentErrorCode?: string; subagentRetryable?: boolean;
   profile?: WireProfile; // subagent model/effort resolved for this call
   execution?: WireShellExecution; // local shell metadata; never provider-visible
 }

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -108,9 +108,7 @@ export const SUBAGENT_PROGRESS_NOTICE = "reasonix.subagent.notice";
 // to ordinary tool output on older frontends.
 const SUBAGENT_PROGRESS_PREFIX = "reasonix.subagent.";
 const TURN_ACTIVITY_KINDS = new Set(["turn_started", "text", "reasoning", "message", "tool_dispatch", "tool_progress", "tool_result_preview", "tool_result"]);
-const SUBAGENT_PROGRESS_PHASES = new Set([
-  "queued", "running", "reasoning", "responding", "tool", "retrying", "completed", "partial", "failed", "cancelled",
-]);
+const SUBAGENT_PROGRESS_PHASES = new Set(["queued", "running", "reasoning", "responding", "tool", "retrying", "completed", "partial", "failed", "cancelled"]);
 // Tool names that initialize a sub-agent progress card. parallel_tasks/fleet
 // are group cards: they settle when their whole child progress tree is
 // terminal, since they never receive a terminal status of their own.
@@ -122,9 +120,7 @@ const SUBAGENT_PREVIEW_REASONING_LIMIT = 8 << 10;
 const SUBAGENT_PREVIEW_TEXT_LIMIT = 8 << 10;
 const SUBAGENT_PREVIEW_NOTICE_LIMIT = 2 << 10;
 const RUNTIME_STATUS_ONLY = { hydrateSessionData: false } as const;
-export type SubagentPhase =
-  | "queued" | "running" | "reasoning" | "responding" | "tool" | "retrying"
-  | "completed" | "partial" | "failed" | "cancelled";
+export type SubagentPhase = "queued" | "running" | "reasoning" | "responding" | "tool" | "retrying" | "completed" | "partial" | "failed" | "cancelled";
 // In-memory-only sub-agent progress preview. Never persisted: history
 // hydration rebuilds tool items from the transcript without these fields, and
 // the full sub-agent transcript stays the source of truth after a restart.

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -706,7 +706,7 @@ export function runtimeReadyForSubmit(meta?: Meta): boolean {
   return !meta.runtime || meta.runtime.phase === "ready";
 }
 
-export { isLocalRuntimeCommand, normalizeTurnSubmit } from "./inboxSubmit";
+export { normalizeTurnSubmit } from "./inboxSubmit";
 
 const frontendSubmissionEpoch = typeof globalThis.crypto?.randomUUID === "function"
   ? globalThis.crypto.randomUUID()

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -12,8 +12,8 @@ import { settleForkConversationForTab } from "./forkWorktree";
 import type { MessageActionScope, MessageActionState } from "./messageActions";
 import { mergeRateBand, type AggregatedRateBand } from "./costRateBand";
 import { requestInboxCancel, type CancelOutcome } from "./inboxCancel";
-import { answerPromptForActiveTurn, isLocalRuntimeCommand, normalizeTurnSubmit, resolveActiveTurnId } from "./inboxSubmit";
-import { findTabAfterSubmitFailure, reduceSubmitFailure } from "./turnSubmissionFailure";
+import { answerPromptForActiveTurn, normalizeTurnSubmit, resolveActiveTurnId } from "./inboxSubmit";
+import { findTabAfterSubmitFailure, reduceManagementConfirmation, reduceSubmitFailure } from "./turnSubmissionFailure";
 import { formatContextMaintenanceNotice, isNewMaintenanceOperation, rememberMaintenanceOperation } from "./contextMaintenanceTypes";
 import { formatGuardianAssessmentNotice } from "./guardianEvents";
 import { completionSummaryPresentation, normalizeCompletionSummary, sessionQualityFloor } from "./completionSummary";
@@ -783,6 +783,7 @@ type Action =
   | { type: "user"; text: string; submitText?: string; seq: number; submissionId: string; deliveryRecovery?: boolean }
   | { type: "unsend" }
   | { type: "send_confirmed"; submissionId: string }
+  | { type: "management_confirmed"; submissionId: string }
   | { type: "turn_admitted"; turnId: string; submissionId: string }
   | { type: "turn_submit_rejected"; submissionId: string; error: string }
   | { type: "send_failed"; submissionId: string; error: string }
@@ -2067,6 +2068,7 @@ export function reducer(s: State, a: Action): State {
       });
     }
     case "send_confirmed": return confirmPendingUser(s, a.submissionId);
+    case "management_confirmed": return reduceManagementConfirmation(s, a.submissionId, promptEventClock());
     case "turn_admitted":
       return s.pendingSubmissionId === a.submissionId && a.turnId
         ? { ...s, activeTurnId: a.turnId }
@@ -3738,7 +3740,7 @@ export function useController() {
         ? app.SubmitEditedDisplayToTabWithID(tabId, display, submit, original, submissionId)
         : display !== submit
         ? app.SubmitDisplayToTabWithID(tabId, display, submit, submissionId)
-        : typeof app.StartTurnForTab === "function" && !isLocalRuntimeCommand(submit)
+        : typeof app.StartTurnForTab === "function"
         ? app.StartTurnForTab(tabId, submit, submissionId)
         : app.SubmitToTabWithID(tabId, submit, submissionId);
       if (initialGoal) {
@@ -3750,6 +3752,7 @@ export function useController() {
       }
       void submitPromise.then(
         (receipt) => {
+          if (receipt && typeof receipt === "object" && "disposition" in receipt && receipt.disposition === "management_handled") return void dispatchTo(tabId, { type: "management_confirmed", submissionId });
           if (receipt && typeof receipt === "object" && "turnId" in receipt && typeof receipt.turnId === "string") {
             dispatchTo(tabId, { type: "turn_admitted", turnId: receipt.turnId, submissionId });
           }

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -53,6 +53,7 @@ import type { SearchSource } from "./searchSources";
 import { attachWebSearchOutput, historySearchAndAnswer } from "./searchTranscript";
 import { fileDiffFromWire, parseTodos, summarize, summarizeFileDiff, type ToolFileDiff } from "./tools";
 import { modeHasAutoApproveTools, normalizeMode, normalizeToolApprovalMode, type QualityFloor } from "./types";
+import { parseSubagentOutcomeText } from "./subagentOutcome";
 import type {
   BalanceInfo,
   CheckpointMeta,
@@ -108,7 +109,7 @@ export const SUBAGENT_PROGRESS_NOTICE = "reasonix.subagent.notice";
 const SUBAGENT_PROGRESS_PREFIX = "reasonix.subagent.";
 const TURN_ACTIVITY_KINDS = new Set(["turn_started", "text", "reasoning", "message", "tool_dispatch", "tool_progress", "tool_result_preview", "tool_result"]);
 const SUBAGENT_PROGRESS_PHASES = new Set([
-  "queued", "running", "reasoning", "responding", "tool", "retrying", "completed", "failed", "cancelled",
+  "queued", "running", "reasoning", "responding", "tool", "retrying", "completed", "partial", "failed", "cancelled",
 ]);
 // Tool names that initialize a sub-agent progress card. parallel_tasks/fleet
 // are group cards: they settle when their whole child progress tree is
@@ -123,7 +124,7 @@ const SUBAGENT_PREVIEW_NOTICE_LIMIT = 2 << 10;
 const RUNTIME_STATUS_ONLY = { hydrateSessionData: false } as const;
 export type SubagentPhase =
   | "queued" | "running" | "reasoning" | "responding" | "tool" | "retrying"
-  | "completed" | "failed" | "cancelled";
+  | "completed" | "partial" | "failed" | "cancelled";
 // In-memory-only sub-agent progress preview. Never persisted: history
 // hydration rebuilds tool items from the transcript without these fields, and
 // the full sub-agent transcript stays the source of truth after a restart.
@@ -141,7 +142,7 @@ export function isSubagentProgressName(name: string | undefined): boolean {
   return !!name && name.startsWith(SUBAGENT_PROGRESS_PREFIX);
 }
 export function isTerminalSubagentPhase(phase: string | undefined): boolean {
-  return phase === "completed" || phase === "failed" || phase === "cancelled";
+  return phase === "completed" || phase === "partial" || phase === "failed" || phase === "cancelled";
 }
 function isGroupSubagentTool(name: string): boolean {
   return name === "parallel_tasks" || name === "fleet";
@@ -149,6 +150,7 @@ function isGroupSubagentTool(name: string): boolean {
 function terminalStatusOf(phase: string): ToolStatus {
   switch (phase) {
     case "completed": return "done";
+    case "partial": return "error";
     case "failed": return "error";
     case "cancelled": return "stopped";
   }
@@ -285,7 +287,7 @@ export type Item =
       args: string;
       readOnly: boolean;
       resolvedName?: string;
-      capabilityId?: string;
+      capabilityId?: string; subagentRef?: string; subagentStatus?: string; subagentErrorCode?: string; subagentRetryable?: boolean;
       status: ToolStatus;
       output?: string; searchSources?: SearchSource[]; // display-only provider search results; replay data stays in output/serverSearch
       error?: string;
@@ -950,7 +952,7 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
           summary: summarizeFileDiff(fileDiff) || tc.summary,
           fileDiff,
           isShell: tc.name === "bash" || (tc.id || "").startsWith("shell-"),
-          execution: result?.execution,
+          execution: result?.execution, ...parseSubagentOutcomeText(output),
         });
         seq++;
       }
@@ -971,7 +973,7 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
         error,
         dataArchived: m.toolResultArchived || undefined,
         isShell: (m.toolName || "") === "bash" || (m.toolCallId || "").startsWith("shell-"),
-        execution: m.execution,
+        execution: m.execution, ...parseSubagentOutcomeText(output),
       });
       seq++;
       continue;
@@ -1664,7 +1666,7 @@ function applyEvent(s: State, e: WireEvent, preserveToolPayloads = false): State
           const args = t.args ? t.args : it.args;
           const fileDiff = fileDiffFromWire(t);
           const summary = summarizeFileDiff(fileDiff) || summarize(t.name, args) || (t.name === it.name && args === it.args ? it.summary : undefined);
-          next[idx] = { ...it, name: t.name, args, readOnly: t.readOnly, resolvedName: t.resolvedName ?? it.resolvedName, capabilityId: t.capabilityId ?? it.capabilityId, profile: t.profile ?? it.profile, summary, fileDiff, argChars: undefined, isShell: it.isShell || t.name === "bash" || id.startsWith("shell-"), execution: t.execution ?? it.execution, subagentProgress: it.subagentProgress ?? (SUBAGENT_PROGRESS_TOOLS.has(t.name) ? freshSubagentProgress() : undefined) };
+            next[idx] = { ...it, name: t.name, args, readOnly: t.readOnly, resolvedName: t.resolvedName ?? it.resolvedName, capabilityId: t.capabilityId ?? it.capabilityId, profile: t.profile ?? it.profile, subagentRef: t.subagentRef ?? it.subagentRef, subagentStatus: t.subagentStatus ?? it.subagentStatus, subagentErrorCode: t.subagentErrorCode ?? it.subagentErrorCode, subagentRetryable: t.subagentRetryable ?? it.subagentRetryable, summary, fileDiff, argChars: undefined, isShell: it.isShell || t.name === "bash" || id.startsWith("shell-"), execution: t.execution ?? it.execution, subagentProgress: it.subagentProgress ?? (SUBAGENT_PROGRESS_TOOLS.has(t.name) ? freshSubagentProgress() : undefined) };
         }
         if (t.parentId) touchSubagentParent(next, t.parentId);
         return { ...settled, items: next };
@@ -1732,7 +1734,7 @@ function applyEvent(s: State, e: WireEvent, preserveToolPayloads = false): State
             durationMs: t.durationMs,
             summary,
             isShell: existing.isShell || existing.name === "bash" || t.name === "bash",
-            execution: t.execution ?? existing.execution,
+            execution: t.execution ?? existing.execution, subagentRef: t.subagentRef ?? existing.subagentRef, subagentStatus: t.subagentStatus ?? existing.subagentStatus, subagentErrorCode: t.subagentErrorCode ?? existing.subagentErrorCode, subagentRetryable: t.subagentRetryable ?? existing.subagentRetryable,
           };
         }
       }

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -53,6 +53,7 @@ import type { SearchSource } from "./searchSources";
 import { attachWebSearchOutput, historySearchAndAnswer } from "./searchTranscript";
 import { fileDiffFromWire, parseTodos, summarize, summarizeFileDiff, type ToolFileDiff } from "./tools";
 import { modeHasAutoApproveTools, normalizeMode, normalizeToolApprovalMode, type QualityFloor } from "./types";
+import { parseSubagentOutcomeText } from "./subagentOutcome";
 import type {
   BalanceInfo,
   CheckpointMeta,
@@ -108,7 +109,7 @@ export const SUBAGENT_PROGRESS_NOTICE = "reasonix.subagent.notice";
 const SUBAGENT_PROGRESS_PREFIX = "reasonix.subagent.";
 const TURN_ACTIVITY_KINDS = new Set(["turn_started", "text", "reasoning", "message", "tool_dispatch", "tool_progress", "tool_result_preview", "tool_result"]);
 const SUBAGENT_PROGRESS_PHASES = new Set([
-  "queued", "running", "reasoning", "responding", "tool", "retrying", "completed", "failed", "cancelled",
+  "queued", "running", "reasoning", "responding", "tool", "retrying", "completed", "partial", "failed", "cancelled",
 ]);
 // Tool names that initialize a sub-agent progress card. parallel_tasks/fleet
 // are group cards: they settle when their whole child progress tree is
@@ -123,7 +124,7 @@ const SUBAGENT_PREVIEW_NOTICE_LIMIT = 2 << 10;
 const RUNTIME_STATUS_ONLY = { hydrateSessionData: false } as const;
 export type SubagentPhase =
   | "queued" | "running" | "reasoning" | "responding" | "tool" | "retrying"
-  | "completed" | "failed" | "cancelled";
+  | "completed" | "partial" | "failed" | "cancelled";
 // In-memory-only sub-agent progress preview. Never persisted: history
 // hydration rebuilds tool items from the transcript without these fields, and
 // the full sub-agent transcript stays the source of truth after a restart.
@@ -141,7 +142,7 @@ export function isSubagentProgressName(name: string | undefined): boolean {
   return !!name && name.startsWith(SUBAGENT_PROGRESS_PREFIX);
 }
 export function isTerminalSubagentPhase(phase: string | undefined): boolean {
-  return phase === "completed" || phase === "failed" || phase === "cancelled";
+  return phase === "completed" || phase === "partial" || phase === "failed" || phase === "cancelled";
 }
 function isGroupSubagentTool(name: string): boolean {
   return name === "parallel_tasks" || name === "fleet";
@@ -149,6 +150,7 @@ function isGroupSubagentTool(name: string): boolean {
 function terminalStatusOf(phase: string): ToolStatus {
   switch (phase) {
     case "completed": return "done";
+    case "partial": return "error";
     case "failed": return "error";
     case "cancelled": return "stopped";
   }
@@ -285,7 +287,7 @@ export type Item =
       args: string;
       readOnly: boolean;
       resolvedName?: string;
-      capabilityId?: string;
+      capabilityId?: string; subagentRef?: string; subagentStatus?: string; subagentErrorCode?: string; subagentRetryable?: boolean;
       status: ToolStatus;
       output?: string; searchSources?: SearchSource[]; // display-only provider search results; replay data stays in output/serverSearch
       error?: string;
@@ -949,7 +951,7 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
           summary: summarizeFileDiff(fileDiff) || tc.summary,
           fileDiff,
           isShell: tc.name === "bash" || (tc.id || "").startsWith("shell-"),
-          execution: result?.execution,
+          execution: result?.execution, ...parseSubagentOutcomeText(output),
         });
         seq++;
       }
@@ -970,7 +972,7 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
         error,
         dataArchived: m.toolResultArchived || undefined,
         isShell: (m.toolName || "") === "bash" || (m.toolCallId || "").startsWith("shell-"),
-        execution: m.execution,
+        execution: m.execution, ...parseSubagentOutcomeText(output),
       });
       seq++;
       continue;
@@ -1663,7 +1665,7 @@ function applyEvent(s: State, e: WireEvent, preserveToolPayloads = false): State
           const args = t.args ? t.args : it.args;
           const fileDiff = fileDiffFromWire(t);
           const summary = summarizeFileDiff(fileDiff) || summarize(t.name, args) || (t.name === it.name && args === it.args ? it.summary : undefined);
-          next[idx] = { ...it, name: t.name, args, readOnly: t.readOnly, resolvedName: t.resolvedName ?? it.resolvedName, capabilityId: t.capabilityId ?? it.capabilityId, profile: t.profile ?? it.profile, summary, fileDiff, argChars: undefined, isShell: it.isShell || t.name === "bash" || id.startsWith("shell-"), execution: t.execution ?? it.execution, subagentProgress: it.subagentProgress ?? (SUBAGENT_PROGRESS_TOOLS.has(t.name) ? freshSubagentProgress() : undefined) };
+            next[idx] = { ...it, name: t.name, args, readOnly: t.readOnly, resolvedName: t.resolvedName ?? it.resolvedName, capabilityId: t.capabilityId ?? it.capabilityId, profile: t.profile ?? it.profile, subagentRef: t.subagentRef ?? it.subagentRef, subagentStatus: t.subagentStatus ?? it.subagentStatus, subagentErrorCode: t.subagentErrorCode ?? it.subagentErrorCode, subagentRetryable: t.subagentRetryable ?? it.subagentRetryable, summary, fileDiff, argChars: undefined, isShell: it.isShell || t.name === "bash" || id.startsWith("shell-"), execution: t.execution ?? it.execution, subagentProgress: it.subagentProgress ?? (SUBAGENT_PROGRESS_TOOLS.has(t.name) ? freshSubagentProgress() : undefined) };
         }
         if (t.parentId) touchSubagentParent(next, t.parentId);
         return { ...settled, items: next };
@@ -1731,7 +1733,7 @@ function applyEvent(s: State, e: WireEvent, preserveToolPayloads = false): State
             durationMs: t.durationMs,
             summary,
             isShell: existing.isShell || existing.name === "bash" || t.name === "bash",
-            execution: t.execution ?? existing.execution,
+            execution: t.execution ?? existing.execution, subagentRef: t.subagentRef ?? existing.subagentRef, subagentStatus: t.subagentStatus ?? existing.subagentStatus, subagentErrorCode: t.subagentErrorCode ?? existing.subagentErrorCode, subagentRetryable: t.subagentRetryable ?? existing.subagentRetryable,
           };
         }
       }

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -3318,6 +3318,7 @@ export const en = {
   "subagent.phase.tool": "using tools",
   "subagent.phase.retrying": "retrying",
   "subagent.phase.completed": "completed",
+  "subagent.phase.partial": "partially complete",
   "subagent.phase.failed": "failed",
   "subagent.phase.cancelled": "cancelled",
   "subagent.phase.elapsed": "{n}s",
@@ -3326,6 +3327,12 @@ export const en = {
   "subagent.preview.text": "Response preview",
   "subagent.preview.notice": "Notices",
   "subagent.preview.truncated": "preview truncated",
+  "subagent.outcome.label": "subagent",
+  "subagent.outcome.completed": "completed",
+  "subagent.outcome.partial": "partially complete",
+  "subagent.outcome.failed": "failed",
+  "subagent.outcome.cancelled": "cancelled",
+  "subagent.outcome.retryable": "retryable",
 
   // software update
   "config.loadWarning": "Configuration issue: {msg}",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2374,6 +2374,7 @@ export const zhTW: Record<DictKey, string> = {
   "subagent.phase.tool": "使用工具",
   "subagent.phase.retrying": "重試中",
   "subagent.phase.completed": "已完成",
+  "subagent.phase.partial": "部分完成",
   "subagent.phase.failed": "失敗",
   "subagent.phase.cancelled": "已取消",
   "subagent.phase.elapsed": "{n} 秒",
@@ -2382,6 +2383,12 @@ export const zhTW: Record<DictKey, string> = {
   "subagent.preview.text": "回答預覽",
   "subagent.preview.notice": "提示",
   "subagent.preview.truncated": "預覽已截斷",
+  "subagent.outcome.label": "子代理",
+  "subagent.outcome.completed": "已完成",
+  "subagent.outcome.partial": "部分完成",
+  "subagent.outcome.failed": "失敗",
+  "subagent.outcome.cancelled": "已取消",
+  "subagent.outcome.retryable": "可重試",
 
   // 軟體更新
   "config.loadWarning": "設定問題：{msg}",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -3321,6 +3321,7 @@ export const zh: Record<DictKey, string> = {
   "subagent.phase.tool": "使用工具",
   "subagent.phase.retrying": "重试中",
   "subagent.phase.completed": "已完成",
+  "subagent.phase.partial": "部分完成",
   "subagent.phase.failed": "失败",
   "subagent.phase.cancelled": "已取消",
   "subagent.phase.elapsed": "{n} 秒",
@@ -3329,6 +3330,12 @@ export const zh: Record<DictKey, string> = {
   "subagent.preview.text": "回答预览",
   "subagent.preview.notice": "提示",
   "subagent.preview.truncated": "预览已截断",
+  "subagent.outcome.label": "子代理",
+  "subagent.outcome.completed": "已完成",
+  "subagent.outcome.partial": "部分完成",
+  "subagent.outcome.failed": "失败",
+  "subagent.outcome.cancelled": "已取消",
+  "subagent.outcome.retryable": "可重试",
 
   // 软件更新
   "config.loadWarning": "配置问题：{msg}",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6616,6 +6616,20 @@ body > .mermaid-diagram--fullscreen {
   overflow-y: auto;
   color: inherit;
 }
+.tool__subagent-outcome {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 4px 0 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-soft);
+  font-family: var(--font-code-family);
+  font-size: var(--font-caption);
+}
+.tool__subagent-outcome-status { color: var(--fg-dim); }
+.tool__subagent-outcome code { overflow-wrap: anywhere; }
 .tool__nested-count {
   display: inline-flex;
   align-items: center;

--- a/desktop/metrics_app.go
+++ b/desktop/metrics_app.go
@@ -365,6 +365,20 @@ func (m *metricsAggregator) observeCompletionValidation(info event.CompletionVal
 	}
 }
 
+func (m *metricsAggregator) observeSubagentLifecycle(info event.SubagentLifecycleInfo) {
+	phase := knownBucket(info.Phase, "child_created", "child_running", "child_completed", "child_partial", "child_failed", "child_cancelled", "child_resume")
+	status := knownBucket(info.Status, "completed", "partial", "failed", "cancelled")
+	m.inc("subagent_lifecycle", phase+"_"+status)
+	if info.ErrorCode != "" {
+		m.inc("subagent_error", knownBucket(info.ErrorCode, "completion_uncertain", "final_readiness", "review_unavailable", "max_steps", "incomplete_read", "provider_connection", "subagent_error"))
+	}
+	if info.Retryable {
+		m.inc("subagent_retryable", "yes")
+	} else {
+		m.inc("subagent_retryable", "no")
+	}
+}
+
 func completionValidationLatencyBucket(ms int64) string {
 	switch {
 	case ms < 1_000:

--- a/desktop/metrics_app.go
+++ b/desktop/metrics_app.go
@@ -367,7 +367,7 @@ func (m *metricsAggregator) observeCompletionValidation(info event.CompletionVal
 
 func (m *metricsAggregator) observeSubagentLifecycle(info event.SubagentLifecycleInfo) {
 	phase := knownBucket(info.Phase, "child_created", "child_running", "child_completed", "child_partial", "child_failed", "child_cancelled", "child_resume")
-	status := knownBucket(info.Status, "completed", "partial", "failed", "cancelled")
+	status := knownBucket(info.Status, "queued", "running", "completed", "partial", "failed", "cancelled")
 	m.inc("subagent_lifecycle", phase+"_"+status)
 	if info.ErrorCode != "" {
 		m.inc("subagent_error", knownBucket(info.ErrorCode, "completion_uncertain", "final_readiness", "review_unavailable", "max_steps", "incomplete_read", "provider_connection", "subagent_error"))

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1394,6 +1394,8 @@ func displayEventFromEnvelope(envelope turnevent.Envelope) (event.Event, bool) {
 			StartedAt: w.Tool.StartedAt, EndedAt: w.Tool.EndedAt, Partial: w.Tool.Partial,
 			ArgChars: w.Tool.ArgChars, Refreshed: w.Tool.Refreshed, ParentID: w.Tool.ParentID,
 			AttemptID: w.Tool.AttemptID, FileDiff: event.FileDiff{Diff: w.Tool.Diff, Added: w.Tool.Added, Removed: w.Tool.Removed},
+			SubagentRef: w.Tool.SubagentRef, SubagentStatus: w.Tool.SubagentStatus,
+			SubagentErrorCode: w.Tool.SubagentErrorCode, SubagentRetryable: w.Tool.SubagentRetryable,
 		}
 	}
 	if len(w.MemoryCitations) > 0 {

--- a/desktop/turn_runtime_api.go
+++ b/desktop/turn_runtime_api.go
@@ -12,10 +12,11 @@ import (
 // TurnStartView is the synchronous admission receipt for the new Wails turn
 // API. Events remain the streaming authority after admission.
 type TurnStartView struct {
-	TurnID       string           `json:"turnId"`
-	Status       event.TurnStatus `json:"status"`
-	RuntimeEpoch string           `json:"runtimeEpoch,omitempty"`
-	SubmissionID string           `json:"submissionId,omitempty"`
+	TurnID       string                    `json:"turnId"`
+	Status       event.TurnStatus          `json:"status"`
+	Disposition  control.SubmitDisposition `json:"disposition"`
+	RuntimeEpoch string                    `json:"runtimeEpoch,omitempty"`
+	SubmissionID string                    `json:"submissionId,omitempty"`
 }
 
 // StartTurnForTab is the turn-id-aware replacement for SubmitToTab. Existing
@@ -24,8 +25,12 @@ func (a *App) StartTurnForTab(tabID, input, submissionID string) (TurnStartView,
 	if strings.TrimSpace(submissionID) == "" {
 		return TurnStartView{}, fmt.Errorf("submissionId is required")
 	}
-	if err := a.SubmitToTabWithID(tabID, input, submissionID); err != nil {
+	result, err := a.submitToTabResult(tabID, input, false, true, submissionID)
+	if err != nil {
 		return TurnStartView{}, err
+	}
+	if result.Disposition == control.SubmitManagementHandled {
+		return TurnStartView{Disposition: result.Disposition, SubmissionID: submissionID}, nil
 	}
 	tab, ctrl := a.tabAndCtrlByID(tabID)
 	if ctrl == nil {
@@ -45,7 +50,7 @@ func (a *App) StartTurnForTab(tabID, input, submissionID string) (TurnStartView,
 	// This is an admission receipt, not a potentially raced runtime snapshot.
 	// Ordered events carry every later transition, including a provider that
 	// completed before the Wails Promise was delivered.
-	return TurnStartView{TurnID: turnID, Status: event.TurnQueued, RuntimeEpoch: epoch, SubmissionID: submissionID}, nil
+	return TurnStartView{TurnID: turnID, Status: event.TurnQueued, Disposition: control.SubmitTurnStarted, RuntimeEpoch: epoch, SubmissionID: submissionID}, nil
 }
 
 // InterruptTurnForTab cancels only the exact active turn. A stale Stop button

--- a/desktop/turn_runtime_api_test.go
+++ b/desktop/turn_runtime_api_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -124,5 +125,48 @@ func TestStartTurnForTabReturnsManagementDispositionWithoutTurnID(t *testing.T) 
 	}
 	if len(replay.Events) != 0 {
 		t.Fatalf("management command created durable turn events: %+v", replay.Events)
+	}
+}
+
+func TestStartTurnForTabRejectsManagementDuringActiveTurn(t *testing.T) {
+	dir := t.TempDir()
+	runner := &exactTurnRunner{started: make(chan struct{})}
+	sink := &tabEventSink{tabID: "tab", ctx: context.Background()}
+	terminal := make(chan event.Event, 1)
+	sink.SetBotSink(event.FuncSink(func(e event.Event) {
+		if e.Kind == event.TurnDone {
+			terminal <- e
+		}
+	}))
+	ctrl := control.New(control.Options{
+		Runner: runner, Sink: sink, SessionDir: dir,
+		SessionPath: filepath.Join(dir, "session.jsonl"),
+	})
+	t.Cleanup(ctrl.Close)
+	tab := &WorkspaceTab{ID: "tab", Scope: "global", Ready: true, Ctrl: ctrl, sink: sink}
+	app := &App{tabs: map[string]*WorkspaceTab{tab.ID: tab}, activeTabID: tab.ID}
+	sink.app = app
+
+	start, err := app.StartTurnForTab(tab.ID, "hold this turn", "submission-active")
+	if err != nil {
+		t.Fatalf("StartTurnForTab active turn: %v", err)
+	}
+	select {
+	case <-runner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("turn runner did not start")
+	}
+	if _, err := app.StartTurnForTab(tab.ID, "/context", "submission-management"); !errors.Is(err, control.ErrTurnRunning) {
+		t.Fatalf("management command during active turn = %v, want ErrTurnRunning", err)
+	}
+	status := ctrl.RuntimeStatus()
+	if !status.Running || status.TurnID != start.TurnID {
+		t.Fatalf("active turn changed after rejected management command: %+v", status)
+	}
+	ctrl.Cancel()
+	select {
+	case <-terminal:
+	case <-time.After(5 * time.Second):
+		t.Fatal("turn did not finish after cancellation")
 	}
 }

--- a/desktop/turn_runtime_api_test.go
+++ b/desktop/turn_runtime_api_test.go
@@ -101,3 +101,28 @@ func TestTurnRuntimeAPIRoutesStopAnswerAndReplayByExactTurn(t *testing.T) {
 		t.Fatalf("empty replay events = %#v, want []", empty.Events)
 	}
 }
+
+func TestStartTurnForTabReturnsManagementDispositionWithoutTurnID(t *testing.T) {
+	dir := t.TempDir()
+	sink := &tabEventSink{tabID: "tab", ctx: context.Background()}
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: filepath.Join(dir, "session.jsonl"), Sink: sink})
+	t.Cleanup(ctrl.Close)
+	tab := &WorkspaceTab{ID: "tab", Scope: "global", Ready: true, Ctrl: ctrl, sink: sink}
+	app := &App{tabs: map[string]*WorkspaceTab{tab.ID: tab}, activeTabID: tab.ID}
+	sink.app = app
+
+	start, err := app.StartTurnForTab(tab.ID, "/context", "submission-management")
+	if err != nil {
+		t.Fatalf("StartTurnForTab management command: %v", err)
+	}
+	if start.Disposition != control.SubmitManagementHandled || start.TurnID != "" {
+		t.Fatalf("management receipt = %+v, want management_handled without turn id", start)
+	}
+	replay, err := app.TurnEventsForTab(tab.ID, 0)
+	if err != nil {
+		t.Fatalf("TurnEventsForTab: %v", err)
+	}
+	if len(replay.Events) != 0 {
+		t.Fatalf("management command created durable turn events: %+v", replay.Events)
+	}
+}

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1385,6 +1385,11 @@ are scoped to the current conversation lineage and workspace. Headless runs
 without a persisted parent session remain ephemeral and receive fair bounded
 previews, but cannot mint durable references.
 
+Persisted child results include `status` (`completed`, `partial`, `failed`, or
+`cancelled`) and `retryable`. Partial or retryable failed runs retain a visible
+answer and reference so the parent can inspect them with `read_subagent_result`
+or continue the same `task`/`run_skill` transcript with `continue_from`.
+
 The interactive two-model Planner uses a dedicated construction path
 (`NewPlannerAgent`): it still blocks bash, file writers, and ordinary writers,
 but may call authorized, non-destructive MCP through the fixed

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -1067,6 +1067,11 @@ destructive MCP 目标、来自未授权 server 的 reader，以及一切会改�
 会话 lineage 与工作区约束。没有持久化父会话的 headless 运行仍保持 ephemeral，只返回公平
 分配的有界预览，不能生成持久引用。
 
+已持久化的子 Agent 结果还会带有 `status`（`completed`、`partial`、`failed` 或
+`cancelled`）和 `retryable`。部分完成或可重试的失败会保留最后一条可见回答与引用，父 Agent
+可以用 `read_subagent_result` 查看，或通过 `task` / `run_skill` 的 `continue_from` 继续同一条
+transcript。
+
 交互式双模型 Planner 使用专用构造路径（`NewPlannerAgent`）：仍阻止 bash、文件写入与普通
 writer，但可通过固定的 `use_capability` 代理调用已授权、非 destructive 的 MCP，不再要求
 `readOnlyHint`。直接 `mcp__*` schema 永不进入 Planner 工具列表，因此 MCP 安装/连接变动

--- a/docs/TOOL_CONTRACT.md
+++ b/docs/TOOL_CONTRACT.md
@@ -131,6 +131,12 @@ final answer by UTF-8 byte offset, so long parallel research remains lossless
 without injecting every report into the parent context at once. References are
 restricted to the current conversation lineage and workspace.
 
+Persisted child results also carry an explicit `status` (`completed`, `partial`,
+`failed`, or `cancelled`) and `retryable` flag. A partial or failed child may
+include its last visible answer and reference; use `read_subagent_result` for
+inspection and the original `task`/`run_skill` `continue_from` parameter for a
+retryable continuation. `session:tool_result` is only for ordinary tool output.
+
 `use_capability` (`action` = `list` | `inspect` | `call` | `decline`) is on the
 provider-visible surface for every task. Host verification obligations come
 from real tool actions, not from preclassifying the prompt. Optional tools stay registered for host dispatch but are not

--- a/docs/TOOL_CONTRACT.zh-CN.md
+++ b/docs/TOOL_CONTRACT.zh-CN.md
@@ -99,6 +99,11 @@ call ID 时必须用它消除歧义。`offset` 默认 0，`limit` 默认 16KiB�
 按 UTF-8 字节偏移分页读取某个引用对应的完整最终答案，因此长篇并行调研无需一次性全部
 注入父会话也不会丢失。引用只允许在当前会话 lineage 和工作区内读取。
 
+已持久化的子 Agent 结果还会携带明确的 `status`（`completed`、`partial`、`failed` 或
+`cancelled`）和 `retryable` 标志。部分完成或失败的子 Agent 可能仍带有最后一条可见回答和
+引用：用 `read_subagent_result` 查看，用原有 `task` / `run_skill` 的 `continue_from` 参数
+继续可重试的任务。`session:tool_result` 只用于普通工具输出，不用于读取子 Agent transcript。
+
 `use_capability`（`action` = `list` | `inspect` | `call` | `decline`）在 provider
 可见工具面上始终存在（没有按任务复杂度切换的工具档位）。可选工具仍在 host
 registry 中供调度，但不会展开到 top-level provider schema；模型通过 `use_capability`

--- a/internal/agent/completion_validation.go
+++ b/internal/agent/completion_validation.go
@@ -97,6 +97,12 @@ func (a *Agent) validatorApplies(ctx context.Context) bool {
 	if a.completionValidation == CompletionValidationOff {
 		return false
 	}
+	// Child runs already enforce local final/readiness/report boundaries. Do not
+	// add a second model call to every child; ambiguous outcomes become resumable
+	// partial results at the parent boundary.
+	if a.subagentDepth > 0 {
+		return false
+	}
 	if _, goalScoped := tool.GoalTurnRecorderFromContext(ctx); goalScoped {
 		return false
 	}

--- a/internal/agent/completion_validation_test.go
+++ b/internal/agent/completion_validation_test.go
@@ -300,6 +300,22 @@ func TestCompletionValidatorSkipsDeterministicBoundaries(t *testing.T) {
 	})
 }
 
+func TestCompletionValidatorSkipsNormalSubagentPath(t *testing.T) {
+	eval := &scriptedEvaluator{verdicts: []completioneval.Verdict{{Outcome: completioneval.OutcomeContinue}}}
+	prov := &scriptedProvider{name: "subagent", turns: [][]provider.Chunk{textTurn("findings")}}
+	a := New(prov, tool.NewRegistry(), NewSession("sys"), Options{
+		SubagentDepth:        1,
+		CompletionValidation: CompletionValidationEnforce,
+	}, event.Discard)
+	a.completionEvaluator = eval
+	if err := a.Run(context.Background(), "inspect the repository"); err != nil {
+		t.Fatalf("subagent Run: %v", err)
+	}
+	if eval.calls != 0 {
+		t.Fatalf("evaluator calls = %d, want 0 on the normal subagent path", eval.calls)
+	}
+}
+
 func TestCompletionValidatorEvidenceShape(t *testing.T) {
 	eval := &scriptedEvaluator{verdicts: []completioneval.Verdict{{Outcome: completioneval.OutcomeComplete}}}
 	_, err := runWithValidator(t, CompletionValidationEnforce, eval, [][]provider.Chunk{textTurn("the answer")}, event.Discard)

--- a/internal/agent/execute_batch.go
+++ b/internal/agent/execute_batch.go
@@ -73,6 +73,7 @@ type toolOutcome struct {
 	recoveryStopTurn   bool
 	recoveryStopReason string
 	incompleteRead     *incompleteReadDeferred
+	subagentOutcome    *SubagentOutcome
 }
 
 // batchExecution is the result of one provider tool-call batch.

--- a/internal/agent/execute_batch_audit.go
+++ b/internal/agent/execute_batch_audit.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"strings"
 	"time"
 
 	"reasonix/internal/event"
@@ -34,17 +35,13 @@ func (a *Agent) emitBatchToolResults(calls []provider.ToolCall, outcomes []toolO
 			tr.SubagentStatus = string(o.subagentOutcome.Status)
 			tr.SubagentErrorCode = o.subagentOutcome.ErrorCode
 			tr.SubagentRetryable = o.subagentOutcome.Retryable
-		} else if outcome, ok := ParseSubagentOutcome(o.output); ok {
-			tr.SubagentRef = outcome.Ref
-			tr.SubagentStatus = string(outcome.Status)
-			tr.SubagentErrorCode = outcome.ErrorCode
-			tr.SubagentRetryable = outcome.Retryable
-		}
-		if tr.SubagentRef != "" && tr.SubagentStatus != "" {
-			event.RecordSubagentLifecycle(a.svc.sink, event.SubagentLifecycleInfo{
-				Phase: "child_" + tr.SubagentStatus, Ref: tr.SubagentRef, ParentToolCallID: c.ID,
-				Status: tr.SubagentStatus, ErrorCode: tr.SubagentErrorCode, Retryable: tr.SubagentRetryable, OutputBytes: len(o.output),
-			})
+		} else if isSubagentToolCall(c) {
+			if outcome, ok := ParseSubagentOutcome(o.output); ok {
+				tr.SubagentRef = outcome.Ref
+				tr.SubagentStatus = string(outcome.Status)
+				tr.SubagentErrorCode = outcome.ErrorCode
+				tr.SubagentRetryable = outcome.Retryable
+			}
 		}
 		if startedAt[i] > 0 {
 			tr.StartedAt = startedAt[i]
@@ -61,6 +58,19 @@ func (a *Agent) emitBatchToolResults(calls []provider.ToolCall, outcomes []toolO
 		}
 		a.recordToolExecutionAudit(readOnly, ranParallel[i], startedAt[i], durations[i], batchStart, o)
 	}
+}
+
+func isSubagentToolName(name string) bool {
+	switch name {
+	case "task", "read_only_task", "run_skill", "read_only_skill", "explore", "research", "review", "security_review", "security-review", "parallel_tasks", "fleet":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSubagentToolCall(call provider.ToolCall) bool {
+	return isSubagentToolName(call.Name) || strings.HasPrefix(strings.TrimSpace(call.CapabilityID), "skill:")
 }
 
 func (a *Agent) recordToolExecutionAudit(readOnly, parallel bool, startedAt, durationMs int64, batchStart time.Time, o toolOutcome) {

--- a/internal/agent/execute_batch_audit.go
+++ b/internal/agent/execute_batch_audit.go
@@ -29,6 +29,23 @@ func (a *Agent) emitBatchToolResults(calls []provider.ToolCall, outcomes []toolO
 			DurationMs:   durations[i],
 			Execution:    toEventShellExecution(o.execution, durations[i]),
 		}
+		if o.subagentOutcome != nil {
+			tr.SubagentRef = o.subagentOutcome.Ref
+			tr.SubagentStatus = string(o.subagentOutcome.Status)
+			tr.SubagentErrorCode = o.subagentOutcome.ErrorCode
+			tr.SubagentRetryable = o.subagentOutcome.Retryable
+		} else if outcome, ok := ParseSubagentOutcome(o.output); ok {
+			tr.SubagentRef = outcome.Ref
+			tr.SubagentStatus = string(outcome.Status)
+			tr.SubagentErrorCode = outcome.ErrorCode
+			tr.SubagentRetryable = outcome.Retryable
+		}
+		if tr.SubagentRef != "" && tr.SubagentStatus != "" {
+			event.RecordSubagentLifecycle(a.svc.sink, event.SubagentLifecycleInfo{
+				Phase: "child_" + tr.SubagentStatus, Ref: tr.SubagentRef, ParentToolCallID: c.ID,
+				Status: tr.SubagentStatus, ErrorCode: tr.SubagentErrorCode, Retryable: tr.SubagentRetryable, OutputBytes: len(o.output),
+			})
+		}
 		if startedAt[i] > 0 {
 			tr.StartedAt = startedAt[i]
 			tr.EndedAt = startedAt[i] + durations[i]

--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -708,7 +708,7 @@ func (a *Agent) finishToolExecution(ctx context.Context, plan *toolCallPlan) too
 		body, truncMsg, original := a.boundProviderVisibleResult(rawErr, call.Name, call.ID)
 		out := toolOutcome{
 			output: body, errMsg: firstLine(err.Error()), truncated: truncMsg != "" || original != "", truncMsg: truncMsg,
-			execution: execution, mcpApp: toProviderMCPApp(plan.mcpApp), recoveryGeneration: recoveryGen,
+			execution: execution, mcpApp: toProviderMCPApp(plan.mcpApp), recoveryGeneration: recoveryGen, subagentOutcome: subagentOutcomeFromError(err),
 		}
 		if original != "" {
 			out.rawOutput = original

--- a/internal/agent/subagent_format.go
+++ b/internal/agent/subagent_format.go
@@ -1,0 +1,28 @@
+package agent
+
+import "strings"
+
+func FormatSubagentRunResult(answer string, run *SubagentRun, failed bool) string {
+	answer = GuardSubagentHostDecisionText(answer)
+	if run == nil || run.Ref == "" {
+		return answer
+	}
+	if failed {
+		out := FormatSubagentOutcome(SubagentOutcome{Ref: run.Ref, Status: SubagentOutcomeFailed, FinalAnswer: answer})
+		return strings.Replace(out, "Subagent reference: "+run.Ref, "Subagent reference (failed): "+run.Ref, 1)
+	}
+	guidance := FormatSubagentReference(run)
+	if _, rest, ok := strings.Cut(guidance, "\n"); ok {
+		guidance = rest
+	} else {
+		guidance = ""
+	}
+	out := FormatSubagentOutcome(SubagentOutcome{Ref: run.Ref, Status: SubagentOutcomeCompleted})
+	if guidance != "" {
+		out += "\n\n" + guidance
+	}
+	if answer != "" {
+		out += "\n\nFinal answer:\n" + answer
+	}
+	return out
+}

--- a/internal/agent/subagent_outcome.go
+++ b/internal/agent/subagent_outcome.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
+	"reasonix/internal/completioneval"
+	"reasonix/internal/event"
 	"reasonix/internal/provider"
 	"reasonix/internal/skill"
 )
@@ -90,8 +93,58 @@ func (t *TaskTool) failedSubagentResult(run *SubagentRun, cause error) (string, 
 	return subErr.SubagentOutput(), errors.Join(subErr, saveErr)
 }
 
+// resolveAmbiguousSubagentFailure applies the child-only completion policy.
+// Known partial causes are deterministic and never call a model. Only the
+// ambiguous completion boundary may use the existing bounded evaluator, at
+// most once, with no tools or history; all non-complete verdicts remain partial.
+func (t *TaskTool) resolveAmbiguousSubagentFailure(ctx context.Context, run *SubagentRun, taskText, modelRef string, sink event.Sink, cause error) (string, error) {
+	subErr := NewSubagentRunError(run, cause)
+	if subErr.Outcome.ErrorCode == "completion_uncertain" && strings.TrimSpace(subErr.Outcome.FinalAnswer) != "" && t != nil && t.completion.factory != nil && (ctx == nil || ctx.Err() == nil) {
+		evaluator := t.completion.factory(modelRef, sink)
+		if evaluator != nil {
+			verdict, evalErr := evaluator.Evaluate(ctx, completioneval.Evidence{
+				TaskText: taskText, CandidateAnswer: subErr.Outcome.FinalAnswer,
+				Mode: completioneval.ModeSubagent, HostSummary: "child completion status is ambiguous",
+			})
+			if evalErr == nil && verdict.Outcome == completioneval.OutcomeComplete {
+				subErr.Outcome.Status = SubagentOutcomeCompleted
+				subErr.Outcome.ErrorCode = ""
+				subErr.Outcome.Retryable = false
+				if t.transcripts != nil {
+					if saveErr := t.transcripts.SaveOutcome(run, subErr.Outcome); saveErr != nil {
+						return subErr.SubagentOutput(), errors.Join(subErr, saveErr)
+					}
+				}
+				return FormatSubagentRunResult(subErr.Outcome.FinalAnswer, run, false), nil
+			}
+		}
+	}
+	var saveErr error
+	if t != nil && t.transcripts != nil {
+		saveErr = t.transcripts.SaveOutcome(run, subErr.Outcome)
+	}
+	return subErr.SubagentOutput(), errors.Join(subErr, saveErr)
+}
+
+// ResolveAmbiguousSubagentFailure applies the same bounded child completion
+// policy to boot-wired skill runners.
+func (t *TaskTool) ResolveAmbiguousSubagentFailure(ctx context.Context, run *SubagentRun, taskText, modelRef string, sink event.Sink, cause error) (string, error) {
+	return t.resolveAmbiguousSubagentFailure(ctx, run, taskText, modelRef, sink, cause)
+}
+
+// failBeforeSubagentRelease preserves the run envelope on setup failures that
+// occur after a reference was allocated but before the normal RunProfileSpec
+// cleanup/defer is installed.
+func (t *TaskTool) failBeforeSubagentRelease(run *SubagentRun, cause error) (string, error) {
+	result, err := t.failedSubagentResult(run, cause)
+	if run != nil {
+		run.Release()
+	}
+	return result, err
+}
+
 func subagentErrorDisposition(err error) (string, SubagentOutcomeStatus, bool) {
-	if errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return "cancelled", SubagentOutcomeCancelled, false
 	}
 	var completion *CompletionUncertainError
@@ -175,5 +228,62 @@ func ParseSubagentOutcome(text string) (SubagentOutcome, bool) {
 			}
 		}
 	}
-	return outcome, outcome.Ref != "" && outcome.Status != ""
+	return outcome, validSubagentRef(outcome.Ref) && validSubagentOutcomeStatus(outcome.Status)
+}
+
+func validSubagentOutcomeStatus(status SubagentOutcomeStatus) bool {
+	switch status {
+	case SubagentOutcomeCompleted, SubagentOutcomePartial, SubagentOutcomeFailed, SubagentOutcomeCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func emitSubagentLifecycle(sink event.Sink, phase, parentToolCallID, skillName, model, effort string, run *SubagentRun, outcome *SubagentOutcome) {
+	if run == nil || run.Ref == "" || sink == nil {
+		return
+	}
+	info := event.SubagentLifecycleInfo{
+		Phase: phase, Ref: run.Ref, ParentToolCallID: parentToolCallID,
+		Skill: skillName, Model: model, Effort: effort,
+	}
+	if !run.Meta.CreatedAt.IsZero() {
+		info.StartUnixMs = run.Meta.CreatedAt.UnixMilli()
+	}
+	if outcome != nil {
+		info.Status = string(outcome.Status)
+		info.ErrorCode = outcome.ErrorCode
+		info.Retryable = outcome.Retryable
+		info.OutputBytes = len(outcome.FinalAnswer)
+		info.EndUnixMs = time.Now().UnixMilli()
+	} else if phase == "child_running" {
+		info.Status = "running"
+	} else {
+		info.Status = "queued"
+	}
+	event.RecordSubagentLifecycle(sink, info)
+}
+
+// EmitSubagentLifecycle publishes a content-free lifecycle transition for a
+// child runner implemented outside the agent package, such as boot-wired
+// skills.
+func EmitSubagentLifecycle(sink event.Sink, phase, parentToolCallID, skillName, model, effort string, run *SubagentRun, outcome *SubagentOutcome) {
+	emitSubagentLifecycle(sink, phase, parentToolCallID, skillName, model, effort, run, outcome)
+}
+
+func terminalSubagentLifecycle(runErr error) (string, *SubagentOutcome) {
+	if runErr == nil {
+		return "child_completed", &SubagentOutcome{Status: SubagentOutcomeCompleted}
+	}
+	if outcome := subagentOutcomeFromError(runErr); outcome != nil {
+		return "child_" + string(outcome.Status), outcome
+	}
+	subErr := NewSubagentRunError(nil, runErr)
+	return "child_" + string(subErr.Outcome.Status), &subErr.Outcome
+}
+
+// TerminalSubagentLifecycle classifies a runner error for lifecycle sinks.
+func TerminalSubagentLifecycle(runErr error) (string, *SubagentOutcome) {
+	return terminalSubagentLifecycle(runErr)
 }

--- a/internal/agent/subagent_outcome.go
+++ b/internal/agent/subagent_outcome.go
@@ -1,0 +1,179 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"reasonix/internal/provider"
+	"reasonix/internal/skill"
+)
+
+type SubagentOutcomeStatus string
+
+const (
+	SubagentOutcomeCompleted SubagentOutcomeStatus = "completed"
+	SubagentOutcomePartial   SubagentOutcomeStatus = "partial"
+	SubagentOutcomeFailed    SubagentOutcomeStatus = "failed"
+	SubagentOutcomeCancelled SubagentOutcomeStatus = "cancelled"
+)
+
+// SubagentOutcome is the bounded handoff from a child run to its parent.
+type SubagentOutcome struct {
+	Ref         string                `json:"ref"`
+	Status      SubagentOutcomeStatus `json:"status"`
+	FinalAnswer string                `json:"final_answer,omitempty"`
+	ErrorCode   string                `json:"error_code,omitempty"`
+	Retryable   bool                  `json:"retryable"`
+}
+
+// SubagentRunError carries a recoverable result envelope while preserving the
+// original error for host status classification and logging.
+type SubagentRunError struct {
+	Outcome SubagentOutcome
+	Cause   error
+}
+
+func (e *SubagentRunError) Error() string {
+	if e == nil || e.Cause == nil {
+		return "subagent run failed"
+	}
+	return e.Cause.Error()
+}
+
+func (e *SubagentRunError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+func (e *SubagentRunError) SubagentOutput() string {
+	if e == nil {
+		return ""
+	}
+	return FormatSubagentOutcome(e.Outcome)
+}
+
+var _ skill.SubagentOutputError = (*SubagentRunError)(nil)
+
+func NewSubagentRunError(run *SubagentRun, cause error) *SubagentRunError {
+	outcome := SubagentOutcome{Status: SubagentOutcomeFailed}
+	if run != nil {
+		outcome.Ref = run.Ref
+		outcome.FinalAnswer = latestAssistantAnswer(run.Session)
+	}
+	if cause == nil {
+		cause = errors.New("subagent run failed")
+	}
+	outcome.ErrorCode, outcome.Status, outcome.Retryable = subagentErrorDisposition(cause)
+	return &SubagentRunError{Outcome: outcome, Cause: cause}
+}
+
+func subagentOutcomeFromError(err error) *SubagentOutcome {
+	var subErr *SubagentRunError
+	if !errors.As(err, &subErr) {
+		return nil
+	}
+	outcome := subErr.Outcome
+	return &outcome
+}
+
+func (t *TaskTool) failedSubagentResult(run *SubagentRun, cause error) (string, error) {
+	subErr := NewSubagentRunError(run, cause)
+	var saveErr error
+	if t != nil && t.transcripts != nil {
+		saveErr = t.transcripts.SaveOutcome(run, subErr.Outcome)
+	}
+	return subErr.SubagentOutput(), errors.Join(subErr, saveErr)
+}
+
+func subagentErrorDisposition(err error) (string, SubagentOutcomeStatus, bool) {
+	if errors.Is(err, context.Canceled) {
+		return "cancelled", SubagentOutcomeCancelled, false
+	}
+	var completion *CompletionUncertainError
+	if errors.As(err, &completion) {
+		return "completion_uncertain", SubagentOutcomePartial, true
+	}
+	var readiness *FinalReadinessError
+	if errors.As(err, &readiness) {
+		return "final_readiness", SubagentOutcomePartial, true
+	}
+	var review *ReviewUnavailableError
+	if errors.As(err, &review) {
+		return "review_unavailable", SubagentOutcomePartial, true
+	}
+	var steps *maxStepsPause
+	if errors.As(err, &steps) {
+		return "max_steps", SubagentOutcomePartial, true
+	}
+	var incomplete *IncompleteReadError
+	if errors.As(err, &incomplete) {
+		return "incomplete_read", SubagentOutcomePartial, true
+	}
+	var apiErr *provider.APIError
+	if errors.As(err, &apiErr) {
+		return fmt.Sprintf("provider_http_%d", apiErr.Status), SubagentOutcomeFailed, provider.RetryableStatus(apiErr.Status)
+	}
+	if provider.IsConnReset(err) {
+		return "provider_connection", SubagentOutcomeFailed, true
+	}
+	return "subagent_error", SubagentOutcomeFailed, false
+}
+
+// FormatSubagentOutcome keeps the existing textual reference markers while
+// making status and recovery explicit to the parent model and UI sinks.
+func FormatSubagentOutcome(outcome SubagentOutcome) string {
+	var b strings.Builder
+	status := outcome.Status
+	if status == "" {
+		status = SubagentOutcomeFailed
+	}
+	if outcome.Ref != "" {
+		fmt.Fprintf(&b, "Subagent reference: %s\n", outcome.Ref)
+	}
+	fmt.Fprintf(&b, "Subagent outcome: status=%s retryable=%t", status, outcome.Retryable)
+	if outcome.ErrorCode != "" {
+		fmt.Fprintf(&b, " error_code=%s", outcome.ErrorCode)
+	}
+	b.WriteByte('\n')
+	if answer := strings.TrimSpace(outcome.FinalAnswer); answer != "" {
+		b.WriteString("\n\nFinal answer:\n")
+		b.WriteString(answer)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func ParseSubagentOutcome(text string) (SubagentOutcome, bool) {
+	var outcome SubagentOutcome
+	for line := range strings.SplitSeq(text, "\n") {
+		line = strings.TrimSpace(line)
+		if ref, ok := strings.CutPrefix(line, "Subagent reference: "); ok {
+			outcome.Ref = strings.TrimSpace(ref)
+			continue
+		}
+		if ref, ok := strings.CutPrefix(line, "Subagent reference (failed): "); ok {
+			outcome.Ref = strings.TrimSpace(ref)
+			continue
+		}
+		if status, ok := strings.CutPrefix(line, "Subagent outcome: status="); ok {
+			fields := strings.Fields(status)
+			if len(fields) == 0 {
+				continue
+			}
+			outcome.Status = SubagentOutcomeStatus(fields[0])
+			for _, field := range fields[1:] {
+				if value, ok := strings.CutPrefix(field, "retryable="); ok {
+					outcome.Retryable, _ = strconv.ParseBool(value)
+				}
+				if value, ok := strings.CutPrefix(field, "error_code="); ok {
+					outcome.ErrorCode = value
+				}
+			}
+		}
+	}
+	return outcome, outcome.Ref != "" && outcome.Status != ""
+}

--- a/internal/agent/subagent_outcome_test.go
+++ b/internal/agent/subagent_outcome_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"reasonix/internal/completioneval"
+	"reasonix/internal/event"
 	"reasonix/internal/provider"
 )
 
@@ -32,6 +34,9 @@ func TestSubagentRunErrorClassifiesCancellationAndProviderRetry(t *testing.T) {
 	if code, status, retry := subagentErrorDisposition(context.Canceled); code != "cancelled" || status != SubagentOutcomeCancelled || retry {
 		t.Fatalf("cancellation disposition = %s/%s/%v", code, status, retry)
 	}
+	if code, status, retry := subagentErrorDisposition(context.DeadlineExceeded); code != "cancelled" || status != SubagentOutcomeCancelled || retry {
+		t.Fatalf("deadline disposition = %s/%s/%v", code, status, retry)
+	}
 	if code, status, retry := subagentErrorDisposition(&provider.APIError{Status: 503}); code != "provider_http_503" || status != SubagentOutcomeFailed || !retry {
 		t.Fatalf("retryable provider disposition = %s/%s/%v", code, status, retry)
 	}
@@ -44,5 +49,35 @@ func TestParseSubagentOutcomeFromFormattedResult(t *testing.T) {
 	outcome, ok := ParseSubagentOutcome("Subagent reference: sa_child\nSubagent outcome: status=partial retryable=true error_code=completion_uncertain\n\nFinal answer:\nfindings")
 	if !ok || outcome.Ref != "sa_child" || outcome.Status != SubagentOutcomePartial || !outcome.Retryable || outcome.ErrorCode != "completion_uncertain" {
 		t.Fatalf("parsed outcome = %+v, ok=%v", outcome, ok)
+	}
+}
+
+func TestParseSubagentOutcomeRejectsSpoofedStatus(t *testing.T) {
+	if _, ok := ParseSubagentOutcome("Subagent reference: not-a-subagent\nSubagent outcome: status=completed retryable=false"); ok {
+		t.Fatal("parser accepted a non-sa reference")
+	}
+	if _, ok := ParseSubagentOutcome("Subagent reference: sa_child\nSubagent outcome: status=unknown retryable=false"); ok {
+		t.Fatal("parser accepted an unknown outcome status")
+	}
+	if isSubagentToolCall(provider.ToolCall{Name: "bash", Arguments: "Subagent reference: sa_child"}) {
+		t.Fatal("ordinary bash call was classified as a subagent")
+	}
+	if !isSubagentToolCall(provider.ToolCall{Name: "use_capability", CapabilityID: "skill:research"}) {
+		t.Fatal("skill capability call was not classified as a subagent")
+	}
+}
+
+func TestAmbiguousSubagentFailureUsesAtMostOneEvaluator(t *testing.T) {
+	eval := &scriptedEvaluator{verdicts: []completioneval.Verdict{{Outcome: completioneval.OutcomeContinue, Reason: "more work"}}}
+	task := &TaskTool{completion: taskCompletionConfig{factory: func(string, event.Sink) completioneval.Evaluator { return eval }}}
+	run := &SubagentRun{Ref: "sa_ambiguous", Session: NewSession("sys")}
+	run.Session.Add(provider.Message{Role: provider.RoleAssistant, Content: "candidate"})
+	_, err := task.resolveAmbiguousSubagentFailure(context.Background(), run, "inspect", "model", event.Discard, &CompletionUncertainError{Cause: CompletionUncertainValidatorUncertain})
+	if err == nil || eval.calls != 1 {
+		t.Fatalf("ambiguous evaluation calls=%d err=%v, want one evaluator and retained error", eval.calls, err)
+	}
+	var subErr *SubagentRunError
+	if !errors.As(err, &subErr) || subErr.Outcome.Status != SubagentOutcomePartial {
+		t.Fatalf("ambiguous outcome = %v, want partial typed error", err)
 	}
 }

--- a/internal/agent/subagent_outcome_test.go
+++ b/internal/agent/subagent_outcome_test.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestSubagentRunErrorPreservesPartialAnswerAndReference(t *testing.T) {
+	run := &SubagentRun{Ref: "sa_partial", Session: NewSession("sys")}
+	run.Session.Add(provider.Message{Role: provider.RoleAssistant, Content: "partial findings"})
+	base := &CompletionUncertainError{Cause: CompletionUncertainValidatorFailed}
+	err := NewSubagentRunError(run, base)
+	if !errors.Is(err, base) {
+		t.Fatal("subagent error did not preserve its cause")
+	}
+	if err.Outcome.Status != SubagentOutcomePartial || !err.Outcome.Retryable {
+		t.Fatalf("outcome = %+v, want retryable partial", err.Outcome)
+	}
+	out := err.SubagentOutput()
+	for _, want := range []string{"status=partial", "retryable=true", "error_code=completion_uncertain", "sa_partial", "partial findings"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output %q missing %q", out, want)
+		}
+	}
+}
+
+func TestSubagentRunErrorClassifiesCancellationAndProviderRetry(t *testing.T) {
+	if code, status, retry := subagentErrorDisposition(context.Canceled); code != "cancelled" || status != SubagentOutcomeCancelled || retry {
+		t.Fatalf("cancellation disposition = %s/%s/%v", code, status, retry)
+	}
+	if code, status, retry := subagentErrorDisposition(&provider.APIError{Status: 503}); code != "provider_http_503" || status != SubagentOutcomeFailed || !retry {
+		t.Fatalf("retryable provider disposition = %s/%s/%v", code, status, retry)
+	}
+	if _, _, retry := subagentErrorDisposition(&provider.APIError{Status: 401}); retry {
+		t.Fatal("authentication failure must not be marked retryable")
+	}
+}
+
+func TestParseSubagentOutcomeFromFormattedResult(t *testing.T) {
+	outcome, ok := ParseSubagentOutcome("Subagent reference: sa_child\nSubagent outcome: status=partial retryable=true error_code=completion_uncertain\n\nFinal answer:\nfindings")
+	if !ok || outcome.Ref != "sa_child" || outcome.Status != SubagentOutcomePartial || !outcome.Retryable || outcome.ErrorCode != "completion_uncertain" {
+		t.Fatalf("parsed outcome = %+v, ok=%v", outcome, ok)
+	}
+}

--- a/internal/agent/subagent_progress.go
+++ b/internal/agent/subagent_progress.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"sync"
 	"time"
@@ -30,6 +31,7 @@ const (
 	subagentPhaseTool       subagentProgressPhase = "tool"
 	subagentPhaseRetrying   subagentProgressPhase = "retrying"
 	subagentPhaseCompleted  subagentProgressPhase = "completed"
+	subagentPhasePartial    subagentProgressPhase = "partial"
 	subagentPhaseFailed     subagentProgressPhase = "failed"
 	subagentPhaseCancelled  subagentProgressPhase = "cancelled"
 )
@@ -729,8 +731,8 @@ func (s *subagentProgressSink) Emit(e event.Event) {
 
 // finish flushes pending previews, emits the single terminal status, and — if
 // the tracker owns its merger — closes it. ctxErr non-nil maps to cancelled,
-// other errors to failed, success to completed. Idempotent: late events and
-// repeated calls are ignored.
+// a typed partial outcome maps to partial, other errors to failed, and success
+// to completed. Idempotent: late events and repeated calls are ignored.
 func (t *subagentProgressTracker) finish(ctxErr, runErr error) {
 	t.mu.Lock()
 	if t.done {
@@ -743,6 +745,10 @@ func (t *subagentProgressTracker) finish(ctxErr, runErr error) {
 		phase = subagentPhaseCancelled
 	} else if runErr != nil {
 		phase = subagentPhaseFailed
+		var subErr *SubagentRunError
+		if errors.As(runErr, &subErr) && subErr.Outcome.Status == SubagentOutcomePartial {
+			phase = subagentPhasePartial
+		}
 	}
 	durationMs := t.merger.clock.Now().Sub(t.started).Milliseconds()
 	t.mu.Unlock()

--- a/internal/agent/subagent_progress_partial_test.go
+++ b/internal/agent/subagent_progress_partial_test.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+)
+
+func TestSubagentProgressPartialIsTerminal(t *testing.T) {
+	clock := newFakeProgressClock(time.Unix(0, 0))
+	ch := make(chan event.Event, 16)
+	trk := newTestTracker(t, clock, chanSink{ch: ch}, "child-partial")
+	trk.running()
+	_ = waitEvent(t, ch, "running status")
+	trk.finish(nil, &SubagentRunError{Outcome: SubagentOutcome{Status: SubagentOutcomePartial, Retryable: true}})
+	statuses := collectFor(t, ch, 100*time.Millisecond)
+	if len(statuses) != 1 || statuses[0].Tool.Output != string(subagentPhasePartial) {
+		t.Fatalf("partial terminal events = %+v, want one partial status", statuses)
+	}
+}

--- a/internal/agent/subagent_result.go
+++ b/internal/agent/subagent_result.go
@@ -21,9 +21,10 @@ const (
 	subagentResultMaxBytes       = 24 * 1024
 )
 
-// SubagentResultTool pages through the final answer of a completed persisted
-// sub-agent. Parallel/fleet aggregates use this stable reader instead of
-// forcing every child answer through one fixed-size tool result.
+// SubagentResultTool pages through the retained answer of a persisted
+// sub-agent, including partial and retryable failures. Parallel/fleet
+// aggregates use this stable reader instead of forcing every child answer
+// through one fixed-size tool result.
 type SubagentResultTool struct {
 	store         *SubagentStore
 	workspaceRoot string
@@ -39,7 +40,7 @@ func NewSubagentResultTool(task *TaskTool) *SubagentResultTool {
 func (*SubagentResultTool) Name() string { return "read_subagent_result" }
 
 func (*SubagentResultTool) Description() string {
-	return "Read a completed sub-agent's full final answer by the Subagent reference returned from task, parallel_tasks, or fleet. Results are scoped to the current conversation lineage and paged by UTF-8 byte offset so large answers remain lossless without overflowing one tool result."
+	return "Read a completed or partial sub-agent's retained answer by the Subagent reference returned from task, parallel_tasks, or fleet. Failed runs may expose their last useful output and an explicit retryability status. Results are scoped to the current conversation lineage and paged by UTF-8 byte offset so large answers remain lossless without overflowing one tool result."
 }
 
 func (*SubagentResultTool) Schema() json.RawMessage {
@@ -143,8 +144,11 @@ func (s *SubagentStore) ReadFinalAnswer(ref, parentSession, workspaceRoot string
 	if want := strings.TrimSpace(workspaceRoot); want != "" && strings.TrimSpace(meta.WorkspaceRoot) != want {
 		return "", meta.Status, fmt.Errorf("subagent reference %q belongs to a different workspace", ref)
 	}
-	if meta.Status != SubagentCompleted {
-		return "", meta.Status, fmt.Errorf("subagent reference %q is %s; only completed results can be read", ref, meta.Status)
+	if meta.Status == SubagentRunning {
+		return "", meta.Status, fmt.Errorf("subagent reference %q is still in progress", ref)
+	}
+	if meta.Status == SubagentInterrupted && meta.Outcome != string(SubagentOutcomeCancelled) {
+		return "", meta.Status, fmt.Errorf("subagent reference %q was interrupted; only completed or retained partial results can be read", ref)
 	}
 
 	sess, err := LoadSession(s.sessionPath(ref))
@@ -154,7 +158,11 @@ func (s *SubagentStore) ReadFinalAnswer(ref, parentSession, workspaceRoot string
 	msgs := sess.Snapshot()
 	for _, v := range slices.Backward(msgs) {
 		if v.Role == provider.RoleAssistant && strings.TrimSpace(v.Content) != "" {
-			return v.Content, meta.Status, nil
+			status := meta.Status
+			if meta.Outcome != "" {
+				status = SubagentStatus(meta.Outcome)
+			}
+			return v.Content, status, nil
 		}
 	}
 	return "", meta.Status, fmt.Errorf("subagent reference %q has no final assistant answer", ref)

--- a/internal/agent/subagent_setup_outcome_test.go
+++ b/internal/agent/subagent_setup_outcome_test.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestTaskSetupFailurePreservesAllocatedSubagentOutcome(t *testing.T) {
+	workspace := t.TempDir()
+	store := NewSubagentStore(t.TempDir())
+	task := NewTaskTool(nil, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0, 0, 0, "", "sys", nil, 0, "", "", nil).
+		WithTranscripts(store, workspace, "model", "effort")
+	task.resolveProvider = func(string, string) (provider.Provider, *provider.Pricing, int, error) {
+		return nil, nil, 0, errors.New("profile unavailable")
+	}
+	out, err := task.Execute(WithParentSession(context.Background(), "parent"), []byte(`{"prompt":"inspect","model":"child-model"}`))
+	if err == nil || !strings.Contains(err.Error(), "profile unavailable") {
+		t.Fatalf("Execute error = %v, want setup failure", err)
+	}
+	outcome, ok := ParseSubagentOutcome(out)
+	if !ok || outcome.Ref == "" || outcome.Status != SubagentOutcomeFailed {
+		t.Fatalf("outcome = %+v, output=%q, want failed ref", outcome, out)
+	}
+	meta, metaErr := store.LoadMeta(outcome.Ref)
+	if metaErr != nil || meta.Status != SubagentFailed || meta.ErrorCode != "subagent_error" {
+		t.Fatalf("metadata = %+v/%v, want retained failed outcome", meta, metaErr)
+	}
+}

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -37,6 +37,9 @@ type SubagentMeta struct {
 	CreatedAt        time.Time      `json:"createdAt"`
 	UpdatedAt        time.Time      `json:"updatedAt"`
 	Status           SubagentStatus `json:"status"`
+	Outcome          string         `json:"outcome,omitempty"`
+	Retryable        bool           `json:"retryable,omitempty"`
+	ErrorCode        string         `json:"errorCode,omitempty"`
 	Kind             string         `json:"kind"` // task | skill
 	Name             string         `json:"name"`
 	WorkspaceRoot    string         `json:"workspaceRoot"`
@@ -670,47 +673,6 @@ func (s *SubagentStore) MarkRunning(run *SubagentRun) error {
 	return s.saveMeta(meta)
 }
 
-func (s *SubagentStore) SaveCompleted(run *SubagentRun) error {
-	if s == nil || run == nil || run.Ref == "" {
-		return nil
-	}
-	if s.parentDestroyed(run) {
-		return nil
-	}
-	if err := s.ensureBranchCreatedAt(run); err != nil {
-		return err
-	}
-	if err := run.Session.Save(s.sessionPath(run.Ref)); err != nil {
-		return err
-	}
-	meta := run.Meta
-	meta.Status = SubagentCompleted
-	meta.UpdatedAt = time.Now().UTC()
-	run.Meta = meta
-	return s.saveMeta(meta)
-}
-
-func (s *SubagentStore) SaveFailed(run *SubagentRun) error {
-	if s == nil || run == nil || run.Ref == "" {
-		return nil
-	}
-	if s.parentDestroyed(run) {
-		return nil
-	}
-	// Terminal status is independent from transcript persistence. Keep going so
-	// a sidecar failure cannot leave a failed run marked as running on disk.
-	branchErr := s.ensureBranchCreatedAt(run)
-	var sessionErr error
-	if run.Session != nil {
-		sessionErr = run.Session.Save(s.sessionPath(run.Ref))
-	}
-	meta := run.Meta
-	meta.Status = SubagentFailed
-	meta.UpdatedAt = time.Now().UTC()
-	run.Meta = meta
-	return errors.Join(branchErr, sessionErr, s.saveMeta(meta))
-}
-
 // ensureBranchCreatedAt seeds the session list sidecar before the first
 // transcript save. Subagent transcripts are written only on completion, so
 // Session.Save would otherwise backfill BranchMeta.CreatedAt with the save
@@ -754,7 +716,7 @@ func validateMeta(meta SubagentMeta, spec SubagentSpec) error {
 	if meta.Status == SubagentRunning {
 		return fmt.Errorf("subagent reference %q is still in progress", meta.Ref)
 	}
-	if meta.Status == SubagentFailed {
+	if meta.Status == SubagentFailed && !meta.Retryable && meta.Outcome != string(SubagentOutcomePartial) {
 		return fmt.Errorf("subagent reference %q failed and cannot be continued", meta.Ref)
 	}
 	if meta.Status == SubagentInterrupted {

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -100,8 +100,9 @@ type SubagentRun struct {
 	Meta       SubagentMeta
 	ForkedFrom string
 
-	store   *SubagentStore
-	release func()
+	store             *SubagentStore
+	release           func()
+	terminalPersisted bool
 }
 
 // SubagentArtifact is a persisted sub-agent transcript and metadata pair owned

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -437,6 +437,18 @@ func (s *SubagentStore) PrepareContinue(ref string, spec SubagentSpec) (*Subagen
 	}
 	meta.ParentSession = spec.ParentSession
 	meta.ParentToolCallID = spec.ParentToolCallID
+	// Re-acquire the running state while holding the per-ref lease so a resumed
+	// transcript is visible as active and stale cleanup cannot mark it
+	// interrupted while the continuation is executing.
+	meta.Status = SubagentRunning
+	meta.Outcome = ""
+	meta.Retryable = false
+	meta.ErrorCode = ""
+	meta.UpdatedAt = time.Now().UTC()
+	if err := s.saveMeta(meta); err != nil {
+		release()
+		return nil, fmt.Errorf("mark resumed subagent %q running: %w", ref, err)
+	}
 	return &SubagentRun{Ref: ref, Session: sess, Meta: meta, store: s, release: release}, nil
 }
 

--- a/internal/agent/subagent_store_outcome_test.go
+++ b/internal/agent/subagent_store_outcome_test.go
@@ -56,6 +56,9 @@ func TestSubagentStoreDuplicateTerminalOutcomeIsIdempotent(t *testing.T) {
 	if err := store.SaveOutcome(run, outcome); err != nil {
 		t.Fatalf("duplicate SaveOutcome: %v", err)
 	}
+	if err := store.SaveOutcome(run, SubagentOutcome{Ref: run.Ref, Status: SubagentOutcomeFailed, ErrorCode: "provider_error"}); err == nil {
+		t.Fatal("different terminal outcome overwrote a persisted partial outcome")
+	}
 	meta, err := store.LoadMeta(run.Ref)
 	if err != nil || meta.Outcome != string(SubagentOutcomePartial) || meta.Status != SubagentFailed || !meta.Retryable {
 		t.Fatalf("duplicate terminal metadata = %+v/%v", meta, err)

--- a/internal/agent/subagent_store_outcome_test.go
+++ b/internal/agent/subagent_store_outcome_test.go
@@ -32,7 +32,34 @@ func TestSubagentStorePartialOutcomeCanBeReadAndResumed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrepareContinue partial: %v", err)
 	}
+	meta, err = store.LoadMeta(run.Ref)
+	if err != nil || meta.Status != SubagentRunning || meta.Outcome != "" {
+		t.Fatalf("resumed metadata = %+v/%v, want running without stale outcome", meta, err)
+	}
 	continued.Release()
+}
+
+func TestSubagentStoreDuplicateTerminalOutcomeIsIdempotent(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "explore")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	defer run.Release()
+	answer := "same terminal answer"
+	run.Session.Add(provider.Message{Role: provider.RoleAssistant, Content: answer})
+	outcome := SubagentOutcome{Ref: run.Ref, Status: SubagentOutcomePartial, ErrorCode: "completion_uncertain", Retryable: true}
+	if err := store.SaveOutcome(run, outcome); err != nil {
+		t.Fatalf("first SaveOutcome: %v", err)
+	}
+	if err := store.SaveOutcome(run, outcome); err != nil {
+		t.Fatalf("duplicate SaveOutcome: %v", err)
+	}
+	meta, err := store.LoadMeta(run.Ref)
+	if err != nil || meta.Outcome != string(SubagentOutcomePartial) || meta.Status != SubagentFailed || !meta.Retryable {
+		t.Fatalf("duplicate terminal metadata = %+v/%v", meta, err)
+	}
 }
 
 func TestSubagentStoreFailedOutcomeRetainsReadableLastAnswer(t *testing.T) {

--- a/internal/agent/subagent_store_outcome_test.go
+++ b/internal/agent/subagent_store_outcome_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestSubagentStorePartialOutcomeCanBeReadAndResumed(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "explore")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "inspect"})
+	run.Session.Add(provider.Message{Role: provider.RoleAssistant, Content: "partial finding"})
+	if err := store.SaveOutcome(run, SubagentOutcome{Ref: run.Ref, Status: SubagentOutcomePartial, FinalAnswer: "partial finding", ErrorCode: "completion_uncertain", Retryable: true}); err != nil {
+		t.Fatalf("SaveOutcome: %v", err)
+	}
+	run.Release()
+	answer, status, err := store.ReadFinalAnswer(run.Ref, spec.ParentSession, spec.WorkspaceRoot)
+	if err != nil || answer != "partial finding" || status != SubagentStatus(SubagentOutcomePartial) {
+		t.Fatalf("ReadFinalAnswer = %q/%q/%v, want partial result", answer, status, err)
+	}
+	meta, err := store.LoadMeta(run.Ref)
+	if err != nil || meta.Status != SubagentFailed || meta.Outcome != string(SubagentOutcomePartial) || !meta.Retryable {
+		t.Fatalf("partial metadata = %+v/%v", meta, err)
+	}
+	continued, err := store.PrepareContinue(run.Ref, spec)
+	if err != nil {
+		t.Fatalf("PrepareContinue partial: %v", err)
+	}
+	continued.Release()
+}
+
+func TestSubagentStoreFailedOutcomeRetainsReadableLastAnswer(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "explore")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleAssistant, Content: "last useful answer"})
+	if err := store.SaveOutcome(run, SubagentOutcome{Ref: run.Ref, Status: SubagentOutcomeFailed, ErrorCode: "provider_error"}); err != nil {
+		t.Fatalf("SaveOutcome: %v", err)
+	}
+	run.Release()
+	answer, status, err := store.ReadFinalAnswer(run.Ref, spec.ParentSession, spec.WorkspaceRoot)
+	if err != nil || answer != "last useful answer" || status != SubagentStatus(SubagentOutcomeFailed) {
+		t.Fatalf("ReadFinalAnswer = %q/%q/%v, want retained failed answer", answer, status, err)
+	}
+	if _, err := store.PrepareContinue(run.Ref, spec); err == nil || !strings.Contains(err.Error(), "failed and cannot be continued") {
+		t.Fatalf("non-retryable failed continuation error = %v", err)
+	}
+}

--- a/internal/agent/subagent_store_terminal.go
+++ b/internal/agent/subagent_store_terminal.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -16,6 +17,12 @@ func (s *SubagentStore) SaveFailed(run *SubagentRun) error {
 func (s *SubagentStore) SaveOutcome(run *SubagentRun, outcome SubagentOutcome) error {
 	if s == nil || run == nil || run.Ref == "" || s.parentDestroyed(run) {
 		return nil
+	}
+	if run.terminalPersisted {
+		if terminalOutcomeAlreadyRecorded(run.Meta, outcome) {
+			return nil
+		}
+		return fmt.Errorf("subagent %q already has a persisted terminal outcome", run.Ref)
 	}
 	if terminalOutcomeAlreadyRecorded(run.Meta, outcome) {
 		return nil
@@ -39,7 +46,11 @@ func (s *SubagentStore) SaveOutcome(run *SubagentRun, outcome SubagentOutcome) e
 	meta.ErrorCode = outcome.ErrorCode
 	meta.UpdatedAt = time.Now().UTC()
 	run.Meta = meta
-	return errors.Join(branchErr, sessionErr, s.saveMeta(meta))
+	err := errors.Join(branchErr, sessionErr, s.saveMeta(meta))
+	if err == nil {
+		run.terminalPersisted = true
+	}
+	return err
 }
 
 func terminalOutcomeAlreadyRecorded(meta SubagentMeta, outcome SubagentOutcome) bool {

--- a/internal/agent/subagent_store_terminal.go
+++ b/internal/agent/subagent_store_terminal.go
@@ -17,6 +17,9 @@ func (s *SubagentStore) SaveOutcome(run *SubagentRun, outcome SubagentOutcome) e
 	if s == nil || run == nil || run.Ref == "" || s.parentDestroyed(run) {
 		return nil
 	}
+	if terminalOutcomeAlreadyRecorded(run.Meta, outcome) {
+		return nil
+	}
 	branchErr := s.ensureBranchCreatedAt(run)
 	var sessionErr error
 	if run.Session != nil {
@@ -37,6 +40,25 @@ func (s *SubagentStore) SaveOutcome(run *SubagentRun, outcome SubagentOutcome) e
 	meta.UpdatedAt = time.Now().UTC()
 	run.Meta = meta
 	return errors.Join(branchErr, sessionErr, s.saveMeta(meta))
+}
+
+func terminalOutcomeAlreadyRecorded(meta SubagentMeta, outcome SubagentOutcome) bool {
+	if meta.Outcome == "" {
+		return false
+	}
+	if meta.Outcome != string(outcome.Status) || meta.Retryable != outcome.Retryable || meta.ErrorCode != outcome.ErrorCode {
+		return false
+	}
+	switch outcome.Status {
+	case SubagentOutcomeCompleted:
+		return meta.Status == SubagentCompleted
+	case SubagentOutcomeCancelled:
+		return meta.Status == SubagentInterrupted
+	case SubagentOutcomePartial, SubagentOutcomeFailed:
+		return meta.Status == SubagentFailed
+	default:
+		return false
+	}
 }
 
 func runRef(run *SubagentRun) string {

--- a/internal/agent/subagent_store_terminal.go
+++ b/internal/agent/subagent_store_terminal.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"errors"
+	"time"
+)
+
+func (s *SubagentStore) SaveCompleted(run *SubagentRun) error {
+	return s.SaveOutcome(run, SubagentOutcome{Ref: runRef(run), Status: SubagentOutcomeCompleted})
+}
+
+func (s *SubagentStore) SaveFailed(run *SubagentRun) error {
+	return s.SaveOutcome(run, SubagentOutcome{Ref: runRef(run), Status: SubagentOutcomeFailed})
+}
+
+func (s *SubagentStore) SaveOutcome(run *SubagentRun, outcome SubagentOutcome) error {
+	if s == nil || run == nil || run.Ref == "" || s.parentDestroyed(run) {
+		return nil
+	}
+	branchErr := s.ensureBranchCreatedAt(run)
+	var sessionErr error
+	if run.Session != nil {
+		sessionErr = run.Session.Save(s.sessionPath(run.Ref))
+	}
+	meta := run.Meta
+	switch outcome.Status {
+	case SubagentOutcomeCompleted:
+		meta.Status = SubagentCompleted
+	case SubagentOutcomeCancelled:
+		meta.Status = SubagentInterrupted
+	default:
+		meta.Status = SubagentFailed
+	}
+	meta.Outcome = string(outcome.Status)
+	meta.Retryable = outcome.Retryable
+	meta.ErrorCode = outcome.ErrorCode
+	meta.UpdatedAt = time.Now().UTC()
+	run.Meta = meta
+	return errors.Join(branchErr, sessionErr, s.saveMeta(meta))
+}
+
+func runRef(run *SubagentRun) string {
+	if run == nil {
+		return ""
+	}
+	return run.Ref
+}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -902,17 +902,17 @@ func (t *TaskTool) RunProfileSpec(ctx context.Context, spec ProfileExecSpec) (re
 			// so the parent tool call returns a job id immediately.
 			releaseSlot, claimID, slotErr := t.acquireSlot(jobCtx, slotReq)
 			if slotErr != nil {
-				return FormatSubagentRunResult("", run, true), errors.Join(slotErr, t.transcripts.SaveFailed(run))
+				return t.failedSubagentResult(run, slotErr)
 			}
 			defer releaseSlot()
 			jobCtx = WithSubagentClaimID(jobCtx, claimID)
 			trk.running()
 			answer, err := runSession(jobCtx, trk.wrap(), writerRegistered)
 			if err != nil {
-				return FormatSubagentRunResult("", run, true), errors.Join(err, t.transcripts.SaveFailed(run))
+				return t.failedSubagentResult(run, err)
 			}
 			if err := t.transcripts.SaveCompleted(run); err != nil {
-				return FormatSubagentRunResult("", run, true), errors.Join(err, t.transcripts.SaveFailed(run))
+				return t.failedSubagentResult(run, err)
 			}
 			return FormatSubagentRunResult(answer, run, false), nil
 		})
@@ -941,7 +941,7 @@ func (t *TaskTool) RunProfileSpec(ctx context.Context, spec ProfileExecSpec) (re
 	ctx = WithSubagentClaimID(ctx, claimID)
 	answer, err := runSession(ctx, trk.wrap(), false)
 	if err != nil {
-		return "", errors.Join(err, t.transcripts.SaveFailed(run))
+		return t.failedSubagentResult(run, err)
 	}
 	if t.transcripts != nil && run.Ref != "" {
 		if err := t.transcripts.SaveCompleted(run); err != nil {
@@ -1645,20 +1645,6 @@ func FormatSubagentReference(run *SubagentRun) string {
 	}
 	b.WriteString("To continue this same subagent transcript in a later call, pass this ref as `continue_from`. Start a fresh subagent when the next task is independent.")
 	return b.String()
-}
-
-func FormatSubagentRunResult(answer string, run *SubagentRun, failed bool) string {
-	answer = GuardSubagentHostDecisionText(answer)
-	if run == nil || run.Ref == "" {
-		return answer
-	}
-	if failed {
-		if answer == "" {
-			return "Subagent reference (failed): " + run.Ref
-		}
-		return "Subagent reference (failed): " + run.Ref + "\n\nFinal answer:\n" + answer
-	}
-	return FormatSubagentReference(run) + "\n\nFinal answer:\n" + answer
 }
 
 // GuardSubagentHostDecisionText appends a fixed boundary warning only when a

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -782,16 +781,20 @@ func (t *TaskTool) RunProfileSpec(ctx context.Context, spec ProfileExecSpec) (re
 
 	modelRef, effortRef := spec.Worker.Model, spec.Worker.Effort
 	usageModelRef := t.usageModelRef(modelRef, effortRef)
-	parentID, _, _, _ := CallContext(ctx)
+	parentID, parentSink, _, _ := CallContext(ctx)
 	run, err := t.prepareTranscriptRunWithPrompt(ctx, subReg, modelRef, effortRef, spec.Context.parentSession(ctx), parentID, spec.Context.ContinueFrom, spec.Context.ForkFrom, spec.Worker.SystemPrompt, spec.Worker.Kind, spec.Worker.Name)
 	if err != nil {
 		return "", err
 	}
 	prov, pricing, ctxWin, err := t.resolveSubSessionRuntime(modelRef, effortRef)
 	if err != nil {
-		run.Release()
-		return "", fmt.Errorf("sub-agent profile: %w", err)
+		return t.failBeforeSubagentRelease(run, fmt.Errorf("sub-agent profile: %w", err))
 	}
+	lifecyclePhase := "child_created"
+	if strings.TrimSpace(spec.Context.ContinueFrom) != "" || strings.TrimSpace(spec.Context.ForkFrom) != "" {
+		lifecyclePhase = "child_resume"
+	}
+	emitSubagentLifecycle(parentSink, lifecyclePhase, parentID, spec.Worker.Name, usageModelRef, effortRef, run, nil)
 
 	isWriter := !spec.Grant.ReadOnly
 	acquireReq := AcquireRequest{
@@ -805,8 +808,7 @@ func (t *TaskTool) RunProfileSpec(ctx context.Context, spec ProfileExecSpec) (re
 	if isWriter && spec.Grant.WritePaths.Empty() && spec.Sched.RunInBackground {
 		whole, werr := WholeWorkspaceWriteClaim(t.workspaceRoot)
 		if werr != nil {
-			run.Release()
-			return "", werr
+			return t.failBeforeSubagentRelease(run, werr)
 		}
 		acquireReq.WritePaths = whole
 		spec.Grant.WritePaths = whole
@@ -834,122 +836,126 @@ func (t *TaskTool) RunProfileSpec(ctx context.Context, spec ProfileExecSpec) (re
 	}
 
 	if spec.Sched.RunInBackground {
-		jm, ok := jobs.FromContext(ctx)
-		if !ok {
-			run.Release()
-			return "", fmt.Errorf("background execution is not available in this context")
-		}
-		// Legacy hard-cap remains only when no scheduler is attached. With a
-		// scheduler, return the job immediately and queue for a slot inside the
-		// job so the parent turn is not blocked at concurrency limits.
-		var releaseStart func()
-		if t.scheduler == nil {
-			var running int
-			var okReserve bool
-			releaseStart, running, okReserve = jm.ReserveStartForSession(jobs.SessionFromContext(ctx), "task", maxConcurrentBackgroundTasks)
-			if !okReserve {
-				run.Release()
-				return "", fmt.Errorf("%d background tasks are already running for this session (limit %d); collect their results with wait — or run this sub-task in the foreground — before starting more", running, maxConcurrentBackgroundTasks)
-			}
-			defer releaseStart()
-		} else {
-			releaseStart = func() {}
-		}
-		label := firstNonEmpty(spec.Task.Description, spec.Worker.Name, "task")
-		if t.transcripts != nil && run != nil && run.Ref != "" {
-			if err := t.transcripts.MarkRunning(run); err != nil {
-				releaseStart()
-				run.Release()
-				return "", err
-			}
-		}
-		writerRegistered := false
-		if mutationObserver != nil && backgroundWriter {
-			turn := mutationObserver.OwnershipTurn()
-			if err := mutationObserver.RegisterWriter(recoveryTaskID, "background_subagent", turn); err != nil {
-				releaseStart()
-				run.Release()
-				return "", errors.Join(err, t.transcripts.SaveFailed(run))
-			}
-			writerRegistered = true
-		}
-		parentSession := ParentSession(ctx)
-		backgroundEvidence := evidence.NewLedger()
-		// Capture acquire request by value for the job goroutine.
-		slotReq := acquireReq
-		// Emit queued before the job goroutine can start so the status slot
-		// never regresses to a stale queued after running.
-		trk.queued()
-		job := jm.StartForSession(jobs.SessionFromContext(ctx), "task", label, func(jobCtx context.Context, _ io.Writer) (result string, err error) {
-			if writerRegistered {
-				defer mutationObserver.UnregisterWriter(recoveryTaskID)
-			}
-			jobCtx = WithParentSession(jobCtx, parentSession)
-			jobCtx = evidence.WithLedger(jobCtx, backgroundEvidence)
-			defer run.Release()
-			defer publishBackgroundEvidence(jobCtx, backgroundEvidence, t.workspaceRoot)
-			defer func() {
-				if r := recover(); r != nil {
-					panicErr := fmt.Errorf("internal error: panic: %v\n%s", r, debug.Stack())
-					result = FormatSubagentRunResult("", run, true)
-					err = errors.Join(panicErr, t.transcripts.SaveFailed(run))
-				}
-				// The job owns the terminal status: the parent tool call has
-				// already returned its job id by now.
-				trk.finish(jobCtx.Err(), err)
-			}()
-			// Queue for a concurrency/write slot here — not before Start —
-			// so the parent tool call returns a job id immediately.
-			releaseSlot, claimID, slotErr := t.acquireSlot(jobCtx, slotReq)
-			if slotErr != nil {
-				return t.failedSubagentResult(run, slotErr)
-			}
-			defer releaseSlot()
-			jobCtx = WithSubagentClaimID(jobCtx, claimID)
-			trk.running()
-			answer, err := runSession(jobCtx, trk.wrap(), writerRegistered)
-			if err != nil {
-				return t.failedSubagentResult(run, err)
-			}
-			if err := t.transcripts.SaveCompleted(run); err != nil {
-				return t.failedSubagentResult(run, err)
-			}
-			return FormatSubagentRunResult(answer, run, false), nil
-		})
-		releaseStart()
-		// Hand the tracker to the job goroutine: the outer defer must not
-		// finish (and close) it while the job still runs.
-		backgroundHandoff = true
-		queuedNote := ""
-		if t.scheduler != nil {
-			queuedNote = " It may wait in the session queue until a concurrency/write slot is free."
-		}
-		if run != nil && run.Ref != "" {
-			return fmt.Sprintf("Started background task %q (%s).%s\n%s\nIt runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label, queuedNote, FormatSubagentReference(run)), nil
-		}
-		return fmt.Sprintf("Started background task %q (%s).%s It runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label, queuedNote), nil
+		result, runErr, handedOff := t.runBackgroundProfileSpec(ctx, spec, run, trk, parentID, parentSink, usageModelRef, effortRef, runSession, acquireReq, mutationObserver, backgroundWriter, recoveryTaskID)
+		backgroundHandoff = handedOff
+		return result, runErr
 	}
 
 	// Foreground: acquire a slot (queue if needed), then run synchronously.
 	releaseSlot, claimID, err := t.acquireSlot(ctx, acquireReq)
 	if err != nil {
-		run.Release()
-		return "", err
+		return t.failedSubagentResult(run, err)
 	}
 	defer releaseSlot()
 	defer run.Release()
 	ctx = WithSubagentClaimID(ctx, claimID)
+	emitSubagentLifecycle(parentSink, "child_running", parentID, spec.Worker.Name, usageModelRef, effortRef, run, nil)
 	answer, err := runSession(ctx, trk.wrap(), false)
 	if err != nil {
-		return t.failedSubagentResult(run, err)
+		result, runErr := t.resolveAmbiguousSubagentFailure(ctx, run, spec.Task.Objective, usageModelRef, parentSink, err)
+		phase, outcome := terminalSubagentLifecycle(runErr)
+		emitSubagentLifecycle(parentSink, phase, parentID, spec.Worker.Name, usageModelRef, effortRef, run, outcome)
+		return result, runErr
 	}
 	if t.transcripts != nil && run.Ref != "" {
 		if err := t.transcripts.SaveCompleted(run); err != nil {
-			return "", errors.Join(err, t.transcripts.SaveFailed(run))
+			result, runErr := t.failedSubagentResult(run, err)
+			phase, outcome := terminalSubagentLifecycle(runErr)
+			emitSubagentLifecycle(parentSink, phase, parentID, spec.Worker.Name, usageModelRef, effortRef, run, outcome)
+			return result, runErr
 		}
+		emitSubagentLifecycle(parentSink, "child_completed", parentID, spec.Worker.Name, usageModelRef, effortRef, run, &SubagentOutcome{Status: SubagentOutcomeCompleted, FinalAnswer: answer})
 		return FormatSubagentRunResult(answer, run, false), nil
 	}
 	return GuardSubagentHostDecisionText(answer), nil
+}
+
+func (t *TaskTool) runBackgroundProfileSpec(ctx context.Context, spec ProfileExecSpec, run *SubagentRun, trk *subagentProgressTracker, parentID string, parentSink event.Sink, usageModelRef, effortRef string,
+	runSession func(context.Context, event.Sink, bool) (string, error), acquireReq AcquireRequest, mutationObserver *checkpoint.MutationObserver, backgroundWriter bool, recoveryTaskID string,
+) (string, error, bool) {
+	jm, ok := jobs.FromContext(ctx)
+	if !ok {
+		result, err := t.failBeforeSubagentRelease(run, fmt.Errorf("background execution is not available in this context"))
+		return result, err, false
+	}
+	var releaseStart func()
+	if t.scheduler == nil {
+		var running int
+		var okReserve bool
+		releaseStart, running, okReserve = jm.ReserveStartForSession(jobs.SessionFromContext(ctx), "task", maxConcurrentBackgroundTasks)
+		if !okReserve {
+			result, err := t.failBeforeSubagentRelease(run, fmt.Errorf("%d background tasks are already running for this session (limit %d); collect their results with wait — or run this sub-task in the foreground — before starting more", running, maxConcurrentBackgroundTasks))
+			return result, err, false
+		}
+		defer releaseStart()
+	} else {
+		releaseStart = func() {}
+	}
+	label := firstNonEmpty(spec.Task.Description, spec.Worker.Name, "task")
+	if t.transcripts != nil && run != nil && run.Ref != "" {
+		if err := t.transcripts.MarkRunning(run); err != nil {
+			releaseStart()
+			result, saveErr := t.failBeforeSubagentRelease(run, err)
+			return result, saveErr, false
+		}
+	}
+	writerRegistered := false
+	if mutationObserver != nil && backgroundWriter {
+		turn := mutationObserver.OwnershipTurn()
+		if err := mutationObserver.RegisterWriter(recoveryTaskID, "background_subagent", turn); err != nil {
+			releaseStart()
+			result, saveErr := t.failBeforeSubagentRelease(run, err)
+			return result, saveErr, false
+		}
+		writerRegistered = true
+	}
+	parentSession := ParentSession(ctx)
+	backgroundEvidence := evidence.NewLedger()
+	slotReq := acquireReq
+	trk.queued()
+	job := jm.StartForSession(jobs.SessionFromContext(ctx), "task", label, func(jobCtx context.Context, _ io.Writer) (result string, err error) {
+		if writerRegistered {
+			defer mutationObserver.UnregisterWriter(recoveryTaskID)
+		}
+		jobCtx = WithParentSession(jobCtx, parentSession)
+		jobCtx = evidence.WithLedger(jobCtx, backgroundEvidence)
+		defer run.Release()
+		defer publishBackgroundEvidence(jobCtx, backgroundEvidence, t.workspaceRoot)
+		defer func() {
+			if r := recover(); r != nil {
+				panicErr := fmt.Errorf("internal error: panic: %v\n%s", r, debug.Stack())
+				result, err = t.failedSubagentResult(run, panicErr)
+			}
+			phase, outcome := terminalSubagentLifecycle(err)
+			emitSubagentLifecycle(parentSink, phase, parentID, spec.Worker.Name, usageModelRef, effortRef, run, outcome)
+			trk.finish(jobCtx.Err(), err)
+		}()
+		releaseSlot, claimID, slotErr := t.acquireSlot(jobCtx, slotReq)
+		if slotErr != nil {
+			return t.failedSubagentResult(run, slotErr)
+		}
+		defer releaseSlot()
+		jobCtx = WithSubagentClaimID(jobCtx, claimID)
+		trk.running()
+		emitSubagentLifecycle(parentSink, "child_running", parentID, spec.Worker.Name, usageModelRef, effortRef, run, nil)
+		answer, err := runSession(jobCtx, trk.wrap(), writerRegistered)
+		if err != nil {
+			return t.resolveAmbiguousSubagentFailure(jobCtx, run, spec.Task.Objective, usageModelRef, parentSink, err)
+		}
+		if err := t.transcripts.SaveCompleted(run); err != nil {
+			return t.failedSubagentResult(run, err)
+		}
+		return FormatSubagentRunResult(answer, run, false), nil
+	})
+	releaseStart()
+	queuedNote := ""
+	if t.scheduler != nil {
+		queuedNote = " It may wait in the session queue until a concurrency/write slot is free."
+	}
+	if run != nil && run.Ref != "" {
+		return fmt.Sprintf("Started background task %q (%s).%s\n%s\nIt runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label, queuedNote, FormatSubagentReference(run)), nil, true
+	}
+	return fmt.Sprintf("Started background task %q (%s).%s It runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label, queuedNote), nil, true
 }
 
 func (t *TaskTool) acquireSlot(ctx context.Context, req AcquireRequest) (func(), int64, error) {

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -707,8 +707,8 @@ func TestTaskToolBackgroundPanicPersistsFailedMetadata(t *testing.T) {
 	if len(res) != 1 || res[0].Status != jobs.Failed {
 		t.Fatalf("background job result = %+v, want failed", res)
 	}
-	if !strings.Contains(res[0].Output, "Subagent reference (failed): "+ref) {
-		t.Fatalf("job output = %q, want failed subagent ref %s", res[0].Output, ref)
+	if !strings.Contains(res[0].Output, "Subagent reference: "+ref) || !strings.Contains(res[0].Output, "status=failed") {
+		t.Fatalf("job output = %q, want failed subagent outcome for %s", res[0].Output, ref)
 	}
 	meta, err := store.LoadMeta(ref)
 	if err != nil {

--- a/internal/agent/tool_result_capability.go
+++ b/internal/agent/tool_result_capability.go
@@ -31,7 +31,7 @@ type sessionToolResultTool struct {
 func (*sessionToolResultTool) Name() string { return "session_tool_result" }
 
 func (*sessionToolResultTool) Description() string {
-	return "Read one bounded UTF-8 page from a complete tool result retained in the current agent session."
+	return "Read one bounded UTF-8 page from a complete tool result retained in the current agent session. This uses tr-... result references; for a sa_... subagent reference, use read_subagent_result instead."
 }
 
 func (*sessionToolResultTool) ReadOnly() bool { return true }
@@ -129,6 +129,9 @@ func (t *sessionToolResultTool) Execute(_ context.Context, args json.RawMessage)
 	}
 	p.ToolCallID = strings.TrimSpace(p.ToolCallID)
 	p.ResultRef = strings.TrimSpace(p.ResultRef)
+	if strings.HasPrefix(p.ToolCallID, "sa_") || strings.HasPrefix(p.ResultRef, "sa_") {
+		return "", fmt.Errorf("session tool result: %q is a subagent reference; use read_subagent_result with ref", firstNonEmpty(p.ResultRef, p.ToolCallID))
+	}
 	if p.ToolCallID == "" {
 		return "", fmt.Errorf("session tool result: tool_call_id is required")
 	}

--- a/internal/agent/tool_result_capability_test.go
+++ b/internal/agent/tool_result_capability_test.go
@@ -205,6 +205,16 @@ func TestSessionToolResultValidatesLegacyAndPagingErrors(t *testing.T) {
 	}
 }
 
+func TestSessionToolResultRejectsSubagentReferences(t *testing.T) {
+	_, proxy := newToolResultCapabilityAgent(t, &Session{})
+	if _, _, err := executeToolResultPage(t, proxy, "sa_child", "", 0, 32); err == nil || !strings.Contains(err.Error(), "read_subagent_result") {
+		t.Fatalf("subagent tool call id error = %v, want dedicated reader guidance", err)
+	}
+	if _, _, err := executeToolResultPage(t, proxy, "tool-call", "sa_child", 0, 32); err == nil || !strings.Contains(err.Error(), "read_subagent_result") {
+		t.Fatalf("subagent result ref error = %v, want dedicated reader guidance", err)
+	}
+}
+
 func TestSessionToolResultBindingTracksSetSessionAndCloneIsIsolated(t *testing.T) {
 	parent := &Session{Messages: []provider.Message{{Role: provider.RoleTool, ToolCallID: "call", Name: "bash", Content: "parent"}}}
 	a, proxy := newToolResultCapabilityAgent(t, parent)

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1308,7 +1308,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		if continueFrom != "" && legacyForkFrom != "" {
 			return "", fmt.Errorf("continue_from and fork_from are mutually exclusive; pass only continue_from")
 		}
-		parentID, _, _, _ := agent.CallContext(sctx)
+		parentID, parentSink, _, _ := agent.CallContext(sctx)
 		if runOpts.HostInitiated {
 			parentID = ""
 		}
@@ -1359,14 +1359,15 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		runOptions.WriteRoots = childWriteRoots
 		usageModelRef, _ := subagentIdentity(modelRef, effortRef)
 		runOptions.ModelRef = usageModelRef
+		announceSkillSubagentStart(parentSink, parentID, sk.Name, usageModelRef, effortRef, run, continueFrom != "" || legacyForkFrom != "")
 		// Review gates consume typed, host-verifiable reports so a review
 		// cannot end in unverifiable prose. Review skills run only for
 		// mid/high-risk work under the standard policy.
 		runOptions.RequireReviewReportKind = agent.ReviewReportKindForSkill(sk.Name)
 		var answer string
-		// See the read-only runner above: the child provider, not the parent
-		// model, owns the final vision decision.
+		// The child provider owns the final vision decision, as in read-only runs.
 		childCtx := agent.WithUserImages(sctx, agent.SubagentImageCandidates(sctx))
+		agent.EmitSubagentLifecycle(parentSink, "child_running", parentID, sk.Name, usageModelRef, effortRef, run, nil)
 		if sk.ReadOnly {
 			answer, err = agent.RunReadOnlySubAgentWithSession(childCtx, prov, subReg, run.Session, task,
 				runOptions, agent.NestedSink(sctx, event.Discard))
@@ -1375,11 +1376,12 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 				runOptions, agent.NestedSink(sctx, event.Discard))
 		}
 		if err != nil {
-			return preserveSubagentFailure(run, subagentStore, err)
+			return finishSkillSubagentFailure(sctx, taskTool, subagentStore, parentSink, parentID, sk.Name, usageModelRef, effortRef, task, run, err)
 		}
 		if err := saveSubagentCompleted(subagentStore, run); err != nil {
-			return preserveSubagentFailure(run, subagentStore, err)
+			return finishSkillSubagentFailure(sctx, taskTool, subagentStore, parentSink, parentID, sk.Name, usageModelRef, effortRef, task, run, err)
 		}
+		agent.EmitSubagentLifecycle(parentSink, "child_completed", parentID, sk.Name, usageModelRef, effortRef, run, &agent.SubagentOutcome{Status: agent.SubagentOutcomeCompleted, FinalAnswer: answer})
 		return agent.FormatSubagentRunResult(answer, run, false), nil
 	}
 	skillProfile := func(sk skill.Skill) *event.Profile {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1248,8 +1248,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		// the child model's own vision capability. Text-only children retain the
 		// attachment metadata locally but never receive image parts on the wire.
 		childCtx := agent.WithUserImages(sctx, agent.SubagentImageCandidates(sctx))
-		return agent.RunReadOnlySubAgentWithSession(childCtx, prov, subReg, agent.NewSession(sysPrompt), task,
-			runOptions, agent.NestedSink(sctx, event.Discard))
+		return runReadOnlySkillSession(childCtx, prov, subReg, task, runOptions, agent.NestedSink(sctx, event.Discard), sysPrompt, agent.RunReadOnlySubAgentWithSession)
 	}
 	// Writer-capable subagent skills reuse the sub-agent machinery via this
 	// runner: an isolated loop with the skill body as system prompt, a tool set
@@ -1376,10 +1375,10 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 				runOptions, agent.NestedSink(sctx, event.Discard))
 		}
 		if err != nil {
-			return "", errors.Join(err, subagentStore.SaveFailed(run))
+			return preserveSubagentFailure(run, subagentStore, err)
 		}
-		if err := subagentStore.SaveCompleted(run); err != nil {
-			return "", errors.Join(err, subagentStore.SaveFailed(run))
+		if err := saveSubagentCompleted(subagentStore, run); err != nil {
+			return preserveSubagentFailure(run, subagentStore, err)
 		}
 		return agent.FormatSubagentRunResult(answer, run, false), nil
 	}

--- a/internal/boot/subagent_outcome.go
+++ b/internal/boot/subagent_outcome.go
@@ -36,3 +36,21 @@ func saveSubagentCompleted(store *agent.SubagentStore, run *agent.SubagentRun) e
 	}
 	return store.SaveCompleted(run)
 }
+
+func announceSkillSubagentStart(sink event.Sink, parentID, skillName, model, effort string, run *agent.SubagentRun, continued bool) {
+	phase := "child_created"
+	if continued {
+		phase = "child_resume"
+	}
+	agent.EmitSubagentLifecycle(sink, phase, parentID, skillName, model, effort, run, nil)
+}
+
+func finishSkillSubagentFailure(ctx context.Context, taskTool *agent.TaskTool, store *agent.SubagentStore, sink event.Sink, parentID, skillName, model, effort, taskText string, run *agent.SubagentRun, cause error) (string, error) {
+	result, runErr := preserveSubagentFailure(run, store, cause)
+	if taskTool != nil {
+		result, runErr = taskTool.ResolveAmbiguousSubagentFailure(ctx, run, taskText, model, sink, cause)
+	}
+	phase, outcome := agent.TerminalSubagentLifecycle(runErr)
+	agent.EmitSubagentLifecycle(sink, phase, parentID, skillName, model, effort, run, outcome)
+	return result, runErr
+}

--- a/internal/boot/subagent_outcome.go
+++ b/internal/boot/subagent_outcome.go
@@ -1,0 +1,38 @@
+package boot
+
+import (
+	"context"
+	"errors"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func preserveSubagentFailure(run *agent.SubagentRun, store *agent.SubagentStore, cause error) (string, error) {
+	subErr := agent.NewSubagentRunError(run, cause)
+	var saveErr error
+	if store != nil {
+		saveErr = store.SaveOutcome(run, subErr.Outcome)
+	}
+	return subErr.SubagentOutput(), errors.Join(subErr, saveErr)
+}
+
+func runReadOnlySkillSession(ctx context.Context, prov provider.Provider, reg *tool.Registry, prompt string, opts agent.Options, sink event.Sink, systemPrompt string,
+	runner func(context.Context, provider.Provider, *tool.Registry, *agent.Session, string, agent.Options, event.Sink) (string, error),
+) (string, error) {
+	run := agent.EphemeralSubagentRun(systemPrompt)
+	answer, err := runner(ctx, prov, reg, run.Session, prompt, opts, sink)
+	if err != nil {
+		return preserveSubagentFailure(run, nil, err)
+	}
+	return answer, nil
+}
+
+func saveSubagentCompleted(store *agent.SubagentStore, run *agent.SubagentRun) error {
+	if store == nil {
+		return nil
+	}
+	return store.SaveCompleted(run)
+}

--- a/internal/cli/run_metrics.go
+++ b/internal/cli/run_metrics.go
@@ -556,6 +556,10 @@ func (s *metricsSink) RecordCompletionValidation(info event.CompletionValidation
 	event.RecordCompletionValidation(s.inner, info)
 }
 
+func (s *metricsSink) RecordSubagentLifecycle(info event.SubagentLifecycleInfo) {
+	event.RecordSubagentLifecycle(s.inner, info)
+}
+
 // MergeCapabilityAudit copies a capability audit snapshot plus process-local
 // MCP tools/list stats into RunMetrics.
 func (m *RunMetrics) MergeCapabilityAudit(snap *capability.Audit) {

--- a/internal/completioneval/evaluator_test.go
+++ b/internal/completioneval/evaluator_test.go
@@ -14,19 +14,21 @@ import (
 )
 
 type scriptedProvider struct {
-	turns   []string // one response per call, recycled
-	err     error    // stream-open error
-	timeout bool     // hang until ctx deadline
-	usage   *provider.Usage
-	mu      sync.Mutex
-	calls   int
+	turns    []string // one response per call, recycled
+	err      error    // stream-open error
+	timeout  bool     // hang until ctx deadline
+	usage    *provider.Usage
+	mu       sync.Mutex
+	calls    int
+	requests []provider.Request
 }
 
 func (s *scriptedProvider) Name() string { return "scripted" }
 
-func (s *scriptedProvider) Stream(ctx context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+func (s *scriptedProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
 	s.mu.Lock()
 	s.calls++
+	s.requests = append(s.requests, req)
 	i := s.calls - 1
 	if i >= len(s.turns) {
 		i = len(s.turns) - 1
@@ -52,6 +54,21 @@ func (s *scriptedProvider) Stream(ctx context.Context, _ provider.Request) (<-ch
 	}
 	close(ch)
 	return ch, nil
+}
+
+func TestEvaluateDisablesThinkingPerRequest(t *testing.T) {
+	prov := &scriptedProvider{turns: []string{`{"outcome":"complete"}`}}
+	if _, err := evaluate(t, prov, Evidence{TaskText: "inspect the repository"}); err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	prov.mu.Lock()
+	defer prov.mu.Unlock()
+	if len(prov.requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(prov.requests))
+	}
+	if got := prov.requests[0].EffortOverride; got != EffortDisabled {
+		t.Fatalf("EffortOverride = %q, want %q", got, EffortDisabled)
+	}
 }
 
 func evaluate(t *testing.T, prov provider.Provider, evidence Evidence) (Verdict, error) {

--- a/internal/completioneval/evidence.go
+++ b/internal/completioneval/evidence.go
@@ -10,6 +10,9 @@ import (
 const (
 	// MaxTokens caps the validator's completion.
 	MaxTokens = 256
+	// EffortDisabled turns thinking off for the bounded verdict request. The
+	// evaluator is stateless and should spend its small output budget on JSON.
+	EffortDisabled = "disabled"
 	// Timeout bounds one evaluation call.
 	Timeout = 30 * time.Second
 	// MaxOutputBytes aborts the stream if the provider ignores MaxTokens.

--- a/internal/completioneval/session.go
+++ b/internal/completioneval/session.go
@@ -39,7 +39,8 @@ type Session struct {
 }
 
 // NewSession creates a completion validator with temperature 0 and MaxTokens
-// 256. prov is normally the same provider/model the working agent uses, so
+// 256. Thinking is disabled per request because this stateless exchange must
+// spend its small budget on the verdict JSON. prov is normally the same provider/model the working agent uses, so
 // evidence never implicitly crosses to another model; modelRef labels emitted
 // usage. sink may be nil.
 func NewSession(prov provider.Provider, pricing *provider.Pricing, modelRef string, sink event.Sink) *Session {
@@ -75,6 +76,7 @@ func (s *Session) Evaluate(ctx context.Context, evidence Evidence) (Verdict, err
 		UsageSource:    event.UsageSourceCompletionEvaluator,
 		Timeout:        s.timeout,
 		MaxTokens:      MaxTokens,
+		EffortOverride: EffortDisabled,
 		MaxOutputBytes: MaxOutputBytes,
 		MaxSystemBytes: boundedllm.DefaultMaxSystemBytes,
 		MaxTotalBytes:  boundedllm.DefaultMaxTotalBytes,

--- a/internal/control/extensions.go
+++ b/internal/control/extensions.go
@@ -260,3 +260,7 @@ func (s *frontendEventSink) RecordRunBudget(sample event.RunBudgetSample) {
 func (s *frontendEventSink) RecordCompletionValidation(info event.CompletionValidationInfo) {
 	event.RecordCompletionValidation(s.inner, info)
 }
+
+func (s *frontendEventSink) RecordSubagentLifecycle(info event.SubagentLifecycleInfo) {
+	event.RecordSubagentLifecycle(s.inner, info)
+}

--- a/internal/control/inbox_sink.go
+++ b/internal/control/inbox_sink.go
@@ -171,3 +171,10 @@ func (s *inboxEventSink) RecordCompletionValidation(info event.CompletionValidat
 	}
 	event.RecordCompletionValidation(s.inner, info)
 }
+
+func (s *inboxEventSink) RecordSubagentLifecycle(info event.SubagentLifecycleInfo) {
+	if s == nil {
+		return
+	}
+	event.RecordSubagentLifecycle(s.inner, info)
+}

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -543,6 +543,8 @@ func (c *Controller) managementNotice(trimmed string) bool {
 			return true
 		}
 		c.notice(c.mcpListText())
+	default:
+		return false
 	}
 	return true
 }

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -543,8 +543,6 @@ func (c *Controller) managementNotice(trimmed string) bool {
 			return true
 		}
 		c.notice(c.mcpListText())
-	default:
-		return false
 	}
 	return true
 }

--- a/internal/control/submit_route.go
+++ b/internal/control/submit_route.go
@@ -1,0 +1,138 @@
+package control
+
+import (
+	"strings"
+
+	"reasonix/internal/skill"
+)
+
+var managementNoticeCommands = map[string]struct{}{
+	"/model": {}, "/provider": {}, "/memory": {}, "/migrate": {}, "/migration": {},
+	"/skill": {}, "/skills": {}, "/plugin": {}, "/plugins": {}, "/reload-cmd": {},
+	"/hooks": {}, "/mcp": {},
+}
+
+// SubmitDisposition describes whether a raw submit is expected to create a
+// durable conversational turn. Management commands can still mutate session
+// state or emit notices, but they must not be presented as turn admission.
+type SubmitDisposition string
+
+const (
+	SubmitTurnStarted       SubmitDisposition = "turn_started"
+	SubmitManagementHandled SubmitDisposition = "management_handled"
+)
+
+// ClassifySubmitRoute is the single controller-owned route classifier shared
+// by desktop's turn receipt and the normal Submit path. Keep conditional
+// commands here so a management-only form never gets mistaken for a turn.
+func (c *Controller) ClassifySubmitRoute(input string) SubmitDisposition {
+	trimmed := strings.TrimSpace(input)
+	if isSimpleManagementInput(trimmed) {
+		return SubmitManagementHandled
+	}
+	return c.classifySlashSubmit(trimmed)
+}
+
+func isSimpleManagementInput(trimmed string) bool {
+	if trimmed == "" {
+		return false
+	}
+	if _, ok := MemoryQuickAddNote(trimmed); ok {
+		return true
+	}
+	if _, ok := RememberCommandNote(trimmed); ok {
+		return true
+	}
+	if goal, ok := ParseGoalCommand(trimmed); ok {
+		return goal.Action != GoalCommandSet
+	}
+	if trimmed == "/reload" || trimmed == "/effort" || strings.HasPrefix(trimmed, "/effort ") {
+		return true
+	}
+	switch trimmed {
+	case "/compact", "/context", "/new", "/clear":
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *Controller) classifySlashSubmit(trimmed string) SubmitDisposition {
+	if _, ok := ParseFinalReadinessRecoveryCommand(trimmed); ok || !strings.HasPrefix(trimmed, "/") || strings.HasPrefix(trimmed, "!") {
+		return SubmitTurnStarted
+	}
+	if strings.HasPrefix(trimmed, "/mcp__") || c.isPathSubmit(trimmed) {
+		return SubmitTurnStarted
+	}
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return SubmitTurnStarted
+	}
+	switch fields[0] {
+	case "/tree", "/branch", "/switch", "/rewind":
+		return SubmitManagementHandled
+	case "/plan-exec":
+		return c.classifyPlanExecSubmit()
+	case "/prometheus":
+		return classifyPrometheusSubmit(trimmed, fields[0])
+	}
+	if _, ok := managementNoticeCommands[fields[0]]; ok {
+		return SubmitManagementHandled
+	}
+	if IsBuiltinDocsSlash(fields[0], c.Commands(), c.SlashSkills()) {
+		return classifyDocsSubmit(trimmed, fields[0])
+	}
+	if sk, task, ok := c.resolveSkillInvocation(trimmed); ok && sk.RunAs == skill.RunSubagent && strings.TrimSpace(task) == "" {
+		return SubmitManagementHandled
+	}
+	return SubmitTurnStarted
+}
+
+func (c *Controller) isPathSubmit(trimmed string) bool {
+	if _, ok := FileRefLine(trimmed); ok {
+		return true
+	}
+	if _, ok := SlashPathLineRef(trimmed, c.workspaceRoot); ok {
+		return true
+	}
+	return SlashPathLikeLine(trimmed)
+}
+
+func (c *Controller) classifyPlanExecSubmit() SubmitDisposition {
+	if c.executor == nil || len(c.executor.CanonicalTodoState()) == 0 {
+		return SubmitManagementHandled
+	}
+	return SubmitTurnStarted
+}
+
+func classifyPrometheusSubmit(trimmed, command string) SubmitDisposition {
+	args := strings.TrimSpace(strings.TrimPrefix(trimmed, command))
+	if args == "" || args == "--strict" {
+		return SubmitManagementHandled
+	}
+	if strings.HasPrefix(args, "--strict ") && strings.TrimSpace(strings.TrimPrefix(args, "--strict ")) == "" {
+		return SubmitManagementHandled
+	}
+	return SubmitTurnStarted
+}
+
+func classifyDocsSubmit(trimmed, command string) SubmitDisposition {
+	if strings.TrimSpace(strings.TrimPrefix(trimmed, command)) == "" {
+		return SubmitManagementHandled
+	}
+	return SubmitTurnStarted
+}
+
+// SubmitResult is returned by the result-capable desktop submit path. The
+// legacy Submit* methods intentionally keep their void/error contracts.
+type SubmitResult struct {
+	Disposition SubmitDisposition `json:"disposition"`
+}
+
+// SubmitDisplayWithResult preserves the existing asynchronous submit behavior
+// while exposing the route disposition to hosts that need an admission receipt.
+func (c *Controller) SubmitDisplayWithResult(display, input string) SubmitResult {
+	disposition := c.ClassifySubmitRoute(input)
+	c.SubmitDisplay(display, input)
+	return SubmitResult{Disposition: disposition}
+}

--- a/internal/control/submit_route_test.go
+++ b/internal/control/submit_route_test.go
@@ -40,3 +40,12 @@ func TestClassifySubmitRouteSeparatesManagementFromTurns(t *testing.T) {
 		})
 	}
 }
+
+func TestManagementNoticeLeavesTurnOwnedCommandsUnclaimed(t *testing.T) {
+	c := New(Options{Commands: []command.Command{{Name: "review", Body: "review: $ARGUMENTS"}}})
+	for _, input := range []string{"/unknown", "/review inspect", "/compactly"} {
+		if c.managementNotice(input) {
+			t.Fatalf("managementNotice(%q) claimed a turn-owned command", input)
+		}
+	}
+}

--- a/internal/control/submit_route_test.go
+++ b/internal/control/submit_route_test.go
@@ -1,0 +1,42 @@
+package control
+
+import (
+	"testing"
+
+	"reasonix/internal/command"
+)
+
+func TestClassifySubmitRouteSeparatesManagementFromTurns(t *testing.T) {
+	c := New(Options{Commands: []command.Command{{Name: "review", Body: "review: $ARGUMENTS"}}})
+	tests := []struct {
+		input string
+		want  SubmitDisposition
+	}{
+		{input: "/compact", want: SubmitManagementHandled},
+		{input: "/new", want: SubmitManagementHandled},
+		{input: "/context", want: SubmitManagementHandled},
+		{input: "/model", want: SubmitManagementHandled},
+		{input: "/provider deepseek", want: SubmitManagementHandled},
+		{input: "/memory recall", want: SubmitManagementHandled},
+		{input: "/remember keep this", want: SubmitManagementHandled},
+		{input: "# keep this", want: SubmitManagementHandled},
+		{input: "/goal status", want: SubmitManagementHandled},
+		{input: "/goal pause", want: SubmitManagementHandled},
+		{input: "/docs", want: SubmitManagementHandled},
+		{input: "/plan-exec", want: SubmitManagementHandled},
+		{input: "/prometheus", want: SubmitManagementHandled},
+		{input: "/compactly", want: SubmitTurnStarted},
+		{input: "review the diff", want: SubmitTurnStarted},
+		{input: "/goal ship the fix", want: SubmitTurnStarted},
+		{input: "/docs explain compaction", want: SubmitTurnStarted},
+		{input: "/prometheus ship the fix", want: SubmitTurnStarted},
+		{input: "/review the diff", want: SubmitTurnStarted},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := c.ClassifySubmitRoute(tt.input); got != tt.want {
+				t.Fatalf("ClassifySubmitRoute(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/control/turn_events.go
+++ b/internal/control/turn_events.go
@@ -274,6 +274,10 @@ func (s *turnEventDurableSink) RecordCompletionValidation(a event.CompletionVali
 	event.RecordCompletionValidation(s.inner(), a)
 }
 
+func (s *turnEventDurableSink) RecordSubagentLifecycle(a event.SubagentLifecycleInfo) {
+	event.RecordSubagentLifecycle(s.inner(), a)
+}
+
 func terminalTurnStatus(e event.Event) event.TurnStatus {
 	if e.Cancelled || errors.Is(e.Err, context.Canceled) {
 		return event.TurnInterrupted

--- a/internal/event/audit_forwarder.go
+++ b/internal/event/audit_forwarder.go
@@ -29,6 +29,7 @@ type OptionalSinkCapabilities interface {
 	WorkspaceMutationSink
 	RunBudgetSink
 	CompletionValidationAuditSink
+	SubagentLifecycleAuditSink
 }
 
 var _ OptionalSinkCapabilities = AuditForwarder{}
@@ -81,6 +82,10 @@ func (f AuditForwarder) RecordRunBudget(s RunBudgetSample) {
 
 func (f AuditForwarder) RecordCompletionValidation(info CompletionValidationInfo) {
 	RecordCompletionValidation(f.Inner, info)
+}
+
+func (f AuditForwarder) RecordSubagentLifecycle(info SubagentLifecycleInfo) {
+	RecordSubagentLifecycle(f.Inner, info)
 }
 
 // DelegationAuditSink receives one receipt per completed sub-agent run.

--- a/internal/event/coalesce.go
+++ b/internal/event/coalesce.go
@@ -251,3 +251,7 @@ func (c *coalescer) RecordRunBudget(sample RunBudgetSample) {
 func (c *coalescer) RecordCompletionValidation(info CompletionValidationInfo) {
 	c.enqueueCapability(func() { RecordCompletionValidation(c.inner, info) })
 }
+
+func (c *coalescer) RecordSubagentLifecycle(info SubagentLifecycleInfo) {
+	c.enqueueCapability(func() { RecordSubagentLifecycle(c.inner, info) })
+}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -277,6 +277,11 @@ type Tool struct {
 	AttemptID string
 	FileDiff
 	Profile *Profile // ToolDispatch: subagent model/effort (set for task/skill calls)
+	// Subagent outcome metadata is host/UI-only and never enters provider requests.
+	SubagentRef       string
+	SubagentStatus    string
+	SubagentErrorCode string
+	SubagentRetryable bool
 	// Execution is optional local shell metadata (ToolResult). Never sent to
 	// model providers; omitempty keeps old wire readers compatible.
 	Execution *ShellExecution

--- a/internal/event/subagent_lifecycle.go
+++ b/internal/event/subagent_lifecycle.go
@@ -1,0 +1,41 @@
+package event
+
+import "reasonix/internal/nilutil"
+
+// SubagentLifecycleInfo is content-free host telemetry for one child
+// transition. It intentionally excludes prompts, reasoning, tool output, and
+// paths so it can be forwarded to diagnostics without leaking transcript data.
+type SubagentLifecycleInfo struct {
+	Phase             string // child_created | child_running | child_completed | child_partial | child_failed | child_cancelled | child_resume
+	Ref               string
+	ParentToolCallID  string
+	Skill             string
+	Model             string
+	Effort            string
+	Status            string
+	ErrorCode         string
+	Retryable         bool
+	OutputBytes       int
+	StartUnixMs       int64
+	EndUnixMs         int64
+	ValidatorMode     string
+	ValidatorOutcome  string
+	ValidatorAttempt  int
+	ProviderRequestID string
+}
+
+// SubagentLifecycleAuditSink receives host-only child lifecycle telemetry.
+type SubagentLifecycleAuditSink interface {
+	RecordSubagentLifecycle(SubagentLifecycleInfo)
+}
+
+// RecordSubagentLifecycle forwards content-free child lifecycle telemetry to
+// sinks that explicitly opt in.
+func RecordSubagentLifecycle(s Sink, info SubagentLifecycleInfo) {
+	if nilutil.IsNil(s) {
+		return
+	}
+	if ls, ok := s.(SubagentLifecycleAuditSink); ok {
+		ls.RecordSubagentLifecycle(info)
+	}
+}

--- a/internal/event/subagent_lifecycle_test.go
+++ b/internal/event/subagent_lifecycle_test.go
@@ -1,0 +1,23 @@
+package event
+
+import "testing"
+
+type lifecycleAuditSink struct {
+	info []SubagentLifecycleInfo
+}
+
+func (s *lifecycleAuditSink) Emit(Event) {}
+
+func (s *lifecycleAuditSink) RecordSubagentLifecycle(info SubagentLifecycleInfo) {
+	s.info = append(s.info, info)
+}
+
+func TestRecordSubagentLifecycleForwardsThroughWrappers(t *testing.T) {
+	inner := &lifecycleAuditSink{}
+	wrapped := Sync(inner)
+	want := SubagentLifecycleInfo{Phase: "child_partial", Ref: "sa_child", Status: "partial", Retryable: true}
+	RecordSubagentLifecycle(wrapped, want)
+	if len(inner.info) != 1 || inner.info[0] != want {
+		t.Fatalf("lifecycle audit = %+v, want %+v", inner.info, want)
+	}
+}

--- a/internal/event/sync.go
+++ b/internal/event/sync.go
@@ -127,3 +127,9 @@ func (s *syncSink) RecordCompletionValidation(info CompletionValidationInfo) {
 	defer s.mu.Unlock()
 	RecordCompletionValidation(s.inner, info)
 }
+
+func (s *syncSink) RecordSubagentLifecycle(info SubagentLifecycleInfo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	RecordSubagentLifecycle(s.inner, info)
+}

--- a/internal/eventwire/wire.go
+++ b/internal/eventwire/wire.go
@@ -147,6 +147,8 @@ func ToWire(e event.Event) Event {
 			ArgChars: e.Tool.ArgChars, Refreshed: e.Tool.Refreshed,
 			ParentID: e.Tool.ParentID, AttemptID: e.Tool.AttemptID,
 			Diff: e.Tool.Diff, Added: e.Tool.Added, Removed: e.Tool.Removed,
+			SubagentRef: e.Tool.SubagentRef, SubagentStatus: e.Tool.SubagentStatus,
+			SubagentErrorCode: e.Tool.SubagentErrorCode, SubagentRetryable: e.Tool.SubagentRetryable,
 		}
 		if e.Tool.Profile != nil {
 			wt.Profile = &Profile{Model: e.Tool.Profile.Model, Effort: e.Tool.Profile.Effort}
@@ -395,28 +397,32 @@ type Profile struct {
 
 // Tool is the JSON form of an event.Tool.
 type Tool struct {
-	ID           string          `json:"id,omitempty"`
-	Name         string          `json:"name"`
-	Args         string          `json:"args,omitempty" externalizable:"true"`
-	ResolvedName string          `json:"resolvedName,omitempty"`
-	CapabilityID string          `json:"capabilityId,omitempty"`
-	Output       string          `json:"output,omitempty" externalizable:"true"`
-	Err          string          `json:"err,omitempty" externalizable:"true"`
-	ReadOnly     bool            `json:"readOnly"`
-	Truncated    bool            `json:"truncated,omitempty"`
-	DurationMs   int64           `json:"durationMs,omitempty"`
-	StartedAt    int64           `json:"startedAt,omitempty"` // unix ms; zero when the call never ran
-	EndedAt      int64           `json:"endedAt,omitempty"`
-	Partial      bool            `json:"partial,omitempty"`
-	ArgChars     int             `json:"argChars,omitempty"`
-	Refreshed    bool            `json:"refreshed,omitempty"`
-	ParentID     string          `json:"parentId,omitempty"`
-	AttemptID    string          `json:"attemptId,omitempty"` // host-local stream_attempt id for speculative partials
-	Diff         string          `json:"diff,omitempty" externalizable:"true"`
-	Added        int             `json:"added,omitempty"`
-	Removed      int             `json:"removed,omitempty"`
-	Profile      *Profile        `json:"profile,omitempty"`
-	Execution    *ShellExecution `json:"execution,omitempty"`
+	ID                string          `json:"id,omitempty"`
+	Name              string          `json:"name"`
+	Args              string          `json:"args,omitempty" externalizable:"true"`
+	ResolvedName      string          `json:"resolvedName,omitempty"`
+	CapabilityID      string          `json:"capabilityId,omitempty"`
+	Output            string          `json:"output,omitempty" externalizable:"true"`
+	Err               string          `json:"err,omitempty" externalizable:"true"`
+	ReadOnly          bool            `json:"readOnly"`
+	Truncated         bool            `json:"truncated,omitempty"`
+	DurationMs        int64           `json:"durationMs,omitempty"`
+	StartedAt         int64           `json:"startedAt,omitempty"` // unix ms; zero when the call never ran
+	EndedAt           int64           `json:"endedAt,omitempty"`
+	Partial           bool            `json:"partial,omitempty"`
+	ArgChars          int             `json:"argChars,omitempty"`
+	Refreshed         bool            `json:"refreshed,omitempty"`
+	ParentID          string          `json:"parentId,omitempty"`
+	AttemptID         string          `json:"attemptId,omitempty"` // host-local stream_attempt id for speculative partials
+	SubagentRef       string          `json:"subagentRef,omitempty"`
+	SubagentStatus    string          `json:"subagentStatus,omitempty"`
+	SubagentErrorCode string          `json:"subagentErrorCode,omitempty"`
+	SubagentRetryable bool            `json:"subagentRetryable,omitempty"`
+	Diff              string          `json:"diff,omitempty" externalizable:"true"`
+	Added             int             `json:"added,omitempty"`
+	Removed           int             `json:"removed,omitempty"`
+	Profile           *Profile        `json:"profile,omitempty"`
+	Execution         *ShellExecution `json:"execution,omitempty"`
 }
 
 // ShellExecution is the JSON form of event.ShellExecution (local UI metadata).

--- a/internal/eventwire/wire_test.go
+++ b/internal/eventwire/wire_test.go
@@ -252,6 +252,22 @@ func TestToWireToolCarriesResolvedCapabilityMetadata(t *testing.T) {
 	}
 }
 
+func TestToWireToolCarriesSubagentOutcomeMetadata(t *testing.T) {
+	w := ToWire(event.Event{Kind: event.ToolResult, Tool: event.Tool{
+		ID: "skill-1", Name: "run_skill", SubagentRef: "sa_child",
+		SubagentStatus: "partial", SubagentErrorCode: "completion_uncertain", SubagentRetryable: true,
+	}})
+	b, err := json.Marshal(w)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{`"subagentRef":"sa_child"`, `"subagentStatus":"partial"`, `"subagentErrorCode":"completion_uncertain"`, `"subagentRetryable":true`} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("subagent outcome JSON = %s, want %s", b, want)
+		}
+	}
+}
+
 func TestToWireToolOmitsHostOnlyWorkspaceMutationMetadata(t *testing.T) {
 	privatePath := "/Users/private/secret-project/file.go"
 	w := ToWire(event.Event{Kind: event.ToolResult, Tool: event.Tool{

--- a/internal/provider/anthropic/missing_reasoning_fallback.go
+++ b/internal/provider/anthropic/missing_reasoning_fallback.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"context"
+	"strings"
 
 	"reasonix/internal/provider"
 )
@@ -46,11 +47,23 @@ func (c *client) applyDeepSeekThinking(r *anthRequest, req provider.Request, rec
 	if c.effort == "disabled" {
 		t = "disabled"
 	}
+	effort := normalizeDeepSeekAnthropicEffort(c.model, c.effort)
+	if !recoveryWithoutThinking {
+		switch override := strings.ToLower(strings.TrimSpace(req.EffortOverride)); override {
+		case "disabled":
+			t = "disabled"
+		case "":
+		default:
+			if normalized := normalizeDeepSeekAnthropicEffort(c.model, override); normalized != "" {
+				effort = normalized
+			}
+		}
+	}
 	r.Thinking = &thinkingConfig{Type: t}
 	if t == "disabled" {
 		return
 	}
-	switch effort := normalizeDeepSeekAnthropicEffort(c.model, c.effort); effort {
+	switch effort {
 	case "low", "high", "max":
 		r.OutputConfig = &outputConfig{Effort: effort}
 	}

--- a/internal/provider/openai/effort.go
+++ b/internal/provider/openai/effort.go
@@ -84,6 +84,13 @@ func (c *client) requestEffort(req provider.Request) string {
 	return want
 }
 
+func (c *client) deepSeekRequestThinking(req provider.Request) string {
+	if c.thinkingType == "disabled" || strings.EqualFold(strings.TrimSpace(req.EffortOverride), "disabled") {
+		return "disabled"
+	}
+	return "enabled"
+}
+
 func supportsEffort(levels []string, want string) bool {
 	want = strings.ToLower(strings.TrimSpace(want))
 	for _, level := range levels {

--- a/internal/provider/openai/effort_override_test.go
+++ b/internal/provider/openai/effort_override_test.go
@@ -28,8 +28,9 @@ func TestEffortOverrideDeepSeekFlash(t *testing.T) {
 	if got := c.buildRequest(provider.Request{EffortOverride: "medium"}).ReasoningEffort; got != "high" {
 		t.Fatalf("override outside DeepSeek vocabulary must keep the default, got %q", got)
 	}
-	if got := c.buildRequest(provider.Request{EffortOverride: "disabled"}).ReasoningEffort; got != "high" {
-		t.Fatalf("override must never toggle thinking off, got %q", got)
+	request := c.buildRequest(provider.Request{EffortOverride: "disabled"})
+	if request.ReasoningEffort != "" || request.Thinking == nil || request.Thinking.Type != "disabled" {
+		t.Fatalf("disabled override = thinking:%#v effort:%q, want thinking disabled and no effort", request.Thinking, request.ReasoningEffort)
 	}
 }
 
@@ -62,8 +63,9 @@ func TestEffortOverrideHonorsSupportedEfforts(t *testing.T) {
 	if got := c.buildRequest(provider.Request{EffortOverride: "max"}).ReasoningEffort; got != "high" {
 		t.Fatalf("undeclared level must keep the default, got %q", got)
 	}
-	if got := c.buildRequest(provider.Request{EffortOverride: "disabled"}).ReasoningEffort; got != "high" {
-		t.Fatalf("disabled is a thinking toggle, not a depth; got %q", got)
+	request := c.buildRequest(provider.Request{EffortOverride: "disabled"})
+	if request.ReasoningEffort != "" || request.Thinking == nil || request.Thinking.Type != "disabled" {
+		t.Fatalf("disabled override = thinking:%#v effort:%q, want thinking disabled and no effort", request.Thinking, request.ReasoningEffort)
 	}
 }
 

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -797,12 +797,11 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		out.MaxCompletionTokens = maxOutputTokens
 	case c.deepseek:
 		// DeepSeek's CoT is controlled by `thinking` plus `reasoning_effort` for
-		// depth. Thinking is on by default but can be turned off via
-		// effort=disabled / thinking=disabled (credit @eghrhegpe, #5063).
-		if c.thinkingType == "disabled" {
-			out.Thinking = &thinkingMode{Type: "disabled"}
-		} else {
-			out.Thinking = &thinkingMode{Type: "enabled"}
+		// depth. Thinking is on by default but can be turned off for one
+		// stateless request through EffortOverride=disabled.
+		out.Thinking = &thinkingMode{Type: c.deepSeekRequestThinking(req)}
+		if out.Thinking.Type == "disabled" {
+			out.ReasoningEffort = ""
 		}
 	case c.minimax:
 		// M3 uses a single `thinking.type` field with two valid values:

--- a/internal/skill/tools.go
+++ b/internal/skill/tools.go
@@ -3,6 +3,7 @@ package skill
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -30,6 +31,15 @@ type SubagentRunOptions struct {
 }
 
 type SubagentRunner func(ctx context.Context, sk Skill, task string, opts SubagentRunOptions) (string, error)
+
+// SubagentOutputError is implemented by host runners that can preserve a
+// bounded result envelope alongside a terminal error. Tool dispatchers should
+// return that output to the parent model while retaining the error for host
+// status and recovery classification.
+type SubagentOutputError interface {
+	error
+	SubagentOutput() string
+}
 
 // ProfileResolver returns the model/effort profile a subagent skill will use.
 // It is optional; without one, skill frontmatter still supplies display metadata.
@@ -161,6 +171,10 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 		}
 		out, err := t.runner(ctx, sk, rawArgs, opts)
 		if err != nil {
+			var outputErr SubagentOutputError
+			if errors.As(err, &outputErr) && strings.TrimSpace(outputErr.SubagentOutput()) != "" {
+				return outputErr.SubagentOutput(), err
+			}
 			return "", err
 		}
 		return tool.GuardSubagentHostDecisionText(out), nil
@@ -306,6 +320,10 @@ func (t *readOnlySkillTool) Execute(ctx context.Context, args json.RawMessage) (
 		}
 		out, err := t.runner(ctx, sk, rawArgs, SubagentRunOptions{})
 		if err != nil {
+			var outputErr SubagentOutputError
+			if errors.As(err, &outputErr) && strings.TrimSpace(outputErr.SubagentOutput()) != "" {
+				return outputErr.SubagentOutput(), err
+			}
 			return "", err
 		}
 		return tool.GuardSubagentHostDecisionText(out), nil

--- a/internal/skill/tools_test.go
+++ b/internal/skill/tools_test.go
@@ -179,6 +179,28 @@ func TestRunSkillSubagentRuns(t *testing.T) {
 	}
 }
 
+type subagentOutputError struct{}
+
+func (subagentOutputError) Error() string { return "subagent paused" }
+
+func (subagentOutputError) SubagentOutput() string { return "status=partial ref=sa_test\nlast output" }
+
+func TestRunSkillSubagentPreservesOutputWhenRunnerReturnsTypedFailure(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/dig.md", "---\ndescription: dig\nrunAs: subagent\n---\nbody")
+	runner := func(context.Context, Skill, string, SubagentRunOptions) (string, error) {
+		return "status=partial ref=sa_test\nlast output", subagentOutputError{}
+	}
+	tl := NewRunSkillTool(New(Options{HomeDir: home, DisableBuiltins: true}), runner)
+	out, err := tl.Execute(context.Background(), json.RawMessage(`{"name":"dig","arguments":"find X"}`))
+	if err == nil {
+		t.Fatal("expected typed subagent failure")
+	}
+	if !strings.Contains(out, "ref=sa_test") {
+		t.Fatalf("typed failure output was discarded: %q", out)
+	}
+}
+
 func TestRunSkillSubagentResultWarnsOnHostDecisionLanguage(t *testing.T) {
 	home := t.TempDir()
 	writeSkill(t, home, ".reasonix/skills/dig.md", "---\ndescription: dig\nrunAs: subagent\n---\nbody")

--- a/internal/stats/recorder.go
+++ b/internal/stats/recorder.go
@@ -246,6 +246,10 @@ func (r *Recorder) RecordCompletionValidation(info event.CompletionValidationInf
 	event.RecordCompletionValidation(r.inner, info)
 }
 
+func (r *Recorder) RecordSubagentLifecycle(info event.SubagentLifecycleInfo) {
+	event.RecordSubagentLifecycle(r.inner, info)
+}
+
 func (r *Recorder) recordUsage(e event.Event) {
 	r.recordProviderUsage(e.ModelRef, e.Usage, e.CostQuote, e.UsageSource)
 }

--- a/internal/trajectory/recorder.go
+++ b/internal/trajectory/recorder.go
@@ -35,6 +35,27 @@ type Record struct {
 	OutcomeProgress     *OutcomeProgress     `json:"outcome_progress,omitempty"`
 	DelegationAdmission *DelegationAdmission `json:"delegation_admission,omitempty"`
 	MemoryRecall        *MemoryRecall        `json:"memory_recall,omitempty"`
+	SubagentLifecycle   *SubagentLifecycle   `json:"subagent_lifecycle,omitempty"`
+}
+
+// SubagentLifecycle mirrors the content-free child lifecycle audit.
+type SubagentLifecycle struct {
+	Phase             string `json:"phase"`
+	Ref               string `json:"ref,omitempty"`
+	ParentToolCallID  string `json:"parent_tool_call_id,omitempty"`
+	Skill             string `json:"skill,omitempty"`
+	Model             string `json:"model,omitempty"`
+	Effort            string `json:"effort,omitempty"`
+	Status            string `json:"status,omitempty"`
+	ErrorCode         string `json:"error_code,omitempty"`
+	Retryable         bool   `json:"retryable,omitempty"`
+	OutputBytes       int    `json:"output_bytes,omitempty"`
+	StartUnixMs       int64  `json:"start_unix_ms,omitempty"`
+	EndUnixMs         int64  `json:"end_unix_ms,omitempty"`
+	ValidatorMode     string `json:"validator_mode,omitempty"`
+	ValidatorOutcome  string `json:"validator_outcome,omitempty"`
+	ValidatorAttempt  int    `json:"validator_attempt,omitempty"`
+	ProviderRequestID string `json:"provider_request_id,omitempty"`
 }
 
 // MemoryRecall mirrors event.MemoryRecallAudit with stable snake_case keys.
@@ -341,6 +362,18 @@ func (r *Recorder) RecordRunBudget(sample event.RunBudgetSample) {
 
 func (r *Recorder) RecordCompletionValidation(info event.CompletionValidationInfo) {
 	event.RecordCompletionValidation(r.inner, info)
+}
+
+func (r *Recorder) RecordSubagentLifecycle(info event.SubagentLifecycleInfo) {
+	r.append(Record{SubagentLifecycle: &SubagentLifecycle{
+		Phase: info.Phase, Ref: info.Ref, ParentToolCallID: info.ParentToolCallID,
+		Skill: info.Skill, Model: info.Model, Effort: info.Effort, Status: info.Status,
+		ErrorCode: info.ErrorCode, Retryable: info.Retryable, OutputBytes: info.OutputBytes,
+		StartUnixMs: info.StartUnixMs, EndUnixMs: info.EndUnixMs, ValidatorMode: info.ValidatorMode,
+		ValidatorOutcome: info.ValidatorOutcome, ValidatorAttempt: info.ValidatorAttempt,
+		ProviderRequestID: info.ProviderRequestID,
+	}})
+	event.RecordSubagentLifecycle(r.inner, info)
 }
 
 // Close flushes and closes the file, returning the first error seen. Events


### PR DESCRIPTION
fix: preserve and recover subagent outcomes

## Summary

This PR systematizes subagent result delivery and recovery without adding cost on the normal path.

## Problem

Successful or partially completed child agents could lose their final visible output and stable reference when completion confirmation failed. Continuation and UI paths then treated all terminal errors as unrecoverable.

## Root cause

Task and skill runners returned unstructured errors, persisted metadata only represented completed/failed states, and child validation reused the root evaluator path without a bounded recovery contract.

## Fix

- Add a backward-compatible `SubagentOutcome` envelope and typed child-run errors.
- Classify uncertain child completion as retryable `partial` and retain the last visible answer.
- Save transcripts before terminal metadata and support partial/failed reads plus `continue_from`.
- Preserve references through task, skill, parallel, fleet, eventwire, history hydration, and desktop cards.
- Separate `sa_...` transcript references from `tr-...` ordinary tool-result references.
- Disable thinking only on bounded evaluator requests; normal child runs do not add evaluator calls.
- Add host-only lifecycle diagnostics and a real partial progress terminal state.
- Preserve allocated refs on setup, scheduler, provider-resolution, and save failures.
- Re-enter `running` metadata before a continuation and keep cancellation states consistent for deadlines.
- Apply the existing bounded completion evaluator at most once for an ambiguous child completion.
- Emit child-created/resume/running/terminal lifecycle transitions and reject spoofed outcome markers from ordinary tools.
- Keep duplicate terminal persistence idempotent.
- Document compatibility, downgrade behavior, and recovery semantics in English and Chinese.

## Compatibility and cache impact

Metadata fields are additive and `omitempty`; old transcripts remain readable and old readers ignore unknown fields. Provider-visible schemas remain stable apart from the explicit static boundary clarification. Dynamic refs, statuses, and result bodies stay out of prompts and tool schemas. The normal subagent path adds no model calls, tokens, or waits.

Cache-impact: low - evaluator thinking is disabled only on a separate bounded request; child result metadata is host-only and dynamic refs never enter the cached prompt prefix.

Cache-guard: `./scripts/cache-guard.sh` passed; provider request and schema tests passed; the existing tool-loop guard warning remains at 89%.

Bundle-impact: the CI desktop build measured initial JavaScript gzip at 463.9 KiB versus the previous 463.4 KiB gate and raw JavaScript/CSS at 2474.0 KiB versus 2471.8 KiB; the narrowly rounded budgets are raised to those measured values for the outcome card/history hydration. The Windows locale check also measured `zh` at the exact 60.4 KiB boundary, so its dialect budget gains only 0.1 KiB of platform-compression headroom. No chunk boundary is changed.

System-prompt-review: reviewed; child validation changes are host-side, and static tool-description wording changes only clarify the existing `tr-...` versus `sa_...` boundary.

Documentation-impact: updated - English and Chinese guides and tool contracts document statuses, retained partial output, continuation, and the `session:tool_result` boundary.

## Verification

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `(cd desktop && go test -count=1 ./...)`
- `(cd desktop && go test -race -count=1 ./...)`
- `(cd desktop && go vet ./...)`
- `make lint`
- `./scripts/cache-guard.sh`

Frontend TypeScript typecheck remains environment-blocked because `desktop/frontend/node_modules` is not installed.

The branch is rebased onto the latest `main-v2`; no force-push was used. The previously published PR head is retained as a merge parent so the verified PR branch could advance safely.
