### PR TITLE
test: correct platform and tool-output assertions / 修复平台与工具输出断言

### DIFF
--- a/internal/agent/argument_validation_test.go
+++ b/internal/agent/argument_validation_test.go
@@ -223,21 +223,43 @@ func TestToolArgumentsCorrectedAfterStopWithoutRepeatingSuccess(t *testing.T) {
 	fixed := provider.ToolCall{ID: "fixed", Name: "echo", Arguments: `{"text":"second"}`}
 	p := testutil.NewMock("test", testutil.Turn{Chunks: []provider.Chunk{{Type: provider.ChunkToolCall, ToolCall: &good}, {Type: provider.ChunkToolCall, ToolCall: &bad}, {Type: provider.ChunkUsage, Usage: &provider.Usage{FinishReason: "stop"}}, {Type: provider.ChunkDone}}}, testutil.Turn{ToolCalls: []provider.ToolCall{fixed}}, testutil.Turn{Text: "done"})
 	sink := &recordSink{}
-	a := New(p, echoRegistry(), NewSession("system"), Options{}, sink)
+	a := New(p, echoRegistry(), NewSession("system"), Options{ModelRef: t.Name()}, sink)
+	key := a.softBudgetHistoryKey()
+	for range softBudgetHistorySamples {
+		recordReadonlySoftBudgetDuration(key, 1)
+	}
+	t.Cleanup(func() {
+		readonlySoftBudgetHistory.Lock()
+		delete(readonlySoftBudgetHistory.byKey, key)
+		readonlySoftBudgetHistory.Unlock()
+	})
 	if err := a.Run(withNoClosedLoop(context.Background()), "use echo"); err != nil {
 		t.Fatal(err)
 	}
 	if p.CallCount() != 3 || len(sink.kinds(event.Retrying)) != 0 {
 		t.Fatal("argument correction used network retry")
 	}
+	// Execution output precedes host guidance; both must survive independently.
 	results := map[string]string{}
+	for _, e := range sink.kinds(event.ToolResult) {
+		if _, exists := results[e.Tool.ID]; exists {
+			t.Fatal("duplicate execution result")
+		}
+		results[e.Tool.ID] = e.Tool.Output
+	}
+	recorded := map[string]bool{}
+	budgetGuidance := false
 	for _, m := range a.Session().Snapshot() {
 		if m.Role == provider.RoleTool {
-			if _, exists := results[m.ToolCallID]; exists {
+			if recorded[m.ToolCallID] {
 				t.Fatal("duplicate result")
 			}
-			results[m.ToolCallID] = m.Content
+			recorded[m.ToolCallID] = true
+			budgetGuidance = budgetGuidance || strings.Contains(m.Content, "Host budget check:")
 		}
+	}
+	if len(recorded) != 3 || !budgetGuidance {
+		t.Fatalf("recorded=%v budget guidance=%t", recorded, budgetGuidance)
 	}
 	if results["good"] != "echoed: first" || results["fixed"] != "echoed: second" || !strings.Contains(results["bad"], "text") {
 		t.Fatalf("results=%+v", results)

--- a/internal/agent/argument_validation_test.go
+++ b/internal/agent/argument_validation_test.go
@@ -221,18 +221,10 @@ func TestToolArgumentsCorrectedAfterStopWithoutRepeatingSuccess(t *testing.T) {
 	good := provider.ToolCall{ID: "good", Name: "echo", Arguments: `{"text":"first"}`}
 	bad := provider.ToolCall{ID: "bad", Name: "echo", Arguments: `{"text":123}`}
 	fixed := provider.ToolCall{ID: "fixed", Name: "echo", Arguments: `{"text":"second"}`}
-	p := testutil.NewMock("test", testutil.Turn{Chunks: []provider.Chunk{{Type: provider.ChunkToolCall, ToolCall: &good}, {Type: provider.ChunkToolCall, ToolCall: &bad}, {Type: provider.ChunkUsage, Usage: &provider.Usage{FinishReason: "stop"}}, {Type: provider.ChunkDone}}}, testutil.Turn{ToolCalls: []provider.ToolCall{fixed}}, testutil.Turn{Text: "done"})
+	p := &argumentBudgetProvider{MockProvider: testutil.NewMock("test", testutil.Turn{Chunks: []provider.Chunk{{Type: provider.ChunkToolCall, ToolCall: &good}, {Type: provider.ChunkToolCall, ToolCall: &bad}, {Type: provider.ChunkUsage, Usage: &provider.Usage{FinishReason: "stop"}}, {Type: provider.ChunkDone}}}, testutil.Turn{ToolCalls: []provider.ToolCall{fixed}}, testutil.Turn{Text: "done"})}
 	sink := &recordSink{}
 	a := New(p, echoRegistry(), NewSession("system"), Options{ModelRef: t.Name()}, sink)
-	key := a.softBudgetHistoryKey()
-	for range softBudgetHistorySamples {
-		recordReadonlySoftBudgetDuration(key, 1)
-	}
-	t.Cleanup(func() {
-		readonlySoftBudgetHistory.Lock()
-		delete(readonlySoftBudgetHistory.byKey, key)
-		readonlySoftBudgetHistory.Unlock()
-	})
+	p.before = func() { a.turn.budget.rounds = readonlySoftBudgetRounds }
 	if err := a.Run(withNoClosedLoop(context.Background()), "use echo"); err != nil {
 		t.Fatal(err)
 	}
@@ -264,4 +256,17 @@ func TestToolArgumentsCorrectedAfterStopWithoutRepeatingSuccess(t *testing.T) {
 	if results["good"] != "echoed: first" || results["fixed"] != "echoed: second" || !strings.Contains(results["bad"], "text") {
 		t.Fatalf("results=%+v", results)
 	}
+}
+
+// The stream boundary runs after turn initialization, without a clock dependency.
+type argumentBudgetProvider struct {
+	*testutil.MockProvider
+	before func()
+}
+
+func (p *argumentBudgetProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	if p.CallCount() == 0 {
+		p.before()
+	}
+	return p.MockProvider.Stream(ctx, req)
 }

--- a/internal/config/model_capabilities_v2_test.go
+++ b/internal/config/model_capabilities_v2_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reasonix/internal/provider"
 	"reflect"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -80,8 +81,10 @@ func TestCapabilityV2IgnoresV1AndPersistsUnknown(t *testing.T) {
 		t.Fatal("v1 was modified")
 	}
 	info, err := os.Stat(r.path)
-	if err != nil || info.Mode().Perm() != 0600 {
-		t.Fatalf("cache permissions: %v %v", info, err)
+	if err != nil {
+		t.Fatal(err)
+	} else if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
+		t.Fatalf("cache permissions: %o, want 600", info.Mode().Perm())
 	}
 	for _, content := range []string{"broken", `{"version":999}`, `{"version":1}`} {
 		if err := os.WriteFile(r.path, []byte(content), 0600); err != nil {


### PR DESCRIPTION
Two test assertions block release qualification despite correct production behavior. The model capability cache test expects Unix permission bits on Windows; the argument-recovery test compares raw tool output with transcript content that can legitimately include adaptive host budget guidance.

The cache test retains existence and persistence checks everywhere and checks 0600 only on Unix. The recovery test sets the round threshold at the synchronous first-stream boundary to exercise the budget nudge without any clock dependency, checks exact ToolResult execution outputs, and verifies unique persisted results and retained host guidance. Production behavior and budgets are unchanged.

Verification:
- Configuration tests and vet passed.
- Argument-recovery regression passed 30 coverage repetitions and 10 race repetitions; full Agent coverage suite passed at 81.4%.
- Root and Desktop full race suites, root and Desktop vet, frontend test:all and build, release workflow contracts, and repolint passed during qualification.
- The original coverage failure was reproduced locally before correction. Windows then exposed clock-resolution dependence in the first fixture revision; the final fixture removes elapsed time entirely. Updated CI must pass before merge.

Documentation-impact: none - test-only assertion corrections.
Cache-impact: none - no provider-visible or production changes.
Cache-guard: scripts/cache-guard.sh passed; two existing 89% short-tool-loop warnings match v1.37.0.
System-prompt-review: N/A
