### PR TITLE
docs: sync Go 1.26 prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ everything you need to get started.
 
 ## Prerequisites
 
-- **Go 1.25+** — the project targets the latest stable Go release
+- **Go 1.26+** — the project targets the latest stable Go release
 - **Git** — for version control
 - **Node.js** (optional) — only if you work on the desktop app (`desktop/`)
 - **Wails CLI** (desktop only) — run `make wails-install` so the CLI matches

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,7 +115,7 @@ cd DeepSeek-Reasonix
 
 #### CLI
 
-CLI 构建需要 **Go 1.25+**。模块固定了 `toolchain` 指令；
+CLI 构建需要 **Go 1.26+**。模块固定了 `toolchain` 指令；
 保持 `GOTOOLCHAIN=auto` 让 Go 自动下载固定的工具链，或自行安装。
 
 ```sh


### PR DESCRIPTION
## Summary

- synchronize the Chinese CLI build prerequisite with the modules and English README
- update the contributor prerequisite from Go 1.25+ to Go 1.26+

## Issues

Fixes #9802

## Verification

- compared `go.mod` and `desktop/go.mod` (`go 1.26.0`, `toolchain go1.26.6`) with all three prerequisite documents
- confirmed no `Go 1.25+` prerequisite remains in `README.md`, `README.zh-CN.md`, or `CONTRIBUTING.md`
- `git diff --check`

## Documentation impact

Documentation-impact: updated - corrected two stale Go minimum-version statements

## Cache impact

Cache-impact: none - documentation-only prerequisite corrections do not change provider-visible prompts or runtime behavior
Cache-guard: not applicable - no cache-sensitive path changed
System-prompt-review: N/A
