### PR TITLE
fix(desktop): prevent Automation control overlap / 修复自动化页面控件重叠

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -194,9 +194,10 @@ console.log("\nbundle budgets");
 // 0.5 KiB gzip on the initial path. The model-capability resolver and its
 // read-only provider badges add a measured 0.2 KiB including gzip/toolchain
 // rounding. Direct topic-bar actions replace the overflow trigger; together
-// with per-model image guidance and shared model matching, the merged path
-// measures 464.5 KiB. Export formats and the provider editor remain lazy.
-const initialJSBudgetKiB = 464.6;
+// with per-model image guidance, shared model matching, and Automation's page
+// projection, the merged path measures 464.590 KiB. Export formats and the
+// provider editor remain lazy; retain only the next one-decimal ceiling.
+const initialJSBudgetKiB = 464.7;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -215,9 +216,10 @@ if (initialCSS.length > 0) {
 // the retained-transcript navigation allowance; keep the ratchet explicit.
 // The navigation mask's stable composer footprint and remote tab/surface
 // states bring the merged shell to roughly 115.7 KiB gzip.
-// The one-row model configuration list and responsive stacking measure
-// 116.3 KiB gzip while reusing the shared segmented-control styles.
-assertBudget("deferred app-shell CSS gzip", appShellCSSGzip, 116.4 * 1024);
+// The one-row model configuration list, responsive stacking, and Automation's
+// shared title-safe shell measure 116.423 KiB gzip while reusing existing
+// layout primitives. Retain only the next one-decimal ceiling.
+assertBudget("deferred app-shell CSS gzip", appShellCSSGzip, 116.5 * 1024);
 if (localeChunks.length !== 2) {
   throw new Error(`expected 2 on-demand Chinese locale chunks, found ${localeChunks.length}`);
 }
@@ -364,9 +366,10 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // On the current main-v2 base, the combined measured path is 2474.6 KiB;
 // the model-capability helper and localized status copy add 0.9 KiB; retain
 // the smallest bounded cross-platform ceiling.
-// Direct topic-bar actions, the macOS single-row dock tabs, and the responsive
-// model configuration list measure 2479.7 KiB raw together. Retain only the
-// next decimal ceiling without relaxing the independent chunk gates.
-const rawInitialBudgetKiB = 2_479.8;
+// Direct topic-bar actions, the macOS single-row dock tabs, responsive model
+// configuration, and Automation's shell projection measure 2481.132 KiB raw
+// together. Retain only the next decimal ceiling without relaxing independent
+// chunk gates.
+const rawInitialBudgetKiB = 2_481.2;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1113,6 +1113,7 @@ export default function App() {
   const setSidebarCollapsed = useLayoutStore((s) => s.setSidebarCollapsed);
   const mainView = useOverlayStore((s) => s.mainView);
   const setMainView = useOverlayStore((s) => s.setMainView);
+  const automationView = mainView === "automation";
   type TimeFilter = "all" | "10" | "20" | "1h" | "3h" | "5h" | "1d";
   const [topicTimeFilter, setTopicTimeFilter] = useState<TimeFilter>(() => {
     try {
@@ -1216,7 +1217,7 @@ export default function App() {
   const setRightDockMode = useLayoutStore((s) => s.setRightDockMode);
   const terminalPanelOpen = useLayoutStore((s) => s.terminalPanelOpen);
   const setTerminalPanelOpen = useLayoutStore((s) => s.setTerminalPanelOpen);
-  const { mounted: terminalContentVisible, fitEnabled: terminalFitEnabled, prefetch: prefetchTerminalPanel } = useWarmTerminalPanel(terminalPanelOpen, terminalResizing);
+  const { mounted: terminalContentVisible, fitEnabled: terminalFitEnabled, prefetch: prefetchTerminalPanel } = useWarmTerminalPanel(terminalPanelOpen, terminalResizing, !automationView);
   const terminalHeight = useLayoutStore((s) => s.terminalHeight);
   const setTerminalHeight = useLayoutStore((s) => s.setTerminalHeight);
   const [dockRefreshKey, setDockRefreshKey] = useState(0);
@@ -1578,9 +1579,6 @@ export default function App() {
     minWidth: workspacePanelMinWidth, minRenderWidth: rightDockMinRenderWidth,
     liveWidth: liveWorkspacePanelRenderWidth,
   });
-  const automationView = mainView === "automation";
-  const effectiveWorkspacePanelRenderable = automationView ? false : workspacePanelRenderable;
-  const effectiveWorkspacePanelGridOpen = automationView ? false : workspacePanelGridOpen;
   const resolveLiveWorkspacePanelRenderWidth = useCallback(
     (preferredWidth: number, nextSidebarWidth = sidebarWidth) =>
       resolveLiveWorkspacePanelWidth({
@@ -1607,9 +1605,17 @@ export default function App() {
   // remote tabs publish readiness via remote-tab:<id>:state, which
   const visibleRuntimeState = remoteSurfaceActive ? remoteSession.transcript : state;
   const localWorkspaceDockBlocked = remoteSurfaceActive && (rightDockMode === "files" || rightDockMode === "changed");
-  const surfaceWorkspacePanelRenderable = effectiveWorkspacePanelRenderable && !localWorkspaceDockBlocked;
-  const surfaceWorkspacePanelGridOpen = effectiveWorkspacePanelGridOpen && !localWorkspaceDockBlocked;
-  const terminalSurfaceOpen = terminalPanelOpen && !remoteSurfaceActive;
+  const sidebarImDetailConnection = useMemo(
+    () => sidebarImConnections.find((connection) => connection.id === sidebarImDetailConnectionId) ?? null,
+    [sidebarImConnections, sidebarImDetailConnectionId],
+  );
+  const chatSurfaceVisible = !automationView;
+  const surfaceWorkspacePanelRenderable = chatSurfaceVisible && workspacePanelRenderable && !localWorkspaceDockBlocked;
+  const surfaceWorkspacePanelGridOpen = chatSurfaceVisible && workspacePanelGridOpen && !localWorkspaceDockBlocked;
+  const surfaceWorkspacePanelOverlay = surfaceWorkspacePanelRenderable && workspacePanelOverlay;
+  const surfaceWorkspacePanelMaximized = chatSurfaceVisible && workspacePanelOpen && workspacePanelMaximized;
+  const terminalSurfaceOpen = chatSurfaceVisible && terminalPanelOpen && !remoteSurfaceActive;
+  const statusBarVisible = chatSurfaceVisible && !sidebarImDetailConnection;
   const activePlanRevisionInsertRequest =
     planRevisionInsertRequest &&
     planRevisionInsertRequest.tabId === activeTabId &&
@@ -1664,10 +1670,6 @@ export default function App() {
     // 560 ceiling, so the user's remembered width is preserved when reopened.
     setRightDockTreeWidth(rightDockTreeWidthClamp(treeWidth, workspacePanelAvailableWidth));
   }, [rightDockTreeWidthClamp, workspacePanelAvailableWidth]);
-  const sidebarImDetailConnection = useMemo(
-    () => sidebarImConnections.find((connection) => connection.id === sidebarImDetailConnectionId) ?? null,
-    [sidebarImConnections, sidebarImDetailConnectionId],
-  );
   useEffect(() => {
     let cancelled = false;
     if (!activeTab?.topicId) {
@@ -2911,7 +2913,7 @@ export default function App() {
   }, [activeWorkspaceRoot]);
 
   const toggleWorkspacePanel = useCallback(() => {
-    if (effectiveWorkspacePanelRenderable) {
+    if (surfaceWorkspacePanelRenderable) {
       closeWorkspacePanel();
       return;
     }
@@ -2924,7 +2926,7 @@ export default function App() {
     // Reopen with the previously active tab (rightDockMode is kept in the
     // store across close/open) instead of forcing "context".
     openWorkspacePanel();
-  }, [closeWorkspacePanel, desktopLayoutStyle, effectiveWorkspacePanelRenderable, openWorkspacePanel, rightDockMode]);
+  }, [closeWorkspacePanel, desktopLayoutStyle, openWorkspacePanel, rightDockMode, surfaceWorkspacePanelRenderable]);
 
   const openRightDockMode = useCallback(
     (mode: RightDockMode) => {
@@ -2950,12 +2952,13 @@ export default function App() {
   useEffect(() => { setVerificationRevealRequest(null); }, [activeTabId, state.completionSummary, state.turnStartAt]);
 
   const toggleTerminalPanel = useCallback(() => { if (remoteSurfaceActive) return;
+    if (automationView) { setMainView("chat"); setTerminalPanelOpen(true); saveTerminalPanelOpen(true); return; }
     setTerminalPanelOpen((prev) => {
       const next = !prev;
       saveTerminalPanelOpen(next);
       return next;
     });
-  }, [remoteSurfaceActive, setTerminalPanelOpen]);
+  }, [automationView, remoteSurfaceActive, setMainView, setTerminalPanelOpen]);
 
   const openTerminalForPath = useCallback(
     (path = ".") => { if (remoteSurfaceActive) return;
@@ -2972,9 +2975,10 @@ export default function App() {
   }, [toggleTerminalPanel]);
   useGlobalShortcut("terminal.newSession", () => {
     if (!activeTabId || remoteSurfaceActive) return;
+    if (automationView) setMainView("chat");
     setTerminalPanelOpen(true); saveTerminalPanelOpen(true);
     void useTerminalStore.getState().createSession(activeTabId, ".", "default").catch(() => {});
-  }, [activeTabId, remoteSurfaceActive, setTerminalPanelOpen]);
+  }, [activeTabId, automationView, remoteSurfaceActive, setMainView, setTerminalPanelOpen]);
 
   useEffect(() => {
     if (!remoteExplorerOpen) return;
@@ -3943,7 +3947,7 @@ export default function App() {
   }, [closeTransientOverlays]);
   useGlobalShortcut("tab.close", () => {
     if (activeTabId) void handleTabClose(activeTabId);
-  }, [activeTabId, handleTabClose], Boolean(activeTabId));
+  }, [activeTabId, handleTabClose], Boolean(activeTabId) && !automationView);
   useGlobalShortcut("shortcuts.show", () => setShortcutsOpen(true));
   useGlobalShortcut("sidebar.toggle", toggleSidebar, [toggleSidebar]);
 
@@ -4323,10 +4327,11 @@ export default function App() {
         sidebarWorkbench ? "app--workbench" : "",
         sidebarCreation ? "app--creation" : "",
         !sidebarWorkbench && !sidebarCreation ? "app--classic" : "",
+        automationView ? "app--automation" : "",
       ].filter(Boolean).join(" ")}
     >
       <ThemeBackground />
-      {sidebarWorkbench && <div className="app__dock-toggle">{dockToggleButton}</div>}
+      {sidebarWorkbench && chatSurfaceVisible && <div className="app__dock-toggle">{dockToggleButton}</div>}
       <div
         ref={layoutRef}
         className={[
@@ -4334,16 +4339,17 @@ export default function App() {
           sidebarWorkbench ? "layout--workbench" : "",
           workbenchChromeHidden ? "layout--workbench-chrome-hidden" : "",
           sidebarCreation ? "layout--creation-chrome-hidden" : "",
-          sidebarImDetailConnection ? "layout--statusbar-hidden" : "",
+          automationView ? "layout--automation" : "",
+          !statusBarVisible ? "layout--statusbar-hidden" : "",
           sidebarCollapsed ? "layout--sidebar-collapsed" : "",
           sidebarResizing ? "layout--resizing layout--sidebar-resizing" : "",
           surfaceWorkspacePanelGridOpen ? "layout--workspace-open" : "",
-          workspacePanelOverlay ? "layout--workspace-overlay" : "",
-          "layout--terminal-drawer-open",
+          surfaceWorkspacePanelOverlay ? "layout--workspace-overlay" : "",
+          !automationView ? "layout--terminal-drawer-open" : "",
           terminalSurfaceOpen ? "layout--terminal-drawer-expanded" : "",
-          terminalResizing ? "layout--terminal-resizing" : "",
-          workspacePanelOpen && workspacePanelMaximized ? "layout--workspace-maximized" : "",
-          workspacePanelResizing ? "layout--resizing layout--workspace-resizing" : "",
+          !automationView && terminalResizing ? "layout--terminal-resizing" : "",
+          surfaceWorkspacePanelMaximized ? "layout--workspace-maximized" : "",
+          !automationView && workspacePanelResizing ? "layout--resizing layout--workspace-resizing" : "",
         ]
           .filter(Boolean)
           .join(" ")}
@@ -4457,8 +4463,9 @@ export default function App() {
                   <span>{t("creation.sidebar.messageChannels")}</span>
                 </button>
                 <button
-                  className="sidebar-feature-zone__item"
+                  className={`sidebar-feature-zone__item${automationView ? " sidebar-feature-zone__item--active" : ""}`}
                   type="button"
+                  aria-current={automationView ? "page" : undefined}
                   onClick={() => setMainView("automation")}
                 >
                   <AlarmClock size={14} aria-hidden="true" />
@@ -4565,7 +4572,8 @@ export default function App() {
               {!sidebarCreation && (
                 <Tooltip label={t("heartbeat.scheduler")} fill side="right" disabled={sidebarNavTooltipDisabled}>
                   <button
-                    className="sidebar__navitem"
+                    className={`sidebar__navitem${automationView ? " sidebar__navitem--active" : ""}`}
+                    aria-current={automationView ? "page" : undefined}
                     onClick={() => setMainView("automation")}
                   >
                     <AlarmClock size={15} />
@@ -4602,7 +4610,7 @@ export default function App() {
           onKeyDown={resizeSidebarWithKeyboard}
           onDoubleClick={() => setExpandedSidebarWidth(desktopLayoutStyle === "creation" ? defaultCreationSidebarWidth() : defaultSidebarWidth())}
         />
-        {sidebarCreation && (
+        {sidebarCreation && !automationView && (
           <button
             className={`sidebar-collapse-toggle${sidebarCollapsed ? " sidebar-collapse-toggle--collapsed" : ""}${sidebarTogglePressed ? " sidebar-collapse-toggle--pressed" : ""}`}
             type="button"
@@ -4618,9 +4626,7 @@ export default function App() {
         <section className={`chat-pane${creationEmptyHero ? " chat-pane--creation-empty" : ""}`}>
           {mainView === "automation" ? (
             <Suspense fallback={<div className="heartbeat-page" />}>
-              <HeartbeatView onOpenTopic={(scope, workspaceRoot, topicId) => {
-                void handleOpenTopic(scope, workspaceRoot, topicId);
-              }} />
+              <HeartbeatView onToggleSidebar={toggleSidebar} onOpenTopic={(scope, workspaceRoot, topicId) => { void handleOpenTopic(scope, workspaceRoot, topicId); }} />
             </Suspense>
           ) : (
           <>
@@ -5223,7 +5229,7 @@ export default function App() {
             className={[
               "workbench-dock",
               `workbench-dock--${rightDockMode}`,
-              workspacePanelOverlay ? "workbench-dock--overlay" : "",
+              surfaceWorkspacePanelOverlay ? "workbench-dock--overlay" : "",
             ].join(" ")}
             aria-label={t("rightDock.workbench")}
           >
@@ -5362,26 +5368,19 @@ export default function App() {
               </Suspense>
             )}
           </aside>
-          <button
-            className="terminal-drawer-resizer"
-            type="button"
-            role="separator"
-            aria-orientation="horizontal"
-            aria-label={t("terminal.resize")}
-            aria-valuemin={TERMINAL_MIN_HEIGHT}
-            aria-valuemax={terminalResizeMaxHeight}
-            aria-valuenow={liveTerminalHeight ?? terminalRenderHeight}
-            aria-hidden={!terminalSurfaceOpen}
-            tabIndex={terminalSurfaceOpen ? 0 : -1}
-            onPointerDown={startTerminalResize}
-            onKeyDown={resizeTerminalWithKeyboard}
-            onDoubleClick={() => {
-              setSavedTerminalHeight(TERMINAL_DEFAULT_HEIGHT);
-            }}
-          />
+          {!automationView && (
+            <button
+              className="terminal-drawer-resizer" type="button" role="separator"
+              aria-orientation="horizontal" aria-label={t("terminal.resize")}
+              aria-valuemin={TERMINAL_MIN_HEIGHT} aria-valuemax={terminalResizeMaxHeight}
+              aria-valuenow={liveTerminalHeight ?? terminalRenderHeight} aria-hidden={!terminalSurfaceOpen}
+              tabIndex={terminalSurfaceOpen ? 0 : -1} onPointerDown={startTerminalResize}
+              onKeyDown={resizeTerminalWithKeyboard} onDoubleClick={() => setSavedTerminalHeight(TERMINAL_DEFAULT_HEIGHT)}
+            />
+          )}
         </>
 
-        {!sidebarImDetailConnection && (
+        {statusBarVisible && (
           <StatusBar
             context={visibleRuntimeState.context}
             usage={visibleRuntimeState.usage}

--- a/desktop/frontend/src/__tests__/automation-surface-layout.test.ts
+++ b/desktop/frontend/src/__tests__/automation-surface-layout.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const appSource = readFileSync(new URL("../App.tsx", import.meta.url), "utf8");
+const stylesSource = readFileSync(new URL("../styles.css", import.meta.url), "utf8");
+const heartbeatStyles = readFileSync(new URL("../custom/features/heartbeat/heartbeat.css", import.meta.url), "utf8");
+const terminalWarmthSource = readFileSync(new URL("../lib/useWarmTerminalPanel.ts", import.meta.url), "utf8");
+
+assert.match(appSource, /const chatSurfaceVisible = !automationView;/, "one page projection gates every chat-owned surface");
+assert.match(appSource, /surfaceWorkspacePanelMaximized = chatSurfaceVisible && workspacePanelOpen && workspacePanelMaximized/, "stored workspace maximization is presentation-only on automation");
+assert.match(appSource, /terminalSurfaceOpen = chatSurfaceVisible && terminalPanelOpen && !remoteSurfaceActive/, "stored terminal state remains intact while its surface is hidden");
+
+assert.match(appSource, /automationView \? "app--automation" : ""/, "root marks automation before lazy Heartbeat mounts");
+assert.match(appSource, /!automationView \? "layout--terminal-drawer-open" : ""/, "automation removes the terminal grid row");
+assert.match(appSource, /\{!automationView && \(\s*<button\s+className="terminal-drawer-resizer"/s, "automation does not render the terminal resize handle");
+assert.match(appSource, /Boolean\(activeTabId\) && !automationView/, "automation disables the hidden-chat close shortcut");
+assert.match(heartbeatStyles, /\.app--automation \.skip-to-composer\s*\{\s*display:\s*none;/s, "automation removes the hidden composer focus target");
+assert.match(appSource, /if \(automationView\) \{\s*setMainView\("chat"\);\s*setTerminalPanelOpen\(true\)/s, "terminal toggle leaves automation and opens the terminal");
+assert.match(appSource, /<Tooltip label=\{t\("heartbeat\.scheduler"\)\} fill side="top">[\s\S]{0,300}<AlarmClock size=\{16\}/, "Workbench keeps its existing footer automation entry");
+assert.doesNotMatch(appSource, /sidebar__quick-action--active/, "Workbench does not add a second automation entry beside New session");
+
+assert.match(stylesSource, /\.layout--automation \.terminal-drawer\s*\{\s*display:\s*none;/s, "hidden terminal cannot occupy or receive input");
+assert.match(heartbeatStyles, /\.automation-surface > \.heartbeat-page\s*\{[^}]*flex:\s*1;[^}]*width:\s*100%;/s, "shared automation page fills its shell");
+assert.match(heartbeatStyles, /\.layout--sidebar-collapsed \.automation-surface\s*\{[^}]*padding-top:\s*44px/s, "collapsed automation reserves one shared titlebar safe area");
+assert.match(heartbeatStyles, /\.app--darwin \.automation-sidebar-toggle\s*\{[^}]*left:\s*96px/s, "macOS sidebar recovery stays clear of traffic lights");
+assert.match(stylesSource, /\.layout--automation:not\(\.layout--sidebar-collapsed\)[^}]*grid-template-columns:\s*var\(--sidebar-expanded-width\)/s, "minimum-width automation can restore its sidebar");
+
+assert.match(heartbeatStyles, /container:\s*heartbeat-page \/ inline-size/, "Heartbeat responds to its real content width");
+assert.match(heartbeatStyles, /@container heartbeat-page \(max-width:\s*559px\)/, "narrow editor mode starts below 560px");
+assert.match(heartbeatStyles, /\.heartbeat-split--detail-open \.heartbeat-split__left,[\s\S]*\.heartbeat-split--detail-open \.heartbeat-split__divider\s*\{\s*display:\s*none;/s, "narrow editor hides the list and divider without remounting");
+
+assert.match(terminalWarmthSource, /if \(open\) setMounted\(true\)/, "terminal content remains mounted while presentation is hidden");
+assert.match(terminalWarmthSource, /if \(!open \|\| !visible\) \{\s*setFitEnabled\(false\)/s, "terminal fitting pauses while automation hides it");
+
+console.log("automation surface layout: 20 passed");

--- a/desktop/frontend/src/__tests__/image-viewer-window-controls.test.ts
+++ b/desktop/frontend/src/__tests__/image-viewer-window-controls.test.ts
@@ -25,6 +25,7 @@ function finalDeclaration(selector: string, property: string): string | undefine
 }
 
 const windowsPreviewSelector = ".app--windows-frameless:has(.image-viewer-backdrop) > .windows-window-controls";
+const windowsAutomationSelector = ".app--windows-frameless.app--automation > .windows-window-controls";
 
 assert.equal(finalDeclaration(".image-viewer__close", "right"), "16px");
 assert.equal(finalDeclaration(".app--windows-frameless .image-viewer__close", "right"), undefined);
@@ -32,4 +33,10 @@ assert.equal(finalDeclaration(windowsPreviewSelector, "opacity"), "0");
 assert.equal(finalDeclaration(windowsPreviewSelector, "visibility"), "hidden");
 assert.equal(finalDeclaration(windowsPreviewSelector, "pointer-events"), "none");
 
-console.log("image viewer window controls: 5 passed");
+// The entire automation page (list, editor, and loading fallback) owns this
+// region. Hiding only the icon would leave invisible caption click targets.
+assert.equal(finalDeclaration(windowsAutomationSelector, "opacity"), "0");
+assert.equal(finalDeclaration(windowsAutomationSelector, "visibility"), "hidden");
+assert.equal(finalDeclaration(windowsAutomationSelector, "pointer-events"), "none");
+
+console.log("image viewer and automation window controls: 8 passed");

--- a/desktop/frontend/src/__tests__/remote-project-tree.test.tsx
+++ b/desktop/frontend/src/__tests__/remote-project-tree.test.tsx
@@ -188,7 +188,7 @@ ok(
 );
 ok(
   /localWorkspaceDockBlocked = remoteSurfaceActive && \(rightDockMode === "files" \|\| rightDockMode === "changed"\)/.test(appSource) &&
-    /surfaceWorkspacePanelRenderable = effectiveWorkspacePanelRenderable && !localWorkspaceDockBlocked/.test(appSource) &&
+    /surfaceWorkspacePanelRenderable = chatSurfaceVisible && workspacePanelRenderable && !localWorkspaceDockBlocked/.test(appSource) &&
     /\{surfaceWorkspacePanelRenderable && \([\s\S]*?<WorkspacePanel/.test(appSource),
   "remote surfaces do not mount the local Files or Changes workspace panel",
 );

--- a/desktop/frontend/src/__tests__/topicbar-controls.test.ts
+++ b/desktop/frontend/src/__tests__/topicbar-controls.test.ts
@@ -22,7 +22,7 @@ assert.match(
 );
 assert.match(
   appSource,
-  /const surfaceWorkspacePanelRenderable = effectiveWorkspacePanelRenderable && !localWorkspaceDockBlocked;/,
+  /const surfaceWorkspacePanelRenderable = chatSurfaceVisible && workspacePanelRenderable && !localWorkspaceDockBlocked;/,
   "the topic bar projects the workspace toggle through the active surface boundary",
 );
 assert.ok(!sessionActionsSource.includes('aria-label="Session summary"'), "Session summary does not use a hard-coded English label");

--- a/desktop/frontend/src/__tests__/workspace-layout.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-layout.test.ts
@@ -237,7 +237,8 @@ eq(
   "footer compaction applies only while the terminal is expanded outside Creation mode",
 );
 eq(
-  /sidebarImDetailConnection \? "layout--statusbar-hidden" : ""/.test(appSource)
+  /const statusBarVisible = chatSurfaceVisible && !sidebarImDetailConnection/.test(appSource)
+    && /!statusBarVisible \? "layout--statusbar-hidden" : ""/.test(appSource)
     && /\.layout\.layout--statusbar-hidden,[\s\S]*?--statusbar-height: 0px;/.test(stylesSource),
   true,
   "IM detail collapses the status bar row when the bar is not rendered",
@@ -336,7 +337,7 @@ eq(
   "pointer and keyboard intent prefetch the terminal chunk before opening from the topic bar",
 );
 eq(
-  /useWarmTerminalPanel\(terminalPanelOpen, terminalResizing\)/.test(appSource)
+  /useWarmTerminalPanel\(terminalPanelOpen, terminalResizing, !automationView\)/.test(appSource)
     && /if \(open\) setMounted\(true\)/.test(terminalLifecycleSource)
     && !/setMounted\(false\)/.test(terminalLifecycleSource),
   true,

--- a/desktop/frontend/src/custom/features/heartbeat/AutomationSurface.tsx
+++ b/desktop/frontend/src/custom/features/heartbeat/AutomationSurface.tsx
@@ -1,0 +1,25 @@
+import type { PropsWithChildren } from "react";
+import { PanelRight } from "lucide-react";
+
+interface AutomationSurfaceProps extends PropsWithChildren {
+  onToggleSidebar?: () => void;
+  sidebarLabel: string;
+}
+
+export function AutomationSurface({ children, onToggleSidebar, sidebarLabel }: AutomationSurfaceProps) {
+  return (
+    <div className="automation-surface">
+      <button
+        className="automation-sidebar-toggle"
+        type="button"
+        onClick={onToggleSidebar}
+        aria-label={sidebarLabel}
+        title={sidebarLabel}
+      >
+        <PanelRight size={15} aria-hidden="true" />
+      </button>
+      <div className="automation-surface__drag-region" aria-hidden="true" />
+      {children}
+    </div>
+  );
+}

--- a/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
+++ b/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
@@ -1,8 +1,3 @@
-// Heartbeat Panel — Modal for configuring scheduled heartbeat tasks.
-//
-// Renders a list of tasks with add/edit/delete controls, plus a manual
-// "run now" button for each. The panel is opened from the sidebar nav item.
-
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Activity,
@@ -42,6 +37,7 @@ import "./heartbeat.css";
 import { formatInterval, formatTaskNextRun, prepareTasksByNextRun } from "./heartbeat.presentation";
 import { TaskEditor } from "./HeartbeatTaskEditor";
 import { CirclePlaySolid, mergeEngineRunState } from "./HeartbeatShared";
+import { AutomationSurface } from "./AutomationSurface";
 export { changeHeartbeatFrequency, cronToInterval, heartbeatNextRunAt, intervalToCron, nextCycleRunAt, prepareTasksByNextRun } from "./heartbeat.presentation";
 export { heartbeatBuildCycleInterval } from "./HeartbeatCycleEditor";
 export { TaskEditor } from "./HeartbeatTaskEditor";
@@ -49,9 +45,10 @@ export { mergeEngineRunState } from "./HeartbeatShared";
 
 interface HeartbeatPanelProps {
   onOpenTopic?: (scope: string, workspaceRoot: string, topicId: string) => void;
+  onToggleSidebar?: () => void;
 }
 
-export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
+export function HeartbeatView({ onOpenTopic, onToggleSidebar }: HeartbeatPanelProps) {
   const t = useHeartbeatT();
   const [tasks, setTasks] = useState<HeartbeatTask[]>([]);
   const [loading, setLoading] = useState(false);
@@ -432,10 +429,11 @@ export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
   };
 
   return (
-    <div className="heartbeat-page">
+    <AutomationSurface onToggleSidebar={onToggleSidebar} sidebarLabel={t("sidebar.expand")}>
+      <div className="heartbeat-page">
       {/* 无详情时：页面顶部一条全宽透明窗口拖拽条 */}
       {!detailOpen && <div className="heartbeat-drag-strip" />}
-      <div className="heartbeat-split">
+      <div className={`heartbeat-split${detailOpen ? " heartbeat-split--detail-open" : ""}`}>
           {/* ── Left column: task list（含列表区头部工具栏） ── */}
           <div className={`heartbeat-split__left${detailOpen ? "" : " heartbeat-split__left--full"}`} style={{ width: detailOpen ? `${listWidthPct}%` : "100%" }}>
             {!detailOpen && (
@@ -932,6 +930,7 @@ export function HeartbeatView({ onOpenTopic }: HeartbeatPanelProps) {
           </div>
         )}
       </div>
+    </AutomationSurface>
   );
 }
 

--- a/desktop/frontend/src/custom/features/heartbeat/heartbeat.css
+++ b/desktop/frontend/src/custom/features/heartbeat/heartbeat.css
@@ -26,6 +26,7 @@
   overflow: hidden;
   background: var(--bg);
   position: relative;
+  container: heartbeat-page / inline-size;
 }
 
 /* ── split layout ─────────────────────────────────────────────── */
@@ -290,6 +291,21 @@
   flex-direction: column;
   overflow: hidden;
   background: var(--heartbeat-split-bg);
+}
+
+/* Use the actual task-page width, not the app viewport. At narrow widths the
+   existing editor fills the page without remounting or changing split prefs. */
+@container heartbeat-page (max-width: 559px) {
+  .heartbeat-split--detail-open .heartbeat-split__left,
+  .heartbeat-split--detail-open .heartbeat-split__divider {
+    display: none;
+  }
+
+  .heartbeat-split--detail-open .heartbeat-split__right {
+    flex: 1 1 100%;
+    width: 100%;
+    min-width: 0;
+  }
 }
 
 .heartbeat-split__right .heartbeat-editor {
@@ -1876,4 +1892,75 @@
 }
 .heartbeat-task-menu__item--danger {
   color: var(--danger);
+}
+
+/* Shared automation shell: it owns the collapsed-sidebar recovery control and
+   a native drag-safe title strip without changing Heartbeat's task state. */
+.automation-surface {
+  position: relative;
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.app--automation .skip-to-composer {
+  display: none;
+}
+
+.automation-surface > .heartbeat-page {
+  flex: 1;
+  width: 100%;
+}
+
+.layout--sidebar-collapsed .automation-surface {
+  padding-top: 44px;
+}
+
+.automation-surface__drag-region {
+  display: none;
+}
+
+.layout--sidebar-collapsed .automation-surface__drag-region {
+  --wails-draggable: drag;
+  position: absolute;
+  inset: 0 0 auto;
+  z-index: var(--z-app-chrome);
+  display: block;
+  height: 44px;
+  user-select: none;
+}
+
+.automation-sidebar-toggle {
+  --wails-draggable: no-drag;
+  position: absolute;
+  top: 8px;
+  left: 10px;
+  z-index: var(--z-dock);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--fg-faint);
+}
+
+.layout--sidebar-collapsed .automation-sidebar-toggle {
+  display: inline-flex;
+}
+
+.automation-sidebar-toggle:hover,
+.automation-sidebar-toggle:focus-visible {
+  border-color: var(--border-soft);
+  background: var(--sidebar-hover);
+  color: var(--fg);
+}
+
+.app--darwin .automation-sidebar-toggle {
+  left: 96px;
 }

--- a/desktop/frontend/src/lib/useWarmTerminalPanel.ts
+++ b/desktop/frontend/src/lib/useWarmTerminalPanel.ts
@@ -7,7 +7,7 @@ const TERMINAL_TRANSITION_MS = 220;
 // Load xterm lazily, then keep it mounted so closing the drawer does not lose
 // its live canvas. Fit is paused while the grid row animates because fitting
 // every intermediate height also emits redundant PTY resize traffic.
-export function useWarmTerminalPanel(open: boolean, resizing: boolean): {
+export function useWarmTerminalPanel(open: boolean, resizing: boolean, visible = true): {
   mounted: boolean;
   fitEnabled: boolean;
   prefetch: () => void;
@@ -18,7 +18,7 @@ export function useWarmTerminalPanel(open: boolean, resizing: boolean): {
     if (open) setMounted(true);
   }, [open]);
   useEffect(() => {
-    if (!open) {
+    if (!open || !visible) {
       setFitEnabled(false);
       return;
     }
@@ -29,7 +29,7 @@ export function useWarmTerminalPanel(open: boolean, resizing: boolean): {
     const delay = prefersReducedMotion() ? 0 : TERMINAL_TRANSITION_MS;
     const timer = window.setTimeout(() => setFitEnabled(true), delay);
     return () => window.clearTimeout(timer);
-  }, [open, resizing]);
+  }, [open, resizing, visible]);
   const prefetch = useCallback(() => {
     void import("../components/TerminalPanel");
   }, []);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2105,6 +2105,12 @@ a[href] {
   --statusbar-height: 0px;
 }
 
+/* Automation is a focused main page. These rules only remove presentation
+   rows; workspace and terminal preferences remain in their stores. */
+.layout--automation .terminal-drawer {
+  display: none;
+}
+
 .app--darwin .layout {
   --app-chrome-height: 44px;
   --chrome-toggle-size: 36px;
@@ -23180,11 +23186,12 @@ body > .mermaid-diagram--fullscreen {
   transition: opacity var(--dur-base) ease;
 }
 
-/* The image viewer is an app-level fullscreen surface. Hide the custom
-/* The image viewer is an app-level fullscreen surface. Hide the custom
-   Windows caption controls while it is open so the preview owns the only
-   visible close affordance; native shortcuts such as Alt+F4 remain intact. */
-.app--windows-frameless:has(.image-viewer-backdrop) > .windows-window-controls {
+/* Image previews and the automation page own their close affordances.
+   Hide Windows caption controls while either surface is mounted, including
+   the automation loading fallback, so they cannot cover or intercept clicks
+   on page controls. Native shortcuts such as Alt+F4 remain intact. */
+.app--windows-frameless:has(.image-viewer-backdrop) > .windows-window-controls,
+.app--windows-frameless.app--automation > .windows-window-controls {
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
@@ -33667,8 +33674,10 @@ body > .mermaid-diagram--fullscreen {
 
 .app--creation .sidebar-feature-zone__item:hover,
 .app--creation .sidebar-feature-zone__item:focus-visible,
+.app--creation .sidebar-feature-zone__item--active,
 :root[data-theme-style] .app--creation .sidebar-feature-zone__item:hover,
-:root[data-theme-style] .app--creation .sidebar-feature-zone__item:focus-visible {
+:root[data-theme-style] .app--creation .sidebar-feature-zone__item:focus-visible,
+:root[data-theme-style] .app--creation .sidebar-feature-zone__item--active {
   border-color: color-mix(in srgb, var(--accent) 12%, transparent);
   background: color-mix(in srgb, var(--accent) 6%, transparent);
   color: var(--fg);
@@ -36200,6 +36209,28 @@ body > .mermaid-diagram--fullscreen {
   :root[data-theme-style] .app .topicbar {
     grid-column: 1 !important;
     min-width: 0;
+  }
+
+  /* Automation can restore an explicitly expanded sidebar even at the app's
+     minimum width. The task editor responds to the remaining content width. */
+  .app .layout--automation:not(.layout--sidebar-collapsed),
+  :root[data-theme-style] .app .layout--automation:not(.layout--sidebar-collapsed) {
+    grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr) !important;
+  }
+
+  .app .layout--automation:not(.layout--sidebar-collapsed) .sidebar,
+  :root[data-theme-style] .app .layout--automation:not(.layout--sidebar-collapsed) .sidebar {
+    display: flex !important;
+  }
+
+  .app .layout--automation:not(.layout--sidebar-collapsed) .sidebar-resizer,
+  :root[data-theme-style] .app .layout--automation:not(.layout--sidebar-collapsed) .sidebar-resizer {
+    display: block !important;
+  }
+
+  .app .layout--automation:not(.layout--sidebar-collapsed) .chat-pane,
+  :root[data-theme-style] .app .layout--automation:not(.layout--sidebar-collapsed) .chat-pane {
+    grid-column: 2 !important;
   }
 }
 


### PR DESCRIPTION
## Problem

Opening an Automation task could leave chat-owned controls above the shared task editor. On Windows, custom caption buttons could overlap the task close action and route a click to the application window. On macOS, the workspace toggle could occupy the same corner as the task action.

## Behavior

- Keeps the Workbench Automation entry in its existing footer position.
- Keeps Creation's existing Automation entry and adds a consistent active state.
- Hides the chat workspace, terminal row and resizer, and chat status bar while Automation is active without changing their stored state.
- Restores the previous workspace mode, maximized state, width, terminal height, and live terminal session when returning to chat.
- Hides custom Windows caption controls throughout Automation while preserving native macOS traffic-light controls.
- Gives a collapsed sidebar one shared safe title area and a recovery button.
- Switches the existing shared task editor to a full-width view below 560 px of actual content width without remounting the editor or losing draft input.
- Keeps the existing task list, editor, save, cancel, close, scheduling, permissions, notification, and run-history semantics.

## Implementation

`mainView` is the single source for projecting chat-owned chrome. Automation changes presentation only: it does not call workspace or terminal close actions and does not rewrite persisted layout preferences. The terminal remains mounted and inert, with fitting paused while hidden.

The automation root class is applied before the lazy task module mounts, so Windows caption controls remain non-interactive during loading, empty, list, and editor states.

No Go or Wails API, task JSON, scheduler behavior, prompt, tool definition, model request, or user configuration is changed. This has no prompt-cache impact.

## Verification

- `node scripts/run-tests.mjs` — 256 suites passed
- `pnpm build` — type checks, CSS checks, hook checks, transcript regressions, bundle gates, and production build passed
- Wails macOS arm64 build passed
- Native macOS interaction check passed: task close collapses the editor and leaves the app window open; native window controls remain available
- Browser DOM and click-target checks passed for Workbench and Creation at 1440×900, 1024×768, and 760×480 on Windows and macOS platform modes
- Workspace maximized round trip, terminal DOM/session preservation, collapsed-sidebar recovery, task close hit target, and narrow-draft resize checks passed
- Windows CI builds the native Wails/WebView2 executable and runs native startup and scroll smoke; the exact Automation close-button click has not been checked on a physical Windows desktop

After rebasing on the current `main-v2`, the combined initial bundle measures 464.590 KiB gzip, 116.423 KiB deferred app-shell CSS gzip, and 2481.132 KiB raw. The bounded gates are 464.7 KiB, 116.5 KiB, and 2481.2 KiB; per-chunk and locale gates remain unchanged.

The shared Automation shell is extracted into its own small component; `App.tsx` and `HeartbeatPanel.tsx` both remain below their current `main-v2` line counts. No per-file or repository-wide repolint ceiling is raised.

## Documentation impact

Documentation-impact: none - existing Automation documentation remains accurate because task workflows, commands, configuration, and public interfaces are unchanged.

## Related work

Related to #9807. This PR addresses the Automation control overlap; the issue's requests about the Classic layout and concurrent windows remain outside this change.

This includes the dock-toggle outcome proposed in #9238 and applies it at the shared main-surface boundary. Thanks @ttmouse for identifying that overlap.

#9296 remains a separate Automation detail/filter persistence change and may need a small rebase in `HeartbeatPanel.tsx` after this PR.

This branch is rebased on the merged #9810 desktop shell changes. The shared App/layout changes auto-merged; the combined bundle budgets were remeasured and verified.

