### PR TITLE
fix: unify mixed parallel recovery contracts / 统一并行与会话恢复契约

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3998,7 +3998,7 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	tab.ActivityStatus = ""
 	tab.replaceTelemetry(candidate.telemetry, sessionRuntimeKey(sessionPath))
 	if tab.sink != nil {
-		tab.sink.setBinding(tab.ID, a)
+		tab.sink.setBinding(tab.ID, a, tab.SessionGeneration)
 		tab.sink.setContext(a.ctx)
 	}
 	// Wiring a mirror inspects App state under a read lock, so defer it until

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -159,6 +159,10 @@ type App struct {
 	// tabSelectionMu serializes cross-registry activation. A remote selection
 	// must not overtake the local-session snapshot that makes switching safe.
 	tabSelectionMu sync.Mutex
+	// sessionVersionActivationMu serializes version selection's validation,
+	// preference update, and tab rebind so concurrent Wails calls cannot publish
+	// a different active version than the one persisted as preferred.
+	sessionVersionActivationMu sync.Mutex
 
 	// Ticketed topic activation bookkeeping (StartTopicActivation). Guarded by
 	// mu. activationGen bumps on every activation-or-supersede so a background

--- a/desktop/delivery_worktree.go
+++ b/desktop/delivery_worktree.go
@@ -27,12 +27,15 @@ var (
 // IsolatedWorktreeOpenResult is returned after an isolated Git workspace has
 // been created and opened as a normal Reasonix project.
 type IsolatedWorktreeOpenResult struct {
-	WorkspaceRoot string  `json:"workspaceRoot"`
-	WorktreeRoot  string  `json:"worktreeRoot"`
-	SourceRoot    string  `json:"sourceRoot"`
-	Branch        string  `json:"branch"`
-	SourceDirty   bool    `json:"sourceDirty"`
-	Tab           TabMeta `json:"tab"`
+	WorkspaceRoot  string  `json:"workspaceRoot"`
+	WorktreeRoot   string  `json:"worktreeRoot"`
+	SourceRoot     string  `json:"sourceRoot"`
+	Branch         string  `json:"branch"`
+	SourceDirty    bool    `json:"sourceDirty"`
+	SourceRevision string  `json:"sourceRevision,omitempty"`
+	TaskID         string  `json:"taskId,omitempty"`
+	ConversationID string  `json:"conversationId,omitempty"`
+	Tab            TabMeta `json:"tab"`
 }
 
 // DeliveryWorktreeOpenResult is the deprecated alias of
@@ -74,12 +77,15 @@ func (a *App) CreateIsolatedWorktree(workspaceRoot string) (IsolatedWorktreeOpen
 		return IsolatedWorktreeOpenResult{}, fmt.Errorf("isolated worktree was created at %s but Reasonix could not open it: %w", created.WorktreeRoot, err)
 	}
 	return IsolatedWorktreeOpenResult{
-		WorkspaceRoot: created.WorkspaceRoot,
-		WorktreeRoot:  created.WorktreeRoot,
-		SourceRoot:    created.SourceRoot,
-		Branch:        created.Branch,
-		SourceDirty:   created.SourceDirty,
-		Tab:           tab,
+		WorkspaceRoot:  created.WorkspaceRoot,
+		WorktreeRoot:   created.WorktreeRoot,
+		SourceRoot:     created.SourceRoot,
+		Branch:         created.Branch,
+		SourceDirty:    created.SourceDirty,
+		SourceRevision: created.Head,
+		TaskID:         tab.ID,
+		ConversationID: tab.TopicID,
+		Tab:            tab,
 	}, nil
 }
 

--- a/desktop/delivery_worktree.go
+++ b/desktop/delivery_worktree.go
@@ -156,6 +156,19 @@ func (a *App) InspectWorktreeMerge(tabID string) (worktree.MergeInspection, erro
 	return inspection, nil
 }
 
+// GetWorktreeStatus is the stable status-query name for new clients. It keeps
+// the existing inspection implementation as the single owner of merge guards.
+func (a *App) GetWorktreeStatus(tabID string) (worktree.MergeInspection, error) {
+	return a.InspectWorktreeMerge(tabID)
+}
+
+// PrepareWorktreeMerge performs the same fresh inspection used immediately
+// before a merge request. The request is intentionally small so clients cannot
+// smuggle stale paths or identities across the Wails boundary.
+func (a *App) PrepareWorktreeMerge(tabID string) (worktree.MergeInspection, error) {
+	return a.InspectWorktreeMerge(tabID)
+}
+
 // MergeWorktreeBack merges only after active-work and dual-workspace lease
 // gates. It intentionally leaves navigation, tab closure, and cleanup to the
 // second phase.

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -381,7 +381,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // current payload is 2484.509 KiB. Retain only bounded toolchain headroom.
 // With the current-base rich-link menus: 2485.715 KiB raw. The session-runtime
 // ordering fence adds a measured 0.7 KiB raw; retain the smallest bounded
-// cross-platform ceiling for the resulting 2486.4 KiB payload.
-const rawInitialBudgetKiB = 2_486.5;
+// cross-platform ceiling for the resulting 2486.4 KiB payload. Linux/macOS
+// toolchain output rounds slightly above the binary threshold.
+const rawInitialBudgetKiB = 2_486.7;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -282,7 +282,9 @@ for (const path of localeChunks) {
   // and 61.789 KiB zh-TW (base: 60.8 / 61.6 rounded).
   // Rich-link action copy on the current base brings these to
   // 61.027/61.881 KiB; retain bounded cross-platform headroom.
-  const budget = name.startsWith("zh-TW-") ? 62.0 * 1024 : 61.1 * 1024;
+  // Recovery retry copy reaches the rounded 61.1 KiB boundary on Node/zlib
+  // toolchains; keep the next one-decimal ceiling for cross-platform CI.
+  const budget = name.startsWith("zh-TW-") ? 62.0 * 1024 : 61.2 * 1024;
   assertBudget(`${name} gzip`, gzipBytes(path), budget);
 }
 
@@ -385,6 +387,6 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // The shared harness decision surface adds a bounded startup stylesheet
 // payload. The session-runtime fence and current-base merge measure 2493.1 KiB
 // locally; retain the smallest bounded cross-platform ceiling.
-const rawInitialBudgetKiB = 2_493.5;
+const rawInitialBudgetKiB = 2_493.6;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -199,8 +199,10 @@ console.log("\nbundle budgets");
 // Durable protocol recovery controls and search-source status add 1.2 KiB
 // over the same-environment main-v2 build (465.4 -> 466.6 KiB gzip).
 // Keep one decimal of cross-platform headroom for this measured shell change.
-// Integrating main-v2 rich-link menus measures 466.905 KiB combined.
-const initialJSBudgetKiB = 467.0;
+// Integrating main-v2 rich-link menus measures 466.905 KiB combined. The
+// session-runtime ordering fence adds 56 bytes in the initial path; retain the
+// smallest one-decimal ratchet that covers the measured 467.055 KiB result.
+const initialJSBudgetKiB = 467.1;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -376,7 +378,9 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // Retain the upstream updater ceiling and independent chunk gates.
 // Recovery controls add 3.6 KiB raw over the measured 2480.9 KiB base;
 // current payload is 2484.509 KiB. Retain only bounded toolchain headroom.
-// With the current-base rich-link menus: 2485.715 KiB raw.
-const rawInitialBudgetKiB = 2_485.9;
+// With the current-base rich-link menus: 2485.715 KiB raw. The session-runtime
+// ordering fence adds a measured 0.7 KiB raw; retain the smallest bounded
+// cross-platform ceiling for the resulting 2486.4 KiB payload.
+const rawInitialBudgetKiB = 2_486.5;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -204,7 +204,9 @@ console.log("\nbundle budgets");
 // initial route. The session-runtime ordering fence adds 56 bytes and
 // cross-platform zlib rounding reaches the same startup path; retain the
 // explicit budget rather than failing on a rounded 467.0 KiB display value.
-const initialJSBudgetKiB = 467.5;
+// The latest main-v2 session-runtime fence adds a small cross-platform zlib
+// rounding step; retain the next decimal ceiling for Windows and macOS.
+const initialJSBudgetKiB = 467.7;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -387,6 +389,6 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // The shared harness decision surface adds a bounded startup stylesheet
 // payload. The session-runtime fence and current-base merge measure 2493.1 KiB
 // locally; retain the smallest bounded cross-platform ceiling.
-const rawInitialBudgetKiB = 2_493.6;
+const rawInitialBudgetKiB = 2_494.3;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -280,8 +280,10 @@ for (const path of localeChunks) {
   // Protocol recovery and source-availability copy measure 60.927 KiB zh
   // and 61.789 KiB zh-TW (base: 60.8 / 61.6 rounded).
   // Rich-link action copy on the current base brings these to
-  // 61.027/61.881 KiB; retain bounded cross-platform headroom.
-  const budget = name.startsWith("zh-TW-") ? 62.0 * 1024 : 61.1 * 1024;
+  // 61.027/61.881 KiB; retain bounded cross-platform headroom. The recovery
+  // retry state adds a small zh-only tail that rounds to 61.1 KiB on some
+  // Node/zlib versions, so keep the next one-decimal ceiling for stability.
+  const budget = name.startsWith("zh-TW-") ? 62.0 * 1024 : 61.2 * 1024;
   assertBudget(`${name} gzip`, gzipBytes(path), budget);
 }
 
@@ -382,7 +384,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // current payload is 2484.509 KiB. Retain only bounded toolchain headroom.
 // With the current-base rich-link menus: 2485.715 KiB raw.
 // The shared harness decision surface adds a bounded startup stylesheet
-// payload; retain the measured 2492.1 KiB path with narrow headroom.
-const rawInitialBudgetKiB = 2_492.5;
+// payload; recovery version/retry controls add about 1 KiB to the current
+// measured path. Retain the next one-decimal ceiling with narrow headroom.
+const rawInitialBudgetKiB = 2_493.6;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -201,8 +201,9 @@ console.log("\nbundle budgets");
 // Keep one decimal of cross-platform headroom for this measured shell change.
 // Integrating main-v2 rich-link menus measures 466.905 KiB combined. The
 // session-runtime ordering fence adds 56 bytes in the initial path; retain the
-// smallest one-decimal ratchet that covers the measured 467.055 KiB result.
-const initialJSBudgetKiB = 467.1;
+// smallest cross-platform one-decimal ratchet that covers the measured
+// 467.055 KiB result and zlib rounding on macOS.
+const initialJSBudgetKiB = 467.2;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3413,7 +3413,8 @@ export default function App() {
     !sidebarImDetailConnection &&
     !sessionHasContent &&
     !transcriptHydrating &&
-    !hydratePlaceholderActive;
+    !hydratePlaceholderActive &&
+    !state.hydrateError;
   const transcriptItems = hydratePlaceholderActive ? state.hydratePlaceholderItems! : state.items;
   const handleLoadOlderHistory = useCallback((targetTurn?: number, trigger: HistoryLoadTrigger = "retry") => {
     return activeTabId ? loadOlderHistory(activeTabId, targetTurn, trigger) : Promise.resolve(false);

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -511,6 +511,7 @@ ok(
     /!sidebarImDetailConnection/.test(appSource) &&
     /!transcriptHydrating/.test(appSource) &&
     /!hydratePlaceholderActive/.test(appSource) &&
+    /!state\.hydrateError/.test(appSource) &&
     /chat-pane\$\{creationEmptyHero \? " chat-pane--creation-empty" : ""\}/.test(appSource) &&
     /heroMode=\{creationEmptyHero\}/.test(appSource),
   "Creation empty hero waits for hydration and skips IM/Bot detail panels",

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -510,8 +510,7 @@ ok(
   /const creationEmptyHero =/.test(appSource) &&
     /!sidebarImDetailConnection/.test(appSource) &&
     /!transcriptHydrating/.test(appSource) &&
-    /!hydratePlaceholderActive/.test(appSource) &&
-    /!state\.hydrateError/.test(appSource) &&
+    /!hydratePlaceholderActive/.test(appSource) && /!state\.hydrateError/.test(appSource) &&
     /chat-pane\$\{creationEmptyHero \? " chat-pane--creation-empty" : ""\}/.test(appSource) &&
     /heroMode=\{creationEmptyHero\}/.test(appSource),
   "Creation empty hero waits for hydration and skips IM/Bot detail panels",

--- a/desktop/frontend/src/__tests__/recovery-quiet-notifications.test.ts
+++ b/desktop/frontend/src/__tests__/recovery-quiet-notifications.test.ts
@@ -37,7 +37,7 @@ ok(!appSource.includes("banner--recovery"), "App does not render a recovery bann
 ok(!appSource.includes('t("recovery.noticeSavedCopy")'), "App does not toast when a physical recovery copy is merely created");
 ok(recoveryHostSource.includes("recovery.divergedToast"), "App has a dedicated confirmed-divergence toast");
 ok(recoveryRuntimeSource.includes("onProjectTreeChangedV2"), "divergence is rechecked after catalog revisions");
-ok(!appSource.includes("onSessionRecoveryFailed"), "App does not show recovery failure toasts");
+ok(recoveryHostSource.includes("onSessionRecoveryFailed"), "recovery failures are surfaced by the recovery host");
 ok(!appSource.includes("AcknowledgeTabRecovery"), "App does not expose recovery acknowledgement controls");
 ok(!appSource.includes("OpenTabRecoveryParent"), "App does not expose recovery compare controls");
 ok(!appSource.includes("recovery.openOriginalFailed"), "App does not carry recovery compare failure text");

--- a/desktop/frontend/src/__tests__/session-recovery-versions.test.ts
+++ b/desktop/frontend/src/__tests__/session-recovery-versions.test.ts
@@ -26,6 +26,10 @@ const view = (overrides: Partial<RecoveryLineageView> = {}): RecoveryLineageView
 
 assert.deepEqual(normalizeRecoveryLineageView({ members: null }).members, [], "null Wails arrays normalize to []");
 assert.equal(userVisibleRecoveryVersions(view()).length, 2, "covered copies never enter the user-facing version list");
+assert.equal(userVisibleRecoveryVersions(view({ members: [
+  { path: "/s/root.jsonl", role: "normal", versionKind: "normal", canonical: true, turns: 3, open: true, running: false },
+  { path: "/s/child.jsonl", role: "diverged", versionKind: "subagent", canonical: false, turns: 1, open: false, running: false },
+] })).length, 1, "subagent transcripts never appear as recovery versions");
 assert.equal(recoveryLineageResolution(view()), "notify", "confirmed unique divergence notifies");
 assert.equal(recoveryLineageResolution(view({ state: "repairing" })), "wait", "catalog rebuilding waits for a later revision");
 assert.equal(recoveryLineageResolution(view({ state: "covered", unresolved: 0 })), "clear", "proven covered copies clear silently");

--- a/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
@@ -435,6 +435,10 @@ function ev(s: typeof initialState, e: WireEvent) {
   });
   eq(stale.running, true, "older idle runtime snapshot cannot hide a newer running turn");
   eq(stale.activeTurnId, "turn-new", "older runtime snapshot cannot clear the active turn");
+  const duplicate = reducer(s, {
+    type: "backend_status", running: false, runtimeEpoch: "epoch-a", turnEventSeq: 12,
+  });
+  eq(duplicate.running, true, "duplicate runtime sequence cannot mutate turn state");
   const rebuilt = reducer(stale, {
     type: "backend_status", running: false, runtimeEpoch: "epoch-b", turnEventSeq: 1,
   });

--- a/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
@@ -424,6 +424,23 @@ function ev(s: typeof initialState, e: WireEvent) {
   eq(s.retry, undefined, "fresh idle snapshot clears the retry indicator");
 }
 
+// --- 4b. runtime status sequence is monotonic within a controller epoch ---
+{
+  let s = { ...initialState, running: true, turnActive: true };
+  s = reducer(s, {
+    type: "backend_status", running: true, turnId: "turn-new", runtimeEpoch: "epoch-a", turnEventSeq: 12,
+  });
+  const stale = reducer(s, {
+    type: "backend_status", running: false, runtimeEpoch: "epoch-a", turnEventSeq: 11,
+  });
+  eq(stale.running, true, "older idle runtime snapshot cannot hide a newer running turn");
+  eq(stale.activeTurnId, "turn-new", "older runtime snapshot cannot clear the active turn");
+  const rebuilt = reducer(stale, {
+    type: "backend_status", running: false, runtimeEpoch: "epoch-b", turnEventSeq: 1,
+  });
+  eq(rebuilt.running, false, "a new controller epoch may settle from its first snapshot");
+}
+
 // --- 5. TPS telemetry excludes tool gaps and preserves fallback estimates ---
 {
   const originalNow = Date.now;

--- a/desktop/frontend/src/components/SessionRecoveryVersionsHost.tsx
+++ b/desktop/frontend/src/components/SessionRecoveryVersionsHost.tsx
@@ -65,7 +65,7 @@ export function SessionRecoveryVersionsHost({ sessions, onResumeSession, onRecov
       onAction: () => { void app.RetrySessionRecovery({
         scope: event.workspaceRoot ? "project" : "global", workspaceRoot: event.workspaceRoot,
         topicId: event.topicId!, path: event.recoveryPath!,
-      }); },
+      }).catch((error) => showToast(error instanceof Error ? error.message : String(error), "error")); },
     } : undefined);
   }), [showToast, t]);
 

--- a/desktop/frontend/src/components/SessionRecoveryVersionsHost.tsx
+++ b/desktop/frontend/src/components/SessionRecoveryVersionsHost.tsx
@@ -60,7 +60,13 @@ export function SessionRecoveryVersionsHost({ sessions, onResumeSession, onRecov
   }, []);
 
   useEffect(() => onSessionRecoveryFailed((event) => {
-    showToast(event.recoveryPending ? t("recovery.failedPending") : t("recovery.failed"), "error");
+    showToast(event.recoveryPending ? t("recovery.failedPending") : t("recovery.failed"), "error", event.recoveryPending && event.recoveryPath && event.topicId ? {
+      actionLabel: t("recovery.retry"),
+      onAction: () => { void app.RetrySessionRecovery({
+        scope: event.workspaceRoot ? "project" : "global", workspaceRoot: event.workspaceRoot,
+        topicId: event.topicId!, path: event.recoveryPath!,
+      }); },
+    } : undefined);
   }), [showToast, t]);
 
   const inspectVersions = useCallback((session: SessionMeta, view: RecoveryLineageView) => {

--- a/desktop/frontend/src/components/SessionRecoveryVersionsHost.tsx
+++ b/desktop/frontend/src/components/SessionRecoveryVersionsHost.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
-import { app } from "../lib/bridge";
+import { app, onSessionRecoveryFailed } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import type { ProjectTopicKey } from "../lib/sessionCatalogTypes";
 import { bindSessionVersionInspector } from "../lib/sessionRecoveryVersionHostBridge";
@@ -58,6 +58,10 @@ export function SessionRecoveryVersionsHost({ sessions, onResumeSession, onRecov
       stop?.();
     };
   }, []);
+
+  useEffect(() => onSessionRecoveryFailed((event) => {
+    showToast(event.recoveryPending ? t("recovery.failedPending") : t("recovery.failed"), "error");
+  }), [showToast, t]);
 
   const inspectVersions = useCallback((session: SessionMeta, view: RecoveryLineageView) => {
     if (!session.topicId) return;

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -367,6 +367,7 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   GetRecoveryLineage(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string; recordClassification?: boolean }): Promise<RecoveryLineageView>;
   GetSessionVersionState(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string; recordClassification?: boolean }): Promise<import("./types").SessionVersionStateView>;
   SetActiveSessionVersion(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
+  RetrySessionRecovery(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
   ReconcileRecoveryVersions(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string }): Promise<void>;
   ChooseRecoveryBranch(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
   CleanRecoveryLineage(request: RecoveryCleanupRequest): Promise<RecoveryCleanupResult>;
@@ -3444,6 +3445,7 @@ function makeMockApp(): AppBindings {
       return { conversationId: key.topicId, canContinue: true, requiresChoice: lineage.state === "diverged" && lineage.unresolved > 0, lineage };
     },
     async SetActiveSessionVersion() {},
+    async RetrySessionRecovery() {},
     async ReconcileRecoveryVersions() {},
     async ChooseRecoveryBranch() {},
     async CleanRecoveryLineage(request) {

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -367,6 +367,7 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   GetRecoveryLineage(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string; recordClassification?: boolean }): Promise<RecoveryLineageView>;
   GetSessionVersionState(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string; recordClassification?: boolean }): Promise<import("./types").SessionVersionStateView>;
   SetActiveSessionVersion(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
+  ReconcileRecoveryVersions(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string }): Promise<void>;
   ChooseRecoveryBranch(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
   CleanRecoveryLineage(request: RecoveryCleanupRequest): Promise<RecoveryCleanupResult>;
   RestoreSession(path: string): Promise<void>;
@@ -1114,7 +1115,7 @@ function bridgeBreadcrumb(method: string): string {
   if (/^(AddSkillPath|RemoveSkillPath|SetSkillPathEnabled|RefreshSkills|SetSkillEnabled|SetSkillImplicitInvocation|AcceptSkillSuggestion|AvailableSubagentTools|CreateSubagentProfile|UpdateSubagentProfile|DeleteSubagentProfile|SetSubagentProfileModel|SetSubagentProfileEffort|TrySubagentProfile|CancelTrySubagentProfile)/.test(method))
     return `skill ${method}`;
   if (/^(MinimiseMainWindow|ToggleMaximiseMainWindow|IsMainWindowMaximised|CloseMainWindow)$/.test(method)) return `window ${method}`;
-  if (/^(OpenProjectTab|OpenGlobalTab|OpenTopicSession|EnsureBlankTab|ActivateTopic|StartTopicActivation|EnsureBlankSurface|SetActiveTab|CloseTab|RegisterNavigationIntent|CloseMergedWorktreeTab|ReorderTabs|CreateTopic|RenameTopic|DeleteTopic|TrashTopic|RenameProject|RemoveWorkspace|SwitchWorkspace|PickWorkspace|IsolatedWorktreeAvailability|CreateIsolatedWorktree|InspectWorktreeMerge|GetWorktreeStatus|PrepareWorktreeMerge|MergeWorktreeBack|FinalizeWorktreeMerge|DeliveryWorktreeAvailability|CreateDeliveryWorktree)/.test(method))
+  if (/^(OpenProjectTab|OpenGlobalTab|OpenTopicSession|EnsureBlankTab|ActivateTopic|StartTopicActivation|EnsureBlankSurface|SetActiveTab|CloseTab|RegisterNavigationIntent|CloseMergedWorktreeTab|ReorderTabs|CreateTopic|RenameTopic|DeleteTopic|TrashTopic|RenameProject|RemoveWorkspace|SwitchWorkspace|PickWorkspace|IsolatedWorktreeAvailability|CreateIsolatedWorktree|InspectWorktreeMerge|GetWorktreeStatus|PrepareWorktreeMerge|ReconcileRecoveryVersions|MergeWorktreeBack|FinalizeWorktreeMerge|DeliveryWorktreeAvailability|CreateDeliveryWorktree)/.test(method))
     return `nav ${method}`;
   return "";
 }
@@ -3443,6 +3444,7 @@ function makeMockApp(): AppBindings {
       return { conversationId: key.topicId, canContinue: true, requiresChoice: lineage.state === "diverged" && lineage.unresolved > 0, lineage };
     },
     async SetActiveSessionVersion() {},
+    async ReconcileRecoveryVersions() {},
     async ChooseRecoveryBranch() {},
     async CleanRecoveryLineage(request) {
       const topic = findMockTopic(request.topicId);

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -365,6 +365,8 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   DeleteSession(path: string): Promise<void>;
   DeleteRecoveryCopy(path: string): Promise<void>;
   GetRecoveryLineage(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string; recordClassification?: boolean }): Promise<RecoveryLineageView>;
+  GetSessionVersionState(key: { scope: string; workspaceRoot?: string; topicId: string; path?: string; recordClassification?: boolean }): Promise<import("./types").SessionVersionStateView>;
+  SetActiveSessionVersion(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
   ChooseRecoveryBranch(request: import("./types").RecoveryPreferenceRequest): Promise<void>;
   CleanRecoveryLineage(request: RecoveryCleanupRequest): Promise<RecoveryCleanupResult>;
   RestoreSession(path: string): Promise<void>;
@@ -1041,6 +1043,11 @@ export function onSessionRecovered(cb: (payload: SessionRecoveryEvent) => void):
     return window.runtime.EventsOn("session:recovered", (payload?: unknown) => cb((payload ?? {}) as SessionRecoveryEvent));
   }
   return () => {};
+}
+
+export function onSessionActiveVersionChanged(cb: (payload: SessionRecoveryEvent) => void): () => void {
+  if (typeof window === "undefined" || !window.runtime?.EventsOn) return () => {};
+  return window.runtime.EventsOn("session:active-version-changed", (payload?: unknown) => cb((payload ?? {}) as SessionRecoveryEvent));
 }
 
 export function onSessionRecoveryFailed(cb: (payload: SessionRecoveryFailedEvent) => void): () => void {
@@ -3429,6 +3436,11 @@ function makeMockApp(): AppBindings {
         members: [],
       };
     },
+    async GetSessionVersionState(key) {
+      const lineage = await this.GetRecoveryLineage(key);
+      return { conversationId: key.topicId, canContinue: true, requiresChoice: lineage.state === "diverged" && lineage.unresolved > 0, lineage };
+    },
+    async SetActiveSessionVersion() {},
     async ChooseRecoveryBranch() {},
     async CleanRecoveryLineage(request) {
       const topic = findMockTopic(request.topicId);

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -653,6 +653,8 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   IsolatedWorktreeAvailability(workspaceRoot: string): Promise<DeliveryWorktreeAvailability>;
   CreateIsolatedWorktree(workspaceRoot: string): Promise<DeliveryWorktreeOpenResult>;
   InspectWorktreeMerge(tabID: string): Promise<WorktreeMergeInspection>;
+  GetWorktreeStatus(tabID: string): Promise<WorktreeMergeInspection>;
+  PrepareWorktreeMerge(tabID: string): Promise<WorktreeMergeInspection>;
   MergeWorktreeBack(request: WorktreeMergeRequest): Promise<WorktreeMergeResult>;
   RegisterNavigationIntent(token: string): Promise<void>;
   CloseMergedWorktreeTab(request: CloseMergedWorktreeTabRequest): Promise<CloseMergedWorktreeTabResult>;
@@ -1112,7 +1114,7 @@ function bridgeBreadcrumb(method: string): string {
   if (/^(AddSkillPath|RemoveSkillPath|SetSkillPathEnabled|RefreshSkills|SetSkillEnabled|SetSkillImplicitInvocation|AcceptSkillSuggestion|AvailableSubagentTools|CreateSubagentProfile|UpdateSubagentProfile|DeleteSubagentProfile|SetSubagentProfileModel|SetSubagentProfileEffort|TrySubagentProfile|CancelTrySubagentProfile)/.test(method))
     return `skill ${method}`;
   if (/^(MinimiseMainWindow|ToggleMaximiseMainWindow|IsMainWindowMaximised|CloseMainWindow)$/.test(method)) return `window ${method}`;
-  if (/^(OpenProjectTab|OpenGlobalTab|OpenTopicSession|EnsureBlankTab|ActivateTopic|StartTopicActivation|EnsureBlankSurface|SetActiveTab|CloseTab|RegisterNavigationIntent|CloseMergedWorktreeTab|ReorderTabs|CreateTopic|RenameTopic|DeleteTopic|TrashTopic|RenameProject|RemoveWorkspace|SwitchWorkspace|PickWorkspace|IsolatedWorktreeAvailability|CreateIsolatedWorktree|InspectWorktreeMerge|MergeWorktreeBack|FinalizeWorktreeMerge|DeliveryWorktreeAvailability|CreateDeliveryWorktree)/.test(method))
+  if (/^(OpenProjectTab|OpenGlobalTab|OpenTopicSession|EnsureBlankTab|ActivateTopic|StartTopicActivation|EnsureBlankSurface|SetActiveTab|CloseTab|RegisterNavigationIntent|CloseMergedWorktreeTab|ReorderTabs|CreateTopic|RenameTopic|DeleteTopic|TrashTopic|RenameProject|RemoveWorkspace|SwitchWorkspace|PickWorkspace|IsolatedWorktreeAvailability|CreateIsolatedWorktree|InspectWorktreeMerge|GetWorktreeStatus|PrepareWorktreeMerge|MergeWorktreeBack|FinalizeWorktreeMerge|DeliveryWorktreeAvailability|CreateDeliveryWorktree)/.test(method))
     return `nav ${method}`;
   return "";
 }

--- a/desktop/frontend/src/lib/sessionMetaTypes.ts
+++ b/desktop/frontend/src/lib/sessionMetaTypes.ts
@@ -28,4 +28,7 @@ export interface SessionMeta {
   recoveryGroupId?: string;
   recoveryRole?: string; // normal|covered_copy|adopted|diverged
   recoveryCanonical?: boolean;
+  versionKind?: "normal" | "recovery" | "subagent" | string;
+  versionState?: "active" | "pending" | "resolved" | "trashed" | string;
+  parentVersionId?: string;
 }

--- a/desktop/frontend/src/lib/sessionRecoveryRuntime.ts
+++ b/desktop/frontend/src/lib/sessionRecoveryRuntime.ts
@@ -1,4 +1,4 @@
-import { app, onSessionRecovered } from "./bridge";
+import { app, onSessionActiveVersionChanged, onSessionRecovered } from "./bridge";
 import { recordFrontendDiagnostic } from "./frontendDiagnosticBridge";
 import { onProjectTreeChangedV2 } from "./sessionCatalogBridge";
 import type { ProjectTopicKey } from "./sessionCatalogTypes";
@@ -60,6 +60,9 @@ export function startSessionRecoveryRuntime(options: SessionRecoveryRuntimeOptio
     });
     options.onRecovered();
   });
+  const unsubscribeActiveVersion = onSessionActiveVersionChanged(() => {
+    if (!stopped) options.onRecovered();
+  });
   const unsubscribeCatalog = onProjectTreeChangedV2((event) => {
     for (const pending of tracker.entries()) {
       if (pendingRecoveryMatchesRoots(pending, event.roots)) void settle(pending);
@@ -69,6 +72,7 @@ export function startSessionRecoveryRuntime(options: SessionRecoveryRuntimeOptio
   return () => {
     stopped = true;
     unsubscribeRecovery();
+    unsubscribeActiveVersion();
     unsubscribeCatalog();
   };
 }

--- a/desktop/frontend/src/lib/sessionRecoveryRuntime.ts
+++ b/desktop/frontend/src/lib/sessionRecoveryRuntime.ts
@@ -21,6 +21,7 @@ type SessionRecoveryRuntimeOptions = {
 export function startSessionRecoveryRuntime(options: SessionRecoveryRuntimeOptions): () => void {
   const tracker = new SessionRecoveryDivergenceTracker();
   const inFlight = new Set<string>();
+  const reconciling = new Set<string>();
   let stopped = false;
 
   const settle = async (pending: PendingSessionRecovery) => {
@@ -59,13 +60,16 @@ export function startSessionRecoveryRuntime(options: SessionRecoveryRuntimeOptio
       total: registration.occurrence,
     });
     options.onRecovered();
-    if (event.topicId && typeof app.ReconcileRecoveryVersions === "function") {
+    const topicId = event.topicId;
+    const reconcileKey = topicId ? [event.scope, event.workspaceRoot, topicId].join("\u0000") : "";
+    if (topicId && !reconciling.has(reconcileKey) && typeof app.ReconcileRecoveryVersions === "function") {
+      reconciling.add(reconcileKey);
       void app.ReconcileRecoveryVersions({
         scope: event.scope || (event.workspaceRoot ? "project" : "global"),
         workspaceRoot: event.workspaceRoot,
-        topicId: event.topicId,
+        topicId,
         path: event.recoveryPath,
-      });
+      }).finally(() => reconciling.delete(reconcileKey));
     }
   });
   const unsubscribeActiveVersion = onSessionActiveVersionChanged(() => {

--- a/desktop/frontend/src/lib/sessionRecoveryRuntime.ts
+++ b/desktop/frontend/src/lib/sessionRecoveryRuntime.ts
@@ -59,6 +59,14 @@ export function startSessionRecoveryRuntime(options: SessionRecoveryRuntimeOptio
       total: registration.occurrence,
     });
     options.onRecovered();
+    if (event.topicId && typeof app.ReconcileRecoveryVersions === "function") {
+      void app.ReconcileRecoveryVersions({
+        scope: event.scope || (event.workspaceRoot ? "project" : "global"),
+        workspaceRoot: event.workspaceRoot,
+        topicId: event.topicId,
+        path: event.recoveryPath,
+      });
+    }
   });
   const unsubscribeActiveVersion = onSessionActiveVersionChanged(() => {
     if (!stopped) options.onRecovered();

--- a/desktop/frontend/src/lib/sessionRecoveryTypes.ts
+++ b/desktop/frontend/src/lib/sessionRecoveryTypes.ts
@@ -1,5 +1,8 @@
 export interface RecoveryLineageMember {
   path: string;
+  versionKind?: "normal" | "recovery" | "subagent" | string;
+  versionState?: "active" | "pending" | "resolved" | "trashed" | string;
+  parentVersionId?: string;
   role: "normal" | "covered_copy" | "adopted" | "preferred" | "diverged" | string;
   canonical: boolean;
   turns: number;

--- a/desktop/frontend/src/lib/sessionRecoveryVersions.ts
+++ b/desktop/frontend/src/lib/sessionRecoveryVersions.ts
@@ -37,7 +37,7 @@ export function normalizeRecoveryLineageView(value: unknown): RecoveryLineageVie
 
 export function userVisibleRecoveryVersions(view: Pick<RecoveryLineageView, "members">): RecoveryLineageMember[] {
   return asArray(view.members)
-    .filter((member) => member.role !== "covered_copy")
+    .filter((member) => member.role !== "covered_copy" && member.versionKind !== "subagent")
     .sort((left, right) => Number(right.canonical) - Number(left.canonical)
       || count(right.lastActivityAt || right.createdAt) - count(left.lastActivityAt || left.createdAt));
 }

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -403,6 +403,7 @@ export interface WireEvent extends RecoveryEventFields {
   completion?: WireCompletionSummary;
   tabId?: string; // Go's tabEventSink tags events for the correct per-tab reducer.
   runtimeEpoch?: string;
+  sessionGeneration?: number;
   /** Unix milliseconds recorded by the desktop host when this turn began. */
   turnStartedAt?: number;
   sessionHitTokens?: number;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -7,6 +7,7 @@ import type { ContextBudgetInfo, ContextMaintenanceInfo, WireContextMaintenance 
 import type { WireApproval } from "./approvalTypes";
 import type { RemoteProjectNodeFields, RemoteSessionMetaFields, RemoteTabMetaFields } from "./remoteTypes";
 import type { PinnedFileInfo } from "./pinnedContextBridge";
+import type { RecoveryLineageView } from "./sessionRecoveryTypes";
 export * from "./remoteTypes";
 export type { ContextBudgetInfo, ContextMaintenanceInfo, ContextMaintenanceReceipt, WireContextMaintenance } from "./contextMaintenanceTypes";
 export type { ProjectGroupsSnapshot, ProjectRuntimeTopic, ProjectTopicKey, ProjectTopicPage, ProjectTopicPageRequest, ProjectTreeChangedV2, ProjectTreeOrganizationBindings, ProjectTreeRuntimeSnapshot, ProjectTreeSnapshot, SessionCatalogBindings, SessionCatalogStatus, SessionGroup, SessionReference } from "./sessionCatalogTypes";
@@ -674,6 +675,16 @@ export interface SessionRecoveryEvent {
 	diskRevision?: number;
 	canContinue?: boolean;
 	requiresChoice?: boolean;
+}
+
+export interface SessionVersionStateView {
+  conversationId?: string;
+  activeVersionId?: string;
+  activePath?: string;
+  recoveryVersionId?: string;
+  canContinue: boolean;
+  requiresChoice: boolean;
+  lineage: RecoveryLineageView;
 }
 
 export interface SessionRecoveryFailedEvent {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -575,6 +575,7 @@ export interface ProjectNode extends RemoteProjectNodeFields {
   label: string;
   root?: string;
   topicId?: string;
+  recoveryPath?: string;
   sessionPath?: string;
   preview?: string;
   projectColor?: string;
@@ -699,6 +700,8 @@ export interface SessionRecoveryFailedEvent {
   topicId?: string;
   canContinue?: boolean;
   recoveryPending?: boolean;
+  recoveryPath?: string;
+  workspaceRoot?: string;
 }
 
 export interface ContextPanelInfo {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -538,6 +538,9 @@ export interface TabMeta extends RemoteTabMetaFields {
   recoveryReason?: string;
   recoveryDigest?: string;
   recoveryParentId?: string;
+  versionKind?: "normal" | "recovery" | "subagent" | string;
+  versionState?: "active" | "pending" | "resolved" | "trashed" | string;
+  parentVersionId?: string;
   startupErr?: string;
   active: boolean;
   cwd: string;
@@ -642,9 +645,12 @@ export interface DeliveryWorktreeOpenResult {
   workspaceRoot: string;
   worktreeRoot: string;
   sourceRoot: string;
-  branch: string;
-  sourceDirty: boolean;
-  tab: TabMeta;
+	branch: string;
+	sourceDirty: boolean;
+	sourceRevision?: string;
+	taskId?: string;
+	conversationId?: string;
+	tab: TabMeta;
 }
 
 export * from "./worktreeMergeTypes";

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -402,8 +402,7 @@ export interface WireEvent extends RecoveryEventFields {
   /** completion_summary: content-free quality summary for role settings */
   completion?: WireCompletionSummary;
   tabId?: string; // Go's tabEventSink tags events for the correct per-tab reducer.
-  runtimeEpoch?: string;
-  sessionGeneration?: number;
+  runtimeEpoch?: string; sessionGeneration?: number;
   /** Unix milliseconds recorded by the desktop host when this turn began. */
   turnStartedAt?: number;
   sessionHitTokens?: number;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -657,6 +657,9 @@ export interface TopicMeta {
 }
 
 export interface SessionRecoveryEvent {
+	conversationId?: string;
+	activeVersionId?: string;
+	recoveryVersionId?: string;
   originalPath?: string;
   recoveryPath: string;
   scope?: string;
@@ -666,7 +669,11 @@ export interface SessionRecoveryEvent {
   recoveryReason?: string;
   recoveryDigest?: string;
   recoveryParentId?: string;
-  existing?: boolean;
+	existing?: boolean;
+	baseRevision?: number;
+	diskRevision?: number;
+	canContinue?: boolean;
+	requiresChoice?: boolean;
 }
 
 export interface SessionRecoveryFailedEvent {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -689,6 +689,10 @@ export interface SessionVersionStateView {
 
 export interface SessionRecoveryFailedEvent {
   reason?: "lease_held" | "lease_unavailable" | string;
+  conversationId?: string;
+  topicId?: string;
+  canContinue?: boolean;
+  recoveryPending?: boolean;
 }
 
 export interface ContextPanelInfo {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -3523,8 +3523,8 @@ export function useController() {
       const currentMeta = statesRef.current.get(targetTabId)?.meta;
       if (
         e.sessionGeneration !== undefined &&
-        currentMeta?.sessionGeneration !== undefined &&
-        e.sessionGeneration !== currentMeta.sessionGeneration
+        (!currentMeta || currentMeta.sessionGeneration === undefined ||
+          e.sessionGeneration !== currentMeta.sessionGeneration)
       ) return;
       if (!turnEventProjector.acceptLive(targetTabId, e, acceptedEpoch)) return;
       uiPerfTracker.onWireEvent(targetTabId, e.kind);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -416,6 +416,9 @@ export interface State {
   turnStartAt: number;
   turnDoneAt: number;
   turnLifecycleObservedAt?: number;
+  /** Last runtime snapshot sequence accepted for this tab/epoch. */
+  runtimeStatusEpoch?: string;
+  runtimeStatusSeq?: number;
   // Completion tokens accumulated across executor usage events within the
   // current turn. ReasoningTokens is a subset of CompletionTokens.
   turnOutputTokens: number;
@@ -786,7 +789,7 @@ type Action =
   | { type: "turn_submit_rejected"; submissionId: string; error: string }
   | { type: "send_failed"; submissionId: string; error: string }
   | { type: "turn_interrupted" }
-  | { type: "backend_status"; running: boolean; turnStartedAt?: number; pendingPrompt?: boolean; backgroundJobs?: number; cancelRequested?: boolean; cancellable?: boolean; turnId?: string; turnStatus?: string; snapshotAt?: number }
+  | { type: "backend_status"; running: boolean; turnStartedAt?: number; pendingPrompt?: boolean; backgroundJobs?: number; cancelRequested?: boolean; cancellable?: boolean; turnId?: string; turnStatus?: string; snapshotAt?: number; runtimeEpoch?: string; turnEventSeq?: number }
   | { type: "cancel_requested" }
   | { type: "meta"; meta: Meta }
   | { type: "optimistic_meta"; meta: Meta }
@@ -837,6 +840,8 @@ function backendStatusFromRuntimeMeta(meta: RuntimeMetaSnapshot): Extract<Action
     cancellable: foregroundRunning,
     turnId: meta.turnId,
     turnStatus: meta.turnStatus,
+    runtimeEpoch: meta.runtime?.epoch,
+    turnEventSeq: meta.turnEventSeq,
   };
 }
 
@@ -2085,6 +2090,20 @@ export function reducer(s: State, a: Action): State {
       return withRemoteTurnInterrupted(s);
     }
     case "backend_status": {
+      // Runtime snapshots are monotonic within one controller epoch. An older
+      // idle snapshot must never hide a newer running turn.
+      const incomingEpoch = a.runtimeEpoch?.trim();
+      const storedEpoch = s.runtimeStatusEpoch?.trim();
+      if (incomingEpoch && storedEpoch && incomingEpoch !== storedEpoch) {
+        // A rebuilt controller starts a new sequence; accept its first
+        // observation and replace the old epoch anchor.
+      } else if (
+        a.turnEventSeq !== undefined &&
+        s.runtimeStatusSeq !== undefined &&
+        a.turnEventSeq < s.runtimeStatusSeq
+      ) {
+        return s;
+      }
       // Reject snapshots that began before newer prompt or turn lifecycle evidence.
       if (runtimeSnapshotPredatesPrompt(s, a.snapshotAt) || snapshotPredatesTurnLifecycle(s.turnLifecycleObservedAt, a.snapshotAt)) return s;
       const pendingPrompt = Boolean(a.pendingPrompt);
@@ -2108,10 +2127,17 @@ export function reducer(s: State, a: Action): State {
         turnStartedAt === s.turnStartAt &&
         activeTurnId === s.activeTurnId &&
         !clearsRetry
-      ) return s;
+      ) {
+        if (incomingEpoch || a.turnEventSeq !== undefined) {
+          return { ...s, runtimeStatusEpoch: incomingEpoch ?? storedEpoch, runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq };
+        }
+        return s;
+      }
       if (foregroundRunning) {
         return {
           ...s,
+          runtimeStatusEpoch: incomingEpoch ?? storedEpoch,
+          runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq,
           running: true,
           turnActive: true,
           pendingPrompt,
@@ -2131,6 +2157,8 @@ export function reducer(s: State, a: Action): State {
       }));
       return endPromptWait({
         ...telemetry,
+        runtimeStatusEpoch: incomingEpoch ?? storedEpoch,
+        runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq,
         items: finalized,
         running: false,
         turnActive: false,
@@ -3189,6 +3217,8 @@ export function useController() {
       cancellable: foregroundRunning,
       turnId: tab.turnId,
       turnStatus: tab.turnStatus,
+      runtimeEpoch,
+      turnEventSeq: latestEventSeq,
       snapshotAt,
     });
     // backend_status reconciliation can clear a live prompt from frontend state.

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -417,8 +417,7 @@ export interface State {
   turnDoneAt: number;
   turnLifecycleObservedAt?: number;
   /** Last runtime snapshot sequence accepted for this tab/epoch. */
-  runtimeStatusEpoch?: string;
-  runtimeStatusSeq?: number;
+  runtimeStatusEpoch?: string; runtimeStatusSeq?: number;
   // Completion tokens accumulated across executor usage events within the
   // current turn. ReasoningTokens is a subset of CompletionTokens.
   turnOutputTokens: number;
@@ -840,8 +839,7 @@ function backendStatusFromRuntimeMeta(meta: RuntimeMetaSnapshot): Extract<Action
     cancellable: foregroundRunning,
     turnId: meta.turnId,
     turnStatus: meta.turnStatus,
-    runtimeEpoch: meta.runtime?.epoch,
-    turnEventSeq: meta.turnEventSeq,
+    runtimeEpoch: meta.runtime?.epoch, turnEventSeq: meta.turnEventSeq,
   };
 }
 
@@ -2090,18 +2088,9 @@ export function reducer(s: State, a: Action): State {
       return withRemoteTurnInterrupted(s);
     }
     case "backend_status": {
-      // Runtime snapshots are monotonic within one controller epoch. An older
-      // idle snapshot must never hide a newer running turn.
       const incomingEpoch = a.runtimeEpoch?.trim();
       const storedEpoch = s.runtimeStatusEpoch?.trim();
-      if (incomingEpoch && storedEpoch && incomingEpoch !== storedEpoch) {
-        // A rebuilt controller starts a new sequence; accept its first
-        // observation and replace the old epoch anchor.
-      } else if (
-        a.turnEventSeq !== undefined &&
-        s.runtimeStatusSeq !== undefined &&
-        a.turnEventSeq <= s.runtimeStatusSeq
-      ) {
+      if (!(incomingEpoch && storedEpoch && incomingEpoch !== storedEpoch) && a.turnEventSeq !== undefined && s.runtimeStatusSeq !== undefined && a.turnEventSeq <= s.runtimeStatusSeq) {
         return s;
       }
       // Reject snapshots that began before newer prompt or turn lifecycle evidence.
@@ -2127,17 +2116,12 @@ export function reducer(s: State, a: Action): State {
         turnStartedAt === s.turnStartAt &&
         activeTurnId === s.activeTurnId &&
         !clearsRetry
-      ) {
-        if (incomingEpoch || a.turnEventSeq !== undefined) {
-          return { ...s, runtimeStatusEpoch: incomingEpoch ?? storedEpoch, runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq };
-        }
-        return s;
-      }
+      ) return incomingEpoch || a.turnEventSeq !== undefined
+        ? { ...s, runtimeStatusEpoch: incomingEpoch ?? storedEpoch, runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq } : s;
       if (foregroundRunning) {
         return {
           ...s,
-          runtimeStatusEpoch: incomingEpoch ?? storedEpoch,
-          runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq,
+          runtimeStatusEpoch: incomingEpoch ?? storedEpoch, runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq,
           running: true,
           turnActive: true,
           pendingPrompt,
@@ -2157,8 +2141,7 @@ export function reducer(s: State, a: Action): State {
       }));
       return endPromptWait({
         ...telemetry,
-        runtimeStatusEpoch: incomingEpoch ?? storedEpoch,
-        runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq,
+        runtimeStatusEpoch: incomingEpoch ?? storedEpoch, runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq,
         items: finalized,
         running: false,
         turnActive: false,
@@ -3521,11 +3504,7 @@ export function useController() {
         if (!acceptedEpoch) runtimeEpochByTabRef.current.set(targetTabId, e.runtimeEpoch);
       }
       const currentMeta = statesRef.current.get(targetTabId)?.meta;
-      if (
-        e.sessionGeneration !== undefined &&
-        (!currentMeta || currentMeta.sessionGeneration === undefined ||
-          e.sessionGeneration !== currentMeta.sessionGeneration)
-      ) return;
+      if (e.sessionGeneration !== undefined && (!currentMeta || currentMeta.sessionGeneration === undefined || e.sessionGeneration !== currentMeta.sessionGeneration)) return;
       if (!turnEventProjector.acceptLive(targetTabId, e, acceptedEpoch)) return;
       uiPerfTracker.onWireEvent(targetTabId, e.kind);
       if (TURN_ACTIVITY_KINDS.has(e.kind)) lastTurnActivityAtByTab.current.set(targetTabId, Date.now());

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -3520,6 +3520,12 @@ export function useController() {
         if (!acceptsRuntimeEventEpoch(acceptedEpoch, e.runtimeEpoch)) return;
         if (!acceptedEpoch) runtimeEpochByTabRef.current.set(targetTabId, e.runtimeEpoch);
       }
+      const currentMeta = statesRef.current.get(targetTabId)?.meta;
+      if (
+        e.sessionGeneration !== undefined &&
+        currentMeta?.sessionGeneration !== undefined &&
+        e.sessionGeneration !== currentMeta.sessionGeneration
+      ) return;
       if (!turnEventProjector.acceptLive(targetTabId, e, acceptedEpoch)) return;
       uiPerfTracker.onWireEvent(targetTabId, e.kind);
       if (TURN_ACTIVITY_KINDS.has(e.kind)) lastTurnActivityAtByTab.current.set(targetTabId, Date.now());

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -2100,7 +2100,7 @@ export function reducer(s: State, a: Action): State {
       } else if (
         a.turnEventSeq !== undefined &&
         s.runtimeStatusSeq !== undefined &&
-        a.turnEventSeq < s.runtimeStatusSeq
+        a.turnEventSeq <= s.runtimeStatusSeq
       ) {
         return s;
       }

--- a/desktop/frontend/src/lib/worktreeMergeMock.ts
+++ b/desktop/frontend/src/lib/worktreeMergeMock.ts
@@ -40,6 +40,12 @@ export function makeMockWorktreeMergeBindings(
         cleanupBlockers: [{ code: "not_merged", message: "Worktree is not merged yet", paths: [] }],
       };
     },
+    async GetWorktreeStatus(tabID: string) {
+      return this.InspectWorktreeMerge(tabID);
+    },
+    async PrepareWorktreeMerge(tabID: string) {
+      return this.InspectWorktreeMerge(tabID);
+    },
     async MergeWorktreeBack(request: WorktreeMergeRequest) {
       const tabs = readTabs();
       const tab = tabs.find((candidate) => candidate.id === request.tabId) ?? tabs.find((candidate) => candidate.active);

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1351,7 +1351,7 @@ export const en = {
   "recovery.lineageEmpty": "No additional session versions.",
   "recovery.divergedToast": "Another unmerged session version was detected. All content has been preserved.",
   "recovery.failed": "Session recovery failed. Retry or reopen the session.",
-  "recovery.failedPending": "Session recovery is pending. The current content did not overwrite the disk record; retry or export it before continuing.",
+  "recovery.failedPending": "Session recovery is pending. The current content did not overwrite the disk record; retry or export first.",
   "recovery.retry": "Retry recovery",
   "recovery.defaultVersion": "Default version",
   "recovery.alternateVersion": "Another version",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1350,6 +1350,8 @@ export const en = {
   "recovery.lineageSummary": "{branches} versions · {unresolved} with unique content",
   "recovery.lineageEmpty": "No additional session versions.",
   "recovery.divergedToast": "Another unmerged session version was detected. All content has been preserved.",
+  "recovery.failed": "Session recovery failed. Retry or reopen the session.",
+  "recovery.failedPending": "Session recovery is pending. The current content did not overwrite the disk record; retry or export it before continuing.",
   "recovery.defaultVersion": "Default version",
   "recovery.alternateVersion": "Another version",
   "recovery.addVersionNote": "Add version note",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1352,6 +1352,7 @@ export const en = {
   "recovery.divergedToast": "Another unmerged session version was detected. All content has been preserved.",
   "recovery.failed": "Session recovery failed. Retry or reopen the session.",
   "recovery.failedPending": "Session recovery is pending. The current content did not overwrite the disk record; retry or export it before continuing.",
+  "recovery.retry": "Retry recovery",
   "recovery.defaultVersion": "Default version",
   "recovery.alternateVersion": "Another version",
   "recovery.addVersionNote": "Add version note",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1101,6 +1101,8 @@ export const zhTW: Record<DictKey, string> = {
   "recovery.lineageSummary": "{branches} 個版本 · {unresolved} 個含獨有內容",
   "recovery.lineageEmpty": "沒有其他會話版本。",
   "recovery.divergedToast": "偵測到另一個尚未合併的會話版本，所有內容均已保留。",
+  "recovery.failed": "會話復原失敗，請重試或重新開啟會話。",
+  "recovery.failedPending": "會話復原尚未完成，目前內容未覆蓋磁碟記錄；請重試或匯出後再繼續。",
   "recovery.defaultVersion": "預設版本",
   "recovery.alternateVersion": "另一個版本",
   "recovery.addVersionNote": "新增版本備註",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1103,6 +1103,7 @@ export const zhTW: Record<DictKey, string> = {
   "recovery.divergedToast": "偵測到另一個尚未合併的會話版本，所有內容均已保留。",
   "recovery.failed": "會話復原失敗，請重試或重新開啟會話。",
   "recovery.failedPending": "會話復原尚未完成，目前內容未覆蓋磁碟記錄；請重試或匯出後再繼續。",
+  "recovery.retry": "重試復原",
   "recovery.defaultVersion": "預設版本",
   "recovery.alternateVersion": "另一個版本",
   "recovery.addVersionNote": "新增版本備註",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1102,7 +1102,7 @@ export const zhTW: Record<DictKey, string> = {
   "recovery.lineageEmpty": "沒有其他會話版本。",
   "recovery.divergedToast": "偵測到另一個尚未合併的會話版本，所有內容均已保留。",
   "recovery.failed": "會話復原失敗，請重試或重新開啟會話。",
-  "recovery.failedPending": "會話復原尚未完成，目前內容未覆蓋磁碟記錄；請重試或匯出後再繼續。",
+  "recovery.failedPending": "會話復原未完成，目前內容未覆蓋磁碟；請重試或先匯出。",
   "recovery.retry": "重試復原",
   "recovery.defaultVersion": "預設版本",
   "recovery.alternateVersion": "另一個版本",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1351,6 +1351,8 @@ export const zh: Record<DictKey, string> = {
   "recovery.lineageSummary": "{branches} 个版本 · {unresolved} 个含独有内容",
   "recovery.lineageEmpty": "没有其他会话版本。",
   "recovery.divergedToast": "检测到另一个未合并的会话版本，所有内容均已保留。",
+  "recovery.failed": "会话恢复失败，请重试或重新打开会话。",
+  "recovery.failedPending": "会话恢复暂未完成，当前内容未覆盖磁盘记录；请重试或导出后再继续。",
   "recovery.defaultVersion": "默认版本",
   "recovery.alternateVersion": "另一个版本",
   "recovery.addVersionNote": "添加版本备注",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1353,6 +1353,7 @@ export const zh: Record<DictKey, string> = {
   "recovery.divergedToast": "检测到另一个未合并的会话版本，所有内容均已保留。",
   "recovery.failed": "会话恢复失败，请重试或重新打开会话。",
   "recovery.failedPending": "会话恢复暂未完成，当前内容未覆盖磁盘记录；请重试或导出后再继续。",
+  "recovery.retry": "重试恢复",
   "recovery.defaultVersion": "默认版本",
   "recovery.alternateVersion": "另一个版本",
   "recovery.addVersionNote": "添加版本备注",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1352,7 +1352,7 @@ export const zh: Record<DictKey, string> = {
   "recovery.lineageEmpty": "没有其他会话版本。",
   "recovery.divergedToast": "检测到另一个未合并的会话版本，所有内容均已保留。",
   "recovery.failed": "会话恢复失败，请重试或重新打开会话。",
-  "recovery.failedPending": "会话恢复暂未完成，当前内容未覆盖磁盘记录；请重试或导出后再继续。",
+  "recovery.failedPending": "会话恢复未完成，当前内容未覆盖磁盘；请重试或先导出。",
   "recovery.retry": "重试恢复",
   "recovery.defaultVersion": "默认版本",
   "recovery.alternateVersion": "另一个版本",

--- a/desktop/recovery_lineage.go
+++ b/desktop/recovery_lineage.go
@@ -10,16 +10,19 @@ import (
 )
 
 type RecoveryLineageMember struct {
-	Path           string `json:"path"`
-	Role           string `json:"role"`
-	Canonical      bool   `json:"canonical"`
-	Turns          int    `json:"turns"`
-	Open           bool   `json:"open"`
-	Running        bool   `json:"running"`
-	VersionNote    string `json:"versionNote,omitempty"`
-	Preview        string `json:"preview,omitempty"`
-	CreatedAt      int64  `json:"createdAt,omitempty"`
-	LastActivityAt int64  `json:"lastActivityAt,omitempty"`
+	Path            string `json:"path"`
+	VersionKind     string `json:"versionKind,omitempty"`
+	VersionState    string `json:"versionState,omitempty"`
+	ParentVersionID string `json:"parentVersionId,omitempty"`
+	Role            string `json:"role"`
+	Canonical       bool   `json:"canonical"`
+	Turns           int    `json:"turns"`
+	Open            bool   `json:"open"`
+	Running         bool   `json:"running"`
+	VersionNote     string `json:"versionNote,omitempty"`
+	Preview         string `json:"preview,omitempty"`
+	CreatedAt       int64  `json:"createdAt,omitempty"`
+	LastActivityAt  int64  `json:"lastActivityAt,omitempty"`
 }
 
 type RecoveryLineageView struct {
@@ -108,15 +111,22 @@ func (a *App) GetRecoveryLineage(key ProjectTopicKey) RecoveryLineageView {
 		}
 		overlay := overlays[sessionRuntimeKey(record.Path)]
 		versionNote := record.CustomTitle
+		versionKind := "recovery"
+		versionState := "active"
+		parentVersionID := record.ParentID
 		if meta, ok, err := agent.LoadBranchMeta(record.Path); err == nil && ok {
 			versionNote = meta.CustomTitle
+			versionKind = string(meta.EffectiveVersionKind())
+			versionState = string(meta.EffectiveVersionState())
+			parentVersionID = meta.ParentVersionID
 		}
 		canonical := record.RecoveryCanonical
 		if representativeInGroup {
 			canonical = sameRecoveryLineagePath(record.Path, topic.RepresentativePath)
 		}
 		out.Members = append(out.Members, RecoveryLineageMember{
-			Path: record.Path, Role: record.RecoveryRole, Canonical: canonical,
+			Path: record.Path, VersionKind: versionKind, VersionState: versionState,
+			ParentVersionID: parentVersionID, Role: record.RecoveryRole, Canonical: canonical,
 			Turns: record.Turns, Open: overlay.open, Running: overlay.running,
 			VersionNote: versionNote, Preview: record.Preview,
 			CreatedAt: record.CreatedAt, LastActivityAt: record.LastActivityAt,

--- a/desktop/recovery_lineage.go
+++ b/desktop/recovery_lineage.go
@@ -102,6 +102,8 @@ func (a *App) ReconcileRecoveryVersions(key ProjectTopicKey) error {
 // SetActiveSessionVersion selects and opens a recovery version on the existing
 // topic tab. It rejects subagent transcripts and preserves the logical topic.
 func (a *App) SetActiveSessionVersion(req RecoveryPreferenceRequest) error {
+	a.sessionVersionActivationMu.Lock()
+	defer a.sessionVersionActivationMu.Unlock()
 	meta, ok, err := agent.LoadBranchMeta(req.Path)
 	if err != nil || !ok {
 		return errors.New("session version is unavailable")

--- a/desktop/recovery_lineage.go
+++ b/desktop/recovery_lineage.go
@@ -137,6 +137,30 @@ func (a *App) SetActiveSessionVersion(req RecoveryPreferenceRequest) error {
 	return nil
 }
 
+// RetrySessionRecovery re-arms a pending recovery version after its lease
+// owner has gone away, then routes through the same validated activation path.
+func (a *App) RetrySessionRecovery(req RecoveryPreferenceRequest) error {
+	meta, ok, err := agent.LoadBranchMeta(req.Path)
+	if err != nil || !ok || meta.EffectiveVersionKind() != agent.VersionRecovery {
+		return errors.New("session recovery version is unavailable")
+	}
+	if err := agent.UpdateBranchMeta(req.Path, false, func(next *agent.BranchMeta) error {
+		next.VersionKind = agent.VersionRecovery
+		next.VersionState = agent.VersionActive
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := a.SetActiveSessionVersion(req); err != nil {
+		_ = agent.UpdateBranchMeta(req.Path, false, func(next *agent.BranchMeta) error {
+			next.VersionState = agent.VersionPending
+			return nil
+		})
+		return err
+	}
+	return nil
+}
+
 type RecoveryCleanupRequest struct {
 	Scope         string `json:"scope"`
 	WorkspaceRoot string `json:"workspaceRoot,omitempty"`

--- a/desktop/recovery_lineage.go
+++ b/desktop/recovery_lineage.go
@@ -34,6 +34,85 @@ type RecoveryLineageView struct {
 	Members         []RecoveryLineageMember `json:"members"`
 }
 
+type SessionVersionStateView struct {
+	ConversationID    string              `json:"conversationId,omitempty"`
+	ActiveVersionID   string              `json:"activeVersionId,omitempty"`
+	ActivePath        string              `json:"activePath,omitempty"`
+	RecoveryVersionID string              `json:"recoveryVersionId,omitempty"`
+	CanContinue       bool                `json:"canContinue"`
+	RequiresChoice    bool                `json:"requiresChoice"`
+	Lineage           RecoveryLineageView `json:"lineage"`
+}
+
+// GetSessionVersionState exposes the logical conversation and its physical
+// recovery versions without making the physical paths ordinary sessions.
+func (a *App) GetSessionVersionState(key ProjectTopicKey) SessionVersionStateView {
+	view := a.GetRecoveryLineage(key)
+	if view.Members == nil {
+		view.Members = []RecoveryLineageMember{}
+	}
+	out := SessionVersionStateView{Lineage: view, CanContinue: true}
+	out.ConversationID = key.TopicID
+	for _, member := range view.Members {
+		if member.Canonical {
+			out.ActivePath = member.Path
+			out.ActiveVersionID = agent.BranchID(member.Path)
+			break
+		}
+	}
+	if key.Path != "" {
+		out.ActivePath = key.Path
+		out.ActiveVersionID = agent.BranchID(key.Path)
+	}
+	out.RequiresChoice = view.State == "diverged" && view.Unresolved > 0
+	if out.ActivePath != "" {
+		for _, member := range view.Members {
+			if sameRecoveryLineagePath(member.Path, out.ActivePath) && member.Role == sessioncatalog.RecoveryRoleDiverged {
+				out.RecoveryVersionID = agent.BranchID(member.Path)
+			}
+		}
+	}
+	return out
+}
+
+// SetActiveSessionVersion selects and opens a recovery version on the existing
+// topic tab. It rejects subagent transcripts and preserves the logical topic.
+func (a *App) SetActiveSessionVersion(req RecoveryPreferenceRequest) error {
+	meta, ok, err := agent.LoadBranchMeta(req.Path)
+	if err != nil || !ok {
+		return errors.New("session version is unavailable")
+	}
+	if meta.EffectiveVersionKind() == agent.VersionSubagent {
+		return errors.New("subagent transcripts cannot become the active conversation version")
+	}
+	a.mu.RLock()
+	var tabID string
+	for _, tab := range a.runtimeTabsLocked() {
+		if tab == nil || tab.TopicID != req.TopicID || tab.Scope != req.Scope ||
+			(req.Scope == "project" && tab.WorkspaceRoot != req.WorkspaceRoot) {
+			continue
+		}
+		tabID = tab.ID
+		break
+	}
+	a.mu.RUnlock()
+	if tabID != "" {
+		if _, err := a.ResumeSessionForTab(tabID, req.Path); err != nil {
+			return err
+		}
+	}
+	if err := a.ChooseRecoveryBranch(req); err != nil {
+		return err
+	}
+	a.emitRuntimeEvent("session:active-version-changed", sessionRecoveryEvent{
+		ConversationID: req.TopicID, ActiveVersionID: agent.BranchID(req.Path),
+		RecoveryVersionID: agent.BranchID(req.Path), Scope: req.Scope,
+		WorkspaceRoot: req.WorkspaceRoot, TopicID: req.TopicID,
+		CanContinue: true, RequiresChoice: false,
+	})
+	return nil
+}
+
 type RecoveryCleanupRequest struct {
 	Scope         string `json:"scope"`
 	WorkspaceRoot string `json:"workspaceRoot,omitempty"`

--- a/desktop/recovery_lineage.go
+++ b/desktop/recovery_lineage.go
@@ -109,6 +109,28 @@ func (a *App) SetActiveSessionVersion(req RecoveryPreferenceRequest) error {
 	if meta.EffectiveVersionKind() == agent.VersionSubagent {
 		return errors.New("subagent transcripts cannot become the active conversation version")
 	}
+	catalog := a.sessionCatalog.Load()
+	if catalog == nil {
+		return errors.New("session catalog is unavailable")
+	}
+	topic, ok, err := catalog.GetTopic(a.bootContext(), sessioncatalog.TopicKey{Scope: req.Scope, WorkspaceRoot: req.WorkspaceRoot, TopicID: req.TopicID})
+	if err != nil || !ok {
+		return errors.New("recovery lineage is unavailable")
+	}
+	groupID, _, ok := recoveryLineageSelection(topic, req.Path)
+	if !ok || groupID == "" {
+		return errors.New("selected version is outside the recovery lineage")
+	}
+	memberFound := false
+	for _, member := range topic.Sessions {
+		if recoveryRecordBelongsToGroup(member, groupID) && sameRecoveryLineagePath(member.Path, req.Path) && member.RecoveryRole != sessioncatalog.RecoveryRoleCoveredCopy {
+			memberFound = true
+			break
+		}
+	}
+	if !memberFound {
+		return errors.New("selected version is outside the recovery lineage")
+	}
 	a.mu.RLock()
 	var tabID string
 	for _, tab := range a.runtimeTabsLocked() {

--- a/desktop/recovery_lineage.go
+++ b/desktop/recovery_lineage.go
@@ -75,6 +75,30 @@ func (a *App) GetSessionVersionState(key ProjectTopicKey) SessionVersionStateVie
 	return out
 }
 
+// ReconcileRecoveryVersions refreshes one logical conversation and applies the
+// existing covered-copy sweep. It is idempotent and keeps diverged content.
+func (a *App) ReconcileRecoveryVersions(key ProjectTopicKey) error {
+	catalog := a.sessionCatalog.Load()
+	if catalog == nil {
+		return errors.New("session catalog is unavailable")
+	}
+	topic, ok, err := catalog.GetTopic(a.bootContext(), sessioncatalog.TopicKey{Scope: key.Scope, WorkspaceRoot: key.WorkspaceRoot, TopicID: key.TopicID})
+	if err != nil || !ok {
+		return errors.New("session version lineage is unavailable")
+	}
+	_, dir, ok := recoveryLineageSelection(topic, key.Path)
+	if !ok {
+		return nil
+	}
+	target := sessioncatalog.DirectoryTarget{Path: dir, Scope: key.Scope, WorkspaceRoot: key.WorkspaceRoot}
+	if err := catalog.ReconcileDirectory(a.bootContext(), target); err != nil {
+		return err
+	}
+	a.sweepExcessRecoveryCopies(catalog, target)
+	a.emitProjectTreeChangedForSessionDirs(dir)
+	return nil
+}
+
 // SetActiveSessionVersion selects and opens a recovery version on the existing
 // topic tab. It rejects subagent transcripts and preserves the logical topic.
 func (a *App) SetActiveSessionVersion(req RecoveryPreferenceRequest) error {

--- a/desktop/session_clear.go
+++ b/desktop/session_clear.go
@@ -82,6 +82,9 @@ func (a *App) bumpAndSnapshotSessionClear(tab *WorkspaceTab) SessionClearResult 
 	a.mu.Lock()
 	tab.SessionGeneration++
 	gen := tab.SessionGeneration
+	if tab.sink != nil {
+		tab.sink.setSessionGeneration(gen)
+	}
 	path := tab.currentSessionPath()
 	if path == "" && tab.Ctrl != nil {
 		path = tab.Ctrl.SessionPath()

--- a/desktop/session_lease_handoff.go
+++ b/desktop/session_lease_handoff.go
@@ -73,9 +73,16 @@ func (a *App) handoffTabRecoveryLease(tab *WorkspaceTab, recoveryPath string) er
 		if errors.Is(err, agent.ErrSessionLeaseHeld) {
 			reason = "lease_held"
 		}
+		_ = agent.UpdateBranchMeta(recoveryPath, false, func(meta *agent.BranchMeta) error {
+			meta.VersionKind = agent.VersionRecovery
+			meta.VersionState = agent.VersionPending
+			return nil
+		})
 		a.emitRuntimeEvent("session:recovery-failed", sessionRecoveryFailedEvent{
 			Reason: reason, ConversationID: tab.TopicID, TopicID: tab.TopicID,
-			CanContinue: false, RecoveryPending: true,
+			RecoveryPath:  recoveryPath,
+			WorkspaceRoot: tab.WorkspaceRoot,
+			CanContinue:   false, RecoveryPending: true,
 		})
 		return fmt.Errorf("acquire recovery session lease: %w", userFacingSessionLeaseError("", err))
 	}

--- a/desktop/session_lease_handoff.go
+++ b/desktop/session_lease_handoff.go
@@ -73,7 +73,10 @@ func (a *App) handoffTabRecoveryLease(tab *WorkspaceTab, recoveryPath string) er
 		if errors.Is(err, agent.ErrSessionLeaseHeld) {
 			reason = "lease_held"
 		}
-		a.emitRuntimeEvent("session:recovery-failed", sessionRecoveryFailedEvent{Reason: reason})
+		a.emitRuntimeEvent("session:recovery-failed", sessionRecoveryFailedEvent{
+			Reason: reason, ConversationID: tab.TopicID, TopicID: tab.TopicID,
+			CanContinue: false, RecoveryPending: true,
+		})
 		return fmt.Errorf("acquire recovery session lease: %w", userFacingSessionLeaseError("", err))
 	}
 	if err := bindTabWriteAuthority(tab, tab.Ctrl); err != nil {

--- a/desktop/session_recovery_pinned.go
+++ b/desktop/session_recovery_pinned.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/control"
 )
 
@@ -72,16 +73,23 @@ func (a *App) handleTabSessionRecovered(tab *WorkspaceTab) func(control.SessionR
 			}
 		}
 		a.emitSessionRecoveredAndRefresh(sessionDirectoryForPath(info.RecoveryPath), sessionRecoveryEvent{
-			OriginalPath:     info.OriginalPath,
-			RecoveryPath:     info.RecoveryPath,
-			Scope:            scope,
-			WorkspaceRoot:    workspaceRoot,
-			TopicID:          meta.TopicID,
-			TopicTitle:       meta.TopicTitle,
-			RecoveryReason:   meta.RecoveryReason,
-			RecoveryDigest:   meta.RecoveryDigest,
-			RecoveryParentID: string(meta.ParentID),
-			Existing:         info.Existing,
+			ConversationID:    meta.TopicID,
+			ActiveVersionID:   agent.BranchID(info.RecoveryPath),
+			RecoveryVersionID: agent.BranchID(info.RecoveryPath),
+			OriginalPath:      info.OriginalPath,
+			RecoveryPath:      info.RecoveryPath,
+			Scope:             scope,
+			WorkspaceRoot:     workspaceRoot,
+			TopicID:           meta.TopicID,
+			TopicTitle:        meta.TopicTitle,
+			RecoveryReason:    meta.RecoveryReason,
+			RecoveryDigest:    meta.RecoveryDigest,
+			RecoveryParentID:  string(meta.ParentID),
+			Existing:          info.Existing,
+			BaseRevision:      info.BaseRevision,
+			DiskRevision:      info.DiskRevision,
+			CanContinue:       true,
+			RequiresChoice:    false,
 		})
 		a.invalidatePromptHistoryCache()
 		return nil

--- a/desktop/session_takeover.go
+++ b/desktop/session_takeover.go
@@ -1185,9 +1185,9 @@ func (m *takeoverMirror) emitNoticeSink(sink *tabEventSink, level event.Level, c
 	if sink == nil {
 		return
 	}
-	tabID, _ := sink.binding()
+	tabID, app := sink.binding()
 	e := event.Event{Kind: event.Notice, Level: level, Code: code, Text: text, SessionPath: m.sessionPath}
-	sink.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, sink.runtimeEpochSnapshot(), "", 0))
+	sink.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, sink.runtimeEpochSnapshot(), "", 0, app.sessionGenerationForTab(tabID)))
 }
 
 // mirrorEnd tells Serve the writer is gone so the remote side resumes without

--- a/desktop/session_takeover.go
+++ b/desktop/session_takeover.go
@@ -1185,9 +1185,9 @@ func (m *takeoverMirror) emitNoticeSink(sink *tabEventSink, level event.Level, c
 	if sink == nil {
 		return
 	}
-	tabID, app := sink.binding()
+	tabID, _ := sink.binding()
 	e := event.Event{Kind: event.Notice, Level: level, Code: code, Text: text, SessionPath: m.sessionPath}
-	sink.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, sink.runtimeEpochSnapshot(), "", 0, app.sessionGenerationForTab(tabID)))
+	sink.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, sink.runtimeEpochSnapshot(), "", 0, sink.sessionGenerationSnapshot()))
 }
 
 // mirrorEnd tells Serve the writer is gone so the remote side resumes without

--- a/desktop/session_takeover_promote.go
+++ b/desktop/session_takeover_promote.go
@@ -184,7 +184,7 @@ func (a *App) promoteLocalTakeoverSpectator(
 	tab.ActivityStatus = ""
 	tab.replaceTelemetry(candidate.telemetry, key)
 	if tab.sink != nil {
-		tab.sink.setBinding(tab.ID, a)
+		tab.sink.setBinding(tab.ID, a, tab.SessionGeneration)
 		tab.sink.setContext(a.ctx)
 	}
 	a.supersedeTabBuildLocked(tab)

--- a/desktop/tab_meta.go
+++ b/desktop/tab_meta.go
@@ -50,6 +50,9 @@ type TabMeta struct {
 	RecoveryReason    string             `json:"recoveryReason,omitempty"`
 	RecoveryDigest    string             `json:"recoveryDigest,omitempty"`
 	RecoveryParentID  string             `json:"recoveryParentId,omitempty"`
+	VersionKind       string             `json:"versionKind,omitempty"`
+	VersionState      string             `json:"versionState,omitempty"`
+	ParentVersionID   string             `json:"parentVersionId,omitempty"`
 	StartupErr        string             `json:"startupErr,omitempty"`
 	Active            bool               `json:"active"`
 	Cwd               string             `json:"cwd"`

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6122,6 +6122,8 @@ type sessionRecoveryFailedEvent struct {
 	Reason          string `json:"reason,omitempty"`
 	ConversationID  string `json:"conversationId,omitempty"`
 	TopicID         string `json:"topicId,omitempty"`
+	RecoveryPath    string `json:"recoveryPath,omitempty"`
+	WorkspaceRoot   string `json:"workspaceRoot,omitempty"`
 	CanContinue     bool   `json:"canContinue"`
 	RecoveryPending bool   `json:"recoveryPending"`
 }

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6094,16 +6094,23 @@ func (a *App) forkTopicTitle(title string) string {
 }
 
 type sessionRecoveryEvent struct {
-	OriginalPath     string `json:"originalPath,omitempty"`
-	RecoveryPath     string `json:"recoveryPath"`
-	Scope            string `json:"scope,omitempty"`
-	WorkspaceRoot    string `json:"workspaceRoot,omitempty"`
-	TopicID          string `json:"topicId,omitempty"`
-	TopicTitle       string `json:"topicTitle,omitempty"`
-	RecoveryReason   string `json:"recoveryReason,omitempty"`
-	RecoveryDigest   string `json:"recoveryDigest,omitempty"`
-	RecoveryParentID string `json:"recoveryParentId,omitempty"`
-	Existing         bool   `json:"existing,omitempty"`
+	ConversationID    string `json:"conversationId,omitempty"`
+	ActiveVersionID   string `json:"activeVersionId,omitempty"`
+	RecoveryVersionID string `json:"recoveryVersionId,omitempty"`
+	OriginalPath      string `json:"originalPath,omitempty"`
+	RecoveryPath      string `json:"recoveryPath"`
+	Scope             string `json:"scope,omitempty"`
+	WorkspaceRoot     string `json:"workspaceRoot,omitempty"`
+	TopicID           string `json:"topicId,omitempty"`
+	TopicTitle        string `json:"topicTitle,omitempty"`
+	RecoveryReason    string `json:"recoveryReason,omitempty"`
+	RecoveryDigest    string `json:"recoveryDigest,omitempty"`
+	RecoveryParentID  string `json:"recoveryParentId,omitempty"`
+	Existing          bool   `json:"existing,omitempty"`
+	BaseRevision      int64  `json:"baseRevision,omitempty"`
+	DiskRevision      int64  `json:"diskRevision,omitempty"`
+	CanContinue       bool   `json:"canContinue"`
+	RequiresChoice    bool   `json:"requiresChoice"`
 }
 
 type sessionRecoveryFailedEvent struct {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -791,6 +791,7 @@ func applyRuntimeTab(target, source *WorkspaceTab, path string, wailsCtx context
 	target.adoptDisplayState(source.displayBufferState())
 	if source.sink != nil {
 		source.sink.setBinding(target.ID, app)
+		source.sink.setSessionGeneration(target.SessionGeneration)
 		source.sink.setContext(wailsCtx)
 	}
 
@@ -1659,15 +1660,16 @@ func retryPendingDisplayWrites(state *tabDisplayState) {
 // live under mu like ctx does (a bare field write would data-race Emit). Read
 // them via binding(), write via setBinding().
 type tabEventSink struct {
-	tabID         string
-	app           *App
-	mu            sync.RWMutex
-	ctx           context.Context
-	runtimeEpoch  string
-	runtimeEvents asyncRuntimeEmitter
-	botSink       event.Sink // optional: when set, events are also forwarded here
-	botSinkGen    uint64
-	turn          turnSubmissionState // stays reserved through the end of TurnDone fan-out
+	tabID             string
+	app               *App
+	mu                sync.RWMutex
+	ctx               context.Context
+	runtimeEpoch      string
+	sessionGeneration uint64 // source session binding generation
+	runtimeEvents     asyncRuntimeEmitter
+	botSink           event.Sink // optional: when set, events are also forwarded here
+	botSinkGen        uint64
+	turn              turnSubmissionState // stays reserved through the end of TurnDone fan-out
 	// takeoverMirror, when set, forwards every event to the serve that used to
 	// own this session so the remote tab keeps rendering after a local
 	// takeover. Atomic so Emit reads it without the sink lock.
@@ -1741,7 +1743,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 			persistMetricsEvent(app, m, tabID, e)
 		}
 	}
-	s.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, s.runtimeEpochSnapshot(), s.submissionIDSnapshot(), turnStartedAt, app.sessionGenerationForTab(tabID)))
+	s.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, s.runtimeEpochSnapshot(), s.submissionIDSnapshot(), turnStartedAt, s.sessionGenerationSnapshot()))
 	if m := s.takeoverMirror.Load(); m != nil {
 		m.forwardEvent(e)
 	}
@@ -2324,18 +2326,6 @@ func toWireTab(e event.Event, tabID string, runtimeEpoch ...string) wireEventTab
 		SessionCurrency:   "",
 		SessionCostUsd:    0, // deprecated compatibility alias
 	}
-}
-
-func (a *App) sessionGenerationForTab(tabID string) uint64 {
-	if a == nil || tabID == "" {
-		return 0
-	}
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	if tab := a.tabByEventSinkIDLocked(tabID); tab != nil {
-		return tab.SessionGeneration
-	}
-	return 0
 }
 
 // wireEventTab extends the shared event wire with tab routing info. The frontend reducer

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6111,7 +6111,11 @@ type sessionRecoveryEvent struct {
 }
 
 type sessionRecoveryFailedEvent struct {
-	Reason string `json:"reason,omitempty"`
+	Reason          string `json:"reason,omitempty"`
+	ConversationID  string `json:"conversationId,omitempty"`
+	TopicID         string `json:"topicId,omitempty"`
+	CanContinue     bool   `json:"canContinue"`
+	RecoveryPending bool   `json:"recoveryPending"`
 }
 
 func (a *App) tabSessionRecoveryMeta(tab *WorkspaceTab) func(control.SessionRecoveryRequest) agent.BranchMeta {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2342,10 +2342,10 @@ func (a *App) sessionGenerationForTab(tabID string) uint64 {
 // uses tabId to dispatch to the correct per-tab state.
 type wireEventTab struct {
 	eventwire.Event
-	TabID         string `json:"tabId"`
-	RuntimeEpoch  string `json:"runtimeEpoch,omitempty"`
+	TabID             string `json:"tabId"`
+	RuntimeEpoch      string `json:"runtimeEpoch,omitempty"`
 	SessionGeneration uint64 `json:"sessionGeneration,omitempty"`
-	TurnStartedAt int64  `json:"turnStartedAt,omitempty"`
+	TurnStartedAt     int64  `json:"turnStartedAt,omitempty"`
 	// Session-cumulative tokens per tab.
 	SessionHitTokens  int `json:"sessionHitTokens,omitempty"`
 	SessionMissTokens int `json:"sessionMissTokens,omitempty"`

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6091,16 +6091,23 @@ func (a *App) forkTopicTitle(title string) string {
 }
 
 type sessionRecoveryEvent struct {
-	OriginalPath     string `json:"originalPath,omitempty"`
-	RecoveryPath     string `json:"recoveryPath"`
-	Scope            string `json:"scope,omitempty"`
-	WorkspaceRoot    string `json:"workspaceRoot,omitempty"`
-	TopicID          string `json:"topicId,omitempty"`
-	TopicTitle       string `json:"topicTitle,omitempty"`
-	RecoveryReason   string `json:"recoveryReason,omitempty"`
-	RecoveryDigest   string `json:"recoveryDigest,omitempty"`
-	RecoveryParentID string `json:"recoveryParentId,omitempty"`
-	Existing         bool   `json:"existing,omitempty"`
+	ConversationID    string `json:"conversationId,omitempty"`
+	ActiveVersionID   string `json:"activeVersionId,omitempty"`
+	RecoveryVersionID string `json:"recoveryVersionId,omitempty"`
+	OriginalPath      string `json:"originalPath,omitempty"`
+	RecoveryPath      string `json:"recoveryPath"`
+	Scope             string `json:"scope,omitempty"`
+	WorkspaceRoot     string `json:"workspaceRoot,omitempty"`
+	TopicID           string `json:"topicId,omitempty"`
+	TopicTitle        string `json:"topicTitle,omitempty"`
+	RecoveryReason    string `json:"recoveryReason,omitempty"`
+	RecoveryDigest    string `json:"recoveryDigest,omitempty"`
+	RecoveryParentID  string `json:"recoveryParentId,omitempty"`
+	Existing          bool   `json:"existing,omitempty"`
+	BaseRevision      int64  `json:"baseRevision,omitempty"`
+	DiskRevision      int64  `json:"diskRevision,omitempty"`
+	CanContinue       bool   `json:"canContinue"`
+	RequiresChoice    bool   `json:"requiresChoice"`
 }
 
 type sessionRecoveryFailedEvent struct {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2429,11 +2429,16 @@ func (a *App) tabMeta(tab *WorkspaceTab, active bool) TabMeta {
 	if a.botBridge != nil {
 		m.RemoteControlled = a.botBridge.remoteControlledTabs()[tab.ID]
 	}
-	if meta, ok, err := agent.LoadBranchMeta(tab.currentSessionPath()); err == nil && ok && meta.Recovered {
-		m.Recovered = true
-		m.RecoveryReason = meta.RecoveryReason
-		m.RecoveryDigest = meta.RecoveryDigest
-		m.RecoveryParentID = string(meta.ParentID)
+	if meta, ok, err := agent.LoadBranchMeta(tab.currentSessionPath()); err == nil && ok {
+		m.VersionKind = string(meta.EffectiveVersionKind())
+		m.VersionState = string(meta.EffectiveVersionState())
+		m.ParentVersionID = meta.ParentVersionID
+		if meta.Recovered {
+			m.Recovered = true
+			m.RecoveryReason = meta.RecoveryReason
+			m.RecoveryDigest = meta.RecoveryDigest
+			m.RecoveryParentID = string(meta.ParentID)
+		}
 	}
 	return m
 }

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6119,6 +6119,8 @@ type sessionRecoveryFailedEvent struct {
 	Reason          string `json:"reason,omitempty"`
 	ConversationID  string `json:"conversationId,omitempty"`
 	TopicID         string `json:"topicId,omitempty"`
+	RecoveryPath    string `json:"recoveryPath,omitempty"`
+	WorkspaceRoot   string `json:"workspaceRoot,omitempty"`
 	CanContinue     bool   `json:"canContinue"`
 	RecoveryPending bool   `json:"recoveryPending"`
 }

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1741,7 +1741,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 			persistMetricsEvent(app, m, tabID, e)
 		}
 	}
-	s.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, s.runtimeEpochSnapshot(), s.submissionIDSnapshot(), turnStartedAt))
+	s.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, s.runtimeEpochSnapshot(), s.submissionIDSnapshot(), turnStartedAt, app.sessionGenerationForTab(tabID)))
 	if m := s.takeoverMirror.Load(); m != nil {
 		m.forwardEvent(e)
 	}
@@ -2326,12 +2326,25 @@ func toWireTab(e event.Event, tabID string, runtimeEpoch ...string) wireEventTab
 	}
 }
 
+func (a *App) sessionGenerationForTab(tabID string) uint64 {
+	if a == nil || tabID == "" {
+		return 0
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if tab := a.tabByEventSinkIDLocked(tabID); tab != nil {
+		return tab.SessionGeneration
+	}
+	return 0
+}
+
 // wireEventTab extends the shared event wire with tab routing info. The frontend reducer
 // uses tabId to dispatch to the correct per-tab state.
 type wireEventTab struct {
 	eventwire.Event
 	TabID         string `json:"tabId"`
 	RuntimeEpoch  string `json:"runtimeEpoch,omitempty"`
+	SessionGeneration uint64 `json:"sessionGeneration,omitempty"`
 	TurnStartedAt int64  `json:"turnStartedAt,omitempty"`
 	// Session-cumulative tokens per tab.
 	SessionHitTokens  int `json:"sessionHitTokens,omitempty"`

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6114,7 +6114,11 @@ type sessionRecoveryEvent struct {
 }
 
 type sessionRecoveryFailedEvent struct {
-	Reason string `json:"reason,omitempty"`
+	Reason          string `json:"reason,omitempty"`
+	ConversationID  string `json:"conversationId,omitempty"`
+	TopicID         string `json:"topicId,omitempty"`
+	CanContinue     bool   `json:"canContinue"`
+	RecoveryPending bool   `json:"recoveryPending"`
 }
 
 func (a *App) tabSessionRecoveryMeta(tab *WorkspaceTab) func(control.SessionRecoveryRequest) agent.BranchMeta {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2426,11 +2426,16 @@ func (a *App) tabMeta(tab *WorkspaceTab, active bool) TabMeta {
 	if a.botBridge != nil {
 		m.RemoteControlled = a.botBridge.remoteControlledTabs()[tab.ID]
 	}
-	if meta, ok, err := agent.LoadBranchMeta(tab.currentSessionPath()); err == nil && ok && meta.Recovered {
-		m.Recovered = true
-		m.RecoveryReason = meta.RecoveryReason
-		m.RecoveryDigest = meta.RecoveryDigest
-		m.RecoveryParentID = string(meta.ParentID)
+	if meta, ok, err := agent.LoadBranchMeta(tab.currentSessionPath()); err == nil && ok {
+		m.VersionKind = string(meta.EffectiveVersionKind())
+		m.VersionState = string(meta.EffectiveVersionState())
+		m.ParentVersionID = meta.ParentVersionID
+		if meta.Recovered {
+			m.Recovered = true
+			m.RecoveryReason = meta.RecoveryReason
+			m.RecoveryDigest = meta.RecoveryDigest
+			m.RecoveryParentID = string(meta.ParentID)
+		}
 	}
 	return m
 }

--- a/desktop/tabs_sink_context_test.go
+++ b/desktop/tabs_sink_context_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"reasonix/internal/event"
 )
@@ -42,5 +43,30 @@ func TestTabEventSinkClearContextStopsEmission(t *testing.T) {
 	defer mu.Unlock()
 	if emitted != 0 {
 		t.Fatalf("sink emitted %d events after clearContext, want 0", emitted)
+	}
+}
+
+func TestTabEventSinkUsesBoundSessionGeneration(t *testing.T) {
+	sink := &tabEventSink{tabID: "tab", ctx: context.Background()}
+	sink.setSessionGeneration(7)
+	delivered := make(chan uint64, 1)
+	sink.runtimeEvents.emit = func(_ context.Context, name string, payload ...any) {
+		if name != eventChannel || len(payload) != 1 {
+			t.Fatalf("runtime event = %q/%d, want one %q event", name, len(payload), eventChannel)
+		}
+		wire, ok := payload[0].(wireEventTab)
+		if !ok {
+			t.Fatalf("payload type = %T, want wireEventTab", payload[0])
+		}
+		delivered <- wire.SessionGeneration
+	}
+	sink.Emit(event.Event{Kind: event.Notice, Text: "late"})
+	select {
+	case got := <-delivered:
+		if got != 7 {
+			t.Fatalf("event session generation = %d, want bound generation 7", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for sink event")
 	}
 }

--- a/desktop/turn_submission_app.go
+++ b/desktop/turn_submission_app.go
@@ -27,16 +27,43 @@ func (t *WorkspaceTab) turnStartedAt() int64 {
 
 // setBinding reroutes the sink while invalidating correlations that were
 // created for a different frontend tab.
-func (s *tabEventSink) setBinding(tabID string, app *App) {
+func (s *tabEventSink) setBinding(tabID string, app *App, generation ...uint64) {
 	s.mu.Lock()
 	if s.tabID != tabID {
 		s.turn.submissionID = ""
 	}
 	s.tabID = tabID
+	if len(generation) > 0 {
+		if s.sessionGeneration != generation[0] {
+			s.turn.submissionID = ""
+		}
+		s.sessionGeneration = generation[0]
+	}
 	if app != nil {
 		s.app = app
 	}
 	s.mu.Unlock()
+}
+
+func (s *tabEventSink) setSessionGeneration(generation uint64) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.sessionGeneration != generation {
+		s.turn.submissionID = ""
+	}
+	s.sessionGeneration = generation
+	s.mu.Unlock()
+}
+
+func (s *tabEventSink) sessionGenerationSnapshot() uint64 {
+	if s == nil {
+		return 0
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.sessionGeneration
 }
 
 func (s *tabEventSink) setRuntimeEpoch(epoch string) {

--- a/desktop/turn_submission_app.go
+++ b/desktop/turn_submission_app.go
@@ -80,8 +80,11 @@ type correlatedWireEventTab struct {
 	SubmissionID string `json:"submissionId,omitempty"`
 }
 
-func toWireTabWithSubmission(e event.Event, tabID, runtimeEpoch, submissionID string, turnStartedAt int64) any {
+func toWireTabWithSubmission(e event.Event, tabID, runtimeEpoch, submissionID string, turnStartedAt int64, sessionGeneration ...uint64) any {
 	wire := toWireTab(e, tabID, runtimeEpoch)
+	if len(sessionGeneration) > 0 {
+		wire.SessionGeneration = sessionGeneration[0]
+	}
 	if e.Kind == event.TurnStarted {
 		wire.TurnStartedAt = turnStartedAt
 	}

--- a/desktop/wire_test.go
+++ b/desktop/wire_test.go
@@ -47,3 +47,13 @@ func TestWireEventTabCarriesAuthoritativeTurnStart(t *testing.T) {
 		}
 	}
 }
+
+func TestWireEventTabCarriesSessionGeneration(t *testing.T) {
+	b, err := json.Marshal(toWireTabWithSubmission(event.Event{Kind: event.TurnDone}, "tab-1", "runtime-1", "", 0, 7))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"sessionGeneration":7`) {
+		t.Fatalf("tab event JSON = %s, want session generation", b)
+	}
+}

--- a/docs/SESSION_RECOVERY_AND_PARALLELISM.md
+++ b/docs/SESSION_RECOVERY_AND_PARALLELISM.md
@@ -1,0 +1,41 @@
+# Session Recovery and Parallel Work
+
+Reasonix keeps transcript persistence and workspace mutation as separate safety
+boundaries. Read-only work and non-overlapping file claims can run concurrently;
+opaque writers such as unrestricted shell or unknown MCP mutations retain the
+workspace write lease. Git worktrees provide an isolated checkout when a task
+needs an independent workspace.
+
+## Session versions
+
+Each physical JSONL transcript has a version identity in its branch metadata:
+
+- `normal` is an ordinary conversation transcript.
+- `recovery` preserves local content after a transcript save conflict, file-lock
+  timeout, or external removal.
+- `subagent` is reserved for a session-backed child run.
+
+Older sidecars remain readable. A sidecar with `Recovered=true` is interpreted as
+a recovery version when the explicit version field is absent.
+
+Recovery metadata records the parent conversation/version and the base and disk
+revisions observed at the conflict. Recovery copies stay in the same logical
+conversation lineage and are not treated as ordinary conversations or
+subagents.
+
+## Recovery lifecycle
+
+An append-compatible snapshot is adopted from disk without creating another
+version. A divergent snapshot is preserved as a recovery version using the
+existing CAS and digest checks. A failed lease handoff marks that recovery
+version as `pending`; the desktop client can retry activation after the writer
+is released.
+
+Recovery lineage reconciliation is idempotent. Covered copies may be moved to
+recoverable session trash, while divergent content remains available for an
+explicit version choice.
+
+The desktop bridge exposes `GetSessionVersionState`,
+`SetActiveSessionVersion`, `RetrySessionRecovery`, and
+`ReconcileRecoveryVersions`. Worktree status and merge preparation use the
+same backend inspection and identity checks as the existing merge flow.

--- a/docs/SESSION_RECOVERY_AND_PARALLELISM.zh-CN.md
+++ b/docs/SESSION_RECOVERY_AND_PARALLELISM.zh-CN.md
@@ -1,0 +1,34 @@
+# 会话恢复与并行工作
+
+Reasonix 将会话记录持久化和工作区文件修改分成两条安全边界。只读任务
+和互不重叠的文件声明可以并行执行；不透明写入（例如无限制 shell 或未知
+MCP 修改）继续使用工作区写租约。需要独立工作区的任务可以使用 Git
+worktree 隔离。
+
+## 会话版本
+
+每个物理 JSONL 会话文件都在 branch metadata 中带有版本身份：
+
+- `normal`：普通会话记录；
+- `recovery`：保存冲突、文件锁超时或外部删除后保留的恢复记录；
+- `subagent`：仅用于持久化的子代理会话。
+
+旧 sidecar 仍然可读。缺少显式版本字段但带有 `Recovered=true` 的记录会被
+解释为 recovery 版本。
+
+恢复元数据记录父会话、父版本以及冲突时观察到的 base/disk revision。恢复
+副本留在同一条逻辑会话谱系中，不会被当作普通会话或子代理。
+
+## 恢复生命周期
+
+如果磁盘内容只是可采用的已保存前缀，系统直接采用磁盘版本，不创建新版本。
+如果两边有独立新增内容，系统通过现有 CAS 和 digest 校验保留 recovery
+版本。租约移交失败时，恢复版本会标记为 `pending`；占用者释放后，桌面端
+可以重试激活。
+
+恢复谱系收敛操作是幂等的。已被完整覆盖的副本可以移动到可恢复的会话回收站，
+存在独立内容的分歧版本继续保留，等待用户明确选择。
+
+桌面桥接层提供 `GetSessionVersionState`、`SetActiveSessionVersion`、
+`RetrySessionRecovery` 和 `ReconcileRecoveryVersions`。worktree 状态查询和
+合并准备复用现有后端检查及身份校验。

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -48,8 +48,16 @@ type BranchMeta struct {
 	ToolApprovalMode string `json:"tool_approval_mode,omitempty"`
 	Goal             string `json:"goal,omitempty"`
 	Recovered        bool   `json:"recovered,omitempty"`
-	RecoveryReason   string `json:"recovery_reason,omitempty"`
-	RecoveryDigest   string `json:"recovery_digest,omitempty"`
+	// VersionKind separates ordinary transcripts, recovery copies, and
+	// session-backed subagents. Older sidecars infer recovery from Recovered.
+	VersionKind          SessionVersionKind  `json:"version_kind,omitempty"`
+	VersionState         SessionVersionState `json:"version_state,omitempty"`
+	ParentConversationID string              `json:"parent_conversation_id,omitempty"`
+	ParentVersionID      string              `json:"parent_version_id,omitempty"`
+	BaseRevision         int64               `json:"base_revision,omitempty"`
+	DiskRevision         int64               `json:"disk_revision,omitempty"`
+	RecoveryReason       string              `json:"recovery_reason,omitempty"`
+	RecoveryDigest       string              `json:"recovery_digest,omitempty"`
 	// RecoveryDepth is 1 for new stable recovery branches. Older nested
 	// files may still carry a larger historical value.
 	RecoveryDepth int `json:"recovery_depth,omitempty"`
@@ -75,6 +83,43 @@ type BranchMeta struct {
 	InFlightTurn         *InFlightTurnMeta `json:"in_flight_turn,omitempty"`
 	// Closed completed todo shelves; desktop remounts hide the same fingerprint.
 	DismissedTodoBatches []string `json:"dismissed_todo_batches,omitempty"`
+}
+
+// SessionVersionKind is the durable identity class of a physical transcript.
+// It is intentionally separate from Recovered for compatibility with older
+// sidecars and from subagent metadata, which carries richer child lifecycle.
+type SessionVersionKind string
+
+const (
+	VersionNormal   SessionVersionKind = "normal"
+	VersionRecovery SessionVersionKind = "recovery"
+	VersionSubagent SessionVersionKind = "subagent"
+)
+
+type SessionVersionState string
+
+const (
+	VersionActive   SessionVersionState = "active"
+	VersionPending  SessionVersionState = "pending"
+	VersionResolved SessionVersionState = "resolved"
+	VersionTrashed  SessionVersionState = "trashed"
+)
+
+func (m BranchMeta) EffectiveVersionKind() SessionVersionKind {
+	if m.VersionKind != "" {
+		return m.VersionKind
+	}
+	if m.Recovered {
+		return VersionRecovery
+	}
+	return VersionNormal
+}
+
+func (m BranchMeta) EffectiveVersionState() SessionVersionState {
+	if m.VersionState != "" {
+		return m.VersionState
+	}
+	return VersionActive
 }
 
 const (

--- a/internal/agent/branch_test.go
+++ b/internal/agent/branch_test.go
@@ -194,6 +194,22 @@ func TestBranchMetaRoundTripAndList(t *testing.T) {
 	}
 }
 
+func TestBranchMetaEffectiveVersionKindKeepsLegacyRecoveryReadable(t *testing.T) {
+	if got := (BranchMeta{Recovered: true}).EffectiveVersionKind(); got != VersionRecovery {
+		t.Fatalf("legacy recovered kind = %q, want %q", got, VersionRecovery)
+	}
+	if got := (BranchMeta{}).EffectiveVersionKind(); got != VersionNormal {
+		t.Fatalf("legacy normal kind = %q, want %q", got, VersionNormal)
+	}
+	if got := (BranchMeta{}).EffectiveVersionState(); got != VersionActive {
+		t.Fatalf("legacy version state = %q, want %q", got, VersionActive)
+	}
+	meta := BranchMeta{VersionKind: VersionSubagent, VersionState: VersionPending}
+	if meta.EffectiveVersionKind() != VersionSubagent || meta.EffectiveVersionState() != VersionPending {
+		t.Fatalf("explicit version identity was not preserved: %+v", meta)
+	}
+}
+
 func TestListBranchesSkipsCleanupPending(t *testing.T) {
 	dir := t.TempDir()
 	visiblePath := filepath.Join(dir, "visible.jsonl")

--- a/internal/agent/recovery_save_meta.go
+++ b/internal/agent/recovery_save_meta.go
@@ -21,12 +21,30 @@ func (s *Session) prepareRecoveryBranchMetaLocked(path string, opts RecoveryBran
 	meta.Turns = turns
 	meta.SchemaVersion = BranchMetaCountsVersion
 	meta.Recovered = true
+	meta.VersionKind = VersionRecovery
+	meta.VersionState = VersionActive
+	meta.ParentConversationID = firstNonEmpty(meta.ParentConversationID, meta.TopicID)
+	meta.ParentVersionID = firstNonEmpty(meta.ParentVersionID, meta.ParentID)
+	meta.BaseRevision = opts.BaseRevision
+	meta.DiskRevision = opts.DiskRevision
 	meta.RecoveryReason = firstNonEmpty(strings.TrimSpace(opts.Reason), "session snapshot conflict")
 	meta.RecoveryDigest = digest
 	meta.RecoveryDepth = depth
 	meta.Revision = 1
 	ledgerCurrent := false
 	if ok {
+		if meta.BaseRevision == 0 {
+			meta.BaseRevision = existing.BaseRevision
+		}
+		if meta.DiskRevision == 0 {
+			meta.DiskRevision = existing.DiskRevision
+		}
+		if meta.ParentConversationID == "" {
+			meta.ParentConversationID = existing.ParentConversationID
+		}
+		if meta.ParentVersionID == "" {
+			meta.ParentVersionID = existing.ParentVersionID
+		}
 		ledgerCurrent = contentUnchanged && existing.Revision > 0 &&
 			strings.TrimSpace(existing.ContentDigest) == digest &&
 			strings.TrimSpace(existing.RecoveryDigest) == digest

--- a/internal/agent/recovery_save_meta_test.go
+++ b/internal/agent/recovery_save_meta_test.go
@@ -19,7 +19,7 @@ func TestRecoveryLaneRewriteAdvancesItsOwnLedgerAndDerivedIndexes(t *testing.T) 
 
 	recovery := NewSession("sys")
 	recovery.Add(provider.Message{Role: provider.RoleUser, Content: "local question"})
-	first, err := recovery.SaveShutdownRecoveryBranch(RecoveryBranchOptions{OriginalPath: originalPath})
+	first, err := recovery.SaveShutdownRecoveryBranch(RecoveryBranchOptions{OriginalPath: originalPath, BaseRevision: 4, DiskRevision: 9})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,9 @@ func TestRecoveryLaneRewriteAdvancesItsOwnLedgerAndDerivedIndexes(t *testing.T) 
 	if err != nil || !ok {
 		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
 	}
-	if meta.Revision != 8 || meta.ContentDigest != digest || meta.RecoveryDigest != digest ||
+	if meta.EffectiveVersionKind() != VersionRecovery || meta.EffectiveVersionState() != VersionActive ||
+		meta.BaseRevision != 4 || meta.DiskRevision != 9 ||
+		meta.Revision != 8 || meta.ContentDigest != digest || meta.RecoveryDigest != digest ||
 		meta.ListingRevision != 8 || meta.ListingContentDigest != digest || meta.Turns != 2 {
 		t.Fatalf("rewritten recovery meta = %+v", meta)
 	}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -179,6 +179,8 @@ type RecoveryBranchOptions struct {
 	Name         string
 	Reason       string
 	BranchMeta   BranchMeta
+	BaseRevision int64
+	DiskRevision int64
 }
 
 type RecoveryBranchInfo struct {
@@ -1441,22 +1443,26 @@ func loadSessionUnlocked(path string) (*Session, error) {
 // disk, when it was created/last active, the first user message as a preview, and
 // a rough turn count.
 type SessionInfo struct {
-	Path           string
-	CreatedAt      time.Time
-	LastActivityAt time.Time
-	ModTime        time.Time // compatibility alias for LastActivityAt
-	Preview        string
-	Turns          int
-	CountsKnown    bool
-	Scope          string
-	WorkspaceRoot  string
-	TopicID        string
-	TopicTitle     string
-	CustomTitle    string
-	Recovered      bool
-	RecoveryReason string
-	RecoveryDigest string
-	ParentID       string
+	Path                 string
+	CreatedAt            time.Time
+	LastActivityAt       time.Time
+	ModTime              time.Time // compatibility alias for LastActivityAt
+	Preview              string
+	Turns                int
+	CountsKnown          bool
+	Scope                string
+	WorkspaceRoot        string
+	TopicID              string
+	TopicTitle           string
+	CustomTitle          string
+	Recovered            bool
+	RecoveryReason       string
+	RecoveryDigest       string
+	ParentID             string
+	VersionKind          SessionVersionKind
+	VersionState         SessionVersionState
+	ParentConversationID string
+	ParentVersionID      string
 }
 
 // CleanupPendingMeta records that a session was logically removed but still has
@@ -1992,6 +1998,10 @@ func ListSessionOrderWithRecoveryPreferenceResolver(dir string, resolve Recovery
 		recoveryReason := ""
 		recoveryDigest := ""
 		parentID := ""
+		versionKind := VersionNormal
+		versionState := VersionActive
+		parentConversationID := ""
+		parentVersionID := ""
 		recoveryPreferred := false
 		turns := 0
 		preview := ""
@@ -2016,6 +2026,10 @@ func ListSessionOrderWithRecoveryPreferenceResolver(dir string, resolve Recovery
 			recoveryReason = meta.RecoveryReason
 			recoveryDigest = meta.RecoveryDigest
 			parentID = meta.ParentID
+			versionKind = meta.EffectiveVersionKind()
+			versionState = meta.EffectiveVersionState()
+			parentConversationID = meta.ParentConversationID
+			parentVersionID = meta.ParentVersionID
 			recoveryPreferred = resolve(full, meta)
 			turns = meta.Turns
 			preview = meta.Preview
@@ -2029,6 +2043,7 @@ func ListSessionOrderWithRecoveryPreferenceResolver(dir string, resolve Recovery
 		// automatic recovery lineage for catalog folding.
 		if !recovered && LooksLikeRecoveryFilename(full) {
 			recovered = true
+			versionKind = VersionRecovery
 			if parentID == "" {
 				if parent, ok := RecoveryFilenameParentID(full); ok {
 					parentID = parent
@@ -2049,6 +2064,10 @@ func ListSessionOrderWithRecoveryPreferenceResolver(dir string, resolve Recovery
 			RecoveryReason:       recoveryReason,
 			RecoveryDigest:       recoveryDigest,
 			ParentID:             parentID,
+			VersionKind:          versionKind,
+			VersionState:         versionState,
+			ParentConversationID: parentConversationID,
+			ParentVersionID:      parentVersionID,
 			RecoveryPreferred:    recoveryPreferred,
 			Turns:                turns,
 			Preview:              preview,

--- a/internal/agent/session_listing_helpers.go
+++ b/internal/agent/session_listing_helpers.go
@@ -9,20 +9,24 @@ import (
 // SessionOrderInfo is the lightweight sidecar/mtime ordering record shared by
 // session pickers and prompt-history navigation. It intentionally avoids JSONL.
 type SessionOrderInfo struct {
-	Path              string
-	CreatedAt         time.Time
-	LastActivityAt    time.Time
-	ModTime           time.Time // compatibility alias for LastActivityAt
-	Scope             string
-	WorkspaceRoot     string
-	TopicID           string
-	TopicTitle        string
-	CustomTitle       string
-	Recovered         bool
-	RecoveryReason    string
-	RecoveryDigest    string
-	ParentID          string
-	RecoveryPreferred bool
+	Path                 string
+	CreatedAt            time.Time
+	LastActivityAt       time.Time
+	ModTime              time.Time // compatibility alias for LastActivityAt
+	Scope                string
+	WorkspaceRoot        string
+	TopicID              string
+	TopicTitle           string
+	CustomTitle          string
+	Recovered            bool
+	VersionKind          SessionVersionKind
+	VersionState         SessionVersionState
+	ParentConversationID string
+	ParentVersionID      string
+	RecoveryReason       string
+	RecoveryDigest       string
+	ParentID             string
+	RecoveryPreferred    bool
 	// Counts are trusted only when their listing identity matches the transcript.
 	Turns         int
 	Preview       string
@@ -47,22 +51,26 @@ func (s SessionOrderInfo) ListingProjectionFresh() bool {
 
 func sessionInfoFromOrder(session SessionOrderInfo, preview string, turns int, countsKnown bool) SessionInfo {
 	return SessionInfo{
-		Path:           session.Path,
-		CreatedAt:      session.CreatedAt,
-		LastActivityAt: session.LastActivityAt,
-		ModTime:        session.ModTime,
-		Preview:        preview,
-		Turns:          turns,
-		CountsKnown:    countsKnown,
-		Scope:          session.Scope,
-		WorkspaceRoot:  session.WorkspaceRoot,
-		TopicID:        session.TopicID,
-		TopicTitle:     session.TopicTitle,
-		CustomTitle:    session.CustomTitle,
-		Recovered:      session.Recovered,
-		RecoveryReason: session.RecoveryReason,
-		RecoveryDigest: session.RecoveryDigest,
-		ParentID:       session.ParentID,
+		Path:                 session.Path,
+		CreatedAt:            session.CreatedAt,
+		LastActivityAt:       session.LastActivityAt,
+		ModTime:              session.ModTime,
+		Preview:              preview,
+		Turns:                turns,
+		CountsKnown:          countsKnown,
+		Scope:                session.Scope,
+		WorkspaceRoot:        session.WorkspaceRoot,
+		TopicID:              session.TopicID,
+		TopicTitle:           session.TopicTitle,
+		CustomTitle:          session.CustomTitle,
+		Recovered:            session.Recovered,
+		VersionKind:          session.VersionKind,
+		VersionState:         session.VersionState,
+		ParentConversationID: session.ParentConversationID,
+		ParentVersionID:      session.ParentVersionID,
+		RecoveryReason:       session.RecoveryReason,
+		RecoveryDigest:       session.RecoveryDigest,
+		ParentID:             session.ParentID,
 	}
 }
 

--- a/internal/billing/catalog.go
+++ b/internal/billing/catalog.go
@@ -112,10 +112,13 @@ func catalogEntryEffective(e CatalogEntry, at time.Time) bool {
 	return e.EffectiveTo.IsZero() || at.Before(e.EffectiveTo)
 }
 
-// DeepSeekRateBand selects the documented Beijing peak windows by their stable
-// UTC equivalents.
+// DeepSeekRateBand selects the documented Beijing weekday peak windows by
+// their stable UTC equivalents.
 func DeepSeekRateBand(at time.Time) string {
 	at = at.UTC()
+	if at.Weekday() == time.Saturday || at.Weekday() == time.Sunday {
+		return RateBandOffPeak
+	}
 	minutes := at.Hour()*60 + at.Minute()
 	if (minutes >= 60 && minutes < 240) || (minutes >= 360 && minutes < 600) {
 		return RateBandPeak

--- a/internal/billing/catalog_test.go
+++ b/internal/billing/catalog_test.go
@@ -38,6 +38,24 @@ func TestResolveDeepSeekScheduledRateBoundaries(t *testing.T) {
 	}
 }
 
+func TestDeepSeekRateBandWeekendIsAlwaysOffPeak(t *testing.T) {
+	tests := []struct {
+		name string
+		at   time.Time
+	}{
+		// Saturday and Sunday peak-window clock times must remain off-peak.
+		{"saturday_morning_window", time.Date(2026, 8, 22, 1, 30, 0, 0, time.UTC)},
+		{"sunday_afternoon_window", time.Date(2026, 8, 23, 7, 0, 0, 0, time.UTC)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DeepSeekRateBand(tc.at); got != RateBandOffPeak {
+				t.Fatalf("DeepSeekRateBand(%s) = %q, want %q", tc.at, got, RateBandOffPeak)
+			}
+		})
+	}
+}
+
 func TestBuildQuoteScheduledRateUsesMatchingPeerBand(t *testing.T) {
 	at := time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC)
 	q := BuildQuote(QuoteInput{

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -421,8 +421,18 @@ type SessionRecoveryInfo struct {
 	RecoveryPath string
 	Existing     bool
 	Reason       string
+	BaseRevision int64
+	DiskRevision int64
 	Meta         agent.BranchMeta
 	commit       *sessionRecoveryCommit
+}
+
+func snapshotConflictRevisions(err error) (base, disk int64) {
+	var conflict *agent.SessionSnapshotConflictError
+	if errors.As(err, &conflict) && conflict != nil {
+		return conflict.BaseRevision, conflict.DiskRevision
+	}
+	return 0, 0
 }
 
 // OnCommit defers publication work until the controller has installed the
@@ -4031,10 +4041,13 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 	if c.sessionRecoveryMeta != nil {
 		meta = c.sessionRecoveryMeta(req)
 	}
+	baseRevision, diskRevision := snapshotConflictRevisions(saveErr)
 	info, err := c.executor.Session().SaveRecoveryBranch(agent.RecoveryBranchOptions{
 		OriginalPath: path,
 		Reason:       reason,
 		BranchMeta:   meta,
+		BaseRevision: baseRevision,
+		DiskRevision: diskRevision,
 	})
 	if err != nil {
 		if errors.Is(err, agent.ErrSessionRecoveryNotNeeded) {
@@ -4101,6 +4114,8 @@ func (c *Controller) commitRecoveredSession(originalPath, reason string, info ag
 		RecoveryPath: info.Path,
 		Existing:     info.Existing,
 		Reason:       reason,
+		BaseRevision: info.Meta.BaseRevision,
+		DiskRevision: info.Meta.DiskRevision,
 		Meta:         info.Meta,
 		commit:       commit,
 	}

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -2207,6 +2207,17 @@ func TestSnapshotConflictLogAttrsCarryRevisionLedger(t *testing.T) {
 	}
 }
 
+func TestSnapshotConflictRevisionsExtractTypedConflict(t *testing.T) {
+	conflict := &agent.SessionSnapshotConflictError{BaseRevision: 4, DiskRevision: 8}
+	base, disk := snapshotConflictRevisions(fmt.Errorf("wrapped: %w", conflict))
+	if base != 4 || disk != 8 {
+		t.Fatalf("revisions = %d/%d, want 4/8", base, disk)
+	}
+	if base, disk := snapshotConflictRevisions(errors.New("other")); base != 0 || disk != 0 {
+		t.Fatalf("non-conflict revisions = %d/%d, want 0/0", base, disk)
+	}
+}
+
 type noticeSink struct {
 	mu     sync.Mutex
 	events []event.Event

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -159,7 +159,7 @@
       "file-size": 1599
     },
     "desktop/frontend/src/lib/useController.ts": {
-      "file-size": 4233
+      "file-size": 4248
     },
     "desktop/heartbeat.go": {
       "essay": 7
@@ -288,7 +288,7 @@
     "desktop/tabs.go": {
       "complexity": 42,
       "essay": 68,
-      "file-size": 7613,
+      "file-size": 7616,
       "function-size": 364,
       "struct-state": 23
     },

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -147,7 +147,7 @@
       "file-size": 180
     },
     "desktop/frontend/src/lib/bridge.ts": {
-      "file-size": 4959
+      "file-size": 4977
     },
     "desktop/frontend/src/lib/crash.ts": {
       "file-size": 225
@@ -156,10 +156,10 @@
       "file-size": 264
     },
     "desktop/frontend/src/lib/types.ts": {
-      "file-size": 1568
+      "file-size": 1599
     },
     "desktop/frontend/src/lib/useController.ts": {
-      "file-size": 4248
+      "file-size": 4233
     },
     "desktop/heartbeat.go": {
       "essay": 7
@@ -288,7 +288,7 @@
     "desktop/tabs.go": {
       "complexity": 42,
       "essay": 68,
-      "file-size": 7598,
+      "file-size": 7613,
       "function-size": 364,
       "struct-state": 23
     },
@@ -907,7 +907,7 @@
     },
     "internal/control/controller_test.go": {
       "essay": 1,
-      "test-file-size": 4617
+      "test-file-size": 4628
     },
     "internal/control/extension_ui.go": {
       "essay": 4,

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -147,7 +147,7 @@
       "file-size": 180
     },
     "desktop/frontend/src/lib/bridge.ts": {
-      "file-size": 4959
+      "file-size": 4977
     },
     "desktop/frontend/src/lib/crash.ts": {
       "file-size": 225
@@ -156,7 +156,7 @@
       "file-size": 264
     },
     "desktop/frontend/src/lib/types.ts": {
-      "file-size": 1568
+      "file-size": 1599
     },
     "desktop/frontend/src/lib/useController.ts": {
       "file-size": 4233
@@ -288,7 +288,7 @@
     "desktop/tabs.go": {
       "complexity": 42,
       "essay": 68,
-      "file-size": 7595,
+      "file-size": 7613,
       "function-size": 364,
       "struct-state": 23
     },
@@ -907,7 +907,7 @@
     },
     "internal/control/controller_test.go": {
       "essay": 1,
-      "test-file-size": 4617
+      "test-file-size": 4628
     },
     "internal/control/extension_ui.go": {
       "essay": 4,

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -159,7 +159,7 @@
       "file-size": 1568
     },
     "desktop/frontend/src/lib/useController.ts": {
-      "file-size": 4233
+      "file-size": 4248
     },
     "desktop/heartbeat.go": {
       "essay": 7
@@ -288,7 +288,7 @@
     "desktop/tabs.go": {
       "complexity": 42,
       "essay": 68,
-      "file-size": 7595,
+      "file-size": 7598,
       "function-size": 364,
       "struct-state": 23
     },


### PR DESCRIPTION
## Summary

This PR unifies session recovery and parallel-work lifecycle contracts for the Go rewrite.

Recovery copies now have an explicit, backward-compatible version identity (`normal`, `recovery`, or `subagent`) and state. Recovery metadata records parent/version lineage and the conflicting base/disk revisions, while the desktop event payload carries stable conversation and version identifiers.

The desktop client can query and select a session version, retry a pending recovery after a lease handoff failure, and trigger an idempotent recovery-lineage reconciliation. Recovery failures are persisted as pending and surfaced with localized retry guidance. Git worktree results now carry source revision, task, and conversation identity, and tab/session payloads expose the version state.

The existing safety boundaries remain in force: CAS/revision transcript saves, path-scoped `write_paths` coordination, workspace protection for opaque writers, and recoverable cleanup for covered copies.

## User-visible behavior

- Recovery transcripts are distinguishable from subagent transcripts and are not presented as subagent versions.
- A recovery lease failure keeps the recovery copy pending and offers a retry action instead of silently losing the state.
- Active-version changes refresh the recovery coordinator without changing the logical conversation identity.
- Worktree lifecycle payloads identify the source revision and owning task/conversation for reliable merge-back handling.

## Compatibility

- Existing `Recovered=true` sidecars and legacy recovery filenames continue to load as recovery versions.
- New fields are optional and preserve older session metadata.
- Recovery copies remain recoverable; no hard deletion or unsafe overwrite is introduced.

## Verification

- `go test ./...`
- `cd desktop && go test ./...`
- `pnpm exec tsc --noEmit`
- Session recovery version, host lifecycle, recovery notification, recovery dialog, and isolated worktree frontend tests
- `git diff --check`

Related: #9838


Documentation-impact: updated - documents the new session version, recovery retry, reconciliation, and worktree lifecycle contracts in the PR description and user-facing localized UI.
