### PR TITLE
fix(provider): stop compaction summaries inheriting reasoning effort / 压缩摘要请求强制无推理，避免思维等级消耗摘要预算 (#9613)

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -382,6 +382,11 @@ func (a *Agent) summaryRequest(region []provider.Message, instructions string) p
 		Tools:       schemas,
 		MaxTokens:   a.summaryOutputBudget(),
 		Temperature: provider.OptionalTemperature(a.temperature),
+		// The compaction prompt explicitly asks for a direct briefing with no
+		// thinking, and the summary budget must not be consumed by reasoning on
+		// thinking models. Force reasoning off so compaction works even when the
+		// user has a reasoning effort configured (#9613).
+		EffortOverride: "none",
 	}
 }
 

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -268,7 +268,13 @@ func (c *client) buildRequestBody(req provider.Request) (map[string]any, bool, [
 	messages := provider.SanitizeToolPairing(provider.ModelMessages(req.Messages))
 	body := map[string]any{"model": c.model, "stream": true}
 
-	effort := strings.ToLower(strings.TrimSpace(c.effort))
+	// A per-request EffortOverride (e.g. summary/compaction forcing thinking
+	// off) wins over the client's configured effort; otherwise client effort
+	// reaches every request it builds (#9613).
+	effort := strings.ToLower(strings.TrimSpace(req.EffortOverride))
+	if effort == "" {
+		effort = strings.ToLower(strings.TrimSpace(c.effort))
+	}
 	if c.vendor == "deepseek" && (strings.EqualFold(strings.TrimSpace(c.model), "deepseek-v4-flash") || strings.EqualFold(strings.TrimSpace(c.model), "deepseek-v4-pro")) {
 		if effort == "medium" || effort == "xhigh" {
 			effort = "high"

--- a/internal/provider/responses/responses_test.go
+++ b/internal/provider/responses/responses_test.go
@@ -116,6 +116,30 @@ func TestDeepSeekV4ResponsesEffortAliasesNormalizeToHigh(t *testing.T) {
 	}
 }
 
+// TestEffortOverrideWinsOverClientEffort covers #9613: a per-request
+// EffortOverride (used by compaction summary requests to force thinking off)
+// must override the client's configured effort in the serialized body, while a
+// request without an override still inherits the configured effort.
+func TestEffortOverrideWinsOverClientEffort(t *testing.T) {
+	message := []provider.Message{{Role: provider.RoleUser, Content: "hi"}}
+
+	// No override -> client effort (high) reaches the wire unchanged.
+	inherited := New(Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", Effort: "high"}).(*client)
+	body, _, _ := inherited.buildRequestBody(provider.Request{Messages: message})
+	if got, _ := body["reasoning"].(map[string]any)["effort"].(string); got != "high" {
+		t.Fatalf("no override inherited effort = %q, want high", got)
+	}
+
+	// Override "none" wins even when the client effort is high.
+	for _, clientEffort := range []string{"high", ""} {
+		overridden := New(Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", Effort: clientEffort}).(*client)
+		b, _, _ := overridden.buildRequestBody(provider.Request{Messages: message, EffortOverride: "none"})
+		if got, _ := b["reasoning"].(map[string]any)["effort"].(string); got != "none" {
+			t.Fatalf("override none with client effort %q serialized as %q, want none", clientEffort, got)
+		}
+	}
+}
+
 func TestRequestSerializesExplicitMaxOutputTokens(t *testing.T) {
 	client := New(Config{Name: "responses", BaseURL: "https://example.com", Model: "model"}).(*client)
 	body, _, _ := client.buildRequestBody(provider.Request{


### PR DESCRIPTION
## Summary

Fixes #9613. On long DeepSeek sessions with a reasoning effort configured, manual compaction kept failing; it only succeeded after the user disabled reasoning effort in settings. Root cause: the compaction **summary** request (which the prompt itself says must be produced directly, without a thinking block) inherited the client-level configured effort, so the thinking model spent the 8192-output summary budget on reasoning and was truncated with an empty result — compaction failed.

`internal/provider/responses/responses.go`:
- `buildRequestBody` now prefers a per-request `req.EffortOverride` (non-empty), falling back to the configured client `c.effort` only when no override is set. The `EffortOverride` wire field was previously never read on the Responses adapter — ordinary conversation requests set no override, so their wire is unchanged; only requests that set one (compaction, ACP) change.

`internal/agent/compact.go`:
- `summaryRequest` sets `EffortOverride: "none"`, forcing compaction summaries to skip reasoning as their prompt already demands. Compaction now works while the user keeps a reasoning effort configured.

## Issues

Fixes #9613

## Verification

- New test `TestEffortOverrideWinsOverClientEffort` (`internal/provider/responses`): a request with no override inherits the client effort (high → `reasoning.effort=high`); a request with `EffortOverride: "none"` serializes `reasoning.effort=none` even when the client effort is high (or empty).
- `go test ./internal/provider/responses/ ./internal/agent/` — existing effort-alias/alias-to-high/token-default tests and the compaction suite all pass.
- `go vet ./internal/provider/responses/ ./internal/agent/`; `gofmt` clean.

## Documentation impact

Documentation-impact: none - behavior fix for summary/compaction only; no user-facing config or docs/*.md change.

## Cache impact

Cache-impact: none - compaction summary requests are run-time, turn-tail writes; only a reasoning-effort override leaks there is removed. The stable system-prompt prefix and provider-visible tool schema/list are byte-identical, so the prefix-cache stays warm.

Cache-guard: `go test ./internal/provider/responses/ -run TestEffortOverrideWinsOverClientEffort -count=1` + `go test ./internal/agent/` (existing compaction suite).