### PR TITLE
Fix topicbar opener key collision / 修复主题栏打开器 key 冲突

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4705,10 +4705,10 @@ export default function App() {
                 </button>
               </Tooltip>
               {shouldMountExternalOpener(activeTab, Boolean(sidebarImDetailConnection)) && activeTab && (
-                <ExternalOpener key={activeTab.id} tabId={activeTab.id} dismissSignal={transientOverlayDismissSignal} />
+                <ExternalOpener key={`external-opener:${activeTab.id}`} tabId={activeTab.id} dismissSignal={transientOverlayDismissSignal} />
               )}
               {!sidebarImDetailConnection && (
-                <TopicbarSessionActions key={activeTab?.id}
+                <TopicbarSessionActions key={`session-actions:${activeTab?.id || "none"}`}
                   sessionHasContent={sessionHasContent}
                   getSessionMarkdown={getSessionMarkdown}
                   exportSession={(format) => void exportSession(format)}

--- a/desktop/frontend/src/__tests__/external-opener.test.tsx
+++ b/desktop/frontend/src/__tests__/external-opener.test.tsx
@@ -100,6 +100,8 @@ ok(
   "preserves the slimmer Creation application artwork size",
 );
 
+ok(appSource.includes("key={`external-opener:${activeTab.id}`}"), "external opener has a distinct React key namespace");
+ok(appSource.includes("key={`session-actions:${activeTab?.id || \"none\"}`}"), "session actions have a distinct React key namespace");
 ok(shouldMountExternalOpener({ id: "tab-project", scope: "project" }, false), "mounts for a Project tab");
 ok(shouldMountExternalOpener({ id: "tab-global", scope: "global" }, false), "mounts for a Global tab without guessing from scope");
 ok(!shouldMountExternalOpener({ id: "tab-global", scope: "global" }, true), "stays hidden while an IM detail surface owns the header");


### PR DESCRIPTION
## Problem

Switching projects could leave an additional external-opener control in the topic bar. Each project click increased the visible duplicate count.

## Root cause

`ExternalOpener` and `TopicbarSessionActions` were sibling components keyed by the same tab ID. React reconciliation could retain stale component instances when the active tab changed.

## Fix

Namespace the two component keys independently and add regression assertions that enforce the distinct key namespaces.

## Verification

- `git diff --check` passed
- Focused React/JSDOM reproduction: duplicate-key layout grew to 1, 2, 3... controls before the fix; distinct namespaces remained at 1
- Frontend `tsx` test could not run in the original checkout because dependencies were not installed

## Documentation impact

Documentation-impact: none - this is an internal React reconciliation fix; existing user and developer documentation remains correct.

Fixes the reported duplicate topic-bar controls.
