### PR TITLE
docs: align Go prerequisites with the 1.26 module directives

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ everything you need to get started.
 
 ## Prerequisites
 
-- **Go 1.25+** — the project targets the latest stable Go release
+- **Go 1.26+** — the project targets the latest stable Go release
 - **Git** — for version control
 - **Node.js** (optional) — only if you work on the desktop app (`desktop/`)
 - **Wails CLI** (desktop only) — run `make wails-install` so the CLI matches

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,7 +115,7 @@ cd DeepSeek-Reasonix
 
 #### CLI
 
-CLI 构建需要 **Go 1.25+**。模块固定了 `toolchain` 指令；
+CLI 构建需要 **Go 1.26+**。模块固定了 `toolchain` 指令；
 保持 `GOTOOLCHAIN=auto` 让 Go 自动下载固定的工具链，或自行安装。
 
 ```sh


### PR DESCRIPTION
## Summary

Closes #9802

Both `go.mod` and `desktop/go.mod` declare `go 1.26.0` (toolchain `go1.26.6`), and `README.md` already states **Go 1.26+**. Two contributor-facing docs still said **Go 1.25+**:

- `README.zh-CN.md`: "CLI 构建需要 Go 1.25+"
- `CONTRIBUTING.md`: "Go 1.25+ — the project targets the latest stable Go release"

This PR aligns both to Go 1.26+ so all setup instructions match the modules' minimum version. No code changes.

## Cache-impact

None. Documentation-only change; no Go source, no cache-key-relevant files touched.

## Cache-guard

None. No CI workflow, build script, or cache configuration changes.

## Documentation-impact

This is the documentation fix itself: `README.zh-CN.md` and `CONTRIBUTING.md` now state Go 1.26+, consistent with `go.mod`, `desktop/go.mod`, and `README.md`.

## System-prompt-review

None. No prompt, agent-instruction, or system-prompt-adjacent content touched.