### PR TITLE
fix(goal/recovery): boundedllm falls back to reasoning when content is empty / content 为空且 reasoning 有内容时以推理文本作为响应，避免 thinking 模型上 goal evaluator 空响应暂停 (#9678)

### DIFF
--- a/internal/boundedllm/bounded.go
+++ b/internal/boundedllm/bounded.go
@@ -136,6 +136,7 @@ func Call(ctx context.Context, cfg Config, system, evidence string) (string, err
 	}
 
 	var text strings.Builder
+	var reasoning strings.Builder
 	for chunk := range ch {
 		switch chunk.Type {
 		case provider.ChunkText:
@@ -143,6 +144,19 @@ func Call(ctx context.Context, cfg Config, system, evidence string) (string, err
 			if text.Len() > maxOutputBytes {
 				cancel()
 				return "", fmt.Errorf("bounded reviewer output exceeded %d bytes", maxOutputBytes)
+			}
+		case provider.ChunkReasoning:
+			// Keep reasoning alongside text: a thinking-only vendor (DeepSeek
+			// on a thinking model as the fallback reviewer) streams its verdict
+			// into reasoning_content with an empty content block. Captured here
+			// it can stand in for the response, otherwise the goal evaluator and
+			// recovery reviewer would fail-closed on an "empty" verdict every
+			// turn (#9678). Bounded like text so an oversize thinking dump still
+			// fails closed rather than leaking past the budget.
+			reasoning.WriteString(chunk.Text)
+			if text.Len() == 0 && reasoning.Len() > maxOutputBytes {
+				cancel()
+				return "", fmt.Errorf("bounded reviewer reasoning exceeded %d bytes", maxOutputBytes)
 			}
 		case provider.ChunkUsage:
 			if chunk.Usage != nil {
@@ -158,6 +172,12 @@ func Call(ctx context.Context, cfg Config, system, evidence string) (string, err
 	}
 	if callCtx.Err() != nil && text.Len() == 0 {
 		return "", callCtx.Err()
+	}
+	if text.Len() == 0 && reasoning.Len() > 0 {
+		// No visible content but the model did think: fall back to the reasoning
+		// text so callers that extract a JSON verdict from the response still
+		// succeed on reasoning-only streams (#9678, cf. #6617 for the main loop).
+		return reasoning.String(), nil
 	}
 	return text.String(), nil
 }

--- a/internal/boundedllm/bounded_test.go
+++ b/internal/boundedllm/bounded_test.go
@@ -1,0 +1,85 @@
+package boundedllm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// scriptedProvider replays a fixed chunk stream for a single call, satisfying
+// provider.Provider without any real network.
+type scriptedProvider struct {
+	chunks []provider.Chunk
+}
+
+func (p *scriptedProvider) Name() string { return "scripted" }
+func (p *scriptedProvider) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
+	ch := make(chan provider.Chunk, len(p.chunks))
+	for _, c := range p.chunks {
+		ch <- c
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestCallReturnsVisibleTextWhenPresent(t *testing.T) {
+	got, err := Call(context.Background(), Config{Provider: &scriptedProvider{chunks: []provider.Chunk{
+		{Type: provider.ChunkReasoning, Text: "some thinking"},
+		{Type: provider.ChunkText, Text: "final verdict"},
+		{Type: provider.ChunkUsage, Usage: &provider.Usage{TotalTokens: 9}},
+	}}}, "sys", "e")
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if got != "final verdict" {
+		t.Fatalf("Call = %q, want visible text only (reasoning must not leak)", got)
+	}
+}
+
+// TestCallFallsBackToReasoningWhenContentEmpty covers #9678: a thinking-only
+// model streams everything into reasoning with an empty content block. The
+// reviewer must get that reasoning (callers extract a JSON verdict from it)
+// instead of an empty response that fails the goal closed.
+func TestCallFallsBackToReasoningWhenContentEmpty(t *testing.T) {
+	got, err := Call(context.Background(), Config{Provider: &scriptedProvider{chunks: []provider.Chunk{
+		{Type: provider.ChunkReasoning, Text: `{"outcome":"succeeded","summary":"done"}`},
+		{Type: provider.ChunkUsage, Usage: &provider.Usage{TotalTokens: 12}},
+	}}}, "sys", "e")
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if !strings.Contains(got, "succeeded") {
+		t.Fatalf("reasoning-only Call = %q, want the reasoning text to stand in for content", got)
+	}
+}
+
+func TestCallReturnsEmptyWhenNothingStreamed(t *testing.T) {
+	got, err := Call(context.Background(), Config{Provider: &scriptedProvider{chunks: []provider.Chunk{
+		{Type: provider.ChunkDone},
+	}}}, "sys", "e")
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("empty stream Call = %q, want empty (fail-closed upstream)", got)
+	}
+}
+
+func TestCallSurfacesStreamErrorWithoutReasoningFallback(t *testing.T) {
+	_, err := Call(context.Background(), Config{Provider: &scriptedProvider{chunks: []provider.Chunk{
+		{Type: provider.ChunkReasoning, Text: "thought before failure"},
+		{Type: provider.ChunkError, Err: &customErr{}},
+	}}}, "sys", "e")
+	if err == nil {
+		t.Fatal("expected stream error to surface")
+	}
+	if _, ok := err.(*customErr); !ok {
+		t.Fatalf("Call error = %T, want customErr (reasoning-before-error must not be returned)", err)
+	}
+}
+
+type customErr struct{}
+
+func (*customErr) Error() string { return "boom" }


### PR DESCRIPTION
## Summary

Fixes #9678. When the Goal evaluator (or recovery reviewer) runs on a thinking model as the fallback (`recovery_model → guardian_model → main model`), the model streams its verdict into `reasoning_content` and finishes with an **empty visible content block**. `boundedllm.Call` only collected `ChunkText` and dropped `ChunkReasoning`, so it returned an empty response and the goal **fail-closed paused** on every turn ("empty goal evaluator response"), even though output tokens were consumed.

`internal/boundedllm/bounded.go`:
- `Call` now also accumulates `ChunkReasoning` into its own builder, bounded by `maxOutputBytes` just like text.
- When the stream ends with **empty visible content but non-empty reasoning** and no error, the reasoning text is returned as the response. Callers (`goaleval`, `completioneval`, recovery reviewer) extract a JSON verdict between the first and last `{`/`}`, so a verdict emitted at the end of the thinking stream parses directly.
- Visible-text requests are unchanged (reasoning is never mixed into a non-empty text response). Empty streams still return `""` (fail-closed upstream). Stream errors still surface instead of leaking the reasoning-before-error.

This complements the main-loop fix #6617 (`reasoningOnlyFinishHonoured`) on the bounded reviewer channel.

## Issues

Fixes #9678

## Verification

- New tests in `internal/boundedllm/bounded_test.go`:
  - `TestCallReturnsVisibleTextWhenPresent` — reasoning never leaks into a present visible answer.
  - `TestCallFallsBackToReasoningWhenContentEmpty` — reasoning-only stream returns the reasoning text.
  - `TestCallReturnsEmptyWhenNothingStreamed` — truly empty stays empty (fail-closed).
  - `TestCallSurfacesStreamErrorWithoutReasoningFallback` — an error after reasoning must surface, not return the thinking.
- `go test ./internal/boundedllm/ ./internal/goaleval/ ./internal/completioneval/ ./internal/recovery/`
- `go test ./internal/control/` `go test ./internal/agent/`
- `go vet` on all affected packages; `gofmt` clean.

## Documentation impact

Documentation-impact: none - internal reviewer-channel fallback only; no user-facing config or docs/*.md change.

## Cache impact

Cache-impact: none - bounded reviewer calls are isolated run-time requests (temperature 0, no tools/history), not part of the cache-stable system-prompt prefix or provider-visible tool schema. `scripts/check-cache-impact.sh` reports no cache-sensitive files changed.

Cache-guard: `go test ./internal/boundedllm/` (new reasoning-fallback suite) plus the goal-evaluator/recovery/completion suites that run the same channel.