### PR TITLE
Retire Classic desktop style selection / 下架经典桌面风格并迁移至工作台

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -4467,7 +4467,7 @@ reasoning_protocol = "none"
 	}
 }
 
-func TestClassicLayoutQuickClicksSerializeWorkspaceRebuild(t *testing.T) {
+func TestLegacyClassicLayoutQuickClicksSerializeWorkspaceRebuild(t *testing.T) {
 	runQuickClickWorkspaceReconcileTest(t, "classic")
 }
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -328,9 +328,9 @@ function isThemeMode(value: string): value is Theme {
 type DesktopLayoutStyle = "classic" | "workbench" | "creation";
 
 function normalizeDesktopLayoutStyle(style: string | undefined): DesktopLayoutStyle {
-  if (style === "workbench") return "workbench";
   if (style === "creation") return "creation";
-  return "classic";
+  if (style === "classic") return "classic";
+  return "workbench";
 }
 const SHOW_CONTEXT_DOCK = true;
 const DISMISSED_TODO_STORAGE_KEY = "todoPanel:dismissedKeys";

--- a/desktop/frontend/src/__tests__/settings-navigation-contract.test.ts
+++ b/desktop/frontend/src/__tests__/settings-navigation-contract.test.ts
@@ -23,7 +23,8 @@ function ok(condition: boolean, label: string) {
 
 console.log("\nsettings navigation contract");
 
-ok(panel.includes('["workbench", "classic", "creation"] as const'), "desktop styles prioritize workbench before classic and creation");
+ok(panel.includes('["workbench", "creation"] as const'), "desktop settings expose only workbench and creation");
+ok(!panel.includes('["workbench", "classic", "creation"] as const'), "desktop settings no longer offer classic");
 ok(/useEffect\(\(\) => \{[\s\S]*?content\.scrollTop = 0;[\s\S]*?content\.scrollLeft = 0;[\s\S]*?\}, \[tab\]\);/.test(panel), "switching settings pages resets both content scroll axes");
 ok(navigation.includes('aria-current={activeTab === id ? "page" : undefined}'), "the active settings page is exposed semantically");
 ok(navigation.includes('item.meta && (activeTab === id || query.trim())'), "navigation metadata stays limited to the active or searched items");

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1677,7 +1677,7 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
       <SettingsSection title={t("settings.general.sectionAppearance")} description={t("settings.general.sectionAppearanceHint")}>
       <SettingsField label={t("settings.desktopLayoutStyle")} hint={t("settings.desktopLayoutStyleHint")} icon={<Monitor size={18} />}>
         <div className="set-seg">
-          {(["workbench", "classic", "creation"] as const).map((style) => (
+          {(["workbench", "creation"] as const).map((style) => (
             <button
               key={style}
               className={`set-seg__btn${desktopLayoutStyle === style ? " set-seg__btn--on" : ""}`}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -281,7 +281,7 @@ type CLIConfig struct {
 type DesktopConfig struct {
 	Language                string   `toml:"language"`                   // auto|en|zh; empty/auto = browser/OS auto-detect
 	Currency                string   `toml:"currency"`                   // legacy display currency; migrated to [billing].display_currency
-	LayoutStyle             string   `toml:"layout_style"`               // classic|workbench|creation; desktop layout style
+	LayoutStyle             string   `toml:"layout_style"`               // workbench|creation; legacy classic is migrated on startup
 	Theme                   string   `toml:"theme"`                      // auto|dark|light; empty resolves to auto
 	ThemeStyle              string   `toml:"theme_style"`                // graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
 	TerminalTheme           string   `toml:"terminal_theme"`             // auto|dark|light; auto follows the desktop app theme
@@ -467,8 +467,7 @@ func (c *Config) DesktopTerminalTheme() string {
 	}
 }
 
-// DesktopLayoutStyle normalizes the desktop layout style. New installs default
-// to workbench; explicit classic remains respected.
+// DesktopLayoutStyle defaults to workbench; retired classic stays readable until startup migration persists its replacement.
 func (c *Config) DesktopLayoutStyle() string {
 	if strings.EqualFold(strings.TrimSpace(c.Desktop.ThemeStyle), "workbench") && strings.TrimSpace(c.Desktop.LayoutStyle) == "" {
 		return "workbench"

--- a/internal/config/desktop_layout_upgrade_test.go
+++ b/internal/config/desktop_layout_upgrade_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApplyUserConfigUpgradesOnStartupMigratesClassicDesktopLayout(t *testing.T) {
+	path := isolatedDesktopLayoutUserConfigPath(t)
+	original := fmt.Sprintf(`config_version = %d
+
+[desktop]
+layout_style = "classic"
+theme = "dark"
+`, Default().ConfigVersion)
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := ApplyUserConfigUpgradesOnStartup(path)
+	if err != nil {
+		t.Fatalf("ApplyUserConfigUpgradesOnStartup: %v", err)
+	}
+	if !changed {
+		t.Fatal("classic desktop layout was not migrated")
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, `layout_style = "workbench"`) || strings.Contains(text, `layout_style = "classic"`) {
+		t.Fatalf("migrated desktop layout not persisted:\n%s", text)
+	}
+	if !strings.Contains(text, `theme = "dark"`) {
+		t.Fatalf("desktop migration dropped an unrelated preference:\n%s", text)
+	}
+	if got := LoadForEditWithoutCredentials(path).DesktopLayoutStyle(); got != "workbench" {
+		t.Fatalf("DesktopLayoutStyle() = %q, want workbench", got)
+	}
+
+	again, err := ApplyUserConfigUpgradesOnStartup(path)
+	if err != nil || again {
+		t.Fatalf("second upgrade changed=%v err=%v", again, err)
+	}
+}
+
+func TestApplyUserConfigUpgradesOnStartupLeavesCurrentDesktopLayoutsAlone(t *testing.T) {
+	for _, layout := range []string{"workbench", "creation"} {
+		t.Run(layout, func(t *testing.T) {
+			path := isolatedDesktopLayoutUserConfigPath(t)
+			original := fmt.Sprintf("config_version = %d\n\n[desktop]\nlayout_style = %q\n", Default().ConfigVersion, layout)
+			if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			changed, err := ApplyUserConfigUpgradesOnStartup(path)
+			if err != nil || changed {
+				t.Fatalf("upgrade changed=%v err=%v", changed, err)
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(raw) != original {
+				t.Fatalf("current %s config was rewritten:\n%s", layout, raw)
+			}
+		})
+	}
+}
+
+func TestApplyUserConfigUpgradesOnStartupDoesNotRewriteFutureClassicConfig(t *testing.T) {
+	path := isolatedDesktopLayoutUserConfigPath(t)
+	original := fmt.Sprintf("config_version = %d\n\n[desktop]\nlayout_style = \"classic\"\n", Default().ConfigVersion+1)
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := ApplyUserConfigUpgradesOnStartup(path)
+	if err != nil || changed {
+		t.Fatalf("future config upgrade changed=%v err=%v", changed, err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != original {
+		t.Fatalf("future config was rewritten:\n%s", raw)
+	}
+}
+
+func isolatedDesktopLayoutUserConfigPath(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	path := UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -307,9 +307,9 @@ func (c *Config) SetDesktopTerminalTheme(theme string) error {
 // affect CLI output or provider-visible request data.
 func (c *Config) SetDesktopLayoutStyle(style string) error {
 	switch strings.ToLower(strings.TrimSpace(style)) {
-	case "", "classic":
+	case "classic":
 		c.Desktop.LayoutStyle = "classic"
-	case "workbench", "workspace":
+	case "", "workbench", "workspace":
 		c.Desktop.LayoutStyle = "workbench"
 	case "creation":
 		c.Desktop.LayoutStyle = "creation"

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -237,7 +237,7 @@ func TestDesktopLayoutStyleNormalizes(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"", "classic", false},
+		{"", "workbench", false},
 		{"classic", "classic", false},
 		{" workbench ", "workbench", false},
 		{"workspace", "workbench", false},

--- a/internal/config/pricing.go
+++ b/internal/config/pricing.go
@@ -277,11 +277,20 @@ func ApplyUserConfigUpgradesOnStartup(path string) (bool, error) {
 	if _, err := decodeTOMLFile(path, &header); err != nil {
 		return false, fmt.Errorf("config %s: %w", path, err)
 	}
-	if header.ConfigVersion >= Default().ConfigVersion {
+	defaultVersion := Default().ConfigVersion
+	if header.ConfigVersion > defaultVersion {
+		return false, nil
+	}
+	classicDesktopLayout := strings.EqualFold(strings.TrimSpace(header.Desktop.LayoutStyle), "classic")
+	if header.ConfigVersion == defaultVersion && !classicDesktopLayout {
 		return false, nil
 	}
 	cfg := LoadForEdit(path)
 	changed := false
+	if classicDesktopLayout {
+		cfg.Desktop.LayoutStyle = "workbench"
+		changed = true
+	}
 	if header.ConfigVersion < deepSeekPricingResetConfigVersion {
 		resetOfficialProviderPricingDefaults(cfg)
 		changed = true
@@ -313,7 +322,9 @@ func ApplyUserConfigUpgradesOnStartup(path string) (bool, error) {
 	if !changed {
 		return false, nil
 	}
-	cfg.ConfigVersion = Default().ConfigVersion
+	if header.ConfigVersion < defaultVersion {
+		cfg.ConfigVersion = defaultVersion
+	}
 	if err := cfg.SaveTo(path); err != nil {
 		return false, err
 	}

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -104,7 +104,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		if currency := c.DesktopCurrency(); currency != "" {
 			fmt.Fprintf(&b, "currency = %q   # legacy display currency; prefer [billing].display_currency\n", currency)
 		}
-		fmt.Fprintf(&b, "layout_style = %q   # desktop layout: classic|workbench|creation\n", c.DesktopLayoutStyle())
+		fmt.Fprintf(&b, "layout_style = %q   # desktop layout: workbench|creation; legacy classic migrates to workbench\n", c.DesktopLayoutStyle())
 		fmt.Fprintf(&b, "theme = %q   # desktop only: auto|dark|light\n", c.DesktopTheme())
 		fmt.Fprintf(&b, "terminal_theme = %q   # integrated terminal: auto|dark|light; auto follows the desktop app\n", c.DesktopTerminalTheme())
 		if style := c.DesktopThemeStyle(); style != "" {

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -17,7 +17,7 @@ show_turn_usage = true   # CLI/TUI: show per-request token and cost receipts in 
 [desktop]
 # language = "auto"   # auto|en|zh; auto follows the browser/OS locale
 # currency = "auto"   # legacy display currency; prefer [billing].display_currency
-layout_style = "classic"   # classic|workbench|creation; desktop layout style
+layout_style = "workbench"   # workbench|creation; legacy classic migrates to workbench
 # theme = "auto"   # desktop only: auto|dark|light
 # terminal_theme = "auto"   # integrated terminal: auto|dark|light; auto follows the desktop app
 # theme_style = "graphite"   # graphite|aurora|slate|carbon|nocturne|amber and legacy aliases


### PR DESCRIPTION
## Summary

- Remove the retired Classic layout from Desktop Settings so new users can choose only Workbench or Creation.
- Migrate existing `layout_style = "classic"` user configs to Workbench during startup.
- Keep legacy Classic values readable as a safe fallback when a migration cannot be persisted, while unknown or empty frontend values default to Workbench.
- Update the example config and add idempotency, current-layout, and future-version compatibility coverage.

## Compatibility

| Scenario | Behavior |
| --- | --- |
| Existing Classic config | Rewritten once to Workbench at startup |
| Existing Workbench or Creation config | Left byte-for-byte unchanged |
| Future-version config | Not rewritten by an older binary |
| Migration write failure | Legacy Classic remains readable and renderable |
| Downgrade after migration | Workbench remains understood by previous releases |

## Verification

- `go test ./...`
- `go test -race ./internal/config -run 'TestApplyUserConfigUpgradesOnStartup.*DesktopLayout|TestDesktopLayoutStyleNormalizes' -count=1`
- `(cd desktop && go test ./...)`
- `pnpm exec tsx src/__tests__/settings-navigation-contract.test.ts`
- `pnpm typecheck`
- ESLint on the changed frontend files
- Browser interaction: confirmed Settings exposes only Workbench and Creation and both selections update correctly

## Impact declarations

Cache-impact: none - the changed setting controls only desktop layout and does not affect prompt construction, cache keys, or model request inputs.

Cache-guard: `go test ./internal/config` covers config normalization and startup upgrade behavior; the frontend contract test guards the exposed selector values.

System-prompt-review: reviewed - no system prompt construction, serialization, or provider-visible behavior changes.

Documentation-impact: none - no `docs/*.md` page documents the desktop layout choices; the user-facing Settings UI, example config, and generated TOML comments are updated in this PR.
