### PR TITLE
feat(desktop): unify Ask and decision popups with harness UI / 统一 Ask 与决策弹窗界面

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -200,7 +200,10 @@ console.log("\nbundle budgets");
 // over the same-environment main-v2 build (465.4 -> 466.6 KiB gzip).
 // Keep one decimal of cross-platform headroom for this measured shell change.
 // Integrating main-v2 rich-link menus measures 466.905 KiB combined.
-const initialJSBudgetKiB = 467.0;
+// The AskCard session-draft wiring adds a bounded 30-byte gzip drift on the
+// initial route; retain the explicit budget rather than failing on a rounded
+// 467.0 KiB display value.
+const initialJSBudgetKiB = 467.5;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -377,6 +380,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // Recovery controls add 3.6 KiB raw over the measured 2480.9 KiB base;
 // current payload is 2484.509 KiB. Retain only bounded toolchain headroom.
 // With the current-base rich-link menus: 2485.715 KiB raw.
-const rawInitialBudgetKiB = 2_485.9;
+// The session-scoped Ask draft adds a small startup payload; keep the raw gate
+// explicit and bounded alongside the gzip ratchet above.
+const rawInitialBudgetKiB = 2_487.5;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -222,10 +222,11 @@ if (initialCSS.length > 0) {
 // the retained-transcript navigation allowance; keep the ratchet explicit.
 // The navigation mask's stable composer footprint and remote tab/surface
 // states bring the merged shell to roughly 115.7 KiB gzip.
-// The one-row model configuration list, responsive stacking, and Automation's
-// shared title-safe shell measure 116.423 KiB gzip while reusing existing
-// layout primitives. Retain only the next one-decimal ceiling.
-assertBudget("deferred app-shell CSS gzip", appShellCSSGzip, 116.5 * 1024);
+// The one-row model configuration list, responsive stacking, Automation's
+// shared title-safe shell, and the shared harness decision surface measure
+// 116.9 KiB gzip while reusing existing layout primitives. Retain a bounded
+// 0.1 KiB headroom ratchet.
+assertBudget("deferred app-shell CSS gzip", appShellCSSGzip, 117.0 * 1024);
 if (localeChunks.length !== 2) {
   throw new Error(`expected 2 on-demand Chinese locale chunks, found ${localeChunks.length}`);
 }
@@ -380,8 +381,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // Recovery controls add 3.6 KiB raw over the measured 2480.9 KiB base;
 // current payload is 2484.509 KiB. Retain only bounded toolchain headroom.
 // With the current-base rich-link menus: 2485.715 KiB raw.
-// The session-scoped Ask draft adds a small startup payload; keep the raw gate
-// explicit and bounded alongside the gzip ratchet above.
-const rawInitialBudgetKiB = 2_487.5;
+// The shared harness decision surface adds a bounded startup stylesheet
+// payload; retain the measured 2492.1 KiB path with narrow headroom.
+const rawInitialBudgetKiB = 2_492.5;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4996,6 +4996,7 @@ export default function App() {
               <AskCard
                 key={`${activeTabId ?? ""}:${state.ask.id}`}
                 ask={state.ask}
+                draftScope={activeTabId ?? "local"}
                 onAnswer={answerQuestion}
                 onDismiss={() => answerQuestion(state.ask!.id, [])}
                 onStop={() => {

--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -170,7 +170,7 @@ console.log("\nask card layout");
 
   const optionButtons = [...document.querySelectorAll(".prompt-shelf__actions .prompt-action")] as HTMLElement[];
   // options + custom; skip is a secondary footer action
-  eq(optionButtons.length, 3, "ask renders options plus custom without a skip row");
+  eq(optionButtons.length, 2, "ask renders only selectable options; custom answer is an always-visible input row");
   ok(
     optionButtons[0]?.textContent?.includes("Reuse the archive flow") === true,
     "option descriptions render inline on each decision row",

--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -1,5 +1,4 @@
 // Run: tsx src/__tests__/ask-card-layout.test.ts
-
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,13 +9,10 @@ import { createRoot } from "react-dom/client";
 import { AskCard } from "../components/AskCard";
 import { LocaleProvider } from "../lib/i18n";
 import type { QuestionAnswer, WireAsk } from "../lib/types";
-
 const testDir = dirname(fileURLToPath(import.meta.url));
 const styles = readFileSync(resolve(testDir, "../styles.css"), "utf8");
-
 let passed = 0;
 let failed = 0;
-
 function ok(value: boolean, label: string) {
   if (value) {
     process.stdout.write(`  PASS  ${label}\n`);
@@ -26,16 +22,13 @@ function ok(value: boolean, label: string) {
     failed += 1;
   }
 }
-
 function eq(actual: unknown, expected: unknown, label: string) {
   if (actual === expected) ok(true, label);
   else ok(false, `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
 }
-
 function flushTimers(delay = 0): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, delay));
 }
-
 function installDom() {
   const dom = new JSDOM("<!doctype html><html><head></head><body><div id=\"root\"></div></body></html>", {
     pretendToBeVisual: true,
@@ -99,15 +92,12 @@ function installDom() {
       this.setAttribute("data-scrolled-into-view", "true");
     },
   });
-
   const style = document.createElement("style");
   style.textContent = styles;
   document.head.appendChild(style);
   return dom;
 }
-
 console.log("\nask card layout");
-
 {
   const dom = installDom();
   const rootEl = document.getElementById("root");
@@ -131,7 +121,6 @@ console.log("\nask card layout");
       },
     ],
   };
-
   await act(async () => {
     root.render(
       React.createElement(LocaleProvider, null,
@@ -145,15 +134,12 @@ console.log("\nask card layout");
     );
     await flushTimers();
   });
-
   const card = document.querySelector(".prompt-shelf__card") as HTMLElement | null;
   const content = document.querySelector(".prompt-shelf__content") as HTMLElement | null;
   const meta = document.querySelector(".prompt-shelf__meta") as HTMLElement | null;
   const footer = document.querySelector(".prompt-shelf__footer") as HTMLElement | null;
   if (!card || !content || !meta || !footer) throw new Error("ask prompt shelf did not render");
-
   eq(meta.textContent, ask.questions[0].prompt, "ask question text remains complete in the prompt shelf");
-
   const computed = window.getComputedStyle(meta);
   eq(computed.whiteSpace, "normal", "ask question can wrap instead of staying on one line");
   eq(computed.overflow, "visible", "ask question is not clipped by the prompt shelf");
@@ -167,7 +153,6 @@ console.log("\nask card layout");
   eq(content.contains(footer), false, "Ask confirmation footer stays outside the scrolling content");
   const secondary = footer.querySelector(".decision-confirm-bar__secondary") as HTMLButtonElement | null;
   ok(Boolean(secondary?.textContent?.trim()), "Ask skip is a quiet footer action");
-
   const optionButtons = [...document.querySelectorAll(".prompt-shelf__actions .prompt-action")] as HTMLElement[];
   // options + custom; skip is a secondary footer action
   eq(optionButtons.length, 2, "ask renders only selectable options; custom answer is an always-visible input row");
@@ -179,19 +164,16 @@ console.log("\nask card layout");
   const firstOption = optionButtons[0];
   const firstDescription = firstOption?.querySelector(".prompt-action__desc") as HTMLElement | null;
   if (!actions || !firstOption || !firstDescription) throw new Error("ask option layout did not render");
-
   const actionsStyle = window.getComputedStyle(actions);
   eq(actionsStyle.gridAutoRows, "max-content", "decision row wrappers accommodate optional external details");
   eq(actionsStyle.alignContent, "start", "decision rows stay content-sized at the top of the scroll region");
   eq(actionsStyle.maxHeight, "none", "Ask options do not create a nested scroll region");
   eq(actionsStyle.overflow, "visible", "Ask option overflow belongs to the shared content scroller");
-
   const optionStyle = window.getComputedStyle(firstOption);
   eq(optionStyle.height, "38px", "desktop decision rows keep a stable compact height");
   eq(optionStyle.minHeight, "38px", "short decision rows retain a compact click target");
   eq(optionStyle.alignItems, "center", "single-line decision copy stays vertically centered with the option key");
   eq(window.getComputedStyle(firstOption.querySelector(".prompt-action__key") as HTMLElement).marginTop, "0px", "decision keys do not carry a top offset");
-
   ok(
     /\.prompt-shelf--decision \.prompt-shelf__actions \.prompt-action__copy \{[^}]*grid-template-columns:\s*fit-content\(44%\) minmax\(0, 1fr\)/s.test(styles),
     "decision option labels size to content while staying capped at 44% of the row",
@@ -200,7 +182,6 @@ console.log("\nask card layout");
     !/\.prompt-shelf--decision \.prompt-shelf__actions \.prompt-action__label \{[^}]*max-width:\s*[\d.]/s.test(styles),
     "decision option labels never resolve their width cap against their own content-sized track",
   );
-
   const descriptionStyle = window.getComputedStyle(firstDescription);
   eq(descriptionStyle.whiteSpace, "nowrap", "long option descriptions stay on one stable summary line");
   eq(descriptionStyle.display, "block", "Ask summaries use ordinary single-line flow");
@@ -213,7 +194,6 @@ console.log("\nask card layout");
     ask.questions[0].options[0].description,
     "normal short labels preserve the existing description tooltip",
   );
-
   const descriptionToggle = document.querySelector(".prompt-action__description-toggle") as HTMLButtonElement | null;
   if (!descriptionToggle) throw new Error("long Ask description disclosure did not render");
   eq(descriptionToggle.textContent?.trim(), "View full description", "truncated descriptions expose an explicit full-text action");
@@ -222,7 +202,6 @@ console.log("\nask card layout");
   if (!descriptionDetail) throw new Error("long Ask detail region did not render");
   eq(descriptionToggle.getAttribute("aria-controls"), descriptionDetail.id, "disclosure identifies the separate detail region");
   eq(descriptionDetail.hidden, true, "full detail region starts hidden");
-
   let disclosureEnterDefaultPrevented = true;
   await act(async () => {
     const event = new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
@@ -233,7 +212,6 @@ console.log("\nask card layout");
   eq(answers.length, 0, "Enter on Ask disclosure never confirms the selected answer");
   eq(disclosureEnterDefaultPrevented, true, "Ask disclosure owns keyboard activation before global shortcuts");
   eq(descriptionToggle.getAttribute("aria-expanded"), "true", "Enter expands the Ask description");
-
   await act(async () => {
     descriptionToggle.dispatchEvent(new window.KeyboardEvent("keydown", {
       key: "Enter",
@@ -243,7 +221,6 @@ console.log("\nask card layout");
     await flushTimers();
   });
   eq(descriptionToggle.getAttribute("aria-expanded"), "false", "Enter collapses the Ask description again");
-
   await act(async () => {
     descriptionToggle.click();
     await flushTimers();
@@ -259,34 +236,29 @@ console.log("\nask card layout");
     true,
     "separate detail region reveals the complete text",
   );
-
   await act(async () => {
     descriptionToggle.click();
     await flushTimers();
   });
   eq(descriptionDetail.hidden, true, "separate detail region can be collapsed again");
   eq(descriptionToggle.getAttribute("aria-expanded"), "false", "collapsed state is announced");
-
   await act(async () => {
     optionButtons[1].click();
     await flushTimers(200);
   });
   eq(document.querySelector(".prompt-action__description-toggle"), null, "short selected descriptions do not show a redundant disclosure");
   eq(answers.length, 0, "single-select click advances without submitting the final answer");
-
   await act(async () => {
     (document.querySelector(".decision-confirm-bar__confirm") as HTMLButtonElement).click();
     await flushTimers();
   });
   eq(answers.length, 1, "confirm submits the selected single-select answer");
   eq(answers[0]?.[0]?.selected?.[0], "Minimal repair", "submitted answer matches the selected option");
-
   await act(async () => {
     root.unmount();
   });
   dom.window.close();
 }
-
 // Legacy or malformed Ask payloads may omit description and put the entire
 // decision in label. Give those rows the full copy column, then disclose the
 // original label only when it still overflows. The answer value stays exact.
@@ -308,7 +280,6 @@ console.log("\nask card layout");
       ],
     }],
   };
-
   await act(async () => {
     root.render(
       React.createElement(LocaleProvider, null,
@@ -322,18 +293,15 @@ console.log("\nask card layout");
     );
     await flushTimers(200);
   });
-
   const firstOption = document.querySelector(".prompt-shelf__actions .prompt-action") as HTMLButtonElement | null;
   const label = firstOption?.querySelector(".prompt-action__label") as HTMLElement | null;
   const copy = firstOption?.querySelector(".prompt-action__copy") as HTMLElement | null;
   const toggle = document.querySelector(".prompt-action__description-toggle") as HTMLButtonElement | null;
   if (!firstOption || !label || !copy || !toggle) throw new Error("long label fallback did not render");
-
   eq(window.getComputedStyle(copy).gridTemplateColumns, "minmax(0, 1fr)", "label-only decisions use the full copy width before truncating");
   eq(window.getComputedStyle(label).textOverflow, "ellipsis", "overflowing legacy labels keep the stable compact row");
   eq(firstOption.getAttribute("title"), longLabel, "overflowing labels retain their complete native tooltip");
   eq(toggle.getAttribute("aria-expanded"), "false", "overflowing label detail starts collapsed");
-
   await act(async () => {
     toggle.click();
     await flushTimers();
@@ -349,20 +317,17 @@ console.log("\nask card layout");
     "full label detail wraps instead of being ellipsized again",
   );
   eq(answers.length, 0, "opening a long label never submits the decision");
-
   await act(async () => {
     (document.querySelector(".decision-confirm-bar__confirm") as HTMLButtonElement).click();
     await flushTimers();
   });
   eq(answers.length, 1, "long label decision still submits normally");
   eq(answers[0]?.[0]?.selected?.[0], longLabel, "display fallback does not alter the answer value");
-
   await act(async () => {
     root.unmount();
   });
   dom.window.close();
 }
-
 // Multi-select requires at least one choice before confirm advances.
 {
   const dom = installDom();
@@ -384,7 +349,6 @@ console.log("\nask card layout");
       },
     ],
   };
-
   await act(async () => {
     root.render(
       React.createElement(LocaleProvider, null,
@@ -398,10 +362,8 @@ console.log("\nask card layout");
     );
     await flushTimers();
   });
-
   const confirm = document.querySelector(".decision-confirm-bar__confirm") as HTMLButtonElement;
   eq(confirm.disabled, true, "multi-select confirm stays disabled until an option is chosen");
-
   const optionButtons = [...document.querySelectorAll(".prompt-shelf__actions .prompt-action")] as HTMLElement[];
   await act(async () => {
     optionButtons[0].click();
@@ -409,20 +371,17 @@ console.log("\nask card layout");
   });
   eq(confirm.disabled, false, "multi-select confirm enables after selecting one option");
   eq(answers.length, 0, "multi-select click does not submit");
-
   await act(async () => {
     confirm.click();
     await flushTimers();
   });
   eq(answers.length, 1, "multi-select confirm submits once");
   eq(JSON.stringify(answers[0]?.[0]?.selected), JSON.stringify(["A"]), "multi-select keeps chosen labels");
-
   await act(async () => {
     root.unmount();
   });
   dom.window.close();
 }
-
 // Single-select: keyboard cursor is confirmable without a prior click.
 {
   const dom = installDom();
@@ -443,7 +402,6 @@ console.log("\nask card layout");
       },
     ],
   };
-
   await act(async () => {
     root.render(
       React.createElement(LocaleProvider, null,
@@ -457,12 +415,10 @@ console.log("\nask card layout");
     );
     await flushTimers();
   });
-
   const optionButtons = [...document.querySelectorAll(".prompt-shelf__actions .prompt-action")] as HTMLElement[];
   const confirm = document.querySelector(".decision-confirm-bar__confirm") as HTMLButtonElement;
   eq(optionButtons[0]?.getAttribute("aria-selected"), "true", "initial keyboard cursor marks the first option");
   eq(confirm.disabled, false, "initial option cursor enables confirm without a click");
-
   await act(async () => {
     document.dispatchEvent(new window.KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }));
     await flushTimers();
@@ -471,20 +427,17 @@ console.log("\nask card layout");
   eq(optionButtons[1]?.getAttribute("aria-selected"), "true", "ArrowDown selects the second option visually");
   eq(optionButtons[1]?.getAttribute("data-scrolled-into-view"), "true", "keyboard selection stays inside the visible option viewport");
   eq(confirm.disabled, false, "ArrowDown keeps confirm enabled for the highlighted option");
-
   await act(async () => {
     document.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
     await flushTimers();
   });
   eq(answers.length, 1, "ArrowDown+Enter submits the highlighted single-select option");
   eq(answers[0]?.[0]?.selected?.[0], "Second", "submitted answer matches the keyboard cursor");
-
   await act(async () => {
     root.unmount();
   });
   dom.window.close();
 }
-
 // Single-select: initial Enter confirms the default-highlighted first option.
 {
   const dom = installDom();
@@ -505,7 +458,6 @@ console.log("\nask card layout");
       },
     ],
   };
-
   await act(async () => {
     root.render(
       React.createElement(LocaleProvider, null,
@@ -519,20 +471,17 @@ console.log("\nask card layout");
     );
     await flushTimers();
   });
-
   await act(async () => {
     document.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
     await flushTimers();
   });
   eq(answers.length, 1, "initial Enter submits without a prior click");
   eq(answers[0]?.[0]?.selected?.[0], "Alpha", "initial Enter uses the first highlighted option");
-
   await act(async () => {
     root.unmount();
   });
   dom.window.close();
 }
-
 // Custom answer drafts survive switching to another option and back.
 {
   const dom = installDom();
@@ -548,7 +497,6 @@ console.log("\nask card layout");
       options: [{ label: "Suggested", description: "Use the suggestion" }],
     }],
   };
-
   await act(async () => {
     root.render(React.createElement(LocaleProvider, null,
       React.createElement(AskCard, {
@@ -560,7 +508,6 @@ console.log("\nask card layout");
     ));
     await flushTimers();
   });
-
   const actions = [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")];
   await act(async () => {
     actions[1]?.click();
@@ -575,29 +522,24 @@ console.log("\nask card layout");
     await flushTimers();
   });
   eq(input.value, "Keep this draft", "custom input accepts a draft");
-
   await act(async () => {
     document.querySelector<HTMLButtonElement>(".prompt-action")?.click();
     await flushTimers();
   });
   eq(document.querySelector<HTMLInputElement>(".ask-shelf__custom")?.value, "", "selecting an option clears the visible custom draft without removing the input row");
-
   await act(async () => {
     document.querySelector<HTMLElement>(".ask-shelf__custom-row")?.click();
     await flushTimers();
   });
   eq(document.querySelector<HTMLInputElement>(".ask-shelf__custom")?.value, "Keep this draft", "reopening custom restores the draft");
-
   await act(async () => {
     document.querySelector<HTMLButtonElement>(".decision-confirm-bar__confirm")?.click();
     await flushTimers();
   });
   eq(answers[0]?.[0]?.selected?.[0], "Keep this draft", "custom mode submits the restored draft");
-
   await act(async () => { root.unmount(); });
   dom.window.close();
 }
-
 // Multi-select: keyboard cursor must not look like a checked answer.
 {
   const dom = installDom();
@@ -618,7 +560,6 @@ console.log("\nask card layout");
       },
     ],
   };
-
   await act(async () => {
     root.render(
       React.createElement(LocaleProvider, null,
@@ -632,13 +573,11 @@ console.log("\nask card layout");
     );
     await flushTimers();
   });
-
   const optionButtons = [...document.querySelectorAll(".prompt-shelf__actions .prompt-action")] as HTMLElement[];
   const confirm = document.querySelector(".decision-confirm-bar__confirm") as HTMLButtonElement;
   eq(optionButtons[0]?.getAttribute("aria-selected"), "false", "multi-select cursor alone is not aria-selected");
   eq(optionButtons[0]?.getAttribute("data-active"), "true", "multi-select marks the keyboard cursor with data-active");
   eq(confirm.disabled, true, "multi-select confirm stays disabled until an option is checked");
-
   await act(async () => {
     document.dispatchEvent(new window.KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }));
     await flushTimers();
@@ -647,20 +586,17 @@ console.log("\nask card layout");
   eq(optionButtons[1]?.getAttribute("data-active"), "true", "ArrowDown moves the multi-select cursor");
   eq(optionButtons[1]?.getAttribute("aria-selected"), "false", "ArrowDown does not check the multi-select option");
   eq(confirm.disabled, true, "ArrowDown alone does not enable multi-select confirm");
-
   await act(async () => {
     optionButtons[1].click();
     await flushTimers();
   });
   eq(optionButtons[1]?.getAttribute("aria-selected"), "true", "click checks the multi-select option");
   eq(confirm.disabled, false, "multi-select confirm enables after a real check");
-
   await act(async () => {
     root.unmount();
   });
   dom.window.close();
 }
-
 // A failed asynchronous submit must preserve multi-question progress and
 // selections instead of remounting the card at question 1.
 {
@@ -677,7 +613,6 @@ console.log("\nask card layout");
       { id: "q2", prompt: "Second choice?", options: [{ label: "Second A" }, { label: "Second B" }] },
     ],
   };
-
   await act(async () => {
     root.render(
       React.createElement(LocaleProvider, null,
@@ -695,34 +630,29 @@ console.log("\nask card layout");
     );
     await flushTimers();
   });
-
   await act(async () => {
     [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")]
       .find((button) => button.textContent?.includes("First A"))?.click();
     await flushTimers();
   });
   eq(document.querySelector(".ask-shelf__header-text--progress")?.textContent?.includes("2/2"), true, "multi-question Ask advances to question 2");
-
   await act(async () => {
     document.querySelector<HTMLButtonElement>(".ask-shelf__pager-button")?.click();
     await flushTimers();
   });
   eq(document.querySelector(".ask-shelf__header-text--progress")?.textContent?.includes("1/2"), true, "Back returns to the previous question");
-
   await act(async () => {
     [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")]
       .find((button) => button.textContent?.includes("First B"))?.click();
     await flushTimers();
   });
   eq(document.querySelector(".ask-shelf__header-text--progress")?.textContent?.includes("2/2"), true, "previous question accepts a replacement choice");
-
   await act(async () => {
     [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")]
       .find((button) => button.textContent?.includes("Second B"))?.click();
     document.querySelector<HTMLButtonElement>(".decision-confirm-bar__confirm")?.click();
     await flushTimers();
   });
-
   eq(attempts, 1, "failed final submit is attempted exactly once");
   eq(document.querySelector(".ask-shelf__header-text--progress")?.textContent?.includes("2/2"), true, "failed final submit stays on question 2");
   eq(document.querySelector(".ask-shelf__crumbs")?.textContent?.includes("First B"), true, "failed final submit preserves the revised first answer");
@@ -733,18 +663,15 @@ console.log("\nask card layout");
     "failed final submit preserves the second answer",
   );
   eq(document.querySelector<HTMLButtonElement>(".decision-confirm-bar__confirm")?.disabled, false, "failed final submit re-enables retry");
-
   await act(async () => {
     document.querySelector<HTMLButtonElement>(".decision-confirm-bar__confirm")?.click();
     await flushTimers();
   });
   eq(attempts, 2, "retry submits once after the failure");
   eq(submitted[1]?.map((answer) => answer.selected?.[0]).join("|"), "First B|Second B", "retry submits the preserved answer batch");
-
   await act(async () => { root.unmount(); });
   dom.window.close();
 }
-
 // Skip advances the current question and submits an empty answer on the last.
 {
   const dom = installDom();
@@ -756,7 +683,6 @@ console.log("\nask card layout");
     id: "ask-skip-retry",
     questions: [{ id: "q1", prompt: "Skip this?", options: [{ label: "Continue" }] }],
   };
-
   await act(async () => {
     root.render(
       React.createElement(LocaleProvider, null,
@@ -770,18 +696,15 @@ console.log("\nask card layout");
     );
     await flushTimers();
   });
-
   await act(async () => {
     document.querySelector<HTMLButtonElement>(".decision-confirm-bar__secondary")?.click();
     await flushTimers();
   });
   eq(submitted.length, 1, "skipping the final question submits once");
   eq(submitted[0]?.[0]?.selected?.length, 0, "skipping submits an empty answer");
-
   await act(async () => { root.unmount(); });
   dom.window.close();
 }
-
 // Collapsing an Ask keeps the pending card header visible, while interactive
 // controls continue to work without toggling the card accidentally.
 {
@@ -818,7 +741,6 @@ console.log("\nask card layout");
   await act(async () => { root.unmount(); });
   dom.window.close();
 }
-
 // Session-scoped drafts restore when the Ask surface remounts in the same tab.
 {
   const dom = installDom();
@@ -859,6 +781,5 @@ console.log("\nask card layout");
   await act(async () => { remountRoot.unmount(); });
   dom.window.close();
 }
-
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -272,7 +272,7 @@ console.log("\nask card layout");
     await flushTimers(200);
   });
   eq(document.querySelector(".prompt-action__description-toggle"), null, "short selected descriptions do not show a redundant disclosure");
-  eq(answers.length, 0, "single-select click only selects and does not auto-advance/submit");
+  eq(answers.length, 0, "single-select click advances without submitting the final answer");
 
   await act(async () => {
     (document.querySelector(".decision-confirm-bar__confirm") as HTMLButtonElement).click();
@@ -634,10 +634,23 @@ console.log("\nask card layout");
   await act(async () => {
     [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")]
       .find((button) => button.textContent?.includes("First A"))?.click();
-    document.querySelector<HTMLButtonElement>(".decision-confirm-bar__confirm")?.click();
     await flushTimers();
   });
   eq(document.querySelector(".ask-shelf__header-text--progress")?.textContent?.includes("2/2"), true, "multi-question Ask advances to question 2");
+
+  await act(async () => {
+    [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")]
+      .find((button) => button.textContent?.includes("Back") || button.textContent?.includes("返回"))?.click();
+    await flushTimers();
+  });
+  eq(document.querySelector(".ask-shelf__header-text--progress")?.textContent?.includes("1/2"), true, "Back returns to the previous question");
+
+  await act(async () => {
+    [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")]
+      .find((button) => button.textContent?.includes("First B"))?.click();
+    await flushTimers();
+  });
+  eq(document.querySelector(".ask-shelf__header-text--progress")?.textContent?.includes("2/2"), true, "previous question accepts a replacement choice");
 
   await act(async () => {
     [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")]
@@ -648,7 +661,7 @@ console.log("\nask card layout");
 
   eq(attempts, 1, "failed final submit is attempted exactly once");
   eq(document.querySelector(".ask-shelf__header-text--progress")?.textContent?.includes("2/2"), true, "failed final submit stays on question 2");
-  eq(document.querySelector(".ask-shelf__crumbs")?.textContent?.includes("First A"), true, "failed final submit preserves the first answer");
+  eq(document.querySelector(".ask-shelf__crumbs")?.textContent?.includes("First B"), true, "failed final submit preserves the revised first answer");
   eq(
     [...document.querySelectorAll<HTMLElement>(".prompt-action")]
       .some((button) => button.getAttribute("aria-selected") === "true" && button.textContent?.includes("Second B")),
@@ -662,7 +675,7 @@ console.log("\nask card layout");
     await flushTimers();
   });
   eq(attempts, 2, "retry submits once after the failure");
-  eq(submitted[1]?.map((answer) => answer.selected?.[0]).join("|"), "First A|Second B", "retry submits the preserved answer batch");
+  eq(submitted[1]?.map((answer) => answer.selected?.[0]).join("|"), "First B|Second B", "retry submits the preserved answer batch");
 
   await act(async () => { root.unmount(); });
   dom.window.close();

--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -639,8 +639,7 @@ console.log("\nask card layout");
   eq(document.querySelector(".ask-shelf__header-text--progress")?.textContent?.includes("2/2"), true, "multi-question Ask advances to question 2");
 
   await act(async () => {
-    [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")]
-      .find((button) => button.textContent?.includes("Back") || button.textContent?.includes("返回"))?.click();
+    document.querySelector<HTMLButtonElement>(".ask-shelf__pager-button")?.click();
     await flushTimers();
   });
   eq(document.querySelector(".ask-shelf__header-text--progress")?.textContent?.includes("1/2"), true, "Back returns to the previous question");

--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -714,5 +714,40 @@ console.log("\nask card layout");
   dom.window.close();
 }
 
+// Collapsing an Ask keeps the pending card header visible, while interactive
+// controls continue to work without toggling the card accidentally.
+{
+  const dom = installDom();
+  const rootEl = document.getElementById("root");
+  if (!rootEl) throw new Error("missing root");
+  const root = createRoot(rootEl);
+  const ask: WireAsk = {
+    id: "ask-collapse",
+    questions: [{ id: "q1", prompt: "Choose one", options: [{ label: "Keep" }] }],
+  };
+  await act(async () => {
+    root.render(React.createElement(LocaleProvider, null,
+      React.createElement(AskCard, { ask, onAnswer: () => undefined, onDismiss: () => undefined, onStop: () => undefined }),
+    ));
+    await flushTimers();
+  });
+  const card = document.querySelector(".prompt-shelf__card") as HTMLElement | null;
+  const option = document.querySelector(".prompt-action") as HTMLButtonElement | null;
+  const collapse = [...document.querySelectorAll<HTMLButtonElement>(".prompt-shelf__header-button")]
+    .find((button) => button.getAttribute("aria-label") === "Collapse" || button.getAttribute("aria-label") === "收起");
+  if (!card || !option || !collapse) throw new Error("collapse controls did not render");
+  ok(card.classList.contains("prompt-shelf__card--collapsible"), "Ask exposes the shared collapsible shelf contract");
+  ok(!card.classList.contains("prompt-shelf__card--collapsed"), "Ask starts expanded");
+  await act(async () => { collapse.click(); await flushTimers(); });
+  ok(card.classList.contains("prompt-shelf__card--collapsed"), "collapse action hides the Ask body");
+  ok(Boolean(document.querySelector(".prompt-shelf__header")), "collapsed Ask keeps its header visible");
+  await act(async () => { collapse.click(); await flushTimers(); });
+  ok(!card.classList.contains("prompt-shelf__card--collapsed"), "expand action restores the Ask body");
+  await act(async () => { option.click(); await flushTimers(); });
+  ok(!card.classList.contains("prompt-shelf__card--collapsed"), "clicking an option does not collapse the Ask");
+  await act(async () => { root.unmount(); });
+  dom.window.close();
+}
+
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -754,6 +754,8 @@ console.log("\nask card layout");
   await act(async () => { collapse.click(); await flushTimers(); });
   ok(card.classList.contains("prompt-shelf__card--collapsed"), "collapse action hides the Ask body");
   ok(Boolean(document.querySelector(".prompt-shelf__header")), "collapsed Ask keeps its header visible");
+  eq(window.getComputedStyle(document.querySelector(".prompt-shelf__actions") as HTMLElement).display, "none", "collapsed Ask hides its option list");
+  eq(window.getComputedStyle(document.querySelector(".prompt-shelf__footer") as HTMLElement).display, "none", "collapsed Ask hides its footer");
   await act(async () => { collapse.click(); await flushTimers(); });
   ok(!card.classList.contains("prompt-shelf__card--collapsed"), "expand action restores the Ask body");
   await act(async () => { option.click(); await flushTimers(); });

--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -751,10 +751,10 @@ console.log("\nask card layout");
     id: "ask-session-draft",
     questions: [{ id: "q1", prompt: "Choose one", options: [{ label: "Keep" }, { label: "Change" }] }],
   };
-  const render = async () => {
+  const render = async (draftScope = "tab-a") => {
     await act(async () => {
       root.render(React.createElement(LocaleProvider, null,
-        React.createElement(AskCard, { ask, onAnswer: () => undefined, onDismiss: () => undefined, onStop: () => undefined }),
+        React.createElement(AskCard, { ask, draftScope, onAnswer: () => undefined, onDismiss: () => undefined, onStop: () => undefined }),
       ));
       await flushTimers();
     });
@@ -768,16 +768,25 @@ console.log("\nask card layout");
     await flushTimers();
   });
   await act(async () => { root.unmount(); });
+  const otherRoot = createRoot(rootEl);
+  await act(async () => {
+    otherRoot.render(React.createElement(LocaleProvider, null,
+      React.createElement(AskCard, { ask, draftScope: "tab-b", onAnswer: () => undefined, onDismiss: () => undefined, onStop: () => undefined }),
+    ));
+    await flushTimers();
+  });
+  ok(![...document.querySelectorAll<HTMLElement>(".prompt-action")].some((button) => button.getAttribute("aria-selected") === "true" && button.textContent?.includes("Change")), "Ask drafts do not cross tab scopes");
+  await act(async () => { otherRoot.unmount(); });
   const remountRoot = createRoot(rootEl);
   await act(async () => {
     remountRoot.render(React.createElement(LocaleProvider, null,
-      React.createElement(AskCard, { ask, onAnswer: () => undefined, onDismiss: () => undefined, onStop: () => undefined }),
+      React.createElement(AskCard, { ask, draftScope: "tab-a", onAnswer: () => undefined, onDismiss: () => undefined, onStop: () => undefined }),
     ));
     await flushTimers();
   });
   ok(!document.querySelector(".prompt-shelf__card--collapsed"), "a remounted Ask starts expanded like harness");
-  const restoredDraft = sessionStorage.getItem("reasonix.ask-draft:ask-session-draft") ?? "";
-  ok(restoredDraft.includes("Change"), "Ask answer draft restores from the tab session");
+  ok([...document.querySelectorAll<HTMLElement>(".prompt-action")]
+    .some((button) => button.getAttribute("aria-selected") === "true" && button.textContent?.includes("Change")), "Ask answer draft restores within the tab scope");
   await act(async () => { remountRoot.unmount(); });
   dom.window.close();
 }

--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -52,6 +52,7 @@ function installDom() {
   globalThis.KeyboardEvent = dom.window.KeyboardEvent;
   globalThis.MouseEvent = dom.window.MouseEvent;
   globalThis.localStorage = dom.window.localStorage;
+  globalThis.sessionStorage = dom.window.sessionStorage;
   globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
   globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
   Object.defineProperty(dom.window.HTMLElement.prototype, "clientHeight", {
@@ -746,6 +747,47 @@ console.log("\nask card layout");
   await act(async () => { option.click(); await flushTimers(); });
   ok(!card.classList.contains("prompt-shelf__card--collapsed"), "clicking an option does not collapse the Ask");
   await act(async () => { root.unmount(); });
+  dom.window.close();
+}
+
+// Session-scoped drafts restore when the Ask surface remounts in the same tab.
+{
+  const dom = installDom();
+  const rootEl = document.getElementById("root");
+  if (!rootEl) throw new Error("missing root");
+  const root = createRoot(rootEl);
+  const ask: WireAsk = {
+    id: "ask-session-draft",
+    questions: [{ id: "q1", prompt: "Choose one", options: [{ label: "Keep" }, { label: "Change" }] }],
+  };
+  const render = async () => {
+    await act(async () => {
+      root.render(React.createElement(LocaleProvider, null,
+        React.createElement(AskCard, { ask, onAnswer: () => undefined, onDismiss: () => undefined, onStop: () => undefined }),
+      ));
+      await flushTimers();
+    });
+  };
+  await render();
+  await act(async () => {
+    [...document.querySelectorAll<HTMLButtonElement>(".prompt-action")]
+      .find((button) => button.textContent?.includes("Change"))?.click();
+    [...document.querySelectorAll<HTMLButtonElement>(".prompt-shelf__header-button")]
+      .find((button) => button.getAttribute("aria-label") === "Collapse" || button.getAttribute("aria-label") === "收起")?.click();
+    await flushTimers();
+  });
+  await act(async () => { root.unmount(); });
+  const remountRoot = createRoot(rootEl);
+  await act(async () => {
+    remountRoot.render(React.createElement(LocaleProvider, null,
+      React.createElement(AskCard, { ask, onAnswer: () => undefined, onDismiss: () => undefined, onStop: () => undefined }),
+    ));
+    await flushTimers();
+  });
+  ok(Boolean(document.querySelector(".prompt-shelf__card--collapsed")), "Ask collapse state restores from the tab session");
+  const restoredDraft = sessionStorage.getItem("reasonix.ask-draft:ask-session-draft") ?? "";
+  ok(restoredDraft.includes("Change"), "Ask answer draft restores from the tab session");
+  await act(async () => { remountRoot.unmount(); });
   dom.window.close();
 }
 

--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -788,7 +788,7 @@ console.log("\nask card layout");
     ));
     await flushTimers();
   });
-  ok(Boolean(document.querySelector(".prompt-shelf__card--collapsed")), "Ask collapse state restores from the tab session");
+  ok(!document.querySelector(".prompt-shelf__card--collapsed"), "a remounted Ask starts expanded like harness");
   const restoredDraft = sessionStorage.getItem("reasonix.ask-draft:ask-session-draft") ?? "";
   ok(restoredDraft.includes("Change"), "Ask answer draft restores from the tab session");
   await act(async () => { remountRoot.unmount(); });

--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -680,13 +680,13 @@ console.log("\nask card layout");
   dom.window.close();
 }
 
-// Skip uses the same retry contract as an answered Ask.
+// Skip advances the current question and submits an empty answer on the last.
 {
   const dom = installDom();
   const rootEl = document.getElementById("root");
   if (!rootEl) throw new Error("missing root");
   const root = createRoot(rootEl);
-  let dismissAttempts = 0;
+  const submitted: QuestionAnswer[][] = [];
   const ask: WireAsk = {
     id: "ask-skip-retry",
     questions: [{ id: "q1", prompt: "Skip this?", options: [{ label: "Continue" }] }],
@@ -697,11 +697,8 @@ console.log("\nask card layout");
       React.createElement(LocaleProvider, null,
         React.createElement(AskCard, {
           ask,
-          onAnswer: () => undefined,
-          onDismiss: async () => {
-            dismissAttempts += 1;
-            if (dismissAttempts === 1) throw new Error("skip failed");
-          },
+          onAnswer: (_id: string, answers: QuestionAnswer[]) => { submitted.push(answers); },
+          onDismiss: () => undefined,
           onStop: () => undefined,
         }),
       ),
@@ -713,15 +710,8 @@ console.log("\nask card layout");
     document.querySelector<HTMLButtonElement>(".decision-confirm-bar__secondary")?.click();
     await flushTimers();
   });
-  eq(dismissAttempts, 1, "failed skip is attempted exactly once");
-  eq(Boolean(document.querySelector(".prompt-shelf--ask")), true, "failed skip keeps the Ask visible");
-  eq(document.querySelector<HTMLButtonElement>(".decision-confirm-bar__secondary")?.disabled, false, "failed skip re-enables the action");
-
-  await act(async () => {
-    document.querySelector<HTMLButtonElement>(".decision-confirm-bar__secondary")?.click();
-    await flushTimers();
-  });
-  eq(dismissAttempts, 2, "skip can be retried once after failure");
+  eq(submitted.length, 1, "skipping the final question submits once");
+  eq(submitted[0]?.[0]?.selected?.length, 0, "skipping submits an empty answer");
 
   await act(async () => { root.unmount(); });
   dom.window.close();

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -31,8 +31,9 @@ function readAskDraft(id: string): AskDraft | undefined {
 }
 
 // AskCard renders the `ask` tool as a decision shelf near the composer. It
-// walks multi-question asks one at a time. Selecting (click / digit) never
-// advances; Enter / Confirm submits or moves to the next question.
+// walks multi-question asks one at a time. Single-select choices advance to
+// the next question immediately; multi-select and custom answers wait for an
+// explicit confirm, and the final question still requires submission.
 export function AskCard({
   ask,
   onAnswer,
@@ -183,10 +184,12 @@ export function AskCard({
       if (q.multi) {
         toggleOption(q, option.label);
       } else {
-        // Single-select: click/digit only selects the row and marks the option.
+        // Single-select follows harness behavior: choose and advance, while
+        // keeping the answer in the draft so Back can revise it.
         setCustom((c) => ({ ...c, [q.id]: "" }));
         setSel((s) => ({ ...s, [q.id]: [option.label] }));
         setCustomOpen(false);
+        if (active < questions.length - 1) setActive((i) => i + 1);
       }
     } else if (index === customRowIndex) {
       // Opening custom clears option picks for this question.

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -10,7 +10,8 @@ import {
   PromptShelf,
 } from "./PromptShelf";
 
-const askDraftKey = (id: string) => `reasonix.ask-draft:${id}`;
+const askDrafts = new Map<string, AskDraft>();
+const askDraftKey = (scope: string, id: string) => `${scope}:${id}`;
 type AnswerMode = "option" | "custom";
 type AskDraft = {
   sel: Record<string, string[]>;
@@ -20,16 +21,13 @@ type AskDraft = {
   selectedIndex: number;
 };
 
-function readAskDraft(id: string): AskDraft | undefined {
-  try {
-    const raw = sessionStorage.getItem(askDraftKey(id));
-    if (!raw) return undefined;
-    const parsed = JSON.parse(raw) as Partial<AskDraft>;
-    if (!parsed.sel || !parsed.custom || !parsed.answerMode || typeof parsed.active !== "number" || typeof parsed.selectedIndex !== "number") return undefined;
-    return { sel: parsed.sel, custom: parsed.custom, answerMode: parsed.answerMode, active: parsed.active, selectedIndex: parsed.selectedIndex };
-  } catch {
-    return undefined;
-  }
+function readAskDraft(scope: string, id: string): AskDraft | undefined {
+  const draft = askDrafts.get(askDraftKey(scope, id));
+  return draft ? { ...draft, sel: { ...draft.sel }, custom: { ...draft.custom }, answerMode: { ...draft.answerMode } } : undefined;
+}
+
+function clearAskDraft(scope: string, id: string): void {
+  askDrafts.delete(askDraftKey(scope, id));
 }
 
 // AskCard renders the `ask` tool as a decision shelf near the composer. It
@@ -39,23 +37,25 @@ function readAskDraft(id: string): AskDraft | undefined {
 export function AskCard({
   ask,
   onAnswer,
+  draftScope = "default",
   onStop,
 }: {
   ask: WireAsk;
   onAnswer: (id: string, answers: QuestionAnswer[]) => void | Promise<void>;
   onDismiss?: () => void | Promise<void>;
+  draftScope?: string;
   onStop: () => void;
 }) {
   const t = useT();
   // Per-question state: selected option labels, and an optional typed answer.
-  const [sel, setSel] = useState<Record<string, string[]>>(() => readAskDraft(ask.id)?.sel ?? {});
-  const [custom, setCustom] = useState<Record<string, string>>(() => readAskDraft(ask.id)?.custom ?? {});
-  const [answerMode, setAnswerMode] = useState<Record<string, AnswerMode>>(() => readAskDraft(ask.id)?.answerMode ?? {});
+  const [sel, setSel] = useState<Record<string, string[]>>(() => readAskDraft(draftScope, ask.id)?.sel ?? {});
+  const [custom, setCustom] = useState<Record<string, string>>(() => readAskDraft(draftScope, ask.id)?.custom ?? {});
+  const [answerMode, setAnswerMode] = useState<Record<string, AnswerMode>>(() => readAskDraft(draftScope, ask.id)?.answerMode ?? {});
   const [customOpen, setCustomOpen] = useState(false);
-  const [active, setActive] = useState(() => readAskDraft(ask.id)?.active ?? 0);
+  const [active, setActive] = useState(() => readAskDraft(draftScope, ask.id)?.active ?? 0);
   // Extra decision row after option labels: custom answer. Skip is a
   // secondary footer action rather than an answer choice.
-  const [selectedIndex, setSelectedIndex] = useState(() => readAskDraft(ask.id)?.selectedIndex ?? 0);
+  const [selectedIndex, setSelectedIndex] = useState(() => readAskDraft(draftScope, ask.id)?.selectedIndex ?? 0);
   const [expandedDescriptionId, setExpandedDescriptionId] = useState<string | null>(null);
   const [descriptionTruncated, setDescriptionTruncated] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -64,6 +64,7 @@ export function AskCard({
   const [collapsed, setCollapsed] = useState(false);
   const shelfRef = useRef<HTMLDivElement | null>(null);
   const customInputRef = useRef<HTMLInputElement | null>(null);
+  const initializedActiveRef = useRef(false);
   const instanceId = useId();
 
   const questions = ask.questions;
@@ -86,7 +87,8 @@ export function AskCard({
 
   useEffect(() => {
     shelfRef.current?.focus();
-    const draft = readAskDraft(ask.id);
+    initializedActiveRef.current = false;
+    const draft = readAskDraft(draftScope, ask.id);
     setSel(draft?.sel ?? {});
     setCustom(draft?.custom ?? {});
     setAnswerMode(draft?.answerMode ?? {});
@@ -95,19 +97,20 @@ export function AskCard({
     setSelectedIndex(draft?.selectedIndex ?? 0);
     setSubmitting(false);
     setCollapsed(false);
-  }, [ask.id]);
+  }, [ask.id, draftScope]);
 
   useEffect(() => {
     try {
-      sessionStorage.setItem(askDraftKey(ask.id), JSON.stringify({ sel, custom, answerMode, active, selectedIndex } satisfies AskDraft));
+      askDrafts.set(askDraftKey(draftScope, ask.id), { sel: { ...sel }, custom: { ...custom }, answerMode: { ...answerMode }, active, selectedIndex });
     } catch {
-      // Session storage is best effort; the live pending ask remains authoritative.
+      // Draft storage is best effort; the live pending ask remains authoritative.
     }
-  }, [active, answerMode, ask.id, custom, selectedIndex, sel]);
+  }, [active, answerMode, ask.id, custom, draftScope, selectedIndex, sel]);
 
   useEffect(() => {
     setCustomOpen(false);
-    setSelectedIndex(0);
+    if (initializedActiveRef.current) setSelectedIndex(0);
+    initializedActiveRef.current = true;
   }, [active]);
 
   useEffect(() => {
@@ -152,7 +155,7 @@ export function AskCard({
     if (submitting) return;
     if (isLast) {
       submitAction(() => Promise.resolve(onAnswer(ask.id, answersFrom(nextSel, nextCustom))).then(() => {
-        sessionStorage.removeItem(askDraftKey(ask.id));
+        clearAskDraft(draftScope, ask.id);
       }));
       return;
     }
@@ -182,6 +185,11 @@ export function AskCard({
     setActive((i) => Math.max(0, i - 1));
   };
 
+  const stopAsk = () => {
+    clearAskDraft(draftScope, ask.id);
+    onStop();
+  };
+
   const skipCurrentQuestion = () => {
     if (submitting || !q) return;
     const nextSel = { ...sel, [q.id]: [] };
@@ -194,7 +202,7 @@ export function AskCard({
       return;
     }
     submitAction(() => Promise.resolve(onAnswer(ask.id, answersFrom(nextSel, nextCustom))).then(() => {
-      sessionStorage.removeItem(askDraftKey(ask.id));
+      clearAskDraft(draftScope, ask.id);
     }));
   };
 
@@ -266,7 +274,7 @@ export function AskCard({
 
       if (event.key === "Escape") {
         event.preventDefault();
-        onStop();
+        stopAsk();
         return;
       }
       if (event.key === "ArrowUp") {
@@ -343,7 +351,7 @@ export function AskCard({
           >
             {collapsed ? <ChevronUp size={15} aria-hidden="true" /> : <ChevronDown size={15} aria-hidden="true" />}
           </PromptHeaderAction>
-          <PromptHeaderAction onClick={onStop} ariaLabel={t("decision.stopTask")} disabled={submitting}>
+          <PromptHeaderAction onClick={stopAsk} ariaLabel={t("decision.stopTask")} disabled={submitting}>
             <X size={16} aria-hidden="true" />
           </PromptHeaderAction>
         </>

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -9,6 +9,27 @@ import {
   PromptShelf,
 } from "./PromptShelf";
 
+const askDraftKey = (id: string) => `reasonix.ask-draft:${id}`;
+type AskDraft = {
+  sel: Record<string, string[]>;
+  custom: Record<string, string>;
+  active: number;
+  selectedIndex: number;
+  collapsed: boolean;
+};
+
+function readAskDraft(id: string): AskDraft | undefined {
+  try {
+    const raw = sessionStorage.getItem(askDraftKey(id));
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Partial<AskDraft>;
+    if (!parsed.sel || !parsed.custom || typeof parsed.active !== "number" || typeof parsed.selectedIndex !== "number") return undefined;
+    return { sel: parsed.sel, custom: parsed.custom, active: parsed.active, selectedIndex: parsed.selectedIndex, collapsed: parsed.collapsed === true };
+  } catch {
+    return undefined;
+  }
+}
+
 // AskCard renders the `ask` tool as a decision shelf near the composer. It
 // walks multi-question asks one at a time. Selecting (click / digit) never
 // advances; Enter / Confirm submits or moves to the next question.
@@ -25,17 +46,17 @@ export function AskCard({
 }) {
   const t = useT();
   // Per-question state: selected option labels, and an optional typed answer.
-  const [sel, setSel] = useState<Record<string, string[]>>({});
-  const [custom, setCustom] = useState<Record<string, string>>({});
+  const [sel, setSel] = useState<Record<string, string[]>>(() => readAskDraft(ask.id)?.sel ?? {});
+  const [custom, setCustom] = useState<Record<string, string>>(() => readAskDraft(ask.id)?.custom ?? {});
   const [customOpen, setCustomOpen] = useState(false);
-  const [active, setActive] = useState(0);
+  const [active, setActive] = useState(() => readAskDraft(ask.id)?.active ?? 0);
   // Extra decision row after option labels: custom answer. Skip is a
   // secondary footer action rather than an answer choice.
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(() => readAskDraft(ask.id)?.selectedIndex ?? 0);
   const [expandedDescriptionId, setExpandedDescriptionId] = useState<string | null>(null);
   const [descriptionTruncated, setDescriptionTruncated] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(() => readAskDraft(ask.id)?.collapsed ?? false);
   const shelfRef = useRef<HTMLDivElement | null>(null);
   const customInputRef = useRef<HTMLInputElement | null>(null);
   const instanceId = useId();
@@ -60,13 +81,23 @@ export function AskCard({
 
   useEffect(() => {
     shelfRef.current?.focus();
-    setSel({});
-    setCustom({});
+    const draft = readAskDraft(ask.id);
+    setSel(draft?.sel ?? {});
+    setCustom(draft?.custom ?? {});
     setCustomOpen(false);
-    setActive(0);
-    setSelectedIndex(0);
+    setActive(draft?.active ?? 0);
+    setSelectedIndex(draft?.selectedIndex ?? 0);
     setSubmitting(false);
+    setCollapsed(draft?.collapsed ?? false);
   }, [ask.id]);
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(askDraftKey(ask.id), JSON.stringify({ sel, custom, active, selectedIndex, collapsed } satisfies AskDraft));
+    } catch {
+      // Session storage is best effort; the live pending ask remains authoritative.
+    }
+  }, [active, ask.id, collapsed, custom, selectedIndex, sel]);
 
   useEffect(() => {
     setCustomOpen(false);
@@ -112,7 +143,9 @@ export function AskCard({
   const finishOrAdvance = (nextSel = sel, nextCustom = custom) => {
     if (submitting) return;
     if (isLast) {
-      submitAction(() => onAnswer(ask.id, answersFrom(nextSel, nextCustom)));
+      submitAction(() => Promise.resolve(onAnswer(ask.id, answersFrom(nextSel, nextCustom))).then(() => {
+        sessionStorage.removeItem(askDraftKey(ask.id));
+      }));
       return;
     }
     setActive((i) => Math.min(i + 1, questions.length - 1));
@@ -379,7 +412,9 @@ export function AskCard({
           onConfirm={confirmSelected}
           secondaryLabel={t("ask.justChat")}
           onSecondary={() => {
-            submitAction(onDismiss);
+            submitAction(() => Promise.resolve(onDismiss()).then(() => {
+              sessionStorage.removeItem(askDraftKey(ask.id));
+            }));
           }}
           disabled={submitting}
           confirmDisabled={!canConfirm()}

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -316,7 +316,7 @@ export function AskCard({
       onToggleCollapse={() => setCollapsed((value) => !value)}
       barRef={shelfRef}
       titleId="ask-shelf-title"
-      title={t("ask.title")}
+      title={q.header ?? t("ask.title")}
       badges={
         <span className="ask-shelf__header-meta">
           {q.header && <span className="ask-shelf__header-text">{q.header}</span>}

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -35,6 +35,7 @@ export function AskCard({
   const [expandedDescriptionId, setExpandedDescriptionId] = useState<string | null>(null);
   const [descriptionTruncated, setDescriptionTruncated] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
   const shelfRef = useRef<HTMLDivElement | null>(null);
   const customInputRef = useRef<HTMLInputElement | null>(null);
   const instanceId = useId();
@@ -257,6 +258,9 @@ export function AskCard({
     <PromptShelf
       decision
       className="prompt-shelf--ask"
+      cardCollapsible
+      collapsed={collapsed}
+      onToggleCollapse={() => setCollapsed((value) => !value)}
       barRef={shelfRef}
       titleId="ask-shelf-title"
       title={t("ask.title")}
@@ -272,9 +276,18 @@ export function AskCard({
       }
       meta={q.prompt}
       headerActions={
-        <PromptHeaderAction onClick={onStop} ariaLabel={t("decision.stopTask")} disabled={submitting}>
-          {t("decision.stopTask")}
-        </PromptHeaderAction>
+        <>
+          <PromptHeaderAction
+            onClick={() => setCollapsed((value) => !value)}
+            ariaLabel={collapsed ? t("common.expand") : t("common.collapse")}
+            disabled={submitting}
+          >
+            {collapsed ? t("common.expand") : t("common.collapse")}
+          </PromptHeaderAction>
+          <PromptHeaderAction onClick={onStop} ariaLabel={t("decision.stopTask")} disabled={submitting}>
+            {t("decision.stopTask")}
+          </PromptHeaderAction>
+        </>
       }
       actions={
         <>

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -319,7 +319,6 @@ export function AskCard({
       title={q.header ?? t("ask.title")}
       badges={
         <span className="ask-shelf__header-meta">
-          {q.header && <span className="ask-shelf__header-text">{q.header}</span>}
           {hasMultipleQuestions && (
             <span className="ask-shelf__header-text ask-shelf__header-text--progress">
               {t("ask.questionProgress", { progress })}

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useT } from "../lib/i18n";
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, X } from "lucide-react";
 import type { QuestionAnswer, WireAsk, WireAskQuestion } from "../lib/types";
 import {
   DecisionConfirmBar,
@@ -318,10 +319,10 @@ export function AskCard({
             ariaLabel={collapsed ? t("common.expand") : t("common.collapse")}
             disabled={submitting}
           >
-            {collapsed ? t("common.expand") : t("common.collapse")}
+            {collapsed ? <ChevronUp size={15} aria-hidden="true" /> : <ChevronDown size={15} aria-hidden="true" />}
           </PromptHeaderAction>
           <PromptHeaderAction onClick={onStop} ariaLabel={t("decision.stopTask")} disabled={submitting}>
-            {t("decision.stopTask")}
+            <X size={16} aria-hidden="true" />
           </PromptHeaderAction>
         </>
       }
@@ -358,11 +359,6 @@ export function AskCard({
             disabled={submitting}
           />
         </>
-      }
-      quickActions={
-        active > 0 ? (
-          <PromptAction keyLabel="" label={t("ask.back")} onClick={goBack} quiet disabled={submitting} role="button" />
-        ) : undefined
       }
       crumbs={
         answeredSummary.length > 0 && (
@@ -409,19 +405,30 @@ export function AskCard({
         </>
       }
       footer={
-        <DecisionConfirmBar
-          hint={t("decision.selectHint")}
-          confirmLabel={confirmLabel}
-          onConfirm={confirmSelected}
-          secondaryLabel={t("ask.justChat")}
-          onSecondary={() => {
-            submitAction(() => Promise.resolve(onDismiss()).then(() => {
-              sessionStorage.removeItem(askDraftKey(ask.id));
-            }));
-          }}
-          disabled={submitting}
-          confirmDisabled={!canConfirm()}
-        />
+        <div className="ask-shelf__footer-layout">
+          <div className="ask-shelf__pager" aria-label={t("ask.questionProgress", { progress })}>
+            <button type="button" className="ask-shelf__pager-button" aria-label={t("ask.back")} disabled={active === 0 || submitting} onClick={goBack}>
+              <ChevronLeft size={16} aria-hidden="true" />
+            </button>
+            <span>{progress}</span>
+            <button type="button" className="ask-shelf__pager-button" aria-label={t("ask.next")} disabled={isLast || submitting} onClick={() => setActive((i) => Math.min(i + 1, questions.length - 1))}>
+              <ChevronRight size={16} aria-hidden="true" />
+            </button>
+          </div>
+          <DecisionConfirmBar
+            hint={t("decision.selectHint")}
+            confirmLabel={confirmLabel}
+            onConfirm={confirmSelected}
+            secondaryLabel={t("ask.justChat")}
+            onSecondary={() => {
+              submitAction(() => Promise.resolve(onDismiss()).then(() => {
+                sessionStorage.removeItem(askDraftKey(ask.id));
+              }));
+            }}
+            disabled={submitting}
+            confirmDisabled={!canConfirm()}
+          />
+        </div>
       }
     />
   );

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -365,14 +365,29 @@ export function AskCard({
               />
             );
           })}
-          <PromptAction
-            actionId={`${instanceId}-row-${customRowIndex}`}
-            keyLabel=""
-            label={t("ask.customAnswer")}
-            onClick={() => selectRow(customRowIndex)}
-            selected={selectedIndex === customRowIndex || customOpen}
-            disabled={submitting}
-          />
+          <div
+            className={`ask-shelf__custom-row${custom[q.id]?.trim() ? " ask-shelf__custom-row--active" : ""}`}
+            role="group"
+            onClick={() => { setSelectedIndex(customRowIndex); setCustomOpen(true); customInputRef.current?.focus(); }}
+          >
+            <span className="ask-shelf__custom-indicator" aria-hidden="true">✎</span>
+            <input
+              ref={customInputRef}
+              className="ask-shelf__custom"
+              aria-label={t("ask.customAnswer")}
+              placeholder={t("ask.customPlaceholder")}
+              value={custom[q.id] ?? ""}
+              disabled={submitting}
+              onChange={(e) => setTyped(q, e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canConfirm()) {
+                  e.preventDefault();
+                  confirmSelected();
+                }
+                e.stopPropagation();
+              }}
+            />
+          </div>
         </>
       }
       crumbs={
@@ -397,25 +412,6 @@ export function AskCard({
               onToggle={() => setExpandedDescriptionId((current) => current === selectedDescriptionId ? null : selectedDescriptionId)}
               disabled={submitting}
             />
-          )}
-          {customOpen && (
-            <div className="ask-shelf__custom-row">
-              <input
-                ref={customInputRef}
-                className="ask-shelf__custom"
-                placeholder={t("ask.customPlaceholder")}
-                value={custom[q.id] ?? ""}
-                disabled={submitting}
-                onChange={(e) => setTyped(q, e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && canConfirm()) {
-                    e.preventDefault();
-                    confirmSelected();
-                  }
-                  e.stopPropagation();
-                }}
-              />
-            </div>
           )}
         </>
       }

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -16,7 +16,6 @@ type AskDraft = {
   custom: Record<string, string>;
   active: number;
   selectedIndex: number;
-  collapsed: boolean;
 };
 
 function readAskDraft(id: string): AskDraft | undefined {
@@ -25,7 +24,7 @@ function readAskDraft(id: string): AskDraft | undefined {
     if (!raw) return undefined;
     const parsed = JSON.parse(raw) as Partial<AskDraft>;
     if (!parsed.sel || !parsed.custom || typeof parsed.active !== "number" || typeof parsed.selectedIndex !== "number") return undefined;
-    return { sel: parsed.sel, custom: parsed.custom, active: parsed.active, selectedIndex: parsed.selectedIndex, collapsed: parsed.collapsed === true };
+    return { sel: parsed.sel, custom: parsed.custom, active: parsed.active, selectedIndex: parsed.selectedIndex };
   } catch {
     return undefined;
   }
@@ -57,7 +56,9 @@ export function AskCard({
   const [expandedDescriptionId, setExpandedDescriptionId] = useState<string | null>(null);
   const [descriptionTruncated, setDescriptionTruncated] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-  const [collapsed, setCollapsed] = useState(() => readAskDraft(ask.id)?.collapsed ?? false);
+  // A newly delivered Ask always starts expanded, matching harness. Collapse
+  // is presentation state and must not leak from an earlier request.
+  const [collapsed, setCollapsed] = useState(false);
   const shelfRef = useRef<HTMLDivElement | null>(null);
   const customInputRef = useRef<HTMLInputElement | null>(null);
   const instanceId = useId();
@@ -89,16 +90,16 @@ export function AskCard({
     setActive(draft?.active ?? 0);
     setSelectedIndex(draft?.selectedIndex ?? 0);
     setSubmitting(false);
-    setCollapsed(draft?.collapsed ?? false);
+    setCollapsed(false);
   }, [ask.id]);
 
   useEffect(() => {
     try {
-      sessionStorage.setItem(askDraftKey(ask.id), JSON.stringify({ sel, custom, active, selectedIndex, collapsed } satisfies AskDraft));
+      sessionStorage.setItem(askDraftKey(ask.id), JSON.stringify({ sel, custom, active, selectedIndex } satisfies AskDraft));
     } catch {
       // Session storage is best effort; the live pending ask remains authoritative.
     }
-  }, [active, ask.id, collapsed, custom, selectedIndex, sel]);
+  }, [active, ask.id, custom, selectedIndex, sel]);
 
   useEffect(() => {
     setCustomOpen(false);

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -38,7 +38,6 @@ function readAskDraft(id: string): AskDraft | undefined {
 export function AskCard({
   ask,
   onAnswer,
-  onDismiss,
   onStop,
 }: {
   ask: WireAsk;
@@ -174,6 +173,22 @@ export function AskCard({
   const goBack = () => {
     if (submitting) return;
     setActive((i) => Math.max(0, i - 1));
+  };
+
+  const skipCurrentQuestion = () => {
+    if (submitting || !q) return;
+    const nextSel = { ...sel, [q.id]: [] };
+    const nextCustom = { ...custom, [q.id]: "" };
+    setSel(nextSel);
+    setCustom(nextCustom);
+    setCustomOpen(false);
+    if (!isLast) {
+      setActive((i) => i + 1);
+      return;
+    }
+    submitAction(() => Promise.resolve(onAnswer(ask.id, answersFrom(nextSel, nextCustom))).then(() => {
+      sessionStorage.removeItem(askDraftKey(ask.id));
+    }));
   };
 
   const selectRow = (index: number) => {
@@ -419,12 +434,8 @@ export function AskCard({
             hint={t("decision.selectHint")}
             confirmLabel={confirmLabel}
             onConfirm={confirmSelected}
-            secondaryLabel={t("ask.justChat")}
-            onSecondary={() => {
-              submitAction(() => Promise.resolve(onDismiss()).then(() => {
-                sessionStorage.removeItem(askDraftKey(ask.id));
-              }));
-            }}
+            secondaryLabel={t("ask.skipQuestion")}
+            onSecondary={skipCurrentQuestion}
             disabled={submitting}
             confirmDisabled={!canConfirm()}
           />

--- a/desktop/frontend/src/components/PromptShelf.tsx
+++ b/desktop/frontend/src/components/PromptShelf.tsx
@@ -82,8 +82,14 @@ export function PromptShelf({
         aria-labelledby={titleId}
         aria-describedby={descriptionId}
         tabIndex={cardCollapsible ? 0 : -1}
-        onClick={cardCollapsible ? onToggleCollapse : undefined}
+        onClick={cardCollapsible ? (event) => {
+          const target = event.target as HTMLElement;
+          if (target.closest("button, input, textarea, select, a, [role='button'], [role='option'], [role='radio'], [role='checkbox']")) return;
+          onToggleCollapse?.();
+        } : undefined}
         onKeyDown={cardCollapsible && onToggleCollapse ? (event) => {
+          const target = event.target as HTMLElement;
+          if (target.closest("button, input, textarea, select, a, [role='button'], [role='option'], [role='radio'], [role='checkbox']")) return;
           if (event.key === "Enter" || event.key === " ") {
             event.preventDefault();
             onToggleCollapse();

--- a/desktop/frontend/src/components/PromptShelf.tsx
+++ b/desktop/frontend/src/components/PromptShelf.tsx
@@ -60,6 +60,7 @@ export function PromptShelf({
     <div
       className={[
         "prompt-shelf",
+        "prompt-shelf--harness",
         decision ? "prompt-shelf--decision" : "",
         className ?? "",
       ]

--- a/desktop/frontend/src/components/RemoteSessionSurface.tsx
+++ b/desktop/frontend/src/components/RemoteSessionSurface.tsx
@@ -139,6 +139,7 @@ export function RemoteSessionSurface({ tab, session }: { tab: TabMeta; session: 
         <AskCard
           key={`${tab.id}:${ask.id}`}
           ask={ask}
+          draftScope={tab.id}
           onAnswer={(id, answers) => runAction(() => session.answer(id, answers.map((answer) => ({
             QuestionID: answer.questionId,
             Selected: answer.selected,

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -2733,7 +2733,7 @@ function makeMockApp(): AppBindings {
         emit({
           kind: "ask_request",
           ask: {
-            id: "mock-ask-preview",
+            id: `mock-ask-preview-${Date.now()}`,
             questions: [
               {
                 id: "q1",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1271,6 +1271,7 @@ export const en = {
   "ask.customPlaceholder": "Type your own answer…",
   "ask.justChat": "Skip and keep chatting",
   "ask.justChatDesc": "Submit empty answers and continue the conversation.",
+  "ask.skipQuestion": "Skip this question",
 
   // clear context confirmation
   "clearContext.title": "Clear current context",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1032,6 +1032,7 @@ export const zhTW: Record<DictKey, string> = {
   "ask.customPlaceholder": "輸入你自己的答案…",
   "ask.justChat": "跳過並繼續聊天",
   "ask.justChatDesc": "提交空回答並繼續對話。",
+  "ask.skipQuestion": "跳過本題",
 
   // 歷史抽屜
   "history.title": "歷史",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1272,6 +1272,7 @@ export const zh: Record<DictKey, string> = {
   "ask.customPlaceholder": "输入你自己的答案…",
   "ask.justChat": "跳过并继续聊天",
   "ask.justChatDesc": "提交空回答并继续对话。",
+  "ask.skipQuestion": "跳过本题",
 
   // 清空上下文确认
   "clearContext.title": "清空当前上下文",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -9132,6 +9132,52 @@ body > .mermaid-diagram--fullscreen {
   display: none;
 }
 
+/* Shared harness-style decision surface. Ask adds its own fields and pager;
+   every other PromptShelf keeps its domain controls inside this same visual
+   frame so approvals, forms, and MCP interactions read as one product. */
+.prompt-shelf--harness .prompt-shelf__card {
+  border-radius: 20px;
+  padding: 8px 12px 10px;
+  background: var(--bg-elev);
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--border-soft));
+}
+.prompt-shelf--harness .prompt-shelf__header {
+  align-items: center;
+  gap: 16px;
+  padding: 10px 4px 12px;
+}
+.prompt-shelf--harness .prompt-shelf__heading {
+  font-size: 16px;
+  font-weight: 650;
+}
+.prompt-shelf--harness .prompt-shelf__meta {
+  font-size: 14px;
+}
+.prompt-shelf--harness .prompt-shelf__header-actions {
+  gap: 8px;
+}
+.prompt-shelf--harness .prompt-shelf__header-button {
+  min-height: 32px;
+  border-radius: 999px;
+  padding: 0 10px;
+}
+.prompt-shelf--harness.prompt-shelf--decision .prompt-shelf__actions {
+  gap: 6px;
+}
+.prompt-shelf--harness.prompt-shelf--decision .prompt-action {
+  min-height: 38px;
+  height: 38px;
+  border-radius: 10px;
+  padding: 5px 10px;
+}
+.prompt-shelf--harness .prompt-shelf__footer {
+  padding-top: 10px;
+  margin-top: 4px;
+}
+.prompt-shelf--harness .decision-confirm-bar {
+  gap: 10px;
+}
+
 /* Todo shelf: header actions (collapse/close) appear on card hover/focus. */
 .prompt-shelf--todo .prompt-shelf__header-actions {
   opacity: 0;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10116,6 +10116,39 @@ body > .mermaid-diagram--fullscreen {
   padding: 4px 12px;
   border-radius: 999px;
 }
+.prompt-shelf--ask .prompt-shelf__card {
+  border-radius: 20px;
+  padding: 0 12px 10px;
+  background: var(--bg-elev);
+  border-color: color-mix(in srgb, var(--accent) 48%, var(--border-soft));
+}
+.prompt-shelf--ask .prompt-shelf__content { gap: 0; padding: 0 2px; }
+.prompt-shelf--ask .prompt-shelf__header { align-items: center; padding: 18px 4px 14px; gap: 16px; }
+.prompt-shelf--ask .prompt-shelf__heading { font-size: 16px; font-weight: 650; }
+.prompt-shelf--ask .prompt-shelf__header-actions { gap: 8px; }
+.prompt-shelf--ask .prompt-shelf__header-button {
+  width: 32px; height: 32px; min-height: 32px; padding: 0; border: 0; background: var(--bg-soft);
+}
+.prompt-shelf--ask .prompt-shelf__meta { font-size: 15px; }
+.prompt-shelf--ask .prompt-shelf__actions { gap: 6px; padding: 0 0 8px; }
+.prompt-shelf--ask .prompt-action { min-height: 46px; border-radius: 12px; padding: 9px 14px; background: var(--bg-soft); }
+.prompt-shelf--ask .prompt-action:hover,
+.prompt-shelf--ask .prompt-action--active,
+.prompt-shelf--ask .prompt-action--selected { background: color-mix(in srgb, var(--accent) 15%, var(--bg-soft)); }
+.prompt-shelf--ask .prompt-action__key { min-width: 28px; height: 28px; border-radius: 8px; font-size: 14px; }
+.ask-shelf__footer-layout { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.ask-shelf__pager { display: flex; align-items: center; gap: 8px; color: var(--fg-dim); font-size: 15px; white-space: nowrap; }
+.ask-shelf__pager-button { display: grid; place-items: center; width: 30px; height: 30px; border: 0; border-radius: 999px; background: transparent; color: var(--fg-dim); cursor: pointer; }
+.ask-shelf__pager-button:hover:not(:disabled) { background: var(--bg-soft); color: var(--fg); }
+.ask-shelf__pager-button:disabled { color: var(--fg-faint); cursor: default; }
+.prompt-shelf--ask .prompt-shelf__footer { padding: 12px 0 0; margin-top: 0; }
+.prompt-shelf--ask .decision-confirm-bar { justify-content: flex-end; gap: 10px; }
+.prompt-shelf--ask .decision-confirm-bar__hint { display: none; }
+@media (max-width: 680px) {
+  .ask-shelf__footer-layout { align-items: stretch; flex-direction: column; }
+  .ask-shelf__pager { justify-content: center; }
+  .prompt-shelf--ask .decision-confirm-bar { justify-content: space-between; }
+}
 .prompt-shelf__footnote {
   min-width: 0;
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10144,11 +10144,11 @@ body > .mermaid-diagram--fullscreen {
   display: flex;
   align-items: center;
   gap: 10px;
-  height: 46px;
-  min-height: 46px;
-  flex: 0 0 46px;
+  height: 38px;
+  min-height: 38px;
+  flex: 0 0 38px;
   margin-top: 2px;
-  padding: 9px 14px;
+  padding: 5px 14px;
   border: 1px solid var(--border-soft);
   border-radius: 12px;
   background: var(--bg-soft);
@@ -10157,7 +10157,7 @@ body > .mermaid-diagram--fullscreen {
 }
 .prompt-shelf--ask .ask-shelf__custom-row:focus-within,
 .prompt-shelf--ask .ask-shelf__custom-row--active { border-color: var(--accent); }
-.ask-shelf__custom-indicator { display: grid; place-items: center; flex: 0 0 28px; width: 28px; height: 28px; color: var(--fg-dim); font-size: 16px; line-height: 1; }
+.ask-shelf__custom-indicator { display: grid; place-items: center; flex: 0 0 24px; width: 24px; height: 24px; color: var(--fg-dim); font-size: 16px; line-height: 1; }
 .prompt-shelf--ask .ask-shelf__custom { height: 24px; min-height: 24px; border: 0; padding: 0; background: transparent; font-size: 14px; line-height: 24px; }
 .ask-shelf__footer-layout { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
 .ask-shelf__pager { display: flex; align-items: center; gap: 8px; color: var(--fg-dim); font-size: 15px; white-space: nowrap; }
@@ -10228,9 +10228,9 @@ body > .mermaid-diagram--fullscreen {
   display: flex;
   align-items: center;
   gap: 10px;
-  height: 46px;
-  min-height: 46px;
-  flex: 0 0 46px;
+  height: 38px;
+  min-height: 38px;
+  flex: 0 0 38px;
   box-sizing: border-box;
   overflow: hidden;
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10140,6 +10140,21 @@ body > .mermaid-diagram--fullscreen {
 .prompt-shelf--ask .prompt-action--active,
 .prompt-shelf--ask .prompt-action--selected { background: color-mix(in srgb, var(--accent) 15%, var(--bg-soft)); }
 .prompt-shelf--ask .prompt-action__key { min-width: 28px; height: 28px; border-radius: 8px; font-size: 14px; }
+.prompt-shelf--ask .ask-shelf__custom-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 46px;
+  margin-top: 2px;
+  padding: 9px 14px;
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  background: var(--bg-soft);
+}
+.prompt-shelf--ask .ask-shelf__custom-row:focus-within,
+.prompt-shelf--ask .ask-shelf__custom-row--active { border-color: var(--accent); }
+.ask-shelf__custom-indicator { color: var(--fg-dim); font-size: 18px; }
+.prompt-shelf--ask .ask-shelf__custom { border: 0; padding: 0; background: transparent; font-size: 14px; }
 .ask-shelf__footer-layout { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
 .ask-shelf__pager { display: flex; align-items: center; gap: 8px; color: var(--fg-dim); font-size: 15px; white-space: nowrap; }
 .ask-shelf__pager-button { display: grid; place-items: center; width: 30px; height: 30px; border: 0; border-radius: 999px; background: transparent; color: var(--fg-dim); cursor: pointer; }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10153,11 +10153,12 @@ body > .mermaid-diagram--fullscreen {
   border-radius: 12px;
   background: var(--bg-soft);
   overflow: hidden;
+  box-sizing: border-box;
 }
 .prompt-shelf--ask .ask-shelf__custom-row:focus-within,
 .prompt-shelf--ask .ask-shelf__custom-row--active { border-color: var(--accent); }
-.ask-shelf__custom-indicator { color: var(--fg-dim); font-size: 18px; }
-.prompt-shelf--ask .ask-shelf__custom { border: 0; padding: 0; background: transparent; font-size: 14px; }
+.ask-shelf__custom-indicator { display: grid; place-items: center; flex: 0 0 28px; width: 28px; height: 28px; color: var(--fg-dim); font-size: 16px; line-height: 1; }
+.prompt-shelf--ask .ask-shelf__custom { height: 24px; min-height: 24px; border: 0; padding: 0; background: transparent; font-size: 14px; line-height: 24px; }
 .ask-shelf__footer-layout { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
 .ask-shelf__pager { display: flex; align-items: center; gap: 8px; color: var(--fg-dim); font-size: 15px; white-space: nowrap; }
 .ask-shelf__pager-button { display: grid; place-items: center; width: 30px; height: 30px; border: 0; border-radius: 999px; background: transparent; color: var(--fg-dim); cursor: pointer; }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10224,13 +10224,24 @@ body > .mermaid-diagram--fullscreen {
   overflow-wrap: anywhere;
 }
 .prompt-shelf--ask .ask-shelf__custom-row {
-  margin-top: 4px;
-  display: grid;
-  gap: 4px;
+  margin-top: 2px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 46px;
+  min-height: 46px;
+  flex: 0 0 46px;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 .prompt-shelf--ask .ask-shelf__custom {
-  height: 30px;
-  padding: 0 9px;
+  height: 24px;
+  min-height: 24px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font-size: 14px;
+  line-height: 24px;
 }
 .prompt-shelf--runtime-decision .prompt-shelf__note {
   overflow: hidden;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10144,12 +10144,15 @@ body > .mermaid-diagram--fullscreen {
   display: flex;
   align-items: center;
   gap: 10px;
+  height: 46px;
   min-height: 46px;
+  flex: 0 0 46px;
   margin-top: 2px;
   padding: 9px 14px;
   border: 1px solid var(--border-soft);
   border-radius: 12px;
   background: var(--bg-soft);
+  overflow: hidden;
 }
 .prompt-shelf--ask .ask-shelf__custom-row:focus-within,
 .prompt-shelf--ask .ask-shelf__custom-row--active { border-color: var(--accent); }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10122,6 +10122,10 @@ body > .mermaid-diagram--fullscreen {
   background: var(--bg-elev);
   border-color: color-mix(in srgb, var(--accent) 48%, var(--border-soft));
 }
+.prompt-shelf--ask .prompt-shelf__card--collapsed .prompt-shelf__content > :not(.prompt-shelf__header),
+.prompt-shelf--ask .prompt-shelf__card--collapsed > .prompt-shelf__footer {
+  display: none !important;
+}
 .prompt-shelf--ask .prompt-shelf__content { gap: 0; padding: 0 2px; }
 .prompt-shelf--ask .prompt-shelf__header { align-items: center; padding: 18px 4px 14px; gap: 16px; }
 .prompt-shelf--ask .prompt-shelf__heading { font-size: 16px; font-weight: 650; }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -9183,6 +9183,22 @@ body > .mermaid-diagram--fullscreen {
   opacity: 0;
   transition: opacity 0.12s ease;
 }
+.prompt-shelf--todo .prompt-shelf__card--collapsed {
+  padding: 4px 10px;
+  border-radius: 14px;
+}
+.prompt-shelf--todo .prompt-shelf__card--collapsed .prompt-shelf__header {
+  gap: 10px;
+  padding: 4px 2px;
+}
+.prompt-shelf--todo .prompt-shelf__card--collapsed .prompt-shelf__heading,
+.prompt-shelf--todo .prompt-shelf__card--collapsed .prompt-shelf__meta {
+  font-size: 12px;
+}
+.prompt-shelf--todo .prompt-shelf__card--collapsed .prompt-shelf__header-button {
+  min-height: 26px;
+  padding: 0 8px;
+}
 
 .prompt-shelf--todo:hover .prompt-shelf__header-actions,
 .prompt-shelf--todo .prompt-shelf__header-button:focus-visible {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -9184,8 +9184,11 @@ body > .mermaid-diagram--fullscreen {
   transition: opacity 0.12s ease;
 }
 .prompt-shelf--todo .prompt-shelf__card--collapsed {
+  height: 42px;
+  min-height: 42px;
   padding: 4px 10px;
   border-radius: 14px;
+  box-sizing: border-box;
 }
 .prompt-shelf--todo .prompt-shelf__card--collapsed .prompt-shelf__header {
   gap: 10px;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -9184,8 +9184,8 @@ body > .mermaid-diagram--fullscreen {
   transition: opacity 0.12s ease;
 }
 .prompt-shelf--todo .prompt-shelf__card--collapsed {
-  height: 42px;
-  min-height: 42px;
+  height: 48px;
+  min-height: 48px;
   padding: 4px 10px;
   border-radius: 14px;
   box-sizing: border-box;


### PR DESCRIPTION
## Problem
The desktop Ask surface diverged from DeepSeek Harness: question cards could restore stale collapsed state, custom answers were hidden or misaligned, option rows had inconsistent heights, and other decision popups used different visual shells.

## Changes
- Port the Harness-style Ask presentation while keeping Reasonix `WireAsk`, controller, and answer protocols.
- Add compact Ask header controls, per-question pager, back/next/skip/submit behavior, inline custom answers, draft restoration, and fresh expanded Ask previews.
- Make collapsible shelves ignore interactive descendants so option and form controls do not toggle the card accidentally.
- Apply a shared Harness-style surface to PromptShelf consumers, including approvals, MCP interactions, runtime decisions, context clearing, and extension forms.
- Compact collapsed Todo shelves and keep their expanded checklist behavior unchanged.
- Add focused Ask regression coverage and bounded frontend bundle-budget ratchets for the shared surface.

## Verification
- `pnpm exec tsx src/__tests__/ask-card-layout.test.ts` — 114 passed
- `pnpm run typecheck`
- `pnpm run lint:hooks`
- `pnpm run check:css`
- `pnpm run build`
- Live `/mock-ask`, `/mock-long-options`, and `/todo-preview` browser inspection

## Scope
The shared shell unifies visual hierarchy and common controls. Domain-specific actions remain intact for approvals, MCP forms, runtime decisions, and extension forms.

Documentation-impact: none - existing documentation remains correct because this PR changes desktop implementation, styling, and QA mock coverage only.

## Review follow-up
- Isolated transient Ask drafts by tab/session scope plus request ID.
- Cleared drafts on successful answer, final skip, and stop/cancel.
- Added cross-scope isolation and remount restoration regression coverage.