### PR TITLE
test(agent): pin core loop contract baseline / 锁定 Agent 核心循环契约基线

### DIFF
--- a/docs/AGENT_CORE_SIMPLIFICATION.md
+++ b/docs/AGENT_CORE_SIMPLIFICATION.md
@@ -1,0 +1,92 @@
+# Agent Core Simplification
+
+This document tracks the agent-core simplification effort: the behavioral
+contract of the simplified loop, the metrics used to compare before/after, and
+where each contract item is tested. The Chinese version lives in
+`AGENT_CORE_SIMPLIFICATION.zh-CN.md`.
+
+## Target loop
+
+```text
+build request
+  -> provider stream
+  -> clean final: done
+  -> tool call: execute, next step
+  -> request error: unified retry
+  -> unhandled error: explicit failure
+```
+
+## Product decisions
+
+- Normal requests are executor-only; the planner is opt-in (`planner_model`).
+- Normal agents ship with synthetic continuation disabled; Goal, review,
+  guardian, and typed-report flows keep their own constraints.
+- Compaction defaults to a single summary; chunked/tree-reduce recovery is
+  explicit only (manual `/compact` and marked recovery workflows).
+- Final readiness, tool safety, cancellation, budgets, and incomplete-read
+  stay as hard boundaries.
+- Old configs and old session state stay readable for one release; the new
+  runtime never executes the old fallbacks.
+
+## Metrics baseline
+
+Reuse the existing usage and e2ebench instrumentation; no new fallback
+telemetry is added. Capture before/after per phase with:
+
+- `reasonix run --metrics <path>` — per-run `RunMetrics`: token/cost totals,
+  `usage_by_source` (executor/planner/subagent/compaction/... request calls),
+  `retries`, `compactions`, `steps`.
+- `go run ./cmd/e2ebench -task <task> -json` — per-task request counts,
+  `usage_by_source`, trajectory digest (stream retries, reasoning replays,
+  empty-final retries, TTFT, requests by source), wall time, cache hit/miss.
+
+| Metric | Source |
+|---|---|
+| model requests per normal turn | `usage_by_source["executor"].Calls` / trajectory `ExecutorRequests` |
+| planner requests | `usage_by_source["planner"].Calls` / trajectory `PlannerRequests` |
+| reviewer/evaluator/guardian requests | `usage_by_source["recovery_reviewer"|"goal_evaluator"]`, guardian assessment usage |
+| synthetic continuations | executor requests per clean turn above 1; trajectory `EmptyFinalRetries` |
+| stream retries | trajectory `StreamRetries` / `RunMetrics.Retries` |
+| compaction requests and summary spans | `RunMetrics.Compactions`, compaction telemetry notice (`spans=`, `reqs=`) |
+| first text latency | trajectory `TTFTMs` |
+| turn latency | `RunMetrics.DurationMs` / bench `WallMs` |
+| tool execution success | bench task solved rate / `SolvedThenBroken` |
+| protocol-error terminations | trajectory retry-exhausted outcomes |
+
+Compare at least: normal Q&A, normal code edit, long-context/tool-heavy
+(`context-pressure` tasks). Goal per phase: a normal request is one executor
+request chain, no implicit planner/reviewer/evaluator requests, no extra
+continuation after a clean final, default compaction never enters multi-span
+summaries, and hard-safety failure rates do not increase.
+
+## Contract tests
+
+New consolidated suite: `internal/agent/agent_contract_test.go`.
+
+| Contract item | Test |
+|---|---|
+| clean final makes exactly one model request | `TestContractCleanFinalMakesOneModelRequest` |
+| tool call executes, loop advances | `TestContractToolCallAdvancesToNextStep` |
+| thinking survives the unified retry (frozen request) | `TestContractThinkingSurvivesUnifiedRetry` |
+| no long-lived fallback state after retry exhaustion | `TestContractNoLongLivedFallbackStateAfterRetryExhaustion` |
+| clean final adds no synthetic continuation | `TestContractCleanFinalAddsNoSyntheticContinuation` |
+| reasoning-only clean stop completes | `TestRunAcceptsReasoningOnlyFinalAnswer` |
+| zero content retries via unified `EMPTY_RESPONSE` path | `TestRunRetriesZeroContentWithTheSameFrozenRequest` |
+| exhausted retries return an explicit protocol error | `TestRunStopsAfterExhaustedZeroContentRetriesWithoutCommittingEmptyMessages` |
+| strict-provider missing reasoning: one frozen-request retry | `TestRunSilentlyRecoversMissingToolCallReasoning` and the replay suites in `loop_e2e_test.go`/`retry_e2e_test.go` (#9776 repair) |
+| incomplete-read gate | `incomplete_read_test.go` |
+| final readiness | `final_readiness_test.go` |
+| cancellation | `cancel_test.go` |
+| task/token/cost budgets | `run_budget_test.go` |
+| tool permission/malformed args | `argument_validation_test.go`, gate tests |
+
+## Gates
+
+Every phase runs:
+
+```bash
+go test -count=1 ./internal/agent/... ./internal/control/... ./internal/config/... ./internal/boot/...
+go test -race ./internal/agent/... ./internal/provider/...
+go vet ./...
+go run ./tools/repolint
+```

--- a/docs/AGENT_CORE_SIMPLIFICATION.zh-CN.md
+++ b/docs/AGENT_CORE_SIMPLIFICATION.zh-CN.md
@@ -1,0 +1,87 @@
+# Agent 核心精简
+
+本文档记录 Agent 核心精简改造:精简后循环的行为契约、用于前后对比的指标、
+以及每个契约项的测试位置。英文版见 `AGENT_CORE_SIMPLIFICATION.md`。
+
+## 目标循环
+
+```text
+构造请求
+  → provider stream
+  → clean final:结束
+  → tool call:执行并进入下一 step
+  → request error:统一 retry
+  → 未处理错误:明确失败
+```
+
+## 产品取舍
+
+- 普通请求默认 executor-only;planner 改为显式启用(`planner_model`)。
+- 普通 Agent 默认关闭 synthetic continuation;Goal、review、guardian、
+  typed report 等显式流程保留自己的约束。
+- compaction 默认单次摘要;chunked/tree-reduce 高级恢复仅限显式场景
+  (手动 `/compact` 与明确标记的 recovery workflow)。
+- final readiness、工具安全、取消、预算和 incomplete-read 继续作为硬边界。
+- 旧配置/旧状态保留一版读取兼容;新运行时不再执行旧 fallback。
+
+## 指标基线
+
+复用现有 usage 与 e2ebench 埋点,不新增专用 fallback telemetry。每个阶段
+前后对比使用:
+
+- `reasonix run --metrics <path>`:单次运行 `RunMetrics`:token/成本、
+  `usage_by_source`(executor/planner/subagent/compaction/... 的请求调用数)、
+  `retries`、`compactions`、`steps`。
+- `go run ./cmd/e2ebench -task <task> -json`:每任务请求数、
+  `usage_by_source`、trajectory 摘要(stream retry、reasoning replay、
+  empty-final retry、TTFT、按 source 的请求数)、墙钟时间、cache 命中。
+
+| 指标 | 来源 |
+|---|---|
+| 每个普通 turn 的模型请求数 | `usage_by_source["executor"].Calls` / trajectory `ExecutorRequests` |
+| planner 请求数 | `usage_by_source["planner"].Calls` / trajectory `PlannerRequests` |
+| reviewer/evaluator/guardian 请求数 | `usage_by_source["recovery_reviewer"|"goal_evaluator"]`、guardian assessment usage |
+| synthetic continuation 次数 | clean turn 的 executor 请求数超出 1 的部分;trajectory `EmptyFinalRetries` |
+| stream retry 次数 | trajectory `StreamRetries` / `RunMetrics.Retries` |
+| compaction 请求数与 summary spans | `RunMetrics.Compactions`、compaction telemetry 通知(`spans=`、`reqs=`) |
+| 首个文本事件延迟 | trajectory `TTFTMs` |
+| 总 turn 延迟 | `RunMetrics.DurationMs` / bench `WallMs` |
+| tool 执行成功率 | bench 任务 solved 率 / `SolvedThenBroken` |
+| 因协议错误终止次数 | trajectory retry-exhausted 结果 |
+
+至少对比三类场景:普通问答、普通代码修改、长上下文/工具密集
+(`context-pressure` 任务)。每阶段目标:普通请求一条 executor 请求链,无
+隐式 planner/reviewer/evaluator 请求,clean final 无额外 continuation,
+默认 compaction 不进入多段 summary,硬安全失败率不上升。
+
+## 契约测试
+
+新增的汇总套件:`internal/agent/agent_contract_test.go`。
+
+| 契约项 | 测试 |
+|---|---|
+| clean final 恰好一次模型请求 | `TestContractCleanFinalMakesOneModelRequest` |
+| tool call 执行后进入下一 step | `TestContractToolCallAdvancesToNextStep` |
+| thinking 在统一 retry 中保留(冻结请求) | `TestContractThinkingSurvivesUnifiedRetry` |
+| retry 耗尽后不残留长期 fallback 状态 | `TestContractNoLongLivedFallbackStateAfterRetryExhaustion` |
+| clean final 不追加 synthetic continuation | `TestContractCleanFinalAddsNoSyntheticContinuation` |
+| reasoning-only clean stop 直接完成 | `TestRunAcceptsReasoningOnlyFinalAnswer` |
+| 完全零内容走统一 `EMPTY_RESPONSE` retry | `TestRunRetriesZeroContentWithTheSameFrozenRequest` |
+| retry 耗尽返回明确协议错误 | `TestRunStopsAfterExhaustedZeroContentRetriesWithoutCommittingEmptyMessages` |
+| strict provider 缺失 reasoning 只做一次冻结请求重试 | `TestRunSilentlyRecoversMissingToolCallReasoning` 及 `loop_e2e_test.go`/`retry_e2e_test.go` 的 replay 套件(#9776 修复) |
+| incomplete-read 门 | `incomplete_read_test.go` |
+| final readiness | `final_readiness_test.go` |
+| 取消 | `cancel_test.go` |
+| task/token/cost 预算 | `run_budget_test.go` |
+| 工具权限/畸形参数 | `argument_validation_test.go`、gate 相关测试 |
+
+## 门禁
+
+每个阶段执行:
+
+```bash
+go test -count=1 ./internal/agent/... ./internal/control/... ./internal/config/... ./internal/boot/...
+go test -race ./internal/agent/... ./internal/provider/...
+go vet ./...
+go run ./tools/repolint
+```

--- a/internal/agent/agent_contract_test.go
+++ b/internal/agent/agent_contract_test.go
@@ -1,0 +1,139 @@
+package agent
+
+// Core agent-loop contract tests (agent-core simplification baseline). Each
+// test pins one behavior the simplified loop promises; suites covering the
+// remaining contract items are listed in docs/AGENT_CORE_SIMPLIFICATION.md.
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// TestContractCleanFinalMakesOneModelRequest pins the executor-only happy
+// path: one user turn, one provider request, no host follow-ups.
+func TestContractCleanFinalMakesOneModelRequest(t *testing.T) {
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: "the answer"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "question"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(prov.requests) != 1 {
+		t.Fatalf("provider requests = %d, want exactly one for a clean final", len(prov.requests))
+	}
+	if got := lastAssistantContent(a.sess.conversation); got != "the answer" {
+		t.Fatalf("last assistant content = %q, want the final answer", got)
+	}
+}
+
+// TestContractToolCallAdvancesToNextStep pins the tool-loop shape: a tool-call
+// round executes and the loop continues to a second request for the final.
+func TestContractToolCallAdvancesToNextStep(t *testing.T) {
+	mp := testutil.NewMock("m",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`}}},
+		testutil.Turn{Text: "all set"},
+	)
+	a := New(mp, echoRegistry(), NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(withNoClosedLoop(context.Background()), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := mp.CallCount(); got != 2 {
+		t.Fatalf("provider calls = %d, want tool round + final", got)
+	}
+	if got := lastToolResult(a.Session(), "echo"); got == "" {
+		t.Fatal("tool result missing from session; tool round did not execute")
+	}
+	if got := lastAssistantContent(a.sess.conversation); got != "all set" {
+		t.Fatalf("last assistant content = %q, want the post-tool final", got)
+	}
+}
+
+// TestContractThinkingSurvivesUnifiedRetry pins that the EMPTY_RESPONSE retry
+// replays the same frozen request (thinking never disabled or reshaped) and
+// that recovered reasoning stays on the committed assistant turn.
+func TestContractThinkingSurvivesUnifiedRetry(t *testing.T) {
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{{Type: provider.ChunkDone}},
+		{
+			{Type: provider.ChunkReasoning, Text: "need to think"},
+			{Type: provider.ChunkText, Text: "the answer"},
+			{Type: provider.ChunkDone},
+		},
+	}}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "question"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(prov.requests) != 2 || !reflect.DeepEqual(prov.requests[0], prov.requests[1]) {
+		t.Fatalf("retry must replay the frozen request verbatim:\nfirst=%#v\nsecond=%#v", prov.requests[0], prov.requests[1])
+	}
+	msgs := a.sess.conversation.Snapshot()
+	last := msgs[len(msgs)-1]
+	if last.Role != provider.RoleAssistant || last.ReasoningContent != "need to think" {
+		t.Fatalf("committed assistant turn lost reasoning: %+v", last)
+	}
+}
+
+// TestContractNoLongLivedFallbackStateAfterRetryExhaustion pins that exhausted
+// protocol retries fail the turn without installing any persistent degraded
+// mode: the next turn runs a normal single-request loop.
+func TestContractNoLongLivedFallbackStateAfterRetryExhaustion(t *testing.T) {
+	turns := [][]provider.Chunk{}
+	for range maxSamplingAttempts {
+		turns = append(turns, []provider.Chunk{{Type: provider.ChunkDone}})
+	}
+	turns = append(turns, []provider.Chunk{{Type: provider.ChunkText, Text: "recovered"}, {Type: provider.ChunkDone}})
+	prov := &scriptedProvider{name: "p", turns: turns}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "question"); err == nil {
+		t.Fatal("exhausted empty-response retries must fail the turn")
+	}
+	for _, m := range a.sess.conversation.Snapshot() {
+		if m.Role == provider.RoleAssistant && strings.TrimSpace(m.Content) != "" {
+			t.Fatalf("failed turn committed assistant content %q", m.Content)
+		}
+	}
+	if err := a.Run(context.Background(), "try again"); err != nil {
+		t.Fatalf("second Run after exhausted retries: %v", err)
+	}
+	if got := len(prov.requests) - maxSamplingAttempts; got != 1 {
+		t.Fatalf("second turn made %d requests, want a normal single request (no fallback mode)", got)
+	}
+	if got := lastAssistantContent(a.sess.conversation); got != "recovered" {
+		t.Fatalf("last assistant content = %q, want the clean recovery answer", got)
+	}
+}
+
+// TestContractCleanFinalAddsNoSyntheticContinuation pins that a direct Run
+// ends at the first clean final: no host-generated user message may appear in
+// the session, whatever the model text promises.
+func TestContractCleanFinalAddsNoSyntheticContinuation(t *testing.T) {
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: "I will handle it next round."}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "question"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(prov.requests) != 1 {
+		t.Fatalf("provider requests = %d, want one; a promised-later answer must not buy a continuation", len(prov.requests))
+	}
+	for _, prefix := range []string{StandardTodoContinuationPrefix, "visible answer", executorHandoffMarker} {
+		if sessionHasUserMessageContaining(a.sess.conversation, prefix) {
+			t.Fatalf("session contains synthetic continuation prompt %q", prefix)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Phase 0 of the agent-core simplification: lock the Harness-style loop contract and the metrics reused from existing usage/e2ebench instrumentation.

- One-request clean final, tool-round advancement, frozen-request retry that preserves thinking, no long-lived fallback state, and no synthetic continuation on a clean final.
- Remaining contract items stay in the existing suites listed in `docs/AGENT_CORE_SIMPLIFICATION.md`.
- No runtime behavior change.

Stacked under: this PR is the base for `fix/planner-explicit-only`.

## Test plan

- [x] `go test -count=1 ./internal/agent/ -run TestContract`
- [x] docs exist in English and Chinese

Cache-impact: none - contract tests and documentation only; provider-visible prefix is unchanged.
Cache-guard: `go test -count=1 ./internal/agent/ -run TestContractCleanFinalMakesOneModelRequest`
Documentation-impact: updated - added `docs/AGENT_CORE_SIMPLIFICATION.md` and `docs/AGENT_CORE_SIMPLIFICATION.zh-CN.md`