### PR TITLE
fix(provider,agent): align OpenAI reasoning replay with Harness / 对齐 Harness 的 OpenAI 推理回放与旧历史自愈

### DIFF
--- a/docs/REASONING_PROVIDERS.md
+++ b/docs/REASONING_PROVIDERS.md
@@ -66,7 +66,9 @@ New official entries use this native Messages API path and enable provider-side
 `web_search`; existing explicit providers, including legacy
 `deepseek-anthropic` entries, keep their configured protocol. Reasonix emits
 `thinking.type=enabled|disabled` with `output_config.effort`, replays unsigned
-DeepSeek thinking blocks from historical tool-call turns, omits unsupported
+DeepSeek thinking blocks from every historical assistant turn that carries
+reasoning (tool-call turn or not, as DeepSeek's thinking mode requires when the
+request declares tools), omits unsupported
 images, and relies on DeepSeek's automatic prefix cache instead of ignored
 `cache_control` markers.
 

--- a/docs/REASONING_PROVIDERS.md
+++ b/docs/REASONING_PROVIDERS.md
@@ -67,8 +67,7 @@ New official entries use this native Messages API path and enable provider-side
 `deepseek-anthropic` entries, keep their configured protocol. Reasonix emits
 `thinking.type=enabled|disabled` with `output_config.effort`, replays unsigned
 DeepSeek thinking blocks from every historical assistant turn that carries
-reasoning (tool-call turn or not, as DeepSeek's thinking mode requires when the
-request declares tools), omits unsupported
+reasoning when the request declares tools (tool-call turn or not), omits unsupported
 images, and relies on DeepSeek's automatic prefix cache instead of ignored
 `cache_control` markers.
 
@@ -77,12 +76,13 @@ The preset exposes the same model-specific effort scale for Flash and Pro:
 accepts `low|high|max` on the wire. Legacy `medium` and `xhigh` both normalize
 to `high`.
 
-The OpenAI-compatible DeepSeek path follows the same all-turn replay rule:
-every historical assistant turn with stored `reasoning_content` is serialized
-back verbatim, whether or not that turn called a tool. If an old session still
-fails with the provider's specific reasoning pass-back HTTP 400, Reasonix
-rebuilds only the provider-visible message projection without reasoning,
-retries once, and keeps that stripped projection for later rounds; canonical
+The OpenAI-compatible DeepSeek path follows the same replay rule when a request
+declares tools: every historical assistant turn with stored `reasoning_content`
+is serialized back verbatim, whether or not that turn called a tool. Without
+tools, DeepSeek ignores this field and does not concatenate it into context. If
+an old session still fails with the provider's specific reasoning pass-back HTTP
+400, Reasonix rebuilds only the provider-visible projection of the old history,
+retries once, and leaves later turns on the normal replay path; canonical
 session history remains unchanged.
 
 ## Everything else (standard `reasoning_effort`)

--- a/docs/REASONING_PROVIDERS.md
+++ b/docs/REASONING_PROVIDERS.md
@@ -13,8 +13,8 @@ get a tailored request shape automatically — no extra config needed.
 
 | Provider | Base URL | Reasoning control | `/effort` levels | Notes |
 |----------|----------|-------------------|------------------|-------|
-| DeepSeek V4 Flash | `api.deepseek.com`, `*.deepseek.com` | `thinking.type` + `reasoning_effort` (depth) | `auto`, `disabled`, `low`, `high`, `max` | Thinking on by default; `disabled` turns it off via `thinking.type=disabled`. Compatibility input `medium` normalizes to `high`, while `xhigh` normalizes to `high`. |
-| DeepSeek V4 Pro | `api.deepseek.com`, `*.deepseek.com` | `thinking.type` + `reasoning_effort` (depth) | `auto`, `disabled`, `low`, `high`, `max` | Thinking on by default; `disabled` turns it off via `thinking.type=disabled`. Compatibility inputs `medium` and `xhigh` normalize to `high`. |
+| DeepSeek V4 Flash | `api.deepseek.com`, `*.deepseek.com` | `thinking.type` + `reasoning_effort` (depth) | `auto`, `disabled`, `low`, `high`, `max` | Thinking on by default; `disabled` turns it off via `thinking.type=disabled`. Compatibility input `medium` normalizes to `high`, while `xhigh` normalizes to `high`. Reasoning is replayed on every historical assistant turn that carries it, including turns without tool calls. |
+| DeepSeek V4 Pro | `api.deepseek.com`, `*.deepseek.com` | `thinking.type` + `reasoning_effort` (depth) | `auto`, `disabled`, `low`, `high`, `max` | Thinking on by default; `disabled` turns it off via `thinking.type=disabled`. Compatibility inputs `medium` and `xhigh` normalize to `high`. Reasoning is replayed on every historical assistant turn that carries it, including turns without tool calls. |
 | MiniMax M3 | `api.minimaxi.com`, `*.minimaxi.com` | `thinking.type` (`adaptive`\|`disabled`) | `auto`, `adaptive`, `disabled` | No depth scale; `reasoning_effort` is omitted. |
 | Zhipu GLM | `open.bigmodel.cn` / `*.bigmodel.cn`, `api.z.ai` / `*.z.ai` | `thinking.type` (`enabled`\|`disabled`) | `auto`, `enabled`, `disabled` | **`reasoning_effort` is silently ignored** by the endpoint, so reasoning is driven purely through `thinking.type`. |
 
@@ -76,6 +76,14 @@ The preset exposes the same model-specific effort scale for Flash and Pro:
 `auto`, `disabled`, `low`, `high`, and `max`. The Anthropic-compatible endpoint
 accepts `low|high|max` on the wire. Legacy `medium` and `xhigh` both normalize
 to `high`.
+
+The OpenAI-compatible DeepSeek path follows the same all-turn replay rule:
+every historical assistant turn with stored `reasoning_content` is serialized
+back verbatim, whether or not that turn called a tool. If an old session still
+fails with the provider's specific reasoning pass-back HTTP 400, Reasonix
+rebuilds only the provider-visible message projection without reasoning,
+retries once, and keeps that stripped projection for later rounds; canonical
+session history remains unchanged.
 
 ## Everything else (standard `reasoning_effort`)
 

--- a/docs/REASONING_PROVIDERS.zh-CN.md
+++ b/docs/REASONING_PROVIDERS.zh-CN.md
@@ -16,8 +16,8 @@ Reasonix 只暴露一个 `/effort` 开关（以及 provider 级的 `effort` / `t
 
 | Provider          | Base URL                                                    | 推理控制                                     | `/effort` 档位                           | 备注 |
 |-------------------|-------------------------------------------------------------|----------------------------------------------|------------------------------------------|-------|
-| DeepSeek V4 Flash | `api.deepseek.com`、`*.deepseek.com`                        | `thinking.type` + `reasoning_effort`（深度） | `auto`、`disabled`、`low`、`high`、`max` | 默认开启思考；`disabled` 通过 `thinking.type=disabled` 关闭。兼容性输入 `medium` 归一化为 `high`，`xhigh` 归一化为 `high`。历史 assistant 轮次只要携带 reasoning，都会回传，即使该轮没有工具调用。 |
-| DeepSeek V4 Pro   | `api.deepseek.com`、`*.deepseek.com`                        | `thinking.type` + `reasoning_effort`（深度） | `auto`、`disabled`、`low`、`high`、`max` | 默认开启思考；`disabled` 通过 `thinking.type=disabled` 关闭。兼容性输入 `medium`、`xhigh` 归一化为 `high`。历史 assistant 轮次只要携带 reasoning，都会回传，即使该轮没有工具调用。 |
+| DeepSeek V4 Flash | `api.deepseek.com`、`*.deepseek.com`                        | `thinking.type` + `reasoning_effort`（深度） | `auto`、`disabled`、`low`、`high`、`max` | 默认开启思考；`disabled` 通过 `thinking.type=disabled` 关闭。兼容性输入 `medium` 归一化为 `high`，`xhigh` 归一化为 `high`。请求携带 tools 时，历史 assistant 轮次只要携带 reasoning 都会回传，即使该轮没有工具调用；不带 tools 时该字段会被 DeepSeek 忽略。 |
+| DeepSeek V4 Pro   | `api.deepseek.com`、`*.deepseek.com`                        | `thinking.type` + `reasoning_effort`（深度） | `auto`、`disabled`、`low`、`high`、`max` | 默认开启思考；`disabled` 通过 `thinking.type=disabled` 关闭。兼容性输入 `medium`、`xhigh` 归一化为 `high`。请求携带 tools 时，历史 assistant 轮次只要携带 reasoning 都会回传，即使该轮没有工具调用；不带 tools 时该字段会被 DeepSeek 忽略。 |
 | MiniMax M3        | `api.minimaxi.com`、`*.minimaxi.com`                        | `thinking.type`（`adaptive`\|`disabled`）    | `auto`、`adaptive`、`disabled`           | 无深度档位；`reasoning_effort` 会被省略。 |
 | Zhipu GLM         | `open.bigmodel.cn` / `*.bigmodel.cn`、`api.z.ai` / `*.z.ai` | `thinking.type`（`enabled`\|`disabled`）     | `auto`、`enabled`、`disabled`            | **端点会静默忽略 `reasoning_effort`**，因此推理完全由 `thinking.type` 驱动。 |
 
@@ -63,19 +63,20 @@ reasoning_protocol = "kimi-k3"
 默认官方 DeepSeek provider 指向 `https://api.deepseek.com/anthropic`。
 新建的官方条目使用原生 Messages API 路径并开启 provider 侧 `web_search`；已有显式
 provider（包括旧的 `deepseek-anthropic` 条目）保留其原协议。Reasonix 会发送
-`thinking.type=enabled|disabled` 与 `output_config.effort`，回放历史工具调用轮次
-中未签名的 DeepSeek 思考块，省略不支持的图片，并依赖 DeepSeek 的自动前缀缓存，
+`thinking.type=enabled|disabled` 与 `output_config.effort`，在请求携带 tools 时回放历史
+assistant 轮次中未签名的 DeepSeek 思考块，省略不支持的图片，并依赖 DeepSeek 的自动前缀缓存，
 而不是被忽略的 `cache_control` 标记。
 
 该预设为 Flash 和 Pro 暴露相同的模型专属 effort 档位：`auto`、`disabled`、
 `low`、`high` 和 `max`。Anthropic-compatible 端点在线上接受 `low|high|max`；
 遗留的 `medium`、`xhigh` 均归一化为 `high`。
 
-OpenAI-compatible 的 DeepSeek 路径采用相同的全轮回放规则：历史中每个保存了
-`reasoning_content` 的 assistant 轮次都会原样序列化回请求，不论该轮是否调用过工具。
-如果旧会话仍因提供方特有的 reasoning 回传 HTTP 400 失败，Reasonix 只重建去掉
-reasoning 的 provider-visible 消息投影并重试一次；后续轮次继续使用这个去 reasoning
-投影，而 canonical session history 不会被修改。
+OpenAI-compatible 的 DeepSeek 路径采用相同的全轮回放规则：请求携带 tools 时，历史中
+每个保存了 `reasoning_content` 的 assistant 轮次都会原样序列化回请求，不论该轮是否
+调用过工具；不带 tools 时该字段会被 DeepSeek 忽略。如果旧会话仍因提供方特有的
+reasoning 回传 HTTP 400 失败，Reasonix 只重建旧历史的 provider-visible 消息投影并
+重试一次；后续新增轮次继续走正常 reasoning/tool replay，而 canonical session history
+不会被修改。
 
 ## 其他所有后端（标准 `reasoning_effort`）
 

--- a/docs/REASONING_PROVIDERS.zh-CN.md
+++ b/docs/REASONING_PROVIDERS.zh-CN.md
@@ -16,8 +16,8 @@ Reasonix 只暴露一个 `/effort` 开关（以及 provider 级的 `effort` / `t
 
 | Provider          | Base URL                                                    | 推理控制                                     | `/effort` 档位                           | 备注 |
 |-------------------|-------------------------------------------------------------|----------------------------------------------|------------------------------------------|-------|
-| DeepSeek V4 Flash | `api.deepseek.com`、`*.deepseek.com`                        | `thinking.type` + `reasoning_effort`（深度） | `auto`、`disabled`、`low`、`high`、`max` | 默认开启思考；`disabled` 通过 `thinking.type=disabled` 关闭。兼容性输入 `medium` 归一化为 `high`，`xhigh` 归一化为 `high`。 |
-| DeepSeek V4 Pro   | `api.deepseek.com`、`*.deepseek.com`                        | `thinking.type` + `reasoning_effort`（深度） | `auto`、`disabled`、`low`、`high`、`max` | 默认开启思考；`disabled` 通过 `thinking.type=disabled` 关闭。兼容性输入 `medium`、`xhigh` 归一化为 `high`。 |
+| DeepSeek V4 Flash | `api.deepseek.com`、`*.deepseek.com`                        | `thinking.type` + `reasoning_effort`（深度） | `auto`、`disabled`、`low`、`high`、`max` | 默认开启思考；`disabled` 通过 `thinking.type=disabled` 关闭。兼容性输入 `medium` 归一化为 `high`，`xhigh` 归一化为 `high`。历史 assistant 轮次只要携带 reasoning，都会回传，即使该轮没有工具调用。 |
+| DeepSeek V4 Pro   | `api.deepseek.com`、`*.deepseek.com`                        | `thinking.type` + `reasoning_effort`（深度） | `auto`、`disabled`、`low`、`high`、`max` | 默认开启思考；`disabled` 通过 `thinking.type=disabled` 关闭。兼容性输入 `medium`、`xhigh` 归一化为 `high`。历史 assistant 轮次只要携带 reasoning，都会回传，即使该轮没有工具调用。 |
 | MiniMax M3        | `api.minimaxi.com`、`*.minimaxi.com`                        | `thinking.type`（`adaptive`\|`disabled`）    | `auto`、`adaptive`、`disabled`           | 无深度档位；`reasoning_effort` 会被省略。 |
 | Zhipu GLM         | `open.bigmodel.cn` / `*.bigmodel.cn`、`api.z.ai` / `*.z.ai` | `thinking.type`（`enabled`\|`disabled`）     | `auto`、`enabled`、`disabled`            | **端点会静默忽略 `reasoning_effort`**，因此推理完全由 `thinking.type` 驱动。 |
 
@@ -70,6 +70,12 @@ provider（包括旧的 `deepseek-anthropic` 条目）保留其原协议。Reaso
 该预设为 Flash 和 Pro 暴露相同的模型专属 effort 档位：`auto`、`disabled`、
 `low`、`high` 和 `max`。Anthropic-compatible 端点在线上接受 `low|high|max`；
 遗留的 `medium`、`xhigh` 均归一化为 `high`。
+
+OpenAI-compatible 的 DeepSeek 路径采用相同的全轮回放规则：历史中每个保存了
+`reasoning_content` 的 assistant 轮次都会原样序列化回请求，不论该轮是否调用过工具。
+如果旧会话仍因提供方特有的 reasoning 回传 HTTP 400 失败，Reasonix 只重建去掉
+reasoning 的 provider-visible 消息投影并重试一次；后续轮次继续使用这个去 reasoning
+投影，而 canonical session history 不会被修改。
 
 ## 其他所有后端（标准 `reasoning_effort`）
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1814,7 +1814,7 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 			}
 		}
 		stored = display
-		if a.preserveRawReasoning(signature, reasoningID, reasoningStatus, calls, search.calls) {
+		if a.preserveRawReasoning(original, signature, reasoningID, reasoningStatus, calls, search.calls) {
 			stored = original
 		}
 		return stored, display

--- a/internal/agent/postllmcall_flow_test.go
+++ b/internal/agent/postllmcall_flow_test.go
@@ -42,6 +42,14 @@ type reasoningRoundTripScriptedProvider struct {
 
 func (reasoningRoundTripScriptedProvider) RequiresReasoningRoundTrip() bool { return true }
 
+type assistantReasoningReplayScriptedProvider struct {
+	*scriptedProvider
+}
+
+func (assistantReasoningReplayScriptedProvider) RequiresAssistantReasoningReplay(m provider.Message) bool {
+	return m.ReasoningContent != ""
+}
+
 // TestPostLLMCallAbsentStreamsReasoningLive is the regression guard: with no
 // PostLLMCall hook, reasoning must still stream chunk-by-chunk (one Reasoning
 // event per delta) so the live "thinking…" display keeps working.
@@ -102,6 +110,19 @@ func TestPostLLMCallKeepsOriginalForReasoningRoundTripProvider(t *testing.T) {
 	}
 	if got := assistantReasoning(a.sess.conversation.Messages); got != "think A think B" {
 		t.Fatalf("stored reasoning = %q, want raw provider reasoning for replay", got)
+	}
+}
+
+func TestPostLLMCallKeepsOriginalForPlainReasoningReplayProvider(t *testing.T) {
+	prov := assistantReasoningReplayScriptedProvider{&scriptedProvider{name: "p", turns: reasoningTurn()}}
+	h := &stubHooks{hasPostLLM: true, postLLMOut: "TRANSLATED"}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{Hooks: h}, event.Discard)
+
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := assistantReasoning(a.sess.conversation.Messages); got != "think A think B" {
+		t.Fatalf("stored reasoning = %q, want original provider reasoning", got)
 	}
 }
 

--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -61,6 +61,10 @@ func (a *Agent) InvalidateProjection() {
 	if a == nil {
 		return
 	}
+	// A strong reasoning-replay overlay is indexed against the old canonical
+	// history. Clear it together with the compaction projection so rewind,
+	// branch, and model/system lineage changes cannot reuse a stale anchor.
+	a.sess.clearReasoningReplayStrongProjection()
 	a.sess.compactionMu.Lock()
 	path := a.sess.path
 	a.sess.compactionState = CompactionState{}
@@ -84,6 +88,10 @@ func (a *Agent) InvalidateProjectionIfStale() {
 	if a == nil {
 		return
 	}
+	// This helper is called after a history rewrite even when the existing
+	// compaction fold remains valid (for example a tail-only rewind). The
+	// reasoning-replay overlay still belongs to the pre-rewrite shape.
+	a.sess.clearReasoningReplayStrongProjection()
 	a.sess.compactionMu.Lock()
 	st := a.sess.compactionState
 	if len(st.Projection.Messages) > 0 && a.sess.conversation != nil {

--- a/internal/agent/reasoning_replay.go
+++ b/internal/agent/reasoning_replay.go
@@ -102,6 +102,33 @@ func (a *Agent) finishReasoningReplayRetry(retry streamedTurn, sink *deferredStr
 	return retry
 }
 
+// finishReasoningReplayOverflow terminates an attempt whose required reasoning
+// was truncated by the client limit: audit, finalize usage, and hand the turn
+// to the unreplayable-reasoning policy.
+func (a *Agent) finishReasoningReplayOverflow(result streamedTurn, sink *deferredStreamSink, issue ReasoningReplayFailure, billable *provider.Usage, attemptID string, attempt int) streamedTurn {
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningOverflowDetected})
+	result.usage = finalizeSamplingUsage(billable, result.usage)
+	terminal := a.finishUnreplayableReasoning(result, sink, issue)
+	a.emitReasoningReplayAttemptOutcome(attemptID, attempt, terminal.err)
+	return terminal
+}
+
+// suppressMissingReasoningRetry handles a missing-reasoning turn whose one
+// exact replay was already spent (or claimed cross-process): try the
+// provider-declared fallback, otherwise terminate through the
+// unreplayable-reasoning policy.
+func (a *Agent) suppressMissingReasoningRetry(ctx context.Context, turn int, frozen *samplingRequest, attemptID string, attempt int, sink *deferredStreamSink, result streamedTurn, issue ReasoningReplayFailure, billable *provider.Usage) streamedTurn {
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetrySuppressed})
+	if fallback, ok := a.runMissingReasoningFallback(ctx, turn, frozen, attemptID, attempt, billable, sink); ok {
+		return fallback
+	}
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
+	result.usage = finalizeSamplingUsage(billable, result.usage)
+	terminal := a.finishUnreplayableReasoning(result, sink, issue)
+	a.emitReasoningReplayAttemptOutcome(attemptID, attempt, terminal.err)
+	return terminal
+}
+
 func (a *Agent) finishUnreplayableReasoning(result streamedTurn, sink *deferredStreamSink, issue ReasoningReplayFailure) streamedTurn {
 	if issue == "" {
 		sink.Flush()

--- a/internal/agent/reasoning_replay.go
+++ b/internal/agent/reasoning_replay.go
@@ -44,12 +44,12 @@ func (a *Agent) runMissingReasoningFallback(
 	return fallback, true
 }
 
-func (a *Agent) preserveRawReasoning(signature, reasoningID, reasoningStatus string, calls []provider.ToolCall, searches []provider.ServerSearchCall) bool {
+func (a *Agent) preserveRawReasoning(reasoning, signature, reasoningID, reasoningStatus string, calls []provider.ToolCall, searches []provider.ServerSearchCall) bool {
 	if signature != "" || reasoningID != "" || reasoningStatus != "" {
 		return true
 	}
 	return provider.RequiresAssistantReasoningReplay(a.svc.prov, provider.Message{
-		Role: provider.RoleAssistant, ToolCalls: calls, ServerSearch: searches,
+		Role: provider.RoleAssistant, ReasoningContent: reasoning, ToolCalls: calls, ServerSearch: searches,
 	})
 }
 

--- a/internal/agent/reasoning_replay.go
+++ b/internal/agent/reasoning_replay.go
@@ -53,6 +53,34 @@ func (a *Agent) preserveRawReasoning(reasoning, signature, reasoningID, reasonin
 	})
 }
 
+// reasoningReplayMessageFingerprint identifies the last provider-visible
+// message in the repaired request. It deliberately ignores durable UI fields,
+// matching the same wire-visible fields used by the context projection hash.
+func reasoningReplayMessageFingerprint(message provider.Message) string {
+	return providerVisibleFingerprint(provider.ModelMessages([]provider.Message{message}))
+}
+
+// resolveReasoningReplayPrefix maps the repaired provider prefix back onto a
+// later canonical snapshot. Strong repair can remove old assistant/tool
+// messages, so a raw message count alone can point into a different old turn.
+func resolveReasoningReplayPrefix(msgs []provider.Message, hint int, anchor string) int {
+	if hint <= 0 || hint > len(msgs) {
+		return 0
+	}
+	if anchor == "" {
+		return hint
+	}
+	// Removed messages only make the canonical location move forward. Prefer
+	// the first matching anchor at/after the old provider-visible count; this
+	// also avoids selecting an earlier duplicate user message.
+	for i, message := range msgs {
+		if i+1 >= hint && reasoningReplayMessageFingerprint(message) == anchor {
+			return i + 1
+		}
+	}
+	return 0
+}
+
 func (a *Agent) emitReasoningReplayAttemptOutcome(id string, attempt int, err error) {
 	if err != nil {
 		a.emitStreamAttempt(id, event.StreamAttemptDiscard, attempt, "reasoning_replay", err)

--- a/internal/agent/reasoning_replay_recovery.go
+++ b/internal/agent/reasoning_replay_recovery.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"reasonix/internal/event"
+	"reasonix/internal/i18n"
+	"reasonix/internal/provider"
+)
+
+// reasoningReplayRecoveryBudget bounds the thinking-400 catch-and-repair to one
+// retry per model round. It is independent from the context-recovery budget so
+// one overflow repair and one reasoning repair can never multiply requests.
+type reasoningReplayRecoveryBudget struct {
+	retries int
+}
+
+// recoverReasoningReplay400 applies the vendor-documented self-heal for a
+// provider that rejected replayed thinking history with HTTP 400: rebuild the
+// frozen request's messages through the strong projection (all assistant
+// reasoning stripped, unpaired tool activity dropped) and retry exactly once.
+// Everything except Messages stays byte-identical to the rejected request. A
+// history the projection cannot change is not worth a blind retry.
+func (a *Agent) recoverReasoningReplay400(frozen samplingRequest, err error, budget *reasoningReplayRecoveryBudget) (samplingRequest, bool) {
+	if a == nil || budget == nil || budget.retries > 0 {
+		return samplingRequest{}, false
+	}
+	if provider.AsReasoningReplayError(err) == nil {
+		return samplingRequest{}, false
+	}
+	repaired, changed := provider.ProjectReasoningStrippedMessages(a.svc.prov, frozen.req.Messages)
+	if !changed {
+		return samplingRequest{}, false
+	}
+	budget.retries++
+	next := frozen.req
+	next.Messages = repaired
+	return samplingRequest{req: next}, true
+}
+
+// activateReasoningReplayStrongProjection records that this conversation's
+// canonical history carries reasoning the provider rejects. Later rounds and
+// turns keep projecting through the strong projection instead of paying
+// another 400 plus repair retry per round.
+func (a *Agent) activateReasoningReplayStrongProjection() {
+	if a == nil {
+		return
+	}
+	a.sess.reasoningReplayStrongProjection = true
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Recovered})
+	a.emitReasoningReplayRepairNotice()
+}
+
+func (a *Agent) emitReasoningReplayRepairNotice() {
+	if a == nil || a.svc.sink == nil {
+		return
+	}
+	a.svc.sink.Emit(event.Event{
+		Kind:   event.Notice,
+		Level:  event.LevelWarn,
+		Code:   event.NoticeCodeReasoningReplayRepair,
+		Text:   i18n.M.ReasoningReplayRepair,
+		Detail: "provider rejected replayed thinking blocks (HTTP 400); retried once with reasoning stripped from the projected history",
+	})
+}

--- a/internal/agent/reasoning_replay_recovery.go
+++ b/internal/agent/reasoning_replay_recovery.go
@@ -36,6 +36,24 @@ func (a *Agent) recoverReasoningReplay400(frozen samplingRequest, err error, bud
 	return samplingRequest{req: next}, true
 }
 
+// tryRecoverReasoningReplay400 is the streamWithSamplingRecovery branch for a
+// thinking-400: the frozen history's replayed reasoning is stale for this
+// provider, so repair the projection once and retry; every other 400 falls
+// through to the terminal path. On a repair the speculative attempt's buffered
+// events are discarded and the attempt is audited before the caller replays.
+func (a *Agent) tryRecoverReasoningReplay400(streamSink *deferredStreamSink, frozen samplingRequest, attemptID string, attempt int, err error, budget *reasoningReplayRecoveryBudget) (samplingRequest, bool) {
+	next, ok := a.recoverReasoningReplay400(frozen, err, budget)
+	if !ok {
+		return samplingRequest{}, false
+	}
+	if streamSink != nil {
+		streamSink.Discard()
+	}
+	a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, "reasoning_replay_400", err)
+	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Detected})
+	return next, true
+}
+
 // activateReasoningReplayStrongProjection records that this conversation's
 // canonical history carries reasoning the provider rejects. Later rounds and
 // turns keep projecting through the strong projection instead of paying

--- a/internal/agent/reasoning_replay_recovery.go
+++ b/internal/agent/reasoning_replay_recovery.go
@@ -7,18 +7,17 @@ import (
 )
 
 // reasoningReplayRecoveryBudget bounds the thinking-400 catch-and-repair to one
-// retry per model round. It is independent from the context-recovery budget so
-// one overflow repair and one reasoning repair can never multiply requests.
+// retry per model round and records the repaired provider-message prefix.
 type reasoningReplayRecoveryBudget struct {
 	retries int
+	cutoff  int
 }
 
 // recoverReasoningReplay400 applies the vendor-documented self-heal for a
 // provider that rejected replayed thinking history with HTTP 400: rebuild the
-// frozen request's messages through the strong projection (all assistant
-// reasoning stripped, unpaired tool activity dropped) and retry exactly once.
-// Everything except Messages stays byte-identical to the rejected request. A
-// history the projection cannot change is not worth a blind retry.
+// frozen request's messages through the strong projection and retry exactly
+// once. Everything except Messages stays byte-identical to the rejected
+// request; the repaired message count bounds future projection.
 func (a *Agent) recoverReasoningReplay400(frozen samplingRequest, err error, budget *reasoningReplayRecoveryBudget) (samplingRequest, bool) {
 	if a == nil || budget == nil || budget.retries > 0 {
 		return samplingRequest{}, false
@@ -31,6 +30,7 @@ func (a *Agent) recoverReasoningReplay400(frozen samplingRequest, err error, bud
 		return samplingRequest{}, false
 	}
 	budget.retries++
+	budget.cutoff = len(repaired)
 	next := frozen.req
 	next.Messages = repaired
 	return samplingRequest{req: next}, true
@@ -54,15 +54,13 @@ func (a *Agent) tryRecoverReasoningReplay400(streamSink *deferredStreamSink, fro
 	return next, true
 }
 
-// activateReasoningReplayStrongProjection records that this conversation's
-// canonical history carries reasoning the provider rejects. Later rounds and
-// turns keep projecting through the strong projection instead of paying
-// another 400 plus repair retry per round.
-func (a *Agent) activateReasoningReplayStrongProjection() {
+// activateReasoningReplayStrongProjection records the repaired history prefix.
+// Messages appended after it keep their normal reasoning/tool replay.
+func (a *Agent) activateReasoningReplayStrongProjection(cutoff int) {
 	if a == nil {
 		return
 	}
-	a.sess.reasoningReplayStrongProjection = true
+	a.sess.reasoningReplayStrongProjection = cutoff
 	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Recovered})
 	a.emitReasoningReplayRepairNotice()
 }

--- a/internal/agent/reasoning_replay_recovery.go
+++ b/internal/agent/reasoning_replay_recovery.go
@@ -11,6 +11,7 @@ import (
 type reasoningReplayRecoveryBudget struct {
 	retries int
 	cutoff  int
+	anchor  string
 }
 
 // recoverReasoningReplay400 applies the vendor-documented self-heal for a
@@ -31,6 +32,9 @@ func (a *Agent) recoverReasoningReplay400(frozen samplingRequest, err error, bud
 	}
 	budget.retries++
 	budget.cutoff = len(repaired)
+	if budget.cutoff > 0 {
+		budget.anchor = reasoningReplayMessageFingerprint(repaired[budget.cutoff-1])
+	}
 	next := frozen.req
 	next.Messages = repaired
 	return samplingRequest{req: next}, true
@@ -56,11 +60,12 @@ func (a *Agent) tryRecoverReasoningReplay400(streamSink *deferredStreamSink, fro
 
 // activateReasoningReplayStrongProjection records the repaired history prefix.
 // Messages appended after it keep their normal reasoning/tool replay.
-func (a *Agent) activateReasoningReplayStrongProjection(cutoff int) {
+func (a *Agent) activateReasoningReplayStrongProjection(cutoff int, anchor string) {
 	if a == nil {
 		return
 	}
 	a.sess.reasoningReplayStrongProjection = cutoff
+	a.sess.reasoningReplayStrongProjectionAnchor = anchor
 	event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Recovered})
 	a.emitReasoningReplayRepairNotice()
 }

--- a/internal/agent/reasoning_replay_recovery_test.go
+++ b/internal/agent/reasoning_replay_recovery_test.go
@@ -290,3 +290,143 @@ func TestStrictNoWarningReplayDoesNotLeakSpeculativeEvents(t *testing.T) {
 		}
 	}
 }
+
+func thinkingReplay400Error() error {
+	return provider.ParseReasoningReplayError(&provider.APIError{
+		Provider: "strict-replay", Status: 400,
+		Body: `{"error":{"message":"The ` + "`content[].thinking`" + ` in the thinking mode must be passed back to the API"}}`,
+	})
+}
+
+func reasoningReplaySeededSession() *Session {
+	session := NewSession("system")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "earlier"})
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "old answer", ReasoningContent: "stale thinking"})
+	return session
+}
+
+func TestReasoningReplay400RepairsProjectionAndRetriesOnce(t *testing.T) {
+	mp := testutil.NewMock("strict-replay",
+		testutil.ErrorTurn(thinkingReplay400Error()),
+		testutil.Turn{Text: "done"},
+		testutil.Turn{Text: "again done"},
+	)
+	sink := &recordSink{}
+	session := reasoningReplaySeededSession()
+	a := New(strictAssistantReasoningProvider{mp}, echoRegistry(), session, Options{}, sink)
+
+	if err := a.Run(withNoClosedLoop(context.Background()), "next"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := mp.CallCount(); got != 2 {
+		t.Fatalf("provider calls = %d, want rejected attempt plus one repair retry", got)
+	}
+	requests := mp.Requests()
+	var firstReasoning, secondReasoning int
+	for _, m := range requests[0].Messages {
+		if m.ReasoningContent != "" {
+			firstReasoning++
+		}
+	}
+	for _, m := range requests[1].Messages {
+		if m.ReasoningContent != "" {
+			secondReasoning++
+		}
+	}
+	if firstReasoning != 1 || secondReasoning != 0 {
+		t.Fatalf("reasoning in attempts = %d then %d, want the repair retry stripped", firstReasoning, secondReasoning)
+	}
+	// The frozen request may change only in Messages; everything else is
+	// byte-identical to the rejected attempt.
+	strippedTools := requests[1]
+	strippedTools.Messages = requests[0].Messages
+	if !reflect.DeepEqual(requests[0], strippedTools) {
+		t.Fatalf("repair retry changed more than Messages:\nfirst=%+v\nretry=%+v", requests[0], requests[1])
+	}
+	// Canonical history is never modified by the provider-visible projection.
+	for _, m := range session.Snapshot() {
+		if m.Role == provider.RoleAssistant && m.Content == "old answer" && m.ReasoningContent != "stale thinking" {
+			t.Fatalf("canonical history lost its reasoning: %+v", m)
+		}
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 1 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 1", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Recovered); got != 1 {
+		t.Fatalf("reasoning_replay_400_recovered audits = %d, want 1", got)
+	}
+	var repairNotices int
+	for _, e := range sink.kinds(event.Notice) {
+		if e.Code == event.NoticeCodeReasoningReplayRepair {
+			repairNotices++
+			if e.Level != event.LevelWarn {
+				t.Fatalf("repair notice level = %v, want warn", e.Level)
+			}
+		}
+	}
+	if repairNotices != 1 {
+		t.Fatalf("repair notices = %d, want 1", repairNotices)
+	}
+
+	// The strong projection stays active for the rest of the conversation.
+	if err := a.Run(withNoClosedLoop(context.Background()), "again"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if got := mp.CallCount(); got != 3 {
+		t.Fatalf("provider calls = %d, want no fresh 400 on the next run", got)
+	}
+	for _, m := range mp.Requests()[2].Messages {
+		if m.ReasoningContent != "" {
+			t.Fatalf("later request still carries reasoning under strong projection: %+v", m)
+		}
+	}
+}
+
+func TestReasoningReplay400RepairExhaustionStaysTerminal(t *testing.T) {
+	mp := testutil.NewMock("strict-replay",
+		testutil.ErrorTurn(thinkingReplay400Error()),
+		testutil.ErrorTurn(thinkingReplay400Error()),
+		testutil.Turn{Text: "unreachable"},
+	)
+	sink := &recordSink{}
+	a := New(strictAssistantReasoningProvider{mp}, echoRegistry(), reasoningReplaySeededSession(), Options{}, sink)
+
+	err := a.Run(withNoClosedLoop(context.Background()), "next")
+	var replayErr *provider.ReasoningReplayError
+	if !errors.As(err, &replayErr) {
+		t.Fatalf("Run error = %v, want ReasoningReplayError", err)
+	}
+	if got := mp.CallCount(); got != 2 {
+		t.Fatalf("provider calls = %d, want exactly one repair retry", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 1 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 1", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Recovered); got != 0 {
+		t.Fatalf("reasoning_replay_400_recovered audits = %d, want 0 after a failed repair", got)
+	}
+}
+
+func TestNonReplay400DoesNotTriggerReasoningRepair(t *testing.T) {
+	mp := testutil.NewMock("strict-replay",
+		testutil.ErrorTurn(&provider.APIError{Provider: "strict-replay", Status: 400, Body: `{"error":{"message":"invalid request: unknown tool"}}`}),
+		testutil.Turn{Text: "unreachable"},
+	)
+	sink := &recordSink{}
+	a := New(strictAssistantReasoningProvider{mp}, echoRegistry(), reasoningReplaySeededSession(), Options{}, sink)
+
+	err := a.Run(withNoClosedLoop(context.Background()), "next")
+	var apiErr *provider.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Run error = %v, want the raw APIError", err)
+	}
+	if replayErr := provider.AsReasoningReplayError(err); replayErr != nil {
+		t.Fatalf("unrelated 400 misclassified as reasoning replay: %v", replayErr)
+	}
+	if got := mp.CallCount(); got != 1 {
+		t.Fatalf("provider calls = %d, want no retry for an unrelated 400", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 0 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 0", got)
+	}
+}

--- a/internal/agent/reasoning_replay_recovery_test.go
+++ b/internal/agent/reasoning_replay_recovery_test.go
@@ -463,6 +463,38 @@ func TestReasoningReplay400ProjectsAllStaleToolRoundsBeforeFreshRound(t *testing
 	}
 }
 
+func TestReasoningReplayAnchorMissFallsBackToNormalProjection(t *testing.T) {
+	call := provider.ToolCall{ID: "stale", Name: "echo", Arguments: `{"text":"old"}`}
+	session := NewSession("system")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "old"})
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "old answer", ToolCalls: []provider.ToolCall{call}})
+	session.Add(provider.Message{Role: provider.RoleTool, ToolCallID: call.ID, Name: call.Name, Content: "old result"})
+	a := New(strictAssistantReasoningProvider{testutil.NewMock("strict-replay")}, echoRegistry(), session, Options{}, event.Discard)
+	a.sess.reasoningReplayStrongProjection = 2
+	a.sess.reasoningReplayStrongProjectionAnchor = "anchor no longer present"
+
+	got := a.providerProjectionMessages(modelInputMessages(session.Snapshot()))
+	if a.sess.reasoningReplayStrongProjection != 0 || a.sess.reasoningReplayStrongProjectionAnchor != "" {
+		t.Fatalf("stale strong projection survived anchor miss: cutoff=%d anchor=%q", a.sess.reasoningReplayStrongProjection, a.sess.reasoningReplayStrongProjectionAnchor)
+	}
+	for _, message := range got {
+		if len(message.ToolCalls) > 0 || message.Role == provider.RoleTool {
+			t.Fatalf("normal projection did not remove unreplayable tool history: %+v", got)
+		}
+	}
+}
+
+func TestReasoningReplayProjectionInvalidationClearsOverlay(t *testing.T) {
+	a := New(nil, echoRegistry(), NewSession("system"), Options{}, event.Discard)
+	a.sess.reasoningReplayStrongProjection = 7
+	a.sess.reasoningReplayStrongProjectionAnchor = "anchor"
+
+	a.InvalidateProjection()
+	if a.sess.reasoningReplayStrongProjection != 0 || a.sess.reasoningReplayStrongProjectionAnchor != "" {
+		t.Fatalf("projection invalidation retained repair overlay: cutoff=%d anchor=%q", a.sess.reasoningReplayStrongProjection, a.sess.reasoningReplayStrongProjectionAnchor)
+	}
+}
+
 func TestReasoningReplay400RepairExhaustionStaysTerminal(t *testing.T) {
 	mp := testutil.NewMock("strict-replay",
 		testutil.ErrorTurn(thinkingReplay400Error()),

--- a/internal/agent/reasoning_replay_recovery_test.go
+++ b/internal/agent/reasoning_replay_recovery_test.go
@@ -414,6 +414,55 @@ func TestReasoningReplay400KeepsNewToolRoundOutsideStrongProjection(t *testing.T
 	}
 }
 
+func TestReasoningReplay400ProjectsAllStaleToolRoundsBeforeFreshRound(t *testing.T) {
+	old1 := provider.ToolCall{ID: "old-1", Name: "echo", Arguments: `{"text":"old one"}`}
+	old2 := provider.ToolCall{ID: "old-2", Name: "echo", Arguments: `{"text":"old two"}`}
+	old3 := provider.ToolCall{ID: "old-3", Name: "echo", Arguments: `{"text":"old three"}`}
+	fresh := provider.ToolCall{ID: "fresh", Name: "echo", Arguments: `{"text":"fresh"}`}
+	mp := testutil.NewMock("strict-replay",
+		testutil.ErrorTurn(thinkingReplay400Error()),
+		testutil.Turn{Text: "repaired"},
+		testutil.Turn{Reasoning: "fresh reasoning", ToolCalls: []provider.ToolCall{fresh}},
+		testutil.Turn{Text: "fresh final"},
+	)
+	session := NewSession("system")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "old one", ReasoningContent: "stale one", ToolCalls: []provider.ToolCall{old1}})
+	session.Add(provider.Message{Role: provider.RoleTool, ToolCallID: old1.ID, Name: old1.Name, Content: "old result one"})
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "second"})
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "old two", ReasoningContent: "stale two", ToolCalls: []provider.ToolCall{old2}})
+	session.Add(provider.Message{Role: provider.RoleTool, ToolCallID: old2.ID, Name: old2.Name, Content: "old result two"})
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "third"})
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "old three", ReasoningContent: "stale three", ToolCalls: []provider.ToolCall{old3}})
+	session.Add(provider.Message{Role: provider.RoleTool, ToolCallID: old3.ID, Name: old3.Name, Content: "old result three"})
+	a := New(strictAssistantReasoningProvider{mp}, echoRegistry(), session, Options{}, event.Discard)
+	if err := a.Run(withNoClosedLoop(context.Background()), "repair"); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if err := a.Run(withNoClosedLoop(context.Background()), "fresh"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	requests := mp.Requests()
+	if len(requests) != 4 {
+		t.Fatalf("requests = %d, want repair plus a two-step follow-up", len(requests))
+	}
+	for _, message := range requests[3].Messages {
+		if message.ReasoningContent == "stale one" || message.ReasoningContent == "stale two" || message.ReasoningContent == "stale three" {
+			t.Fatalf("stale reasoning survived prefix projection: %+v", message)
+		}
+	}
+	var sawFreshToolRound bool
+	for _, message := range requests[3].Messages {
+		if len(message.ToolCalls) > 0 || message.Role == provider.RoleTool {
+			sawFreshToolRound = true
+			break
+		}
+	}
+	if !sawFreshToolRound {
+		t.Fatal("strong projection dropped the fresh tool round")
+	}
+}
+
 func TestReasoningReplay400RepairExhaustionStaysTerminal(t *testing.T) {
 	mp := testutil.NewMock("strict-replay",
 		testutil.ErrorTurn(thinkingReplay400Error()),

--- a/internal/agent/reasoning_replay_recovery_test.go
+++ b/internal/agent/reasoning_replay_recovery_test.go
@@ -382,6 +382,38 @@ func TestReasoningReplay400RepairsProjectionAndRetriesOnce(t *testing.T) {
 	}
 }
 
+func TestReasoningReplay400KeepsNewToolRoundOutsideStrongProjection(t *testing.T) {
+	call := provider.ToolCall{ID: "fresh", Name: "echo", Arguments: `{"text":"hello"}`}
+	mp := testutil.NewMock("strict-replay",
+		testutil.ErrorTurn(thinkingReplay400Error()),
+		testutil.Turn{Text: "repaired"},
+		testutil.Turn{Reasoning: "fresh reasoning", ToolCalls: []provider.ToolCall{call}},
+		testutil.Turn{Text: "fresh final"},
+	)
+	a := New(strictAssistantReasoningProvider{mp}, echoRegistry(), reasoningReplaySeededSession(), Options{}, event.Discard)
+	if err := a.Run(withNoClosedLoop(context.Background()), "first"); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if err := a.Run(withNoClosedLoop(context.Background()), "second"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	requests := mp.Requests()
+	if len(requests) != 4 {
+		t.Fatalf("requests = %d, want repair plus a two-step follow-up", len(requests))
+	}
+	var sawFreshToolRound bool
+	for _, message := range requests[3].Messages {
+		if len(message.ToolCalls) > 0 || message.Role == provider.RoleTool {
+			sawFreshToolRound = true
+			break
+		}
+	}
+	if !sawFreshToolRound {
+		t.Fatal("strong projection dropped the new tool round from the follow-up request")
+	}
+}
+
 func TestReasoningReplay400RepairExhaustionStaysTerminal(t *testing.T) {
 	mp := testutil.NewMock("strict-replay",
 		testutil.ErrorTurn(thinkingReplay400Error()),

--- a/internal/agent/retry_e2e_test.go
+++ b/internal/agent/retry_e2e_test.go
@@ -420,12 +420,12 @@ func TestDeepSeekAnthropicThinking400CatchAndRepair(t *testing.T) {
 	}
 	// The adopted answer streamed through and the canonical history keeps both
 	// turns' reasoning untouched by the provider-visible repair.
-	var answer string
+	var answer strings.Builder
 	for _, e := range sink.kinds(event.Text) {
-		answer += e.Text
+		answer.WriteString(e.Text)
 	}
-	if answer != "repaired answer" {
-		t.Fatalf("streamed answer = %q, want the repaired response", answer)
+	if answer.String() != "repaired answer" {
+		t.Fatalf("streamed answer = %q, want the repaired response", answer.String())
 	}
 
 	// The next run keeps the strong projection: no reasoning reaches the wire.

--- a/internal/agent/retry_e2e_test.go
+++ b/internal/agent/retry_e2e_test.go
@@ -3,10 +3,12 @@ package agent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,6 +17,7 @@ import (
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
+	"reasonix/internal/provider/anthropic"
 	"reasonix/internal/provider/openai"
 	"reasonix/internal/tool"
 )
@@ -320,5 +323,128 @@ func TestGLMReasoningOverflowFailsBeforeToolExecution(t *testing.T) {
 	}
 	if got := requests.Load(); got != 1 {
 		t.Fatalf("HTTP requests = %d, want no continuation after incomplete GLM reasoning", got)
+	}
+}
+
+// TestDeepSeekAnthropicThinking400CatchAndRepair drives the full self-heal
+// against the real Anthropic-adapter wire shape: the first request replays the
+// stored thinking block and the server rejects it with DeepSeek's documented
+// 400; the agent must repair the projection once (stripping all reasoning),
+// retry, and keep the strong projection for the following run.
+func TestDeepSeekAnthropicThinking400CatchAndRepair(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, append([]byte(nil), body...))
+		requestNo := len(bodies)
+		mu.Unlock()
+
+		if requestNo == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"The ` + "`content[].thinking`" + ` in the thinking mode must be passed back to the API","type":"invalid_request_error"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":20,\"output_tokens\":1}}}\n\n")
+		if requestNo == 2 {
+			_, _ = io.WriteString(w, "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n")
+			_, _ = io.WriteString(w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"fresh thinking\"}}\n\n")
+			_, _ = io.WriteString(w, "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
+		}
+		_, _ = io.WriteString(w, "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"repaired answer\"}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"content_block_stop\",\"index\":1}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"message_stop\"}\n\n")
+	}))
+	defer srv.Close()
+
+	prov, err := anthropic.New(provider.Config{
+		Name: "deepseek-anthropic", BaseURL: srv.URL, Model: "deepseek-v4-flash", APIKey: "k",
+		Extra: map[string]any{"reasoning_protocol": "deepseek", "thinking": "enabled"},
+	})
+	if err != nil {
+		t.Fatalf("New provider: %v", err)
+	}
+	session := NewSession("system")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "earlier"})
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "old answer", ReasoningContent: "stale thinking"})
+	sink := &recordSink{}
+	a := New(prov, echoRegistry(), session, Options{}, sink)
+
+	if err := a.Run(withNoClosedLoop(context.Background()), "next"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	gotBodies := append([][]byte(nil), bodies...)
+	mu.Unlock()
+	if len(gotBodies) != 2 {
+		t.Fatalf("HTTP requests = %d, want rejected attempt plus one repair retry", len(gotBodies))
+	}
+	if !bytes.Contains(gotBodies[0], []byte(`"type":"thinking"`)) || !bytes.Contains(gotBodies[0], []byte("stale thinking")) {
+		t.Fatalf("first request did not replay the stored thinking block: %s", gotBodies[0])
+	}
+	if bytes.Contains(gotBodies[1], []byte(`"type":"thinking"`)) || bytes.Contains(gotBodies[1], []byte("stale thinking")) {
+		t.Fatalf("repair retry still carries thinking blocks: %s", gotBodies[1])
+	}
+	if !bytes.Contains(gotBodies[1], []byte("old answer")) {
+		t.Fatalf("repair retry lost the visible assistant text: %s", gotBodies[1])
+	}
+	// Only Messages may change between the rejected request and its repair.
+	var first, second map[string]json.RawMessage
+	if err := json.Unmarshal(gotBodies[0], &first); err != nil || json.Unmarshal(gotBodies[1], &second) != nil {
+		t.Fatalf("decode request bodies: %v", err)
+	}
+	delete(first, "messages")
+	delete(second, "messages")
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("repair retry changed non-message fields:\nfirst=%s\nretry=%s", gotBodies[0], gotBodies[1])
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 1 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 1", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Recovered); got != 1 {
+		t.Fatalf("reasoning_replay_400_recovered audits = %d, want 1", got)
+	}
+	var repairNotices int
+	for _, e := range sink.kinds(event.Notice) {
+		if e.Code == event.NoticeCodeReasoningReplayRepair && e.Level == event.LevelWarn {
+			repairNotices++
+		}
+	}
+	if repairNotices != 1 {
+		t.Fatalf("repair notices = %d, want 1", repairNotices)
+	}
+	// The adopted answer streamed through and the canonical history keeps both
+	// turns' reasoning untouched by the provider-visible repair.
+	var answer string
+	for _, e := range sink.kinds(event.Text) {
+		answer += e.Text
+	}
+	if answer != "repaired answer" {
+		t.Fatalf("streamed answer = %q, want the repaired response", answer)
+	}
+
+	// The next run keeps the strong projection: no reasoning reaches the wire.
+	if err := a.Run(withNoClosedLoop(context.Background()), "again"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	mu.Lock()
+	third := append([]byte(nil), bodies[len(bodies)-1]...)
+	total := len(bodies)
+	mu.Unlock()
+	if total != 3 {
+		t.Fatalf("HTTP requests = %d, want one more for the follow-up run", total)
+	}
+	if bytes.Contains(third, []byte(`"type":"thinking"`)) || bytes.Contains(third, []byte("stale thinking")) || bytes.Contains(third, []byte("fresh thinking")) {
+		t.Fatalf("strong projection did not persist into the next run: %s", third)
+	}
+	for _, m := range session.Snapshot() {
+		if m.Role == provider.RoleAssistant && m.Content == "old answer" && m.ReasoningContent != "stale thinking" {
+			t.Fatalf("canonical history lost its reasoning: %+v", m)
+		}
 	}
 }

--- a/internal/agent/retry_e2e_test.go
+++ b/internal/agent/retry_e2e_test.go
@@ -566,7 +566,8 @@ func TestDeepSeekAnthropicThinking400CatchAndRepair(t *testing.T) {
 		t.Fatalf("streamed answer = %q, want the repaired response", answer.String())
 	}
 
-	// The next run keeps the strong projection: no reasoning reaches the wire.
+	// The next run keeps the repaired prefix stripped while replaying reasoning
+	// from the newly committed assistant turn normally.
 	if err := a.Run(withNoClosedLoop(context.Background()), "again"); err != nil {
 		t.Fatalf("second Run: %v", err)
 	}
@@ -577,8 +578,11 @@ func TestDeepSeekAnthropicThinking400CatchAndRepair(t *testing.T) {
 	if total != 3 {
 		t.Fatalf("HTTP requests = %d, want one more for the follow-up run", total)
 	}
-	if bytes.Contains(third, []byte(`"type":"thinking"`)) || bytes.Contains(third, []byte("stale thinking")) || bytes.Contains(third, []byte("fresh thinking")) {
-		t.Fatalf("strong projection did not persist into the next run: %s", third)
+	if bytes.Contains(third, []byte("stale thinking")) {
+		t.Fatalf("strong projection retained stale reasoning in the next run: %s", third)
+	}
+	if !bytes.Contains(third, []byte("fresh thinking")) {
+		t.Fatalf("strong projection dropped new-turn reasoning in the next run: %s", third)
 	}
 	for _, m := range session.Snapshot() {
 		if m.Role == provider.RoleAssistant && m.Content == "old answer" && m.ReasoningContent != "stale thinking" {

--- a/internal/agent/retry_e2e_test.go
+++ b/internal/agent/retry_e2e_test.go
@@ -198,6 +198,144 @@ func TestDeepSeekFlashMissingReasoningRecoveryWithRealSSE(t *testing.T) {
 	}
 }
 
+// TestDeepSeekOpenAIReasoningReplay400RepairsOldHistory drives the OpenAI
+// adapter through the shared stale-history recovery path. The first request
+// replays an old assistant reasoning turn and is rejected; the repair retry
+// strips only provider-visible reasoning while preserving canonical history.
+func TestDeepSeekOpenAIReasoningReplay400RepairsOldHistory(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, append([]byte(nil), body...))
+		requestNo := len(bodies)
+		mu.Unlock()
+
+		if requestNo == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, `{"error":{"message":"The reasoning_content in the thinking mode must be passed back to the API"}}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"content":"recovered"},"finish_reason":"stop"}]}`+"\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	prov, err := openai.New(provider.Config{
+		Name: "deepseek-openai", BaseURL: srv.URL, Model: "deepseek-v4-pro", APIKey: "k",
+		Extra: map[string]any{"reasoning_protocol": "deepseek", "thinking": "enabled"},
+	})
+	if err != nil {
+		t.Fatalf("New provider: %v", err)
+	}
+	session := NewSession("system")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "earlier"})
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "old answer", ReasoningContent: "stale thinking"})
+	sink := &recordSink{}
+	a := New(prov, echoRegistry(), session, Options{}, sink)
+
+	if err := a.Run(withNoClosedLoop(context.Background()), "next"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	gotBodies := append([][]byte(nil), bodies...)
+	mu.Unlock()
+	if len(gotBodies) != 2 {
+		t.Fatalf("HTTP requests = %d, want rejected attempt plus one repair retry", len(gotBodies))
+	}
+	if !bytes.Contains(gotBodies[0], []byte(`"reasoning_content":"stale thinking"`)) {
+		t.Fatalf("first request did not replay old reasoning: %s", gotBodies[0])
+	}
+	if bytes.Contains(gotBodies[1], []byte("stale thinking")) || bytes.Contains(gotBodies[1], []byte("reasoning_content")) {
+		t.Fatalf("repair retry still carries old reasoning: %s", gotBodies[1])
+	}
+	if !bytes.Contains(gotBodies[1], []byte("old answer")) {
+		t.Fatalf("repair retry lost visible assistant text: %s", gotBodies[1])
+	}
+	var first, second map[string]json.RawMessage
+	if err := json.Unmarshal(gotBodies[0], &first); err != nil {
+		t.Fatalf("decode first request: %v", err)
+	}
+	if err := json.Unmarshal(gotBodies[1], &second); err != nil {
+		t.Fatalf("decode repair request: %v", err)
+	}
+	delete(first, "messages")
+	delete(second, "messages")
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("repair retry changed non-message fields:\nfirst=%s\nretry=%s", gotBodies[0], gotBodies[1])
+	}
+	for _, message := range session.Snapshot() {
+		if message.Role == provider.RoleAssistant && message.Content == "old answer" && message.ReasoningContent != "stale thinking" {
+			t.Fatalf("canonical history lost old reasoning: %+v", message)
+		}
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Detected); got != 1 {
+		t.Fatalf("reasoning_replay_400_detected audits = %d, want 1", got)
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryReasoningReplay400Recovered); got != 1 {
+		t.Fatalf("reasoning_replay_400_recovered audits = %d, want 1", got)
+	}
+}
+
+func TestDeepSeekOpenAIReasoningReplay400StripsOldToolHistory(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, append([]byte(nil), body...))
+		requestNo := len(bodies)
+		mu.Unlock()
+		if requestNo == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, `{"error":{"message":"The reasoning_content in the thinking mode must be passed back to the API"}}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"content":"recovered"},"finish_reason":"stop"}]}`+"\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	prov, err := openai.New(provider.Config{
+		Name: "deepseek-openai", BaseURL: srv.URL, Model: "deepseek-v4-pro", APIKey: "k",
+		Extra: map[string]any{"reasoning_protocol": "deepseek", "thinking": "enabled"},
+	})
+	if err != nil {
+		t.Fatalf("New provider: %v", err)
+	}
+	session := NewSession("system")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "earlier"})
+	session.Add(provider.Message{
+		Role: provider.RoleAssistant, Content: "I will inspect the file", ReasoningContent: "stale thinking",
+		ToolCalls: []provider.ToolCall{{ID: "old-call", Name: "read_file", Arguments: `{"path":"old.go"}`}},
+	})
+	session.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "old-call", Name: "read_file", Content: "old result"})
+	a := New(prov, echoRegistry(), session, Options{}, &recordSink{})
+	if err := a.Run(withNoClosedLoop(context.Background()), "next"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	gotBodies := append([][]byte(nil), bodies...)
+	mu.Unlock()
+	if len(gotBodies) != 2 {
+		t.Fatalf("HTTP requests = %d, want rejected attempt plus one repair retry", len(gotBodies))
+	}
+	if !bytes.Contains(gotBodies[0], []byte("old-call")) || !bytes.Contains(gotBodies[0], []byte("stale thinking")) {
+		t.Fatalf("first request did not contain old tool history: %s", gotBodies[0])
+	}
+	if bytes.Contains(gotBodies[1], []byte("old-call")) || bytes.Contains(gotBodies[1], []byte("old result")) || bytes.Contains(gotBodies[1], []byte("stale thinking")) {
+		t.Fatalf("repair retry retained stale tool history: %s", gotBodies[1])
+	}
+	if !bytes.Contains(gotBodies[1], []byte("I will inspect the file")) {
+		t.Fatalf("repair retry lost visible old assistant text: %s", gotBodies[1])
+	}
+}
+
 func TestGLMToolTurnWithoutReasoningContinuesWithoutRecovery(t *testing.T) {
 	var mu sync.Mutex
 	var bodies [][]byte

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -46,78 +46,6 @@ func (s streamedTurn) assistantMessage() provider.Message {
 	}
 }
 
-// deferredStreamSink keeps selected stream events local until the caller
-// chooses which provider response to adopt. On an ordinary healthy DeepSeek
-// turn, reasoning arrives before tool calls and unlocks live tool-card events.
-// On the rare malformed turn with no reasoning, only the speculative partial
-// tool cards remain buffered, so retrying does not flash duplicate cards in the
-// UI. A recovery attempt buffers everything because it may be discarded.
-type deferredStreamSink struct {
-	inner               event.Sink
-	deferAll            bool
-	waitingForReasoning bool
-	sawReasoning        bool
-	events              []event.Event
-}
-
-func newReasoningAwareStreamSink(inner event.Sink) *deferredStreamSink {
-	return &deferredStreamSink{inner: inner, waitingForReasoning: true}
-}
-
-func newDeferredStreamSink(inner event.Sink) *deferredStreamSink {
-	return &deferredStreamSink{inner: inner, deferAll: true}
-}
-
-func (s *deferredStreamSink) Emit(e event.Event) {
-	if s == nil {
-		return
-	}
-	if s.deferAll {
-		s.events = append(s.events, e)
-		return
-	}
-	if s.waitingForReasoning && e.Kind == event.Reasoning && strings.TrimSpace(e.Text) != "" {
-		s.sawReasoning = true
-		s.inner.Emit(e)
-		s.flushBuffered()
-		return
-	}
-	if s.waitingForReasoning && !s.sawReasoning {
-		switch e.Kind {
-		case event.ToolDispatch, event.ToolResult, event.Text, event.Message:
-			// Keep every user-visible speculative event private until reasoning
-			// proves the turn replayable. Healthy DeepSeek responses emit
-			// reasoning first, so their live-streaming fast path is unchanged.
-			s.events = append(s.events, e)
-			return
-		}
-	}
-	s.inner.Emit(e)
-}
-
-func (s *deferredStreamSink) flushBuffered() {
-	if s == nil {
-		return
-	}
-	for _, e := range s.events {
-		s.inner.Emit(e)
-	}
-	s.events = nil
-}
-
-func (s *deferredStreamSink) Flush() {
-	if s == nil {
-		return
-	}
-	s.flushBuffered()
-}
-
-func (s *deferredStreamSink) Discard() {
-	if s != nil {
-		s.events = nil
-	}
-}
-
 // beginRunTurn handles evidence scope, delivery classification, background-job
 // evidence re-lease, and the initial user-turn persistence. Callers still own
 // all Run-level defers (workspace lease, evidence commit, delivery checkpoint,
@@ -392,15 +320,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 				attempt = 0
 				continue
 			}
-			// A thinking-400 means the frozen history's replayed reasoning is
-			// stale for this provider. Repair the projection once and retry;
-			// every other 400 keeps falling through to the terminal path.
-			if next, retryReplay := a.recoverReasoningReplay400(frozen, result.err, &replayRecovery); retryReplay {
-				if streamSink != nil {
-					streamSink.Discard()
-				}
-				a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, "reasoning_replay_400", result.err)
-				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Detected})
+			if next, retryReplay := a.tryRecoverReasoningReplay400(streamSink, frozen, attemptID, attempt, result.err, &replayRecovery); retryReplay {
 				frozen = next
 				reasoningReplayRepaired = true
 				attempt = 0
@@ -431,11 +351,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 			a.observeMissingAssistantReasoning(result.assistantMessage(), result.reasoningComplete)
 		}
 		if issue == ReasoningReplayOverflow {
-			event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningOverflowDetected})
-			result.usage = finalizeSamplingUsage(billable, result.usage)
-			terminal := a.finishUnreplayableReasoning(result, streamSink, issue)
-			a.emitReasoningReplayAttemptOutcome(attemptID, attempt, terminal.err)
-			return terminal
+			return a.finishReasoningReplayOverflow(result, streamSink, issue, billable, attemptID, attempt)
 		}
 		if missing {
 			event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
@@ -475,15 +391,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 				return retry
 			}
 			if !shouldRetry {
-				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetrySuppressed})
-				if fallback, ok := a.runMissingReasoningFallback(ctx, turn, &frozen, attemptID, attempt, billable, streamSink); ok {
-					return fallback
-				}
-				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
-				result.usage = finalizeSamplingUsage(billable, result.usage)
-				terminal := a.finishUnreplayableReasoning(result, streamSink, issue)
-				a.emitReasoningReplayAttemptOutcome(attemptID, attempt, terminal.err)
-				return terminal
+				return a.suppressMissingReasoningRetry(ctx, turn, &frozen, attemptID, attempt, streamSink, result, issue, billable)
 			}
 		}
 
@@ -491,9 +399,6 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
 		result.usage = finalizeSamplingUsage(billable, result.usage)
 		if reasoningReplayRepaired {
-			// The repair retry proved the canonical history's stored reasoning is
-			// stale for this provider; keep the strong projection for the rest of
-			// the conversation so later rounds do not pay another 400.
 			a.activateReasoningReplayStrongProjection()
 		}
 		return result

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -363,6 +363,8 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 	// its delta so RequestCount equals real HTTP POSTs (no triangular growth).
 	ctx = provider.WithRequestAttemptCounter(ctx)
 	var contextRecovery contextRecoveryBudget
+	var replayRecovery reasoningReplayRecoveryBudget
+	reasoningReplayRepaired := false
 
 	var billable *provider.Usage
 	var last streamedTurn
@@ -387,6 +389,20 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 				}
 				a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, "context_limit", result.err)
 				frozen = next
+				attempt = 0
+				continue
+			}
+			// A thinking-400 means the frozen history's replayed reasoning is
+			// stale for this provider. Repair the projection once and retry;
+			// every other 400 keeps falling through to the terminal path.
+			if next, retryReplay := a.recoverReasoningReplay400(frozen, result.err, &replayRecovery); retryReplay {
+				if streamSink != nil {
+					streamSink.Discard()
+				}
+				a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, "reasoning_replay_400", result.err)
+				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryReasoningReplay400Detected})
+				frozen = next
+				reasoningReplayRepaired = true
 				attempt = 0
 				continue
 			}
@@ -474,6 +490,12 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		streamSink.Flush()
 		a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
 		result.usage = finalizeSamplingUsage(billable, result.usage)
+		if reasoningReplayRepaired {
+			// The repair retry proved the canonical history's stored reasoning is
+			// stale for this provider; keep the strong projection for the rest of
+			// the conversation so later rounds do not pay another 400.
+			a.activateReasoningReplayStrongProjection()
+		}
 		return result
 	}
 	return last

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -399,7 +399,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
 		result.usage = finalizeSamplingUsage(billable, result.usage)
 		if reasoningReplayRepaired {
-			a.activateReasoningReplayStrongProjection(replayRecovery.cutoff)
+			a.activateReasoningReplayStrongProjection(replayRecovery.cutoff, replayRecovery.anchor)
 		}
 		return result
 	}

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -399,7 +399,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
 		result.usage = finalizeSamplingUsage(billable, result.usage)
 		if reasoningReplayRepaired {
-			a.activateReasoningReplayStrongProjection()
+			a.activateReasoningReplayStrongProjection(replayRecovery.cutoff)
 		}
 		return result
 	}

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -165,7 +165,13 @@ func (a *Agent) providerProjectionMessages(msgs []provider.Message) []provider.M
 		// The provider-declared fallback owns this tool loop. Strict projection
 		// here would erase its completed tool round before adapter serialization.
 		if !a.sess.missingReasoning.fallbackActive || !provider.SupportsMissingReasoningFallback(a.svc.prov) {
-			if repaired, changed := provider.ProjectReplaySafeMessages(a.svc.prov, msgs); changed {
+			if a.sess.reasoningReplayStrongProjection {
+				// A repaired thinking-400 conversation keeps the stripped
+				// projection: its canonical reasoning is stale for this provider.
+				if repaired, changed := provider.ProjectReasoningStrippedMessages(a.svc.prov, msgs); changed {
+					msgs = repaired
+				}
+			} else if repaired, changed := provider.ProjectReplaySafeMessages(a.svc.prov, msgs); changed {
 				msgs = repaired
 			}
 		}

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -175,8 +175,18 @@ func (a *Agent) providerProjectionMessages(msgs []provider.Message) []provider.M
 				// A repaired thinking-400 conversation keeps the stripped
 				// projection only for the history that caused the rejection.
 				resolvedCutoff := resolveReasoningReplayPrefix(msgs, strongCutoff, a.sess.reasoningReplayStrongProjectionAnchor)
-				if repaired, changed := provider.ProjectReasoningStrippedMessagesPrefix(a.svc.prov, msgs, resolvedCutoff); changed {
-					msgs = repaired
+				if resolvedCutoff > 0 {
+					if repaired, changed := provider.ProjectReasoningStrippedMessagesPrefix(a.svc.prov, msgs, resolvedCutoff); changed {
+						msgs = repaired
+					}
+				} else {
+					// The canonical shape no longer contains the repair anchor
+					// (for example after rewind). Do not silently disable all
+					// provider projection; re-arm from the current history.
+					a.sess.clearReasoningReplayStrongProjection()
+					if repaired, changed := provider.ProjectReplaySafeMessages(a.svc.prov, msgs); changed {
+						msgs = repaired
+					}
 				}
 			} else if repaired, changed := provider.ProjectReplaySafeMessages(a.svc.prov, msgs); changed {
 				msgs = repaired

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -174,7 +174,8 @@ func (a *Agent) providerProjectionMessages(msgs []provider.Message) []provider.M
 			if strongCutoff > 0 {
 				// A repaired thinking-400 conversation keeps the stripped
 				// projection only for the history that caused the rejection.
-				if repaired, changed := provider.ProjectReasoningStrippedMessagesPrefix(a.svc.prov, msgs, strongCutoff); changed {
+				resolvedCutoff := resolveReasoningReplayPrefix(msgs, strongCutoff, a.sess.reasoningReplayStrongProjectionAnchor)
+				if repaired, changed := provider.ProjectReasoningStrippedMessagesPrefix(a.svc.prov, msgs, resolvedCutoff); changed {
 					msgs = repaired
 				}
 			} else if repaired, changed := provider.ProjectReplaySafeMessages(a.svc.prov, msgs); changed {

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -165,17 +165,23 @@ func (a *Agent) providerProjectionMessages(msgs []provider.Message) []provider.M
 		// The provider-declared fallback owns this tool loop. Strict projection
 		// here would erase its completed tool round before adapter serialization.
 		if !a.sess.missingReasoning.fallbackActive || !provider.SupportsMissingReasoningFallback(a.svc.prov) {
-			if a.sess.reasoningReplayStrongProjection {
+			strongCutoff := a.sess.reasoningReplayStrongProjection
+			if strongCutoff > 0 && a.strictAlternatingRoles {
+				// The cutoff is measured after role coalescing on the repaired
+				// request, so apply the same outbound shape before slicing it.
+				msgs = coalesceProjectionUserRuns(msgs)
+			}
+			if strongCutoff > 0 {
 				// A repaired thinking-400 conversation keeps the stripped
-				// projection: its canonical reasoning is stale for this provider.
-				if repaired, changed := provider.ProjectReasoningStrippedMessages(a.svc.prov, msgs); changed {
+				// projection only for the history that caused the rejection.
+				if repaired, changed := provider.ProjectReasoningStrippedMessagesPrefix(a.svc.prov, msgs, strongCutoff); changed {
 					msgs = repaired
 				}
 			} else if repaired, changed := provider.ProjectReplaySafeMessages(a.svc.prov, msgs); changed {
 				msgs = repaired
 			}
 		}
-		if a.strictAlternatingRoles {
+		if a.strictAlternatingRoles && a.sess.reasoningReplayStrongProjection <= 0 {
 			return coalesceProjectionUserRuns(msgs)
 		}
 	}

--- a/internal/agent/sessionstate.go
+++ b/internal/agent/sessionstate.go
@@ -25,10 +25,9 @@ type sessionRuntime struct {
 
 	missingReasoning missingReasoningWatch
 
-	// reasoningReplayStrongProjection is set once a thinking-400 catch-and-repair
-	// retry succeeds: the canonical history carries reasoning this provider
-	// rejects, so every later provider request in this conversation keeps using
-	// the stripped projection instead of paying another 400 per round.
+	// reasoningReplayStrongProjection is set once a thinking-400 repair retry
+	// succeeds: this conversation's stored reasoning is stale for the provider,
+	// so later requests keep using the stripped projection.
 	reasoningReplayStrongProjection bool
 
 	// compactionMu guards projection snapshots/install and the in-memory sidecar

--- a/internal/agent/sessionstate.go
+++ b/internal/agent/sessionstate.go
@@ -25,6 +25,12 @@ type sessionRuntime struct {
 
 	missingReasoning missingReasoningWatch
 
+	// reasoningReplayStrongProjection is set once a thinking-400 catch-and-repair
+	// retry succeeds: the canonical history carries reasoning this provider
+	// rejects, so every later provider request in this conversation keeps using
+	// the stripped projection instead of paying another 400 per round.
+	reasoningReplayStrongProjection bool
+
 	// compactionMu guards projection snapshots/install and the in-memory sidecar
 	// generation. Network summarization never runs while this lock is held.
 	compactionMu sync.Mutex
@@ -65,6 +71,7 @@ func (r *sessionRuntime) reset(s *Session) {
 	r.cacheMiss.Store(0)
 	r.output.reset()
 	r.missingReasoning = missingReasoningWatch{}
+	r.reasoningReplayStrongProjection = false
 	r.compactionMu.Lock()
 	r.compactionState = CompactionState{} // lineage change; disk reloaded on Resume
 	r.cacheState = CacheStateUnknown

--- a/internal/agent/sessionstate.go
+++ b/internal/agent/sessionstate.go
@@ -25,10 +25,10 @@ type sessionRuntime struct {
 
 	missingReasoning missingReasoningWatch
 
-	// reasoningReplayStrongProjection is set once a thinking-400 repair retry
-	// succeeds: this conversation's stored reasoning is stale for the provider,
-	// so later requests keep using the stripped projection.
-	reasoningReplayStrongProjection bool
+	// reasoningReplayStrongProjection is the provider-visible history prefix
+	// that was present when a thinking-400 repair succeeded; later messages stay
+	// on the normal replay path.
+	reasoningReplayStrongProjection int
 
 	// compactionMu guards projection snapshots/install and the in-memory sidecar
 	// generation. Network summarization never runs while this lock is held.
@@ -70,7 +70,7 @@ func (r *sessionRuntime) reset(s *Session) {
 	r.cacheMiss.Store(0)
 	r.output.reset()
 	r.missingReasoning = missingReasoningWatch{}
-	r.reasoningReplayStrongProjection = false
+	r.reasoningReplayStrongProjection = 0
 	r.compactionMu.Lock()
 	r.compactionState = CompactionState{} // lineage change; disk reloaded on Resume
 	r.cacheState = CacheStateUnknown

--- a/internal/agent/sessionstate.go
+++ b/internal/agent/sessionstate.go
@@ -84,6 +84,17 @@ func (r *sessionRuntime) reset(s *Session) {
 	r.compaction.lastTurn.Store(0)
 }
 
+// clearReasoningReplayStrongProjection drops the process-local repair overlay.
+// The overlay is tied to one canonical history shape; any rewind, branch, or
+// other lineage rewrite must not let an old cutoff/anchor govern the new view.
+func (r *sessionRuntime) clearReasoningReplayStrongProjection() {
+	if r == nil {
+		return
+	}
+	r.reasoningReplayStrongProjection = 0
+	r.reasoningReplayStrongProjectionAnchor = ""
+}
+
 // session returns the bound conversation under the lock that guards the
 // pointer against a concurrent SetSession.
 func (r *sessionRuntime) session() *Session {

--- a/internal/agent/sessionstate.go
+++ b/internal/agent/sessionstate.go
@@ -25,10 +25,11 @@ type sessionRuntime struct {
 
 	missingReasoning missingReasoningWatch
 
-	// reasoningReplayStrongProjection is the provider-visible history prefix
-	// that was present when a thinking-400 repair succeeded; later messages stay
-	// on the normal replay path.
-	reasoningReplayStrongProjection int
+	// reasoningReplayStrongProjection records the provider-visible history cutoff
+	// after thinking-400 repair; later messages use normal replay. Its anchor
+	// resolves the cutoff after old tool-result messages are removed.
+	reasoningReplayStrongProjection       int
+	reasoningReplayStrongProjectionAnchor string
 
 	// compactionMu guards projection snapshots/install and the in-memory sidecar
 	// generation. Network summarization never runs while this lock is held.
@@ -71,6 +72,7 @@ func (r *sessionRuntime) reset(s *Session) {
 	r.output.reset()
 	r.missingReasoning = missingReasoningWatch{}
 	r.reasoningReplayStrongProjection = 0
+	r.reasoningReplayStrongProjectionAnchor = ""
 	r.compactionMu.Lock()
 	r.compactionState = CompactionState{} // lineage change; disk reloaded on Resume
 	r.cacheState = CacheStateUnknown

--- a/internal/agent/sessionstate_test.go
+++ b/internal/agent/sessionstate_test.go
@@ -19,10 +19,13 @@ var sessionReset = map[string]bool{
 	"cacheHit":         true,
 	"cacheMiss":        true,
 	"missingReasoning": true,
-	"compactionMu":     true,
-	"compactionState":  true,
-	"cacheState":       true,
-	"compaction":       true,
+	// A strong-projection repair belongs to the corrupted conversation; a new
+	// conversation starts without it.
+	"reasoningReplayStrongProjection": true,
+	"compactionMu":                    true,
+	"compactionState":                 true,
+	"cacheState":                      true,
+	"compaction":                      true,
 }
 
 // sessionCarryOver names the fields reset deliberately leaves alone, each with

--- a/internal/agent/sessionstate_test.go
+++ b/internal/agent/sessionstate_test.go
@@ -21,11 +21,12 @@ var sessionReset = map[string]bool{
 	"missingReasoning": true,
 	// A strong-projection repair belongs to the corrupted conversation; a new
 	// conversation starts without it.
-	"reasoningReplayStrongProjection": true,
-	"compactionMu":                    true,
-	"compactionState":                 true,
-	"cacheState":                      true,
-	"compaction":                      true,
+	"reasoningReplayStrongProjection":       true,
+	"reasoningReplayStrongProjectionAnchor": true,
+	"compactionMu":                          true,
+	"compactionState":                       true,
+	"cacheState":                            true,
+	"compaction":                            true,
 }
 
 // sessionCarryOver names the fields reset deliberately leaves alone, each with
@@ -139,6 +140,7 @@ func TestSetSessionRestartsTheConversationState(t *testing.T) {
 	a.sess.cacheMiss.Store(7)
 	a.sess.missingReasoning = missingReasoningWatch{active: true, stateRecorded: true, healthyStreak: 2}
 	a.sess.reasoningReplayStrongProjection = 7
+	a.sess.reasoningReplayStrongProjectionAnchor = "anchor"
 	a.sess.compaction.stuck = true
 	a.sess.compaction.stuckInputHash = "old-input"
 	a.sess.compaction.consecutive = 3
@@ -161,6 +163,9 @@ func TestSetSessionRestartsTheConversationState(t *testing.T) {
 	}
 	if a.sess.reasoningReplayStrongProjection != 0 {
 		t.Errorf("reasoningReplayStrongProjection = %d, want it restarted", a.sess.reasoningReplayStrongProjection)
+	}
+	if a.sess.reasoningReplayStrongProjectionAnchor != "" {
+		t.Errorf("reasoningReplayStrongProjectionAnchor = %q, want it restarted", a.sess.reasoningReplayStrongProjectionAnchor)
 	}
 	if a.sess.compaction.stuck || a.sess.compaction.stuckInputHash != "" || a.sess.compaction.consecutive != 0 ||
 		a.sess.compaction.failedTurn.Load() != 0 || a.sess.compaction.lastTurn.Load() != 0 {

--- a/internal/agent/sessionstate_test.go
+++ b/internal/agent/sessionstate_test.go
@@ -138,6 +138,7 @@ func TestSetSessionRestartsTheConversationState(t *testing.T) {
 	a.sess.cacheHit.Store(11)
 	a.sess.cacheMiss.Store(7)
 	a.sess.missingReasoning = missingReasoningWatch{active: true, stateRecorded: true, healthyStreak: 2}
+	a.sess.reasoningReplayStrongProjection = 7
 	a.sess.compaction.stuck = true
 	a.sess.compaction.stuckInputHash = "old-input"
 	a.sess.compaction.consecutive = 3
@@ -157,6 +158,9 @@ func TestSetSessionRestartsTheConversationState(t *testing.T) {
 	}
 	if a.sess.missingReasoning != (missingReasoningWatch{}) {
 		t.Errorf("missingReasoning = %+v, want the incident to end with its conversation", a.sess.missingReasoning)
+	}
+	if a.sess.reasoningReplayStrongProjection != 0 {
+		t.Errorf("reasoningReplayStrongProjection = %d, want it restarted", a.sess.reasoningReplayStrongProjection)
 	}
 	if a.sess.compaction.stuck || a.sess.compaction.stuckInputHash != "" || a.sess.compaction.consecutive != 0 ||
 		a.sess.compaction.failedTurn.Load() != 0 || a.sess.compaction.lastTurn.Load() != 0 {

--- a/internal/agent/stream_sink.go
+++ b/internal/agent/stream_sink.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"strings"
+
+	"reasonix/internal/event"
+)
+
+// deferredStreamSink keeps selected stream events local until the caller
+// chooses which provider response to adopt. On an ordinary healthy DeepSeek
+// turn, reasoning arrives before tool calls and unlocks live tool-card events.
+// On the rare malformed turn with no reasoning, only the speculative partial
+// tool cards remain buffered, so retrying does not flash duplicate cards in the
+// UI. A recovery attempt buffers everything because it may be discarded.
+type deferredStreamSink struct {
+	inner               event.Sink
+	deferAll            bool
+	waitingForReasoning bool
+	sawReasoning        bool
+	events              []event.Event
+}
+
+func newReasoningAwareStreamSink(inner event.Sink) *deferredStreamSink {
+	return &deferredStreamSink{inner: inner, waitingForReasoning: true}
+}
+
+func newDeferredStreamSink(inner event.Sink) *deferredStreamSink {
+	return &deferredStreamSink{inner: inner, deferAll: true}
+}
+
+func (s *deferredStreamSink) Emit(e event.Event) {
+	if s == nil {
+		return
+	}
+	if s.deferAll {
+		s.events = append(s.events, e)
+		return
+	}
+	if s.waitingForReasoning && e.Kind == event.Reasoning && strings.TrimSpace(e.Text) != "" {
+		s.sawReasoning = true
+		s.inner.Emit(e)
+		s.flushBuffered()
+		return
+	}
+	if s.waitingForReasoning && !s.sawReasoning {
+		switch e.Kind {
+		case event.ToolDispatch, event.ToolResult, event.Text, event.Message:
+			// Keep every user-visible speculative event private until reasoning
+			// proves the turn replayable. Healthy DeepSeek responses emit
+			// reasoning first, so their live-streaming fast path is unchanged.
+			s.events = append(s.events, e)
+			return
+		}
+	}
+	s.inner.Emit(e)
+}
+
+func (s *deferredStreamSink) flushBuffered() {
+	if s == nil {
+		return
+	}
+	for _, e := range s.events {
+		s.inner.Emit(e)
+	}
+	s.events = nil
+}
+
+func (s *deferredStreamSink) Flush() {
+	if s == nil {
+		return
+	}
+	s.flushBuffered()
+}
+
+func (s *deferredStreamSink) Discard() {
+	if s != nil {
+		s.events = nil
+	}
+}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -673,6 +673,8 @@ const (
 	ProtocolRecoveryClientToolRejected              ProtocolRecoveryKind = "client_tool_rejected_unreplayable_reasoning"
 	ProtocolRecoveryServerSearchSalvaged            ProtocolRecoveryKind = "server_search_history_salvaged"
 	ProtocolRecoveryHistoryRepaired                 ProtocolRecoveryKind = "unreplayable_history_repaired"
+	ProtocolRecoveryReasoningReplay400Detected      ProtocolRecoveryKind = "reasoning_replay_400_detected"
+	ProtocolRecoveryReasoningReplay400Recovered     ProtocolRecoveryKind = "reasoning_replay_400_recovered"
 )
 
 type ProtocolRecoveryAudit struct {

--- a/internal/event/notice_codes.go
+++ b/internal/event/notice_codes.go
@@ -41,4 +41,5 @@ const (
 	NoticeCodeSessionTakenOver                                  = "session_taken_over"
 	NoticeCodeSessionReclaimRequested                           = "session_reclaim_requested"
 	NoticeCodeSessionReclaimed                                  = "session_reclaimed"
+	NoticeCodeReasoningReplayRepair                             = "reasoning_replay_repair"
 )

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -39,6 +39,7 @@ type Messages struct {
 	ReadinessContinuing    string // host is automatically finishing known readiness gaps
 	RecoveryPaused         string // controlled Auto retry pause; user can continue in the next message
 	CompletionUncertain    string // completion validator could not confirm the result; work is kept
+	ReasoningReplayRepair  string // provider rejected replayed thinking blocks; history repaired and retried once
 	ReceiptVerified        string // end-of-turn receipt, nothing unproven
 	ReceiptGapsHeader      string // end-of-turn receipt, header above the unproven list
 	ReceiptRisksHeader     string // end-of-turn receipt, header above declared risks

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -15,6 +15,7 @@ var English = Messages{
 	ReadinessContinuing:    "Reasonix is finishing the remaining task work or checks automatically.",
 	RecoveryPaused:         "Automatic retries paused. Reasonix stopped repeated attempts and kept completed work. Send “Continue” to start a fresh attempt, or add instructions to change direction.",
 	CompletionUncertain:    "Completion could not be confirmed. The current result and completed work are kept. Send \"continue\" to resume, or restate what should change.",
+	ReasoningReplayRepair:  "The model provider rejected this conversation's stored thinking blocks. Reasonix removed them from the provider-visible history and retried once.",
 	ReceiptVerified:        "nothing left unverified",
 	ReceiptGapsHeader:      "not verified:",
 	ReceiptRisksHeader:     "declared risks:",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -16,6 +16,7 @@ var Chinese = Messages{
 	ReadinessContinuing:    "Reasonix 正在自动完成剩余任务或检查。",
 	RecoveryPaused:         "已暂停自动重试。Reasonix 已停止重复尝试，并保留已完成的工作。发送“继续”即可开始新一轮，也可以补充要求来调整方向。",
 	CompletionUncertain:    "完成状态未确认。当前结果和已完成工作均已保留。发送“继续”可接着完成，也可以补充说明需要调整的内容。",
+	ReasoningReplayRepair:  "模型服务拒绝了本会话历史中的 thinking 块。Reasonix 已从发送给模型的历史中移除这些内容，并重试了一次。",
 	ReceiptVerified:        "没有未经验证的部分",
 	ReceiptGapsHeader:      "未验证:",
 	ReceiptRisksHeader:     "已申报的风险:",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -16,6 +16,7 @@ var ChineseTraditional = Messages{
 	ReadinessContinuing:    "Reasonix 正在自動完成剩餘任務或檢查。",
 	RecoveryPaused:         "已暫停自動重試。Reasonix 已停止重複嘗試，並保留已完成的工作。傳送「繼續」即可開始新一輪，也可以補充要求來調整方向。",
 	CompletionUncertain:    "完成狀態未確認。目前結果與已完成工作均已保留。傳送「繼續」可接著完成，也可以補充說明需要調整的內容。",
+	ReasoningReplayRepair:  "模型服務拒絕了本會話歷史中的 thinking 區塊。Reasonix 已從傳送給模型的歷史中移除這些內容，並重試了一次。",
 	ReceiptVerified:        "沒有未經驗證的部分",
 	ReceiptGapsHeader:      "未驗證:",
 	ReceiptRisksHeader:     "已申報的風險:",

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -349,12 +349,25 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 	recoveryWithoutThinking := c.missingReasoningFallback(ctx)
 
 	// appendBlocks adds blocks under role, merging into the previous message when
-	// it shares the role (keeps user/assistant strictly alternating).
+	// it shares the role (keeps user/assistant strictly alternating). A thinking
+	// block must lead its message, so when the appended blocks open with thinking
+	// and the merge target already has content, the thinking run moves to the
+	// front: after projection degrades a reasoning-less turn to plain text, a
+	// following healthy assistant turn merges into it and must stay
+	// [thinking, text, ...], never [text, thinking, ...].
 	appendBlocks := func(role string, blocks ...contentBlock) {
 		if len(blocks) == 0 {
 			return
 		}
 		if n := len(msgs); n > 0 && msgs[n-1].Role == role {
+			if head := leadingThinkingBlocks(blocks); head > 0 && len(msgs[n-1].Content) > 0 {
+				merged := make([]contentBlock, 0, len(msgs[n-1].Content)+len(blocks))
+				merged = append(merged, blocks[:head]...)
+				merged = append(merged, msgs[n-1].Content...)
+				merged = append(merged, blocks[head:]...)
+				msgs[n-1].Content = merged
+				return
+			}
 			msgs[n-1].Content = append(msgs[n-1].Content, blocks...)
 			return
 		}
@@ -459,6 +472,16 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 		}
 	}
 	return r
+}
+
+// leadingThinkingBlocks counts the thinking blocks at the head of blocks.
+// replayReasoningBlock emits at most one, so the run is normally 0 or 1.
+func leadingThinkingBlocks(blocks []contentBlock) int {
+	head := 0
+	for head < len(blocks) && blocks[head].Type == "thinking" {
+		head++
+	}
+	return head
 }
 
 // readStream parses the Messages API SSE stream into Chunks. Text deltas emit live;

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -349,26 +349,13 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 	recoveryWithoutThinking := c.missingReasoningFallback(ctx)
 
 	// appendBlocks adds blocks under role, merging into the previous message when
-	// it shares the role (keeps user/assistant strictly alternating). A thinking
-	// block must lead its message, so when the appended blocks open with thinking
-	// and the merge target already has content, the thinking run moves to the
-	// front: after projection degrades a reasoning-less turn to plain text, a
-	// following healthy assistant turn merges into it and must stay
-	// [thinking, text, ...], never [text, thinking, ...].
+	// it shares the role (keeps user/assistant strictly alternating).
 	appendBlocks := func(role string, blocks ...contentBlock) {
 		if len(blocks) == 0 {
 			return
 		}
 		if n := len(msgs); n > 0 && msgs[n-1].Role == role {
-			if head := leadingThinkingBlocks(blocks); head > 0 && len(msgs[n-1].Content) > 0 {
-				merged := make([]contentBlock, 0, len(msgs[n-1].Content)+len(blocks))
-				merged = append(merged, blocks[:head]...)
-				merged = append(merged, msgs[n-1].Content...)
-				merged = append(merged, blocks[head:]...)
-				msgs[n-1].Content = merged
-				return
-			}
-			msgs[n-1].Content = append(msgs[n-1].Content, blocks...)
+			msgs[n-1].Content = mergeThinkingFirst(msgs[n-1].Content, blocks)
 			return
 		}
 		msgs = append(msgs, anthMessage{Role: role, Content: blocks})
@@ -472,16 +459,6 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 		}
 	}
 	return r
-}
-
-// leadingThinkingBlocks counts the thinking blocks at the head of blocks.
-// replayReasoningBlock emits at most one, so the run is normally 0 or 1.
-func leadingThinkingBlocks(blocks []contentBlock) int {
-	head := 0
-	for head < len(blocks) && blocks[head].Type == "thinking" {
-		head++
-	}
-	return head
 }
 
 // readStream parses the Messages API SSE stream into Chunks. Text deltas emit live;

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -217,8 +217,18 @@ func (c *client) RequiresToolCallReasoning() bool {
 }
 
 func (c *client) RequiresAssistantReasoningReplay(m provider.Message) bool {
+	if c == nil || !c.deepseek {
+		return false
+	}
+	// A turn carrying provider-issued reasoning must replay it, tools or not:
+	// DeepSeek's thinking mode 400s when a stored thinking block is not passed
+	// back. Without stored reasoning there is nothing to replay — plain text
+	// turns stay out of projection so healthy histories keep their backing.
+	if strings.TrimSpace(m.ReasoningContent) != "" {
+		return true
+	}
 	activity := len(m.ToolCalls) > 0 || len(m.ServerSearch) > 0
-	return c != nil && c.deepseek && activity && (c.deepSeekThinkingEnabled() || strings.TrimSpace(m.ReasoningContent) != "")
+	return activity && c.deepSeekThinkingEnabled()
 }
 
 func (c *client) AllowsEmptyReasoningFallback() bool { return false }
@@ -383,11 +393,12 @@ func (c *client) buildRequest(ctx context.Context, req provider.Request) anthReq
 			appendBlocks("user", block)
 		case provider.RoleAssistant:
 			var blocks []contentBlock
-			// Replay provider reasoning before the tool_use it led to. DeepSeek uses
-			// unsigned thinking blocks and requires the reasoning from a tool-call
-			// turn in every subsequent request, even if the current request no longer
-			// declares tools or has since disabled thinking. Anthropic proper requires
-			// a signature, so reasoning without one cannot be replayed on that endpoint.
+			// Replay provider reasoning ahead of the content it led to. DeepSeek's
+			// thinking mode requires every historical assistant turn's thinking
+			// block back whenever the request declares tools — tool-call turn or
+			// not — even if the current request no longer declares tools or has
+			// since disabled thinking. Anthropic proper requires a signature, so
+			// reasoning without one cannot be replayed on that endpoint.
 			if block, ok := c.replayReasoningBlock(m, recoveryWithoutThinking); ok {
 				blocks = append(blocks, block)
 			}

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -702,7 +702,7 @@ func TestMissingToolCallReasoningWarningFingerprintTracksAnthropicConfiguration(
 	}
 }
 
-func TestBuildRequestDeepSeekReplaysOnlyToolCallReasoningFromHistory(t *testing.T) {
+func TestBuildRequestDeepSeekReplaysReasoningFromHistory(t *testing.T) {
 	toolTurn := []provider.Message{
 		{Role: provider.RoleUser, Content: "weather?"},
 		{Role: provider.RoleAssistant, ReasoningContent: "I should call the tool.",
@@ -733,17 +733,21 @@ func TestBuildRequestDeepSeekReplaysOnlyToolCallReasoningFromHistory(t *testing.
 		})
 	}
 
-	t.Run("reasoning without a tool call stays omitted", func(t *testing.T) {
+	t.Run("reasoning without a tool call is replayed", func(t *testing.T) {
+		// DeepSeek's thinking mode requires every historical assistant turn's
+		// thinking block back when the request declares tools, even for plain
+		// question-answer turns (api-docs.deepseek.com/guides/thinking_mode).
 		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
 		r := c.buildRequest(context.Background(), provider.Request{
 			Messages: []provider.Message{
 				{Role: provider.RoleUser, Content: "hello"},
-				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "private scratchpad"},
+				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "scratchpad"},
 			},
 			Tools: []provider.ToolSchema{{Name: "get_weather"}},
 		})
-		if len(r.Messages) != 2 || len(r.Messages[1].Content) != 1 || r.Messages[1].Content[0].Type != "text" {
-			t.Fatalf("non-tool assistant blocks = %+v, want visible text only", r.Messages)
+		blocks := r.Messages[1].Content
+		if len(r.Messages) != 2 || len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "scratchpad" || blocks[1].Type != "text" {
+			t.Fatalf("non-tool assistant blocks = %+v, want thinking before text", r.Messages)
 		}
 	})
 }
@@ -779,7 +783,7 @@ func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "disabled"}
 		r := c.buildRequest(context.Background(), provider.Request{
-			Messages: []provider.Message{{Role: provider.RoleAssistant, ReasoningContent: "do not replay"}},
+			Messages: []provider.Message{{Role: provider.RoleAssistant, ReasoningContent: "replay anyway"}},
 			Tools:    []provider.ToolSchema{{Name: "tool"}},
 		})
 		if r.Thinking == nil || r.Thinking.Type != "disabled" || r.OutputConfig != nil {
@@ -788,8 +792,11 @@ func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 		if provider.RequiresToolCallReasoning(c) || provider.RequiresReasoningRoundTrip(c) {
 			t.Fatal("disabled DeepSeek thinking must not retain reasoning for replay")
 		}
-		if len(r.Messages) != 0 {
-			t.Fatalf("reasoning-only assistant should be omitted when thinking is disabled: %+v", r.Messages)
+		// Historical thinking blocks are replayed even when the current request
+		// disables thinking, the same rule tool-call turns already follow.
+		if len(r.Messages) != 1 || len(r.Messages[0].Content) != 1 || r.Messages[0].Content[0].Type != "thinking" ||
+			r.Messages[0].Content[0].Thinking != "replay anyway" {
+			t.Fatalf("reasoning-only assistant under disabled thinking = %+v, want the thinking block replayed", r.Messages)
 		}
 	})
 }

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -702,56 +702,6 @@ func TestMissingToolCallReasoningWarningFingerprintTracksAnthropicConfiguration(
 	}
 }
 
-func TestBuildRequestDeepSeekReplaysReasoningFromHistory(t *testing.T) {
-	toolTurn := []provider.Message{
-		{Role: provider.RoleUser, Content: "weather?"},
-		{Role: provider.RoleAssistant, ReasoningContent: "I should call the tool.",
-			ToolCalls: []provider.ToolCall{{ID: "t1", Name: "get_weather", Arguments: `{"city":"Paris"}`}}},
-		{Role: provider.RoleTool, ToolCallID: "t1", Content: "sunny"},
-	}
-	for _, tc := range []struct {
-		name     string
-		thinking string
-		effort   string
-	}{
-		{name: "current request has no tools", thinking: "enabled", effort: "high"},
-		{name: "thinking disabled after tool call", thinking: "enabled", effort: "disabled"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: tc.thinking, effort: tc.effort}
-			r := c.buildRequest(context.Background(), provider.Request{Messages: toolTurn})
-			if len(r.Tools) != 0 {
-				t.Fatalf("current request tools = %+v, want none", r.Tools)
-			}
-			if len(r.Messages) != 3 {
-				t.Fatalf("messages = %+v, want user/assistant/user", r.Messages)
-			}
-			blocks := r.Messages[1].Content
-			if len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "I should call the tool." || blocks[1].Type != "tool_use" {
-				t.Fatalf("assistant blocks = %+v, want historical thinking before tool_use", blocks)
-			}
-		})
-	}
-
-	t.Run("reasoning without a tool call is replayed", func(t *testing.T) {
-		// DeepSeek's thinking mode requires every historical assistant turn's
-		// thinking block back when the request declares tools, even for plain
-		// question-answer turns (api-docs.deepseek.com/guides/thinking_mode).
-		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
-		r := c.buildRequest(context.Background(), provider.Request{
-			Messages: []provider.Message{
-				{Role: provider.RoleUser, Content: "hello"},
-				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "scratchpad"},
-			},
-			Tools: []provider.ToolSchema{{Name: "get_weather"}},
-		})
-		blocks := r.Messages[1].Content
-		if len(r.Messages) != 2 || len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "scratchpad" || blocks[1].Type != "text" {
-			t.Fatalf("non-tool assistant blocks = %+v, want thinking before text", r.Messages)
-		}
-	})
-}
-
 func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 	for _, tc := range []struct {
 		name, model, input, want string

--- a/internal/provider/anthropic/missing_reasoning_fallback.go
+++ b/internal/provider/anthropic/missing_reasoning_fallback.go
@@ -37,6 +37,33 @@ func (c *client) replayReasoningBlock(m provider.Message, recoveryWithoutThinkin
 	return contentBlock{}, false
 }
 
+// mergeThinkingFirst merges appended blocks into an existing same-role
+// message's content. A thinking block must lead its message, so a leading
+// thinking run in the appended blocks moves to the front: after projection
+// degrades a reasoning-less turn to plain text, a following healthy assistant
+// turn merging into it must stay [thinking, text, ...], never [text, ...].
+func mergeThinkingFirst(existing, blocks []contentBlock) []contentBlock {
+	head := leadingThinkingBlocks(blocks)
+	if head == 0 || len(existing) == 0 {
+		return append(existing, blocks...)
+	}
+	merged := make([]contentBlock, 0, len(existing)+len(blocks))
+	merged = append(merged, blocks[:head]...)
+	merged = append(merged, existing...)
+	merged = append(merged, blocks[head:]...)
+	return merged
+}
+
+// leadingThinkingBlocks counts the thinking blocks at the head of blocks.
+// replayReasoningBlock emits at most one, so the run is normally 0 or 1.
+func leadingThinkingBlocks(blocks []contentBlock) int {
+	head := 0
+	for head < len(blocks) && blocks[head].Type == "thinking" {
+		head++
+	}
+	return head
+}
+
 func (c *client) applyDeepSeekThinking(r *anthRequest, req provider.Request, recoveryWithoutThinking bool) {
 	r.Temperature = req.Temperature
 	t := c.thinking

--- a/internal/provider/anthropic/missing_reasoning_fallback.go
+++ b/internal/provider/anthropic/missing_reasoning_fallback.go
@@ -25,8 +25,10 @@ func (c *client) replayMessages(messages []provider.Message, recoveryWithoutThin
 }
 
 func (c *client) replayReasoningBlock(m provider.Message, recoveryWithoutThinking bool) (contentBlock, bool) {
-	activity := len(m.ToolCalls) > 0 || len(m.ServerSearch) > 0
-	if c.deepseek && !recoveryWithoutThinking && activity && m.ReasoningContent != "" {
+	// DeepSeek's thinking mode requires every historical assistant turn's
+	// thinking block to be passed back whenever the request declares tools —
+	// including plain question-answer turns with no tool activity.
+	if c.deepseek && !recoveryWithoutThinking && m.ReasoningContent != "" {
 		return contentBlock{Type: "thinking", Thinking: m.ReasoningContent}, true
 	}
 	if !c.deepseek && c.thinking == "adaptive" && m.ReasoningContent != "" && m.ReasoningSignature != "" {

--- a/internal/provider/anthropic/replay_projection_test.go
+++ b/internal/provider/anthropic/replay_projection_test.go
@@ -89,3 +89,53 @@ func TestBuildRequestNativeAnthropicKeepsItsExistingValidationPath(t *testing.T)
 		t.Fatalf("native Anthropic history unexpectedly projected: %#v", r.Messages)
 	}
 }
+
+func TestBuildRequestDeepSeekReplaysReasoningFromHistory(t *testing.T) {
+	toolTurn := []provider.Message{
+		{Role: provider.RoleUser, Content: "weather?"},
+		{Role: provider.RoleAssistant, ReasoningContent: "I should call the tool.",
+			ToolCalls: []provider.ToolCall{{ID: "t1", Name: "get_weather", Arguments: `{"city":"Paris"}`}}},
+		{Role: provider.RoleTool, ToolCallID: "t1", Content: "sunny"},
+	}
+	for _, tc := range []struct {
+		name     string
+		thinking string
+		effort   string
+	}{
+		{name: "current request has no tools", thinking: "enabled", effort: "high"},
+		{name: "thinking disabled after tool call", thinking: "enabled", effort: "disabled"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: tc.thinking, effort: tc.effort}
+			r := c.buildRequest(context.Background(), provider.Request{Messages: toolTurn})
+			if len(r.Tools) != 0 {
+				t.Fatalf("current request tools = %+v, want none", r.Tools)
+			}
+			if len(r.Messages) != 3 {
+				t.Fatalf("messages = %+v, want user/assistant/user", r.Messages)
+			}
+			blocks := r.Messages[1].Content
+			if len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "I should call the tool." || blocks[1].Type != "tool_use" {
+				t.Fatalf("assistant blocks = %+v, want historical thinking before tool_use", blocks)
+			}
+		})
+	}
+
+	t.Run("reasoning without a tool call is replayed", func(t *testing.T) {
+		// DeepSeek's thinking mode requires every historical assistant turn's
+		// thinking block back when the request declares tools, even for plain
+		// question-answer turns (api-docs.deepseek.com/guides/thinking_mode).
+		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
+		r := c.buildRequest(context.Background(), provider.Request{
+			Messages: []provider.Message{
+				{Role: provider.RoleUser, Content: "hello"},
+				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "scratchpad"},
+			},
+			Tools: []provider.ToolSchema{{Name: "get_weather"}},
+		})
+		blocks := r.Messages[1].Content
+		if len(r.Messages) != 2 || len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "scratchpad" || blocks[1].Type != "text" {
+			t.Fatalf("non-tool assistant blocks = %+v, want thinking before text", r.Messages)
+		}
+	})
+}

--- a/internal/provider/anthropic/replay_projection_test.go
+++ b/internal/provider/anthropic/replay_projection_test.go
@@ -46,6 +46,38 @@ func TestDeepSeekReplayProjectionKeepsHealthyHistoryBacking(t *testing.T) {
 	}
 }
 
+func TestBuildRequestDeepSeekMergedAssistantTurnKeepsThinkingFirst(t *testing.T) {
+	c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled"}
+	r := c.buildRequest(context.Background(), provider.Request{Messages: []provider.Message{
+		{Role: provider.RoleUser, Content: "start"},
+		{
+			Role: provider.RoleAssistant, Content: "first answer",
+			ToolCalls: []provider.ToolCall{{ID: "t1", Name: "read_file", Arguments: `{}`}},
+		}, // reasoning lost: projection degrades this turn to plain text
+		{Role: provider.RoleTool, ToolCallID: "t1", Name: "read_file", Content: "data"},
+		{
+			Role: provider.RoleAssistant, Content: "second answer", ReasoningContent: "fresh thinking",
+			ToolCalls: []provider.ToolCall{{ID: "t2", Name: "read_file", Arguments: `{}`}},
+		},
+		{Role: provider.RoleTool, ToolCallID: "t2", Name: "read_file", Content: "more data"},
+		{Role: provider.RoleUser, Content: "continue"},
+	}})
+
+	// The degraded first turn and the healthy second turn merge into one
+	// assistant message; its thinking block must lead.
+	if len(r.Messages) != 3 {
+		t.Fatalf("messages = %#v, want user/merged-assistant/user", r.Messages)
+	}
+	blocks := r.Messages[1].Content
+	if len(blocks) != 4 ||
+		blocks[0].Type != "thinking" || blocks[0].Thinking != "fresh thinking" ||
+		blocks[1].Type != "text" || blocks[1].Text != "first answer" ||
+		blocks[2].Type != "text" || blocks[2].Text != "second answer" ||
+		blocks[3].Type != "tool_use" || blocks[3].ID != "t2" {
+		t.Fatalf("merged assistant blocks = %#v, want [thinking, text, text, tool_use]", blocks)
+	}
+}
+
 func TestBuildRequestNativeAnthropicKeepsItsExistingValidationPath(t *testing.T) {
 	c := &client{model: "claude-sonnet", thinking: "adaptive"}
 	r := c.buildRequest(context.Background(), provider.Request{Messages: []provider.Message{{

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -704,24 +704,18 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 			name := m.Name
 			cm.Name = &name
 		}
-		// DeepSeek thinking mode 400s an assistant tool_calls turn whose
-		// reasoning_content KEY is absent from the request JSON ("reasoning_content
-		// … must be passed back"). The API accepts an empty string, and only
-		// validates turns after the last user message, but emitting the field on
-		// every tool_calls turn is uniform and verified accepted — so always send
-		// it (empty included) rather than fail the request when reasoning was lost
-		// upstream (e.g. a gateway renamed the field). With thinking disabled the
-		// API tolerates every shape, so keep the exact pre-fix bytes there: send
-		// the key only when a thinking-mode round left reasoning in the history
-		// (dropping it would invalidate the prompt-cache prefix of mixed
-		// thinking-on→off sessions for no gain).
+		// DeepSeek thinking mode requires provider reasoning to survive every
+		// assistant history turn when tools are in use, including plain turns.
+		// Tool turns with lost reasoning still get an explicit empty key: the API
+		// accepts it, while omitting the key produces a 400. Preserve non-empty
+		// reasoning even when the current round has since disabled thinking.
 		if m.Role == provider.RoleAssistant {
 			switch {
 			case c.kimiK3 && (m.ReasoningContent != "" || len(m.ToolCalls) > 0):
 				// Kimi K3 requires the complete assistant message on multi-turn
 				// and tool-call requests, including provider-issued reasoning.
 				cm.ReasoningContent = &m.ReasoningContent
-			case (c.deepseek || c.RequiresToolCallReasoning()) && len(m.ToolCalls) > 0:
+			case (c.deepseek || c.RequiresToolCallReasoning()) && (len(m.ToolCalls) > 0 || m.ReasoningContent != ""):
 				if c.RequiresToolCallReasoning() || m.ReasoningContent != "" {
 					cm.ReasoningContent = &m.ReasoningContent
 				}
@@ -1217,10 +1211,8 @@ type chatMessage struct {
 	// Prefix is wire-only and is set exclusively on an automatically recovered
 	// DeepSeek assistant tail. omitempty keeps every ordinary request byte-stable.
 	Prefix bool `json:"prefix,omitempty"`
-	// A pointer so the field can serialize as an empty string: DeepSeek thinking
-	// mode requires the reasoning_content key to be PRESENT on assistant
-	// tool_calls turns (an empty value passes; a missing key 400s), while every
-	// other message must keep omitting it.
+	// A pointer so the field can serialize as an empty string for a malformed
+	// tool turn while preserving non-empty reasoning on every assistant turn.
 	ReasoningContent *string        `json:"reasoning_content,omitempty"`
 	ToolCalls        []chatToolCall `json:"tool_calls,omitempty"`
 	ToolCallID       string         `json:"tool_call_id,omitempty"`

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -715,7 +715,7 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 				// Kimi K3 requires the complete assistant message on multi-turn
 				// and tool-call requests, including provider-issued reasoning.
 				cm.ReasoningContent = &m.ReasoningContent
-			case (c.deepseek || c.RequiresToolCallReasoning()) && (len(m.ToolCalls) > 0 || m.ReasoningContent != ""):
+			case (c.deepseek || c.RequiresToolCallReasoning()) && hasReasoningOrToolCall(m):
 				if c.RequiresToolCallReasoning() || m.ReasoningContent != "" {
 					cm.ReasoningContent = &m.ReasoningContent
 				}

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -963,12 +963,10 @@ func TestNormaliseUsageMiMoShape(t *testing.T) {
 	}
 }
 
-// TestBuildRequestDropsReasoningContent guards the cache/cost fix: an assistant
-// turn's reasoning_content is a response-only signal and must never be echoed
-// back in the outgoing request. DeepSeek otherwise counts it as paid prompt
-// input (~500 tok/turn on a reasoner chain). The session keeps it for
-// display/archive; the wire request must not carry it.
-func TestBuildRequestDropsReasoningOnPlainAssistantTurn(t *testing.T) {
+// TestBuildRequestReplaysReasoningOnPlainAssistantTurn guards the DeepSeek
+// replay contract: a reasoning-bearing assistant turn must keep its exact
+// reasoning_content in later requests even when it made no tool call.
+func TestBuildRequestReplaysReasoningOnPlainAssistantTurn(t *testing.T) {
 	c := &client{model: "deepseek-reasoner", deepseek: true}
 	req := c.buildRequest(provider.Request{
 		Messages: []provider.Message{
@@ -981,11 +979,11 @@ func TestBuildRequestDropsReasoningOnPlainAssistantTurn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if strings.Contains(string(b), "reasoning_content") {
-		t.Errorf("a no-tool-calls assistant turn must not carry reasoning_content: %s", b)
+	if !strings.Contains(string(b), "reasoning_content") {
+		t.Errorf("a reasoning-bearing assistant turn must carry reasoning_content: %s", b)
 	}
-	if strings.Contains(string(b), "SECRET-CHAIN-OF-THOUGHT") {
-		t.Errorf("the assistant chain-of-thought leaked into the request: %s", b)
+	if !strings.Contains(string(b), "SECRET-CHAIN-OF-THOUGHT") {
+		t.Errorf("the assistant chain-of-thought was dropped from the request: %s", b)
 	}
 	if !strings.Contains(string(b), "the answer") {
 		t.Errorf("assistant content was dropped along with reasoning: %s", b)
@@ -1641,11 +1639,9 @@ func TestNewThinkingConfigParsing(t *testing.T) {
 
 // TestBuildRequestDeepSeekDisabled covers both user-facing ways to turn
 // DeepSeek thinking off. Either input must route to thinking.type=disabled,
-// drop reasoning_effort, and keep the pre-fix tool-call history bytes: a
-// tool_calls turn with no reasoning omits the reasoning_content key entirely
-// (only thinking mode requires it), while reasoning left over from a
-// thinking-mode round still round-trips so the prompt-cache prefix of a mixed
-// thinking-on→off session stays stable.
+// drop reasoning_effort, and preserve provider-issued reasoning from earlier
+// assistant turns while still omitting an empty key for a reasoning-less tool
+// turn.
 func TestBuildRequestDeepSeekDisabled(t *testing.T) {
 	base := provider.Config{Name: "ds", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4", APIKey: "k"}
 	for _, tc := range []struct {
@@ -1688,6 +1684,7 @@ func TestBuildRequestDeepSeekDisabled(t *testing.T) {
 						ID: "call_2", Name: "read_file", Arguments: `{"path":"go.mod"}`,
 					}}},
 					{Role: provider.RoleTool, ToolCallID: "call_2", Name: "read_file", Content: "module demo"},
+					{Role: provider.RoleAssistant, Content: "plain answer", ReasoningContent: "plain reasoning"},
 				},
 			})
 			if req.Thinking == nil || req.Thinking.Type != "disabled" {
@@ -1701,6 +1698,9 @@ func TestBuildRequestDeepSeekDisabled(t *testing.T) {
 			}
 			if rc := req.Messages[3].ReasoningContent; rc == nil || *rc != "from a thinking round" {
 				t.Fatalf("disabled mode must keep round-tripping thinking-round reasoning, got %v", rc)
+			}
+			if rc := req.Messages[5].ReasoningContent; rc == nil || *rc != "plain reasoning" {
+				t.Fatalf("disabled mode must keep round-tripping plain-turn reasoning, got %v", rc)
 			}
 		})
 	}
@@ -1873,8 +1873,8 @@ func TestStreamReasoningContentTakesPrecedenceOverFallback(t *testing.T) {
 // assistant tool_calls turn whose reasoning_content KEY is missing from the
 // request JSON, but accepts an empty string. A turn whose reasoning was lost
 // upstream (gateway renamed/dropped the field, legacy session, model switch)
-// must therefore still serialize the key — while plain assistant text turns
-// keep omitting it.
+// must therefore still serialize the key, while plain assistant text turns
+// carrying reasoning are replayed too.
 func TestBuildRequestAlwaysSendsReasoningKeyOnDeepSeekToolCalls(t *testing.T) {
 	p, err := New(provider.Config{
 		Name:    "deepseek-proxy",
@@ -1893,7 +1893,7 @@ func TestBuildRequestAlwaysSendsReasoningKeyOnDeepSeekToolCalls(t *testing.T) {
 				ID: "call_1", Name: "read_file", Arguments: `{"path":"main.go"}`,
 			}}},
 			{Role: provider.RoleTool, ToolCallID: "call_1", Name: "read_file", Content: "package main"},
-			{Role: provider.RoleAssistant, Content: "plain text turn"},
+			{Role: provider.RoleAssistant, Content: "plain text turn", ReasoningContent: "plain reasoning"},
 		},
 	}))
 	if err != nil {
@@ -1915,8 +1915,8 @@ func TestBuildRequestAlwaysSendsReasoningKeyOnDeepSeekToolCalls(t *testing.T) {
 	if string(rc) != `""` {
 		t.Fatalf("reasoning_content = %s, want empty string", rc)
 	}
-	if _, ok := req.Messages[3]["reasoning_content"]; ok {
-		t.Fatal("plain assistant text turn must keep omitting reasoning_content")
+	if got, ok := req.Messages[3]["reasoning_content"]; !ok || string(got) != `"plain reasoning"` {
+		t.Fatalf("plain assistant text turn reasoning_content = %s, want plain reasoning", got)
 	}
 }
 

--- a/internal/provider/openai/reasoning_gateway_test.go
+++ b/internal/provider/openai/reasoning_gateway_test.go
@@ -8,9 +8,9 @@ import (
 	"reasonix/internal/provider"
 )
 
-// Adapted from #7763: a generic gateway explicitly configured with
-// thinking=enabled inherits DeepSeek's empty-key replay fallback.
-func TestBuildRequestThinkingEnabledGatewayRoundTripsToolCallReasoning(t *testing.T) {
+// A generic gateway explicitly configured with thinking=enabled inherits the
+// DeepSeek reasoning replay contract for every reasoning-carrying turn.
+func TestBuildRequestThinkingEnabledGatewayRoundTripsAllReasoning(t *testing.T) {
 	p, err := New(provider.Config{
 		Name: "custom", BaseURL: "https://gateway.example/v1", Model: "ds4-flash", APIKey: "k",
 		Extra: map[string]any{"thinking": "enabled"},
@@ -38,7 +38,10 @@ func TestBuildRequestThinkingEnabledGatewayRoundTripsToolCallReasoning(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(body), "do not replay") {
-		t.Fatalf("plain assistant reasoning leaked: %s", body)
+	if got := req.Messages[4].ReasoningContent; got == nil || *got != "do not replay" {
+		t.Fatalf("plain assistant reasoning = %v, want it replayed", got)
+	}
+	if !strings.Contains(string(body), "do not replay") {
+		t.Fatalf("plain assistant reasoning missing from wire body: %s", body)
 	}
 }

--- a/internal/provider/openai/reasoning_replay_policy.go
+++ b/internal/provider/openai/reasoning_replay_policy.go
@@ -6,10 +6,9 @@ import (
 	"reasonix/internal/provider"
 )
 
-// RequiresAssistantReasoningReplay narrows GLM's broad preservation policy to
-// reasoning the endpoint actually emitted. GLM may omit reasoning on valid
-// thinking-enabled tool turns; those turns remain replayable without inventing
-// an empty chain. Kimi K3 still requires every complete assistant message.
+// RequiresAssistantReasoningReplay keeps provider-issued reasoning replayable
+// on every DeepSeek-style assistant turn that carries it. Tool turns remain
+// required even when reasoning was lost because the wire accepts an empty key.
 func (c *client) RequiresAssistantReasoningReplay(m provider.Message) bool {
 	if c == nil {
 		return false
@@ -20,5 +19,12 @@ func (c *client) RequiresAssistantReasoningReplay(m provider.Message) bool {
 	if c.zhipu {
 		return strings.TrimSpace(m.ReasoningContent) != ""
 	}
-	return len(m.ToolCalls) > 0 && c.RequiresToolCallReasoning()
+	if c.deepseek {
+		return strings.TrimSpace(m.ReasoningContent) != "" ||
+			(len(m.ToolCalls) > 0 && c.RequiresToolCallReasoning())
+	}
+	if c.RequiresToolCallReasoning() {
+		return len(m.ToolCalls) > 0 || strings.TrimSpace(m.ReasoningContent) != ""
+	}
+	return false
 }

--- a/internal/provider/openai/reasoning_replay_policy.go
+++ b/internal/provider/openai/reasoning_replay_policy.go
@@ -6,6 +6,10 @@ import (
 	"reasonix/internal/provider"
 )
 
+func hasReasoningOrToolCall(m provider.Message) bool {
+	return len(m.ToolCalls) > 0 || m.ReasoningContent != ""
+}
+
 // RequiresAssistantReasoningReplay keeps provider-issued reasoning replayable
 // on every DeepSeek-style assistant turn that carries it. Tool turns remain
 // required even when reasoning was lost because the wire accepts an empty key.

--- a/internal/provider/openai/reasoning_replay_policy_test.go
+++ b/internal/provider/openai/reasoning_replay_policy_test.go
@@ -6,6 +6,46 @@ import (
 	"reasonix/internal/provider"
 )
 
+func TestDeepSeekReplaysEveryReasoningCarryingAssistantTurn(t *testing.T) {
+	p, err := New(provider.Config{
+		Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", APIKey: "k",
+		Extra: map[string]any{"reasoning_protocol": "deepseek", "thinking": "enabled"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !provider.RequiresAssistantReasoningReplay(p, provider.Message{
+		Role: provider.RoleAssistant, Content: "plain", ReasoningContent: "provider reasoning",
+	}) {
+		t.Fatal("DeepSeek plain assistant reasoning must be replay-required")
+	}
+	if provider.RequiresAssistantReasoningReplay(p, provider.Message{
+		Role: provider.RoleAssistant, Content: "plain",
+	}) {
+		t.Fatal("DeepSeek plain assistant without reasoning must not invent a replay requirement")
+	}
+	if !provider.RequiresAssistantReasoningReplay(p, provider.Message{
+		Role:      provider.RoleAssistant,
+		ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "read_file"}},
+	}) {
+		t.Fatal("DeepSeek tool turn must remain replay-required when reasoning is missing")
+	}
+
+	disabled := p.(*client)
+	disabled.thinkingType = "disabled"
+	if !provider.RequiresAssistantReasoningReplay(disabled, provider.Message{
+		Role: provider.RoleAssistant, Content: "plain", ReasoningContent: "previous reasoning",
+	}) {
+		t.Fatal("thinking-disabled DeepSeek must still replay stored reasoning")
+	}
+	if provider.RequiresAssistantReasoningReplay(disabled, provider.Message{
+		Role:      provider.RoleAssistant,
+		ToolCalls: []provider.ToolCall{{ID: "call_2", Name: "read_file"}},
+	}) {
+		t.Fatal("thinking-disabled DeepSeek must not require missing tool reasoning")
+	}
+}
+
 func TestGLMPreservesIssuedReasoningAndAllowsEmptyToolFallback(t *testing.T) {
 	p, err := New(provider.Config{
 		Name: "glm", BaseURL: "https://open.bigmodel.cn/api/coding/paas/v4", Model: "glm-5.2", APIKey: "k",

--- a/internal/provider/reasoning_replay.go
+++ b/internal/provider/reasoning_replay.go
@@ -82,6 +82,36 @@ func AllowsEmptyReasoningFallback(p Provider) bool {
 	return ok && policy.AllowsEmptyReasoningFallback()
 }
 
+// ProjectReasoningStrippedMessages is the catch-and-repair projection for a
+// provider that rejected replayed thinking/reasoning history with
+// ReasoningReplayError. It follows the vendor-documented self-heal recipe:
+// strip every assistant message's reasoning/thinking metadata from the
+// provider-visible projection, then drop the tool activity that can no longer
+// be paired with its thinking block. Canonical session messages are never
+// modified; a history with nothing to strip keeps its backing slice.
+func ProjectReasoningStrippedMessages(p Provider, msgs []Message) ([]Message, bool) {
+	work := msgs
+	stripped := false
+	for i, m := range msgs {
+		if m.Role != RoleAssistant {
+			continue
+		}
+		if m.ReasoningContent == "" && m.ReasoningSignature == "" && m.ReasoningID == "" && m.ReasoningStatus == "" {
+			continue
+		}
+		if !stripped {
+			work = append([]Message(nil), msgs...)
+			stripped = true
+		}
+		work[i].ReasoningContent = ""
+		work[i].ReasoningSignature = ""
+		work[i].ReasoningID = ""
+		work[i].ReasoningStatus = ""
+	}
+	projected, projectedChanged := ProjectReplaySafeMessages(p, work)
+	return projected, stripped || projectedChanged
+}
+
 // ProjectReplaySafeMessages returns the provider-visible projection for
 // histories that contain assistant activity without the reasoning required to
 // replay it. Canonical session messages are never modified. Healthy histories

--- a/internal/provider/reasoning_replay.go
+++ b/internal/provider/reasoning_replay.go
@@ -90,9 +90,23 @@ func AllowsEmptyReasoningFallback(p Provider) bool {
 // be paired with its thinking block. Canonical session messages are never
 // modified; a history with nothing to strip keeps its backing slice.
 func ProjectReasoningStrippedMessages(p Provider, msgs []Message) ([]Message, bool) {
+	return projectReasoningStrippedMessages(p, msgs, len(msgs))
+}
+
+// ProjectReasoningStrippedMessagesPrefix applies the strong projection only
+// to the provider-visible prefix that was present when a replay 400 was fixed.
+// Messages appended after that prefix keep their normal reasoning/tool replay.
+func ProjectReasoningStrippedMessagesPrefix(p Provider, msgs []Message, prefix int) ([]Message, bool) {
+	if prefix < 0 || prefix > len(msgs) {
+		return msgs, false
+	}
+	return projectReasoningStrippedMessages(p, msgs, prefix)
+}
+
+func projectReasoningStrippedMessages(p Provider, msgs []Message, prefix int) ([]Message, bool) {
 	work := msgs
 	stripped := false
-	for i, m := range msgs {
+	for i, m := range msgs[:prefix] {
 		if m.Role != RoleAssistant {
 			continue
 		}
@@ -108,7 +122,7 @@ func ProjectReasoningStrippedMessages(p Provider, msgs []Message) ([]Message, bo
 		work[i].ReasoningID = ""
 		work[i].ReasoningStatus = ""
 	}
-	projected, projectedChanged := projectReplaySafeMessages(p, work, false)
+	projected, projectedChanged := projectReplaySafeMessages(p, work, prefix, false)
 	return projected, stripped || projectedChanged
 }
 
@@ -123,10 +137,10 @@ func ProjectReasoningStrippedMessages(p Provider, msgs []Message) ([]Message, bo
 // results are omitted. Providers with an explicit empty-reasoning fallback do
 // not need projection.
 func ProjectReplaySafeMessages(p Provider, msgs []Message) ([]Message, bool) {
-	return projectReplaySafeMessages(p, msgs, true)
+	return projectReplaySafeMessages(p, msgs, len(msgs), true)
 }
 
-func projectReplaySafeMessages(p Provider, msgs []Message, honorEmptyFallback bool) ([]Message, bool) {
+func projectReplaySafeMessages(p Provider, msgs []Message, prefix int, honorEmptyFallback bool) ([]Message, bool) {
 	if honorEmptyFallback && AllowsEmptyReasoningFallback(p) {
 		return msgs, false
 	}
@@ -136,14 +150,14 @@ func projectReplaySafeMessages(p Provider, msgs []Message, honorEmptyFallback bo
 			strings.TrimSpace(m.ReasoningContent) == ""
 	}
 
-	if !slices.ContainsFunc(msgs, isUnreplayable) {
+	if !slices.ContainsFunc(msgs[:prefix], isUnreplayable) {
 		return msgs, false
 	}
 
 	out := make([]Message, 0, len(msgs))
 	for i := 0; i < len(msgs); {
 		m := msgs[i]
-		if !isUnreplayable(m) {
+		if i >= prefix || !isUnreplayable(m) {
 			out = append(out, m)
 			i++
 			continue

--- a/internal/provider/reasoning_replay.go
+++ b/internal/provider/reasoning_replay.go
@@ -108,7 +108,7 @@ func ProjectReasoningStrippedMessages(p Provider, msgs []Message) ([]Message, bo
 		work[i].ReasoningID = ""
 		work[i].ReasoningStatus = ""
 	}
-	projected, projectedChanged := ProjectReplaySafeMessages(p, work)
+	projected, projectedChanged := projectReplaySafeMessages(p, work, false)
 	return projected, stripped || projectedChanged
 }
 
@@ -123,7 +123,11 @@ func ProjectReasoningStrippedMessages(p Provider, msgs []Message) ([]Message, bo
 // results are omitted. Providers with an explicit empty-reasoning fallback do
 // not need projection.
 func ProjectReplaySafeMessages(p Provider, msgs []Message) ([]Message, bool) {
-	if AllowsEmptyReasoningFallback(p) {
+	return projectReplaySafeMessages(p, msgs, true)
+}
+
+func projectReplaySafeMessages(p Provider, msgs []Message, honorEmptyFallback bool) ([]Message, bool) {
+	if honorEmptyFallback && AllowsEmptyReasoningFallback(p) {
 		return msgs, false
 	}
 	isUnreplayable := func(m Message) bool {

--- a/internal/provider/reasoning_replay_error.go
+++ b/internal/provider/reasoning_replay_error.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// ReasoningReplayError is a trusted provider rejection of replayed
+// thinking/reasoning history: HTTP 400 whose body says the request's
+// thinking/reasoning blocks must be passed back. Unwrap returns the original
+// APIError so localization, trace IDs, and telemetry keep working. The body is
+// never persisted or replayed.
+type ReasoningReplayError struct {
+	APIError *APIError
+}
+
+func (e *ReasoningReplayError) Error() string {
+	if e == nil || e.APIError == nil {
+		return "reasoning replay rejected"
+	}
+	return e.APIError.Error()
+}
+
+func (e *ReasoningReplayError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.APIError
+}
+
+// ParseReasoningReplayError extracts a trusted thinking-replay rejection from
+// an APIError. The match is deliberately exact — DeepSeek's documented shape is
+// "The `content[].thinking` in the thinking mode must be passed back to the
+// API" — so only a 400 naming thinking/reasoning content AND the pass-back
+// obligation qualifies. Any other 400 (and every other status) returns nil so
+// the retry budget can never swallow an unrelated client error.
+func ParseReasoningReplayError(apiErr *APIError) *ReasoningReplayError {
+	if apiErr == nil || apiErr.Status != http.StatusBadRequest {
+		return nil
+	}
+	body := strings.ToLower(apiErr.Body)
+	namesReasoning := strings.Contains(body, "content[].thinking") || strings.Contains(body, "reasoning_content")
+	if !namesReasoning || !strings.Contains(body, "must be passed back") {
+		return nil
+	}
+	return &ReasoningReplayError{APIError: apiErr}
+}
+
+// AsReasoningReplayError unwraps err to a trusted thinking-replay rejection,
+// if any.
+func AsReasoningReplayError(err error) *ReasoningReplayError {
+	var replay *ReasoningReplayError
+	if err != nil && errors.As(err, &replay) {
+		return replay
+	}
+	return nil
+}

--- a/internal/provider/reasoning_replay_error_test.go
+++ b/internal/provider/reasoning_replay_error_test.go
@@ -1,0 +1,109 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestParseReasoningReplayError(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{
+			name:   "deepseek anthropic thinking 400",
+			status: 400,
+			body:   `{"error":{"message":"The ` + "`content[].thinking`" + ` in the thinking mode must be passed back to the API","type":"invalid_request_error"}}`,
+			want:   true,
+		},
+		{
+			name:   "openai-style reasoning_content 400",
+			status: 400,
+			body:   `{"error":{"message":"reasoning_content must be passed back to the API in thinking mode"}}`,
+			want:   true,
+		},
+		{
+			name:   "case-insensitive",
+			status: 400,
+			body:   `The CONTENT[].THINKING in the thinking mode MUST BE PASSED BACK to the API`,
+			want:   true,
+		},
+		{
+			name:   "400 without pass-back obligation",
+			status: 400,
+			body:   `{"error":{"message":"content[].thinking is not supported by this model"}}`,
+			want:   false,
+		},
+		{
+			name:   "400 pass-back without reasoning reference",
+			status: 400,
+			body:   `{"error":{"message":"the signed block must be passed back unchanged"}}`,
+			want:   false,
+		},
+		{
+			name:   "401 with the same body",
+			status: 401,
+			body:   `{"error":{"message":"The content[].thinking in the thinking mode must be passed back to the API"}}`,
+			want:   false,
+		},
+		{
+			name:   "422 with the same body",
+			status: 422,
+			body:   `{"error":{"message":"The content[].thinking in the thinking mode must be passed back to the API"}}`,
+			want:   false,
+		},
+		{
+			name:   "unrelated 400",
+			status: 400,
+			body:   `{"error":{"message":"invalid tool schema at index 2"}}`,
+			want:   false,
+		},
+		{
+			name:   "empty body",
+			status: 400,
+			body:   "",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseReasoningReplayError(&APIError{Provider: "p", Status: tc.status, Body: tc.body})
+			if (got != nil) != tc.want {
+				t.Fatalf("ParseReasoningReplayError = %v, want match=%v", got, tc.want)
+			}
+			if got != nil && got.APIError == nil {
+				t.Fatal("matched error lost the underlying APIError")
+			}
+		})
+	}
+	if ParseReasoningReplayError(nil) != nil {
+		t.Fatal("nil APIError must not match")
+	}
+}
+
+func TestAsReasoningReplayError(t *testing.T) {
+	apiErr := &APIError{Provider: "p", Status: 400, Body: "The `content[].thinking` in the thinking mode must be passed back to the API"}
+	replay := ParseReasoningReplayError(apiErr)
+	if replay == nil {
+		t.Fatal("fixture did not match")
+	}
+	if got := AsReasoningReplayError(fmt.Errorf("stream: %w", replay)); got != replay {
+		t.Fatalf("AsReasoningReplayError = %v, want the wrapped error", got)
+	}
+	if got := AsReasoningReplayError(apiErr); got != nil {
+		t.Fatalf("bare APIError must not unwrap as ReasoningReplayError: %v", got)
+	}
+	if got := AsReasoningReplayError(errors.New("other")); got != nil {
+		t.Fatalf("unrelated error = %v, want nil", got)
+	}
+	if got := AsReasoningReplayError(nil); got != nil {
+		t.Fatal("nil error must not match")
+	}
+	var base error = replay
+	if unwrapped := errors.Unwrap(base); unwrapped != apiErr {
+		t.Fatalf("Unwrap = %v, want the APIError", unwrapped)
+	}
+}

--- a/internal/provider/reasoning_replay_error_test.go
+++ b/internal/provider/reasoning_replay_error_test.go
@@ -102,8 +102,7 @@ func TestAsReasoningReplayError(t *testing.T) {
 	if got := AsReasoningReplayError(nil); got != nil {
 		t.Fatal("nil error must not match")
 	}
-	var base error = replay
-	if unwrapped := errors.Unwrap(base); unwrapped != apiErr {
-		t.Fatalf("Unwrap = %v, want the APIError", unwrapped)
+	if !errors.Is(replay, apiErr) {
+		t.Fatal("ReasoningReplayError must unwrap to the APIError")
 	}
 }

--- a/internal/provider/reasoning_replay_projection_test.go
+++ b/internal/provider/reasoning_replay_projection_test.go
@@ -104,3 +104,36 @@ func TestProjectReasoningStrippedMessagesBypassesEmptyFallbackAfter400(t *testin
 		t.Fatal("strong projection mutated canonical history")
 	}
 }
+
+func TestProjectReasoningStrippedMessagesPrefixKeepsAppendedToolRound(t *testing.T) {
+	p := replayProjectionProvider{}
+	msgs := []Message{
+		{Role: RoleUser, Content: "inspect"},
+		{
+			Role:             RoleAssistant,
+			Content:          "old answer",
+			ReasoningContent: "stale reasoning",
+		},
+		{Role: RoleUser, Content: "continue"},
+		{
+			Role:             RoleAssistant,
+			ReasoningContent: "fresh reasoning",
+			ToolCalls:        []ToolCall{{ID: "fresh", Name: "read_file"}},
+		},
+		{Role: RoleTool, ToolCallID: "fresh", Name: "read_file", Content: "fresh result"},
+	}
+
+	got, changed := ProjectReasoningStrippedMessagesPrefix(p, msgs, 3)
+	if !changed {
+		t.Fatal("stale prefix was not projected")
+	}
+	if len(got) != len(msgs) {
+		t.Fatalf("projection length = %d, want %d", len(got), len(msgs))
+	}
+	if got[1].ReasoningContent != "" {
+		t.Fatalf("stale prefix reasoning survived: %#v", got[1])
+	}
+	if got[3].ReasoningContent != "fresh reasoning" || len(got[3].ToolCalls) != 1 || got[4].Role != RoleTool {
+		t.Fatalf("appended tool round changed: %#v", got)
+	}
+}

--- a/internal/provider/reasoning_replay_projection_test.go
+++ b/internal/provider/reasoning_replay_projection_test.go
@@ -74,3 +74,33 @@ func TestProjectReplaySafeMessagesKeepsStableBacking(t *testing.T) {
 		t.Fatal("empty-reasoning fallback history must retain its backing slice")
 	}
 }
+
+func TestProjectReasoningStrippedMessagesBypassesEmptyFallbackAfter400(t *testing.T) {
+	p := replayProjectionProvider{allowEmpty: true}
+	msgs := []Message{
+		{Role: RoleUser, Content: "inspect"},
+		{
+			Role:               RoleAssistant,
+			Content:            "visible answer",
+			ReasoningContent:   "stale reasoning",
+			ToolCalls:          []ToolCall{{ID: "call-1", Name: "read_file"}},
+			ReasoningSignature: "stale signature",
+		},
+		{Role: RoleTool, ToolCallID: "call-1", Name: "read_file", Content: "result"},
+		{Role: RoleUser, Content: "continue"},
+	}
+
+	got, changed := ProjectReasoningStrippedMessages(p, msgs)
+	if !changed {
+		t.Fatal("stale reasoning history was not changed")
+	}
+	if len(got) != 3 || got[1].Role != RoleAssistant || got[1].Content != "visible answer" {
+		t.Fatalf("projection = %#v, want user/plain assistant/user", got)
+	}
+	if got[1].ReasoningContent != "" || got[1].ReasoningSignature != "" || len(got[1].ToolCalls) != 0 {
+		t.Fatalf("stale assistant metadata survived projection: %#v", got[1])
+	}
+	if msgs[1].ReasoningContent != "stale reasoning" || len(msgs[1].ToolCalls) != 1 || len(msgs[2].Content) == 0 {
+		t.Fatal("strong projection mutated canonical history")
+	}
+}

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -338,6 +338,9 @@ func SendWithRetry(ctx context.Context, httpClient *http.Client, opts SendOption
 			if limitErr := ParseContextLimitError(apiErr); limitErr != nil {
 				return nil, limitErr
 			}
+			if replayErr := ParseReasoningReplayError(apiErr); replayErr != nil {
+				return nil, replayErr
+			}
 			return nil, apiErr
 		}
 		lastErr = apiErr


### PR DESCRIPTION
## Summary

- Align the OpenAI-compatible DeepSeek path with DeepSeek Harness: when a request declares tools, replay every historical assistant turn that carries `reasoning_content`, including turns without tool calls.
- Extend stale-history recovery to OpenAI-compatible requests: recognize the exact pass-back HTTP 400, strip stale reasoning and unpaired tool activity from the provider-visible old-history prefix, retry once, and keep later turns on the normal reasoning/tool replay path.
- Preserve canonical session history and provider-original reasoning through `PostLLMCall` display transforms.
- Keep thinking blocks first when assistant messages merge, and document the tools-dependent protocol in both English and Chinese.

## Issues

Refs #9750
Refs #9762

## Verification

- `go test -count=1 ./...`
- `go test -count=1 ./internal/provider/... ./internal/agent/...`
- `go test -race ./internal/provider/... -count=1`
- `go test -race ./internal/agent/ -run 'Replay|Reasoning|Retry|PostLLMCall' -count=1`
- `go vet ./...`
- `make lint`
- `go build ./...`
- `go test ./internal/tool/builtin/ ./internal/boot/ -count=1`
- Bounded live smoke against the official DeepSeek OpenAI-compatible and Anthropic-compatible endpoints: reasoning replay, tool replay, cache probe, no-tools reasoning behavior, and missing-thinking history projection passed. Credentials were process-local and are not included here.
- Added regression coverage for post-repair new tool rounds and `PostLLMCall` reasoning preservation.

## Documentation impact

Documentation-impact: updated - `docs/REASONING_PROVIDERS.md` and `docs/REASONING_PROVIDERS.zh-CN.md` document the tools-dependent replay rule, ignored no-tools reasoning, and prefix-scoped stale-history repair.

## Cache impact

Cache-impact: medium - replaying stored reasoning changes provider-visible history for existing tool-capable sessions once; subsequent serialization is deterministic. DeepSeek ignores historical reasoning when tools are absent, and stale-history repair only changes sessions that already received the specific 400.
Cache-guard: provider and agent replay suites, byte-level recovery assertions, full root tests, `go test -race ./internal/provider/... -count=1`, and bounded live DeepSeek cache/replay probes.
System-prompt-review: N/A - system prompt, memory prefix, output style, and skill index are unchanged.
