### PR TITLE
Fix Ask custom draft loss / 修复 Ask 自定义回答草稿丢失

### DIFF
--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -532,6 +532,71 @@ console.log("\nask card layout");
   dom.window.close();
 }
 
+// Custom answer drafts survive switching to another option and back.
+{
+  const dom = installDom();
+  const rootEl = document.getElementById("root");
+  if (!rootEl) throw new Error("missing root");
+  const root = createRoot(rootEl);
+  const answers: QuestionAnswer[][] = [];
+  const ask: WireAsk = {
+    id: "ask-custom-draft",
+    questions: [{
+      id: "choice",
+      prompt: "Pick or describe",
+      options: [{ label: "Suggested", description: "Use the suggestion" }],
+    }],
+  };
+
+  await act(async () => {
+    root.render(React.createElement(LocaleProvider, null,
+      React.createElement(AskCard, {
+        ask,
+        onAnswer: (_id: string, next: QuestionAnswer[]) => { answers.push(next); },
+        onDismiss: () => undefined,
+        onStop: () => undefined,
+      }),
+    ));
+    await flushTimers();
+  });
+
+  const actions = [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")];
+  await act(async () => {
+    actions[1]?.click();
+    await flushTimers();
+  });
+  const input = document.querySelector<HTMLInputElement>(".ask-shelf__custom");
+  if (!input) throw new Error("custom input did not open");
+  await act(async () => {
+    const propsKey = Object.keys(input).find((key) => key.startsWith("__reactProps"));
+    const props = propsKey ? (input as unknown as Record<string, { onChange?: (event: { target: { value: string } }) => void }>)[propsKey] : undefined;
+    props?.onChange?.({ target: { value: "Keep this draft" } });
+    await flushTimers();
+  });
+  eq(input.value, "Keep this draft", "custom input accepts a draft");
+
+  await act(async () => {
+    document.querySelector<HTMLButtonElement>(".prompt-action")?.click();
+    await flushTimers();
+  });
+  eq(document.querySelector(".ask-shelf__custom"), null, "selecting an option hides custom input");
+
+  await act(async () => {
+    [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")][1]?.click();
+    await flushTimers();
+  });
+  eq(document.querySelector<HTMLInputElement>(".ask-shelf__custom")?.value, "Keep this draft", "reopening custom restores the draft");
+
+  await act(async () => {
+    document.querySelector<HTMLButtonElement>(".decision-confirm-bar__confirm")?.click();
+    await flushTimers();
+  });
+  eq(answers[0]?.[0]?.selected?.[0], "Keep this draft", "custom mode submits the restored draft");
+
+  await act(async () => { root.unmount(); });
+  dom.window.close();
+}
+
 // Multi-select: keyboard cursor must not look like a checked answer.
 {
   const dom = installDom();

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -96,13 +96,13 @@ export function AskCard({
     }));
 
   const answerLabel = (question: WireAskQuestion) => {
-    const typed = custom[question.id]?.trim();
-    if (typed) return typed;
+    if (answerMode[question.id] === "custom") return custom[question.id]?.trim() ?? "";
     return (sel[question.id] ?? []).join(", ");
   };
 
-  const answered = (question: WireAskQuestion) =>
-    (sel[question.id]?.length ?? 0) > 0 || (custom[question.id]?.trim() ?? "") !== "";
+  const answered = (question: WireAskQuestion) => answerMode[question.id] === "custom"
+    ? (custom[question.id]?.trim() ?? "") !== ""
+    : (sel[question.id]?.length ?? 0) > 0;
 
   const currentAnswered = q ? answered(q) : false;
 

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -9,6 +9,8 @@ import {
   PromptShelf,
 } from "./PromptShelf";
 
+type AnswerMode = "option" | "custom";
+
 // AskCard renders the `ask` tool as a decision shelf near the composer. It
 // walks multi-question asks one at a time. Selecting (click / digit) never
 // advances; Enter / Confirm submits or moves to the next question.
@@ -27,6 +29,7 @@ export function AskCard({
   // Per-question state: selected option labels, and an optional typed answer.
   const [sel, setSel] = useState<Record<string, string[]>>({});
   const [custom, setCustom] = useState<Record<string, string>>({});
+  const [answerMode, setAnswerMode] = useState<Record<string, AnswerMode>>({});
   const [customOpen, setCustomOpen] = useState(false);
   const [active, setActive] = useState(0);
   // Extra decision row after option labels: custom answer. Skip is a
@@ -61,6 +64,7 @@ export function AskCard({
     shelfRef.current?.focus();
     setSel({});
     setCustom({});
+    setAnswerMode({});
     setCustomOpen(false);
     setActive(0);
     setSelectedIndex(0);
@@ -86,7 +90,9 @@ export function AskCard({
   ): QuestionAnswer[] =>
     questions.map((question) => ({
       questionId: question.id,
-      selected: nextCustom[question.id]?.trim() ? [nextCustom[question.id].trim()] : (nextSel[question.id] ?? []),
+      selected: answerMode[question.id] === "custom" && nextCustom[question.id]?.trim()
+        ? [nextCustom[question.id].trim()]
+        : (nextSel[question.id] ?? []),
     }));
 
   const answerLabel = (question: WireAskQuestion) => {
@@ -119,18 +125,18 @@ export function AskCard({
 
   const toggleOption = (question: WireAskQuestion, label: string) => {
     if (submitting) return;
-    const nextCustom = { ...custom, [question.id]: "" };
     const cur = sel[question.id] ?? [];
     const nextSel = question.multi
       ? { ...sel, [question.id]: cur.includes(label) ? cur.filter((x) => x !== label) : [...cur, label] }
       : { ...sel, [question.id]: [label] };
 
-    setCustom(nextCustom);
+    setAnswerMode((m) => ({ ...m, [question.id]: "option" }));
     setSel(nextSel);
     setCustomOpen(false);
   };
 
   const setTyped = (question: WireAskQuestion, text: string) => {
+    setAnswerMode((m) => ({ ...m, [question.id]: "custom" }));
     setCustom((c) => ({ ...c, [question.id]: text }));
     if (text.trim()) setSel((s) => ({ ...s, [question.id]: [] }));
   };
@@ -150,12 +156,13 @@ export function AskCard({
         toggleOption(q, option.label);
       } else {
         // Single-select: click/digit only selects the row and marks the option.
-        setCustom((c) => ({ ...c, [q.id]: "" }));
+        setAnswerMode((m) => ({ ...m, [q.id]: "option" }));
         setSel((s) => ({ ...s, [q.id]: [option.label] }));
         setCustomOpen(false);
       }
     } else if (index === customRowIndex) {
       // Opening custom clears option picks for this question.
+      setAnswerMode((m) => ({ ...m, [q.id]: "custom" }));
       setCustomOpen(true);
       setSel((s) => ({ ...s, [q.id]: [] }));
     }


### PR DESCRIPTION
## Problem
When an Ask card's custom answer was entered, selecting a suggested option cleared the draft. Returning to “自定义回答” lost the user's text and could not restore it.

## Root cause
The desktop AskCard used the presence of custom text as both draft storage and the active answer source. Selecting an option cleared that shared value.

## Fix
- Preserve custom drafts per question while switching options.
- Track whether the current answer source is a suggested option or custom text.
- Restore the draft when reopening custom input.
- Add a regression test covering custom input → suggested option → custom input → submit.

## Verification
- `npx tsx src/__tests__/ask-card-layout.test.ts`
- `pnpm typecheck`

Fixes #9834

Documentation-impact: none - Existing Ask interaction documentation remains correct; this restores draft retention within the existing flow.
