### PR TITLE
fix(desktop): fence stale prompt cards / 修复过期交互卡片提交竞态

### DIFF
--- a/desktop/decision_runtime_api.go
+++ b/desktop/decision_runtime_api.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+// PromptAnswerView is the Wails-safe union for all interactive cards.
+type PromptAnswerView struct {
+	Questions []QuestionAnswer `json:"questions,omitempty"`
+	Allow     bool             `json:"allow,omitempty"`
+	Session   bool             `json:"session,omitempty"`
+	Persist   bool             `json:"persist,omitempty"`
+	Action    string           `json:"action,omitempty"`
+	Feedback  string           `json:"feedback,omitempty"`
+	Content   map[string]any   `json:"content,omitempty"`
+}
+
+type PromptIdentityView struct {
+	PromptID     string `json:"promptId"`
+	TurnID       string `json:"turnId"`
+	RuntimeEpoch string `json:"runtimeEpoch,omitempty"`
+	Kind         string `json:"kind"`
+}
+
+func (a *App) PendingPromptIdentitiesForTab(tabID string) ([]PromptIdentityView, error) {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if ctrl == nil {
+		return []PromptIdentityView{}, a.workspaceNotReadyErr(tab)
+	}
+	reader, ok := ctrl.(interface {
+		PendingPromptIdentities() []control.PromptIdentity
+	})
+	if !ok {
+		return []PromptIdentityView{}, fmt.Errorf("prompt identity replay is unavailable")
+	}
+	identities := reader.PendingPromptIdentities()
+	views := make([]PromptIdentityView, 0, len(identities))
+	for _, identity := range identities {
+		views = append(views, PromptIdentityView{PromptID: identity.PromptID, TurnID: identity.TurnID, RuntimeEpoch: identity.RuntimeEpoch, Kind: string(identity.Kind)})
+	}
+	return views, nil
+}
+
+// ReplayPendingPromptIdentitiesForTab returns the authoritative identity list
+// without re-emitting cards. The existing ReplayPendingPromptsForTab method
+// remains the event replay compatibility surface.
+func (a *App) ReplayPendingPromptIdentitiesForTab(tabID string) ([]PromptIdentityView, error) {
+	return a.PendingPromptIdentitiesForTab(tabID)
+}
+
+// ResolvePromptForTab is the canonical exact-identity decision endpoint.
+func (a *App) ResolvePromptForTab(tabID, promptID, turnID, runtimeEpoch, kind string, answer PromptAnswerView) error {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if ctrl == nil {
+		return a.workspaceNotReadyErr(tab)
+	}
+	questions := make([]event.AskAnswer, len(answer.Questions))
+	for i, q := range answer.Questions {
+		questions[i] = event.AskAnswer{QuestionID: q.QuestionID, Selected: q.Selected}
+	}
+	resolver, ok := ctrl.(interface {
+		ResolvePromptExact(control.PromptIdentity, control.PromptAnswer) error
+	})
+	if !ok {
+		return fmt.Errorf("this runtime cannot resolve exact prompts")
+	}
+	return resolver.ResolvePromptExact(
+		control.PromptIdentity{PromptID: promptID, TurnID: turnID, RuntimeEpoch: runtimeEpoch, Kind: control.PromptKind(kind)},
+		control.PromptAnswer{Questions: questions, Allow: answer.Allow, Session: answer.Session, Persist: answer.Persist, Action: answer.Action, Feedback: answer.Feedback, Content: answer.Content},
+	)
+}
+
+// ApproveTabForTurn is the exact-identity approval entry point for new
+// frontends. The legacy ApproveTab method remains available to old clients.
+func (a *App) ApproveTabForTurn(tabID, turnID, runtimeEpoch, id string, allow, session, persist bool) error {
+	ctrl, err := a.validatePromptIdentity(tabID, turnID, runtimeEpoch)
+	if err != nil {
+		return err
+	}
+	ctrl.Approve(id, allow, session, persist)
+	return nil
+}
+
+func (a *App) ResolvePlanDecisionTabForTurn(tabID, turnID, runtimeEpoch, id, action string) error {
+	ctrl, err := a.validatePromptIdentity(tabID, turnID, runtimeEpoch)
+	if err != nil {
+		return err
+	}
+	return ctrl.ResolvePlanDecision(id, control.PlanDecisionAction(action))
+}
+
+func (a *App) ResolveRecoveryTabForTurn(tabID, turnID, runtimeEpoch, id, action, feedback string) error {
+	ctrl, err := a.validatePromptIdentity(tabID, turnID, runtimeEpoch)
+	if err != nil {
+		return err
+	}
+	return ctrl.ResolveRecovery(id, agent.RecoveryAction(action), feedback)
+}
+
+func (a *App) AnswerMCPInteractionForTurn(tabID, turnID, runtimeEpoch, id, action string, content map[string]any) error {
+	ctrl, err := a.validatePromptIdentity(tabID, turnID, runtimeEpoch)
+	if err != nil {
+		return err
+	}
+	resolver, ok := ctrl.(interface {
+		AnswerMCPInteractionChecked(string, string, map[string]any) error
+	})
+	if !ok {
+		return errMCPPromptUnsupported
+	}
+	return resolver.AnswerMCPInteractionChecked(id, action, content)
+}

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -206,7 +206,8 @@ console.log("\nbundle budgets");
 // explicit budget rather than failing on a rounded 467.0 KiB display value.
 // The latest main-v2 session-runtime fence adds a small cross-platform zlib
 // rounding step; retain the next decimal ceiling for Windows and macOS.
-const initialJSBudgetKiB = 467.7;
+// The exact prompt protocol adds a measured 0.3 KiB gzip on this base.
+const initialJSBudgetKiB = 468.0;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -388,7 +389,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // With the current-base rich-link menus: 2485.715 KiB raw.
 // The shared harness decision surface adds a bounded startup stylesheet
 // payload. The session-runtime fence and current-base merge measure 2493.1 KiB
-// locally; retain the smallest bounded cross-platform ceiling.
-const rawInitialBudgetKiB = 2_494.3;
+// locally; exact prompt identity, stale-card recovery, and the browser mock
+// resolver add a measured 1.5 KiB raw; retain the smallest bounded ceiling.
+const rawInitialBudgetKiB = 2_495.0;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -205,8 +205,8 @@ console.log("\nbundle budgets");
 // cross-platform zlib rounding reaches the same startup path; retain the
 // explicit budget rather than failing on a rounded 467.0 KiB display value.
 // The latest main-v2 session-runtime fence and exact prompt protocol measure
-// 468.1 KiB here; retain a 0.1 KiB ceiling for platform zlib rounding.
-const initialJSBudgetKiB = 468.2;
+// 468.2 KiB here; retain a 0.1 KiB ceiling for platform zlib rounding.
+const initialJSBudgetKiB = 468.3;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -388,7 +388,7 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // With the current-base rich-link menus: 2485.715 KiB raw.
 // The shared harness decision surface adds a bounded startup stylesheet
 // payload. The current base plus exact prompt identity and stale-card recovery
-// measure 2495.8 KiB locally; retain the smallest bounded ceiling.
-const rawInitialBudgetKiB = 2_496.0;
+// measure 2496.4 KiB locally; retain the smallest bounded ceiling.
+const rawInitialBudgetKiB = 2_496.5;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -204,10 +204,9 @@ console.log("\nbundle budgets");
 // initial route. The session-runtime ordering fence adds 56 bytes and
 // cross-platform zlib rounding reaches the same startup path; retain the
 // explicit budget rather than failing on a rounded 467.0 KiB display value.
-// The latest main-v2 session-runtime fence adds a small cross-platform zlib
-// rounding step; retain the next decimal ceiling for Windows and macOS.
-// The exact prompt protocol adds a measured 0.3 KiB gzip on this base.
-const initialJSBudgetKiB = 468.0;
+// The latest main-v2 session-runtime fence and exact prompt protocol measure
+// 468.1 KiB here; retain a 0.1 KiB ceiling for platform zlib rounding.
+const initialJSBudgetKiB = 468.2;
 assertBudget("initial JavaScript gzip", initialJSGzip, initialJSBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 // Render-blocking CSS is intentionally absent: styles.css loads deferred via
@@ -388,9 +387,8 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // current payload is 2484.509 KiB. Retain only bounded toolchain headroom.
 // With the current-base rich-link menus: 2485.715 KiB raw.
 // The shared harness decision surface adds a bounded startup stylesheet
-// payload. The session-runtime fence and current-base merge measure 2493.1 KiB
-// locally; exact prompt identity, stale-card recovery, and the browser mock
-// resolver add a measured 1.5 KiB raw; retain the smallest bounded ceiling.
-const rawInitialBudgetKiB = 2_495.0;
+// payload. The current base plus exact prompt identity and stale-card recovery
+// measure 2495.8 KiB locally; retain the smallest bounded ceiling.
+const rawInitialBudgetKiB = 2_496.0;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/__tests__/ask-submit.test.ts
+++ b/desktop/frontend/src/__tests__/ask-submit.test.ts
@@ -33,8 +33,8 @@ console.log("\nAsk prompt active-turn submission");
     ListTabs: async () => { listCalls += 1; return [tab]; },
     ResolvePromptForTab: async (tabId, promptId, turnId) => { exactCalls.push(`${tabId}:${turnId}:${promptId}`); },
   }), "tab-ask", "ask-1", answers, "turn-known");
-  eq(listCalls, 0, "card identity avoids an unnecessary ListTabs lookup");
-  eq(exactCalls.join("|"), "tab-ask:turn-known:ask-1", "card turn id fences the exact answer");
+  eq(listCalls, 1, "Ask refreshes the authoritative turn before submission");
+  eq(exactCalls.join("|"), "tab-ask:turn-authoritative:ask-1", "authoritative turn fences the exact answer");
 }
 
 {

--- a/desktop/frontend/src/__tests__/ask-submit.test.ts
+++ b/desktop/frontend/src/__tests__/ask-submit.test.ts
@@ -31,11 +31,10 @@ console.log("\nAsk prompt active-turn submission");
   const exactCalls: string[] = [];
   await answerPromptForActiveTurn(binding({
     ListTabs: async () => { listCalls += 1; return [tab]; },
-    AnswerQuestionForTab: async () => { throw new Error("legacy must not run"); },
-    AnswerPromptForTab: async (tabId, turnId, promptId) => { exactCalls.push(`${tabId}:${turnId}:${promptId}`); },
+    ResolvePromptForTab: async (tabId, promptId, turnId) => { exactCalls.push(`${tabId}:${turnId}:${promptId}`); },
   }), "tab-ask", "ask-1", answers, "turn-known");
-  eq(listCalls, 0, "known turn id avoids an unnecessary ListTabs lookup");
-  eq(exactCalls.join("|"), "tab-ask:turn-known:ask-1", "known turn id uses the exact prompt endpoint");
+  eq(listCalls, 0, "card identity avoids an unnecessary ListTabs lookup");
+  eq(exactCalls.join("|"), "tab-ask:turn-known:ask-1", "card turn id fences the exact answer");
 }
 
 {
@@ -43,74 +42,63 @@ console.log("\nAsk prompt active-turn submission");
   const exactCalls: string[] = [];
   await answerPromptForActiveTurn(binding({
     ListTabs: async () => { listCalls += 1; return [tab]; },
-    AnswerQuestionForTab: async () => { throw new Error("legacy must not run"); },
-    AnswerPromptForTab: async (tabId, turnId, promptId) => { exactCalls.push(`${tabId}:${turnId}:${promptId}`); },
+    ResolvePromptForTab: async (tabId, promptId, turnId) => { exactCalls.push(`${tabId}:${turnId}:${promptId}`); },
   }), "tab-ask", "ask-2", answers);
   eq(listCalls, 1, "missing local turn id is resolved from ListTabs once");
   eq(exactCalls.join("|"), "tab-ask:turn-authoritative:ask-2", "resolved turn id fences the exact answer");
 }
 
 {
-  let legacyCalls = 0;
   let exactCalls = 0;
   let rejected = "";
   try {
     await answerPromptForActiveTurn(binding({
       ListTabs: async () => [],
-      AnswerQuestionForTab: async () => { legacyCalls += 1; },
-      AnswerPromptForTab: async () => { exactCalls += 1; },
+      ResolvePromptForTab: async () => { exactCalls += 1; },
     }), "tab-ask", "ask-3", answers);
   } catch (error) {
     rejected = error instanceof Error ? error.message : String(error);
   }
-  eq(rejected.includes("active turn id is unavailable"), true, "missing authoritative turn id rejects visibly");
+  eq(rejected.includes("active turn identity is unavailable"), true, "missing authoritative turn id rejects visibly");
   eq(exactCalls, 0, "missing turn id never calls the exact endpoint with an empty fence");
-  eq(legacyCalls, 0, "missing turn id never falls back to the unfenced endpoint");
 }
 
 {
-  let legacyCalls = 0;
   let exactCalls = 0;
   let rejected = "";
   try {
     await answerPromptForActiveTurn(binding({
       ListTabs: async () => { throw new Error("ListTabs failed"); },
-      AnswerQuestionForTab: async () => { legacyCalls += 1; },
-      AnswerPromptForTab: async () => { exactCalls += 1; },
+      ResolvePromptForTab: async () => { exactCalls += 1; },
     }), "tab-ask", "ask-rpc", answers);
   } catch (error) {
     rejected = error instanceof Error ? error.message : String(error);
   }
   eq(rejected, "ListTabs failed", "authoritative turn lookup failure propagates");
   eq(exactCalls, 0, "failed turn lookup never calls the exact endpoint");
-  eq(legacyCalls, 0, "failed turn lookup never falls back to the unfenced endpoint");
 }
 
 {
-  let legacyCalls = 0;
   let rejected = "";
   try {
     await answerPromptForActiveTurn(binding({
       ListTabs: async () => [tab],
-      AnswerQuestionForTab: async () => { legacyCalls += 1; },
-      AnswerPromptForTab: async () => { throw new Error("stale turn"); },
+      ResolvePromptForTab: async () => { throw new Error("stale turn"); },
     }), "tab-ask", "ask-4", answers);
   } catch (error) {
     rejected = error instanceof Error ? error.message : String(error);
   }
   eq(rejected, "stale turn", "exact endpoint rejection propagates to the decision surface");
-  eq(legacyCalls, 0, "exact endpoint rejection never retries through the unfenced endpoint");
 }
 
 {
-  let listCalls = 0;
-  const legacyCalls: string[] = [];
-  await answerPromptForActiveTurn(binding({
-    ListTabs: async () => { listCalls += 1; return [tab]; },
-    AnswerQuestionForTab: async (tabId, promptId) => { legacyCalls.push(`${tabId}:${promptId}`); },
-  }), "tab-ask", "ask-legacy", answers);
-  eq(listCalls, 0, "legacy bridge compatibility does not require turn metadata");
-  eq(legacyCalls.join("|"), "tab-ask:ask-legacy", "legacy endpoint remains available only when the exact method is absent");
+  let rejected = "";
+  try {
+    await answerPromptForActiveTurn(binding({ ListTabs: async () => [tab] }), "tab-ask", "ask-legacy", answers);
+  } catch (error) {
+    rejected = error instanceof Error ? error.message : String(error);
+  }
+  eq(rejected.includes("active turn identity is unavailable"), true, "missing exact prompt API fails closed");
 }
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/__tests__/external-opener.test.tsx
+++ b/desktop/frontend/src/__tests__/external-opener.test.tsx
@@ -69,6 +69,7 @@ const bridge: ExternalOpenerBridge = {
 console.log("\nexternal opener");
 
 const stylesSource = readFileSync(new URL("../styles.css", import.meta.url), "utf8");
+const appSource = readFileSync(new URL("../App.tsx", import.meta.url), "utf8");
 const sharedControlRule = stylesSource.match(/(?:^|\n)\.external-opener\s*\{([^}]*)\}/)?.[1] ?? "";
 const sharedSegmentRule = stylesSource.match(
   /\.external-opener__primary,\s*\.external-opener__menu-trigger\s*\{([^}]*)\}/,

--- a/desktop/frontend/src/__tests__/prompt-expiry.test.ts
+++ b/desktop/frontend/src/__tests__/prompt-expiry.test.ts
@@ -1,0 +1,28 @@
+import { initialState, reducer } from "../lib/useController";
+
+let passed = 0;
+let failed = 0;
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (actual === expected) {
+    passed += 1;
+    process.stdout.write(`  PASS  ${label}\n`);
+  } else {
+    failed += 1;
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}\n`);
+  }
+}
+
+const state = reducer({
+  ...initialState,
+  promptEpoch: 7,
+  ask: { id: "ask-old", questions: [] },
+  mcpInteraction: { id: "mcp-new", server: "server", mode: "form", message: "new" },
+  pendingPrompt: true,
+}, { type: "expire_prompt", id: "ask-old", epoch: 7, kind: "ask" });
+
+eq(state.ask, undefined, "stale Ask expiry removes only its matching card");
+eq(state.mcpInteraction?.id, "mcp-new", "stale Ask expiry preserves a newer MCP card");
+
+console.log(`prompt expiry: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/remote-session-surface.test.tsx
+++ b/desktop/frontend/src/__tests__/remote-session-surface.test.tsx
@@ -404,14 +404,14 @@ await act(async () => {
   await flush();
 });
 await act(async () => {
-  [...document.querySelectorAll<HTMLButtonElement>("button")].find((button) => button.textContent?.trim() === "Other answer")?.click();
+  document.querySelector<HTMLElement>(".ask-shelf__custom-row")?.click();
   await flush();
 });
 await act(async () => {
   const input = document.querySelector<HTMLInputElement>(".ask-shelf__custom");
   if (input) {
-    Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, "value")?.set?.call(input, "canary");
-    input.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    const propsKey = Object.keys(input).find((key) => key.startsWith("__reactProps")); const props = propsKey ? (input as unknown as Record<string, { onChange?: (event: { target: { value: string } }) => void }>)[propsKey] : undefined;
+    props?.onChange?.({ target: { value: "canary" } });
   }
   await flush();
 });

--- a/desktop/frontend/src/__tests__/use-controller-send-fallback.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-send-fallback.test.tsx
@@ -102,6 +102,7 @@ let tabsAvailable = false;
 let submitCalls = 0;
 let rejectSubmit = false;
 let rejectAnswer = false;
+let rejectAnswerMessage = "prompt write failed";
 let rejectListTabs = false;
 let listTabsCalls = 0;
 const exactAnswerCalls: Array<{ tabId: string; turnId: string; promptId: string; answers: unknown[] }> = [];
@@ -144,11 +145,11 @@ window.go = {
       AnswerQuestionForTab: async (_tabId: string, promptId: string) => { legacyAnswerCalls.push(promptId); },
       AnswerPromptForTab: async (tabId: string, turnId: string, promptId: string, answers: unknown[]) => {
         exactAnswerCalls.push({ tabId, turnId, promptId, answers });
-        if (rejectAnswer) throw new Error("prompt write failed");
+        if (rejectAnswer) throw new Error(rejectAnswerMessage);
       },
       ResolvePromptForTab: async (tabId: string, promptId: string, turnId: string, _runtimeEpoch: string, _kind: string, answer: unknown) => {
         exactAnswerCalls.push({ tabId, turnId, promptId, answers: answer });
-        if (rejectAnswer) throw new Error("prompt write failed");
+        if (rejectAnswer) throw new Error(rejectAnswerMessage);
       },
     } as Partial<AppBindings> as AppBindings,
   },
@@ -272,6 +273,26 @@ await act(async () => {
 eq(listTabsCalls - beforeFailedReconcileCalls, 4, "rejected submit retries failed ListTabs reads at every bounded delay");
 eq(controller?.state.running, true, "exhausted status reads leave the composer conservatively blocked");
 rejectListTabs = false;
+
+backendTab = tabMeta({ running: true, pendingPrompt: true, turnId: "turn-authoritative" });
+await act(async () => {
+  for (const handler of eventHandlers) handler({
+    kind: "ask_request",
+    tabId: "tab-send",
+    turnId: "turn-authoritative",
+    ask: { id: "ask-stale", questions: [{ id: "q3", prompt: "Stale?", options: [{ label: "yes" }] }] },
+  } as WireEvent);
+  await flushPromises();
+});
+rejectAnswer = true;
+rejectAnswerMessage = 'turn "turn-old" is not the active turn for tab "tab-send"';
+await act(async () => {
+  try { await controller?.answerQuestion("ask-stale", [{ questionId: "q3", selected: ["yes"] }]); } catch {}
+  await flushPromises();
+});
+eq(controller?.state.ask, undefined, "stale Ask submission expires the old card");
+rejectAnswer = false;
+rejectAnswerMessage = "prompt write failed";
 
 await act(async () => {
   root.unmount();

--- a/desktop/frontend/src/__tests__/use-controller-send-fallback.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-send-fallback.test.tsx
@@ -146,6 +146,10 @@ window.go = {
         exactAnswerCalls.push({ tabId, turnId, promptId, answers });
         if (rejectAnswer) throw new Error("prompt write failed");
       },
+      ResolvePromptForTab: async (tabId: string, promptId: string, turnId: string, _runtimeEpoch: string, _kind: string, answer: unknown) => {
+        exactAnswerCalls.push({ tabId, turnId, promptId, answers: answer });
+        if (rejectAnswer) throw new Error("prompt write failed");
+      },
     } as Partial<AppBindings> as AppBindings,
   },
 };

--- a/desktop/frontend/src/lib/approvalTypes.ts
+++ b/desktop/frontend/src/lib/approvalTypes.ts
@@ -18,4 +18,6 @@ export interface WireApproval {
   kind?: "tool" | "plan" | "recovery" | "write_access" | string;
   recovery?: WireRecoveryApproval;
   write_access?: WireWriteAccessApproval;
+  turnId?: string;
+  runtimeEpoch?: string;
 }

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -282,10 +282,13 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   TurnEventsForTab?(tabID: string, afterSeq: number): Promise<TurnEventReplayView>;
   Approve(id: string, allow: boolean, session: boolean, persist: boolean): Promise<void>;
   ApproveTab(tabID: string, id: string, allow: boolean, session: boolean, persist: boolean): Promise<void>;
+  ApproveTabForTurn?(tabID: string, turnID: string, runtimeEpoch: string, id: string, allow: boolean, session: boolean, persist: boolean): Promise<void>;
   ResolvePlanDecision(id: string, action: "start_execution" | "revise_plan" | "exit_plan"): Promise<void>;
   ResolvePlanDecisionTab(tabID: string, id: string, action: "start_execution" | "revise_plan" | "exit_plan"): Promise<void>;
+  ResolvePlanDecisionTabForTurn?(tabID: string, turnID: string, runtimeEpoch: string, id: string, action: "start_execution" | "revise_plan" | "exit_plan"): Promise<void>;
   ResolveRecovery(id: string, action: string, feedback: string): Promise<void>;
   ResolveRecoveryTab(tabID: string, id: string, action: string, feedback: string): Promise<void>;
+  ResolveRecoveryTabForTurn?(tabID: string, turnID: string, runtimeEpoch: string, id: string, action: string, feedback: string): Promise<void>;
   SetRecoveryCheckpointEnabled(enabled: boolean): Promise<void>;
   SetRecoveryCheckpointEnabledTab(tabID: string, enabled: boolean): Promise<void>;
   RecoveryCheckpointEnabled(): Promise<boolean>;
@@ -298,7 +301,14 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
     action: "accept" | "decline" | "cancel",
     content: Record<string, unknown> | null,
   ): Promise<void>;
+  AnswerMCPInteractionForTurn?(tabID: string, turnID: string, runtimeEpoch: string, id: string, action: "accept" | "decline" | "cancel", content: Record<string, unknown> | null): Promise<void>;
   AnswerPromptForTab?(tabID: string, turnID: string, id: string, answers: QuestionAnswer[]): Promise<void>;
+  ResolvePromptForTab?(tabID: string, promptID: string, turnID: string, runtimeEpoch: string, kind: string, answer: {
+    questions?: QuestionAnswer[]; allow?: boolean; session?: boolean; persist?: boolean;
+    action?: string; feedback?: string; content?: Record<string, unknown> | null;
+  }): Promise<void>;
+  PendingPromptIdentitiesForTab?(tabID: string): Promise<Array<{ promptId: string; turnId: string; runtimeEpoch?: string; kind: string }>>;
+  ReplayPendingPromptIdentitiesForTab?(tabID: string): Promise<Array<{ promptId: string; turnId: string; runtimeEpoch?: string; kind: string }>>;
   ReplayPendingPrompts(): Promise<void>;
   ReplayPendingPromptsForTab(tabID: string): Promise<void>;
   SetPlanMode(on: boolean): Promise<void>;
@@ -3140,6 +3150,16 @@ function makeMockApp(): AppBindings {
         ...makeMockMCPAppBindings(), ...makeMockPinnedContextBindings(),
         async AnswerQuestionForTab(_tabID, id, answers) {
           await withMockTabScope(_tabID, () => this.AnswerQuestion(id, answers));
+        },
+        async ResolvePromptForTab(tabID, promptID, _turnID, _runtimeEpoch, kind, answer) {
+          await withMockTabScope(tabID, async () => {
+            if (kind === "ask") return this.AnswerQuestion(promptID, answer.questions ?? []);
+            if (kind === "approval") return this.Approve(promptID, Boolean(answer.allow), Boolean(answer.session), Boolean(answer.persist));
+            if (kind === "plan") return this.ResolvePlanDecisionTab(tabID, promptID, (answer.action ?? "exit_plan") as "start_execution" | "revise_plan" | "exit_plan");
+            if (kind === "recovery") return this.ResolveRecoveryTab(tabID, promptID, answer.action ?? "revise", answer.feedback ?? "");
+            if (kind === "mcp") return this.AnswerMCPInteractionForTab(tabID, promptID, (answer.action ?? "cancel") as "accept" | "decline" | "cancel", answer.content ?? null);
+            throw new Error(`unsupported prompt kind: ${kind}`);
+          });
         },
         async ReplayPendingPrompts() {},
         async ReplayPendingPromptsForTab(_tabID) {},

--- a/desktop/frontend/src/lib/exactPromptSubmit.ts
+++ b/desktop/frontend/src/lib/exactPromptSubmit.ts
@@ -1,0 +1,18 @@
+import type { AppBindings } from "./bridge";
+
+type ExactPromptBinding = Pick<AppBindings, "ListTabs" | "ResolvePromptForTab">;
+
+export async function resolvePromptForTab(
+  binding: ExactPromptBinding,
+  tabId: string,
+  promptId: string,
+  kind: string,
+  answer: Record<string, unknown>,
+  knownTurnId?: string,
+  knownRuntimeEpoch?: string,
+): Promise<void> {
+  const tab = knownTurnId ? undefined : (await binding.ListTabs()).find((candidate) => candidate.id === tabId);
+  const turnId = knownTurnId ?? tab?.turnId;
+  if (!binding.ResolvePromptForTab || !turnId) throw new Error("active turn identity is unavailable");
+  await binding.ResolvePromptForTab(tabId, promptId, turnId, knownRuntimeEpoch ?? tab?.runtime?.epoch ?? "", kind, answer);
+}

--- a/desktop/frontend/src/lib/exactPromptSubmit.ts
+++ b/desktop/frontend/src/lib/exactPromptSubmit.ts
@@ -11,8 +11,15 @@ export async function resolvePromptForTab(
   knownTurnId?: string,
   knownRuntimeEpoch?: string,
 ): Promise<void> {
-  const tab = knownTurnId ? undefined : (await binding.ListTabs()).find((candidate) => candidate.id === tabId);
-  const turnId = knownTurnId ?? tab?.turnId;
+  // Ask cards must refresh the active turn from the tab owner immediately
+  // before submission. A locally captured turn is useful for the identity
+  // fence, but it is not authoritative during startup/rebind races.
+  // Other prompt kinds keep their immutable card turn and only consult
+  // ListTabs when the card arrived before local turn state was available.
+  const tab = kind === "ask" || !knownTurnId
+    ? (await binding.ListTabs()).find((candidate) => candidate.id === tabId)
+    : undefined;
+  const turnId = kind === "ask" ? tab?.turnId : (knownTurnId ?? tab?.turnId);
   if (!binding.ResolvePromptForTab || !turnId) throw new Error("active turn identity is unavailable");
   await binding.ResolvePromptForTab(tabId, promptId, turnId, knownRuntimeEpoch ?? tab?.runtime?.epoch ?? "", kind, answer);
 }

--- a/desktop/frontend/src/lib/inboxSubmit.ts
+++ b/desktop/frontend/src/lib/inboxSubmit.ts
@@ -6,12 +6,29 @@ import type { QuestionAnswer } from "./types";
 type InboxEnqueueBindings = Pick<AppBindings, "EnqueueInboxFollowup" | "EnqueueInboxFollowupWithInvocations" | "EnqueueInboxSteer" | "EnqueueInboxSteerForTurn">;
 type ActiveTurnBindings = Pick<AppBindings, "ListTabs" | "SteerInboxItem" | "SteerInboxItemForTurn">;
 
-export async function resolveActiveTurnId(binding: Pick<AppBindings, "ListTabs">, tabId: string, known?: string): Promise<string | undefined> {
-  if (known) return known;
-  return asArray(await binding.ListTabs()).find((tab) => tab.id === tabId)?.turnId;
+export async function resolveActiveTurnId(binding: Pick<AppBindings, "ListTabs">, tabId: string, _known?: string): Promise<string | undefined> {
+  // The cached id can outlive the controller turn during startup, recovery,
+  // or a runtime rebuild. Always refresh from the tab owner before crossing
+  // the exact-turn answer/steer boundary; the optional value is only a hint
+  // for callers that have not received local state yet.
+  const authoritative = asArray(await binding.ListTabs()).find((tab) => tab.id === tabId)?.turnId;
+  return authoritative;
 }
 
-type AskAnswerBindings = Pick<AppBindings, "ListTabs" | "AnswerQuestionForTab" | "AnswerPromptForTab">;
+type AskAnswerBindings = Pick<AppBindings, "ListTabs" | "ResolvePromptForTab">;
+
+export async function resolvePromptForTab(
+  binding: Pick<AppBindings, "ListTabs" | "ResolvePromptForTab">,
+  tabId: string,
+  promptId: string,
+  kind: string,
+  answer: Record<string, unknown>,
+  knownTurnId?: string,
+  knownRuntimeEpoch?: string,
+): Promise<void> {
+  const submit = await import("./exactPromptSubmit");
+  return submit.resolvePromptForTab(binding, tabId, promptId, kind, answer, knownTurnId, knownRuntimeEpoch);
+}
 
 // Final frontend boundary before optimistic transcript state is created.
 export function normalizeTurnSubmit(displayText: string, submitText: string) {
@@ -27,14 +44,9 @@ export async function answerPromptForActiveTurn(
   promptId: string,
   answers: QuestionAnswer[],
   knownTurnId?: string,
+  knownRuntimeEpoch?: string,
 ): Promise<void> {
-  if (typeof binding.AnswerPromptForTab !== "function") {
-    await binding.AnswerQuestionForTab(tabId, promptId, answers);
-    return;
-  }
-  const turnId = await resolveActiveTurnId(binding, tabId, knownTurnId);
-  if (!turnId) throw new Error("active turn id is unavailable");
-  await binding.AnswerPromptForTab(tabId, turnId, promptId, answers);
+  await resolvePromptForTab(binding, tabId, promptId, "ask", { questions: answers }, knownTurnId, knownRuntimeEpoch);
 }
 
 export async function steerInboxItemForActiveTurn(binding: ActiveTurnBindings, tabId: string, itemId: string, knownTurnId?: string) {

--- a/desktop/frontend/src/lib/promptReplay.ts
+++ b/desktop/frontend/src/lib/promptReplay.ts
@@ -1,5 +1,7 @@
 import { app } from "./bridge";
 
+const replayInFlight = new Set<string>();
+
 export function replayPendingPromptsForActiveTab(
   activeTabId: string | undefined,
   replay: (tabId: string) => Promise<void> = (tabId) => {
@@ -9,5 +11,7 @@ export function replayPendingPromptsForActiveTab(
   },
 ): void {
   if (!activeTabId) return;
-  void replay(activeTabId).catch(() => {});
+  if (replayInFlight.has(activeTabId)) return;
+  replayInFlight.add(activeTabId);
+  void replay(activeTabId).catch(() => {}).finally(() => replayInFlight.delete(activeTabId));
 }

--- a/desktop/frontend/src/lib/turnSubmissionFailure.ts
+++ b/desktop/frontend/src/lib/turnSubmissionFailure.ts
@@ -71,9 +71,13 @@ export async function findTabAfterSubmitFailure(
 ) {
   for (const delay of delays) {
     if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
-    const snapshotAt = clock();
     try {
       const tab = asArray(await binding.ListTabs()).find((candidate) => candidate.id === tabId);
+      // Sample after the authoritative read. A synchronous bridge may resolve
+      // within the same monotonic tick as the initiating lifecycle event; the
+      // tiny deterministic advance records that the read has completed without
+      // weakening the reducer's tie guard.
+      const snapshotAt = clock() + 0.001;
       return [tab, snapshotAt] as const;
     } catch {
       // The caller's stale-turn watchdog remains the long-tail backstop.

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -248,6 +248,20 @@ export interface WireAskOption {
   description?: string;
 }
 
+export type PromptKind = "ask" | "approval" | "plan" | "recovery" | "mcp";
+export interface PromptIdentity {
+  promptId: string;
+  turnId?: string;
+  runtimeEpoch?: string;
+  kind: PromptKind;
+}
+export type PromptLifecycle = "pending" | "submitting" | "resolved" | "expired";
+export interface DecisionCardState {
+  identity: PromptIdentity;
+  lifecycle: PromptLifecycle;
+  failureNoticeShown?: boolean;
+}
+
 export interface WireAskQuestion {
   id: string;
   header?: string;
@@ -259,6 +273,8 @@ export interface WireAskQuestion {
 export interface WireAsk {
   id: string;
   questions: WireAskQuestion[];
+  turnId?: string;
+  runtimeEpoch?: string;
 }
 
 export type { MCPAppInstanceView, MCPAppPresentation } from "./mcpAppProtocol";
@@ -273,6 +289,8 @@ export interface WireMCPInteraction {
   requestedSchema?: unknown;
   url?: string;
   elicitationId?: string;
+  turnId?: string;
+  runtimeEpoch?: string;
 }
 
 // Extension UI surfaces (stage 8a) — structured-only documents published by
@@ -364,6 +382,9 @@ export interface MemoryCitation {
 
 export interface WireEvent extends RecoveryEventFields {
   kind: EventKind;
+  promptId?: string;
+  promptKind?: "ask" | "approval" | "plan" | "recovery" | "mcp" | string;
+  promptLegacy?: boolean;
   turnId?: string;
   seq?: number;
   status?: TurnStatus;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -364,9 +364,9 @@ function isStalePromptError(error: unknown): boolean {
   return /active turn|runtime changed|stale/i.test(errorMessage(error));
 }
 
-function handlePromptFailure(dispatchTo: (tabId: string, action: Action) => void, tabId: string, id: string, epoch: number, error: unknown, clear?: "clearApproval" | "clearAsk") {
-  if (isStalePromptError(error) && clear) dispatchTo(tabId, { type: clear });
-  else if (clear === "clearApproval") dispatchTo(tabId, { type: "submit_prompt_failed", id, epoch });
+function handlePromptFailure(dispatchTo: (tabId: string, action: Action) => void, tabId: string, id: string, epoch: number, error: unknown, kind?: "approval" | "ask" | "mcp") {
+  if (isStalePromptError(error) && kind) dispatchTo(tabId, { type: "expire_prompt", id, epoch, kind });
+  else if (kind) dispatchTo(tabId, { type: "submit_prompt_failed", id, epoch });
   replayPendingPromptsForActiveTab(tabId);
 }
 
@@ -830,6 +830,7 @@ type Action =
   | { type: "local_notice"; level: "info" | "warn"; text: string; preserveRuntime?: boolean }
   | { type: "clearApproval" }
   | { type: "clearAsk" }
+  | { type: "expire_prompt"; id: string; epoch: number; kind: "approval" | "ask" | "mcp" }
   | { type: "clearExtensionForm" }
   | { type: "extension_notifications_drained" }
   | { type: "approval_drained"; ids: string[]; epoch: number }
@@ -2352,6 +2353,19 @@ export function reducer(s: State, a: Action): State {
         resolvedPromptId: s.ask?.id ?? s.mcpInteraction?.id ?? s.resolvedPromptId,
       };
       return endPromptWaitIfIdle(next);
+    }
+    case "expire_prompt": {
+      if (s.promptEpoch !== a.epoch) return s;
+      if (a.kind === "approval") {
+        if (s.approval?.id !== a.id) return s;
+        return endPromptWaitIfIdle({ ...s, approval: undefined, pendingPrompt: Boolean(s.ask || s.mcpInteraction), resolvedPromptId: a.id });
+      }
+      if (a.kind === "ask") {
+        if (s.ask?.id !== a.id) return s;
+        return endPromptWaitIfIdle({ ...s, ask: undefined, pendingPrompt: Boolean(s.approval || s.mcpInteraction), resolvedPromptId: a.id });
+      }
+      if (s.mcpInteraction?.id !== a.id) return s;
+      return endPromptWaitIfIdle({ ...s, mcpInteraction: undefined, pendingPrompt: Boolean(s.approval || s.ask), resolvedPromptId: a.id });
     }
     case "clearExtensionForm": return s.extensionForm ? { ...s, extensionForm: undefined } : s;
     case "extension_notifications_drained": return s.extensionNotifications.length > 0 ? { ...s, extensionNotifications: [] } : s;
@@ -3942,7 +3956,7 @@ export function useController() {
     // numeric id (#6432 round 4).
     const epoch = statesRef.current.get(tabId)?.promptEpoch ?? 0;
     dispatchTo(tabId, { type: "clearApproval" });
-    resolvePromptForTab(app, tabId, id, "approval", { allow, session, persist }, promptState?.approval?.turnId ?? promptState?.activeTurnId, promptState?.approval?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).catch((error) => handlePromptFailure(dispatchTo, tabId, id, epoch, error, "clearApproval"));
+    resolvePromptForTab(app, tabId, id, "approval", { allow, session, persist }, promptState?.approval?.turnId ?? promptState?.activeTurnId, promptState?.approval?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).catch((error) => handlePromptFailure(dispatchTo, tabId, id, epoch, error, "approval"));
   }, [activeTabId, dispatchTo]);
 
   const resolvePlanDecision = useCallback((id: string, action: "start_execution" | "revise_plan" | "exit_plan") => {
@@ -3951,7 +3965,7 @@ export function useController() {
     const promptState = statesRef.current.get(tabId);
     const epoch = statesRef.current.get(tabId)?.promptEpoch ?? 0;
     dispatchTo(tabId, { type: "clearApproval" });
-    resolvePromptForTab(app, tabId, id, "plan", { action }, promptState?.approval?.turnId ?? promptState?.activeTurnId, promptState?.approval?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).catch((error) => handlePromptFailure(dispatchTo, tabId, id, epoch, error, "clearApproval"));
+    resolvePromptForTab(app, tabId, id, "plan", { action }, promptState?.approval?.turnId ?? promptState?.activeTurnId, promptState?.approval?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).catch((error) => handlePromptFailure(dispatchTo, tabId, id, epoch, error, "approval"));
   }, [activeTabId, dispatchTo]);
 
   const resolveRecovery = useCallback((id: string, action: "continue" | "continue_task" | "revise" | "stop", feedback = "") => {
@@ -3960,7 +3974,7 @@ export function useController() {
     const promptState = statesRef.current.get(tabId);
     const epoch = statesRef.current.get(tabId)?.promptEpoch ?? 0;
     dispatchTo(tabId, { type: "clearApproval" });
-    resolvePromptForTab(app, tabId, id, "recovery", { action, feedback }, promptState?.approval?.turnId ?? promptState?.activeTurnId, promptState?.approval?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).catch((error) => handlePromptFailure(dispatchTo, tabId, id, epoch, error, "clearApproval"));
+    resolvePromptForTab(app, tabId, id, "recovery", { action, feedback }, promptState?.approval?.turnId ?? promptState?.activeTurnId, promptState?.approval?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).catch((error) => handlePromptFailure(dispatchTo, tabId, id, epoch, error, "approval"));
   }, [activeTabId, dispatchTo]);
 
   const answerQuestion = useCallback((id: string, answers: QuestionAnswer[]): Promise<void> => {
@@ -3971,7 +3985,7 @@ export function useController() {
     return answerPromptForActiveTurn(app, tabId, id, answers, state?.ask?.turnId ?? state?.activeTurnId, state?.ask?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).then(
       () => dispatchTo(tabId, { type: "ask_submit_succeeded", id, epoch }),
       (error) => {
-        if (isStalePromptError(error)) dispatchTo(tabId, { type: "clearAsk" });
+        if (isStalePromptError(error)) dispatchTo(tabId, { type: "expire_prompt", id, epoch, kind: "ask" });
         else dispatchTo(tabId, { type: "local_notice", level: "warn", text: t("notice.askSubmitFailed", { error: errorMessage(error) }), preserveRuntime: true });
         void reconcileRuntimeAfterRejectedMutation(tabId);
         throw error;
@@ -3984,8 +3998,9 @@ export function useController() {
       if (!activeTabId) return;
       const tabId = activeTabId;
       const promptState = statesRef.current.get(tabId);
-      dispatchTo(tabId, { type: "clearAsk" });
-      resolvePromptForTab(app, tabId, id, "mcp", { action, content: content ?? null }, promptState?.mcpInteraction?.turnId ?? promptState?.activeTurnId, promptState?.mcpInteraction?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).catch((error) => handlePromptFailure(dispatchTo, tabId, id, promptState?.promptEpoch ?? 0, error));
+      const epoch = promptState?.promptEpoch ?? 0;
+      dispatchTo(tabId, { type: "expire_prompt", id, epoch, kind: "mcp" });
+      resolvePromptForTab(app, tabId, id, "mcp", { action, content: content ?? null }, promptState?.mcpInteraction?.turnId ?? promptState?.activeTurnId, promptState?.mcpInteraction?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).catch((error) => handlePromptFailure(dispatchTo, tabId, id, epoch, error, "mcp"));
     },
     [activeTabId, dispatchTo],
   );

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -12,7 +12,7 @@ import { settleForkConversationForTab } from "./forkWorktree";
 import type { MessageActionScope, MessageActionState } from "./messageActions";
 import { mergeRateBand, type AggregatedRateBand } from "./costRateBand";
 import { requestInboxCancel, type CancelOutcome } from "./inboxCancel";
-import { answerPromptForActiveTurn, normalizeTurnSubmit, resolveActiveTurnId } from "./inboxSubmit";
+import { answerPromptForActiveTurn, normalizeTurnSubmit, resolveActiveTurnId, resolvePromptForTab } from "./inboxSubmit";
 import { findTabAfterSubmitFailure, reduceManagementConfirmation, reduceSubmitFailure } from "./turnSubmissionFailure";
 import { formatContextMaintenanceNotice, isNewMaintenanceOperation, rememberMaintenanceOperation } from "./contextMaintenanceTypes";
 import { formatGuardianAssessmentNotice } from "./guardianEvents";
@@ -89,6 +89,7 @@ import type {
   WireUsage,
   WireShellExecution,
 } from "./types";
+
 export { foregroundRunningFromRuntimeMeta } from "./runtimeMeta";
 export {
   deliveryReadinessDetail,
@@ -358,6 +359,17 @@ export function acceptsExtensionGeneration(stored: number | undefined, incoming:
 // prefixes persisted steers the same way). The prefix is the only durable
 // marker, so display code identifies steers by it.
 export const STEER_NOTICE_PREFIX = "↪ ";
+
+function isStalePromptError(error: unknown): boolean {
+  return /active turn|runtime changed|stale/i.test(errorMessage(error));
+}
+
+function handlePromptFailure(dispatchTo: (tabId: string, action: Action) => void, tabId: string, id: string, epoch: number, error: unknown, clear?: "clearApproval" | "clearAsk") {
+  if (isStalePromptError(error) && clear) dispatchTo(tabId, { type: clear });
+  else if (clear === "clearApproval") dispatchTo(tabId, { type: "submit_prompt_failed", id, epoch });
+  replayPendingPromptsForActiveTab(tabId);
+}
+
 export function isSteerNoticeText(text: string): boolean {
   return text.startsWith(STEER_NOTICE_PREFIX);
 }
@@ -1841,7 +1853,7 @@ function applyEvent(s: State, e: WireEvent, preserveToolPayloads = false): State
       return beginPromptWait({
         ...s,
         activeTurnId: e.turnId ?? s.activeTurnId,
-        approval: e.approval,
+        approval: e.approval ? { ...e.approval, turnId: e.turnId ?? e.approval.turnId, runtimeEpoch: e.runtimeEpoch ?? e.approval.runtimeEpoch } : e.approval,
         // A replay of the SAME prompt (post-answer delayed delivery, or the
         // #6429 re-arm after activation) keeps the original arrival time; only
         // a genuinely new prompt id re-anchors it (#6432 reverse race).
@@ -1859,7 +1871,7 @@ function applyEvent(s: State, e: WireEvent, preserveToolPayloads = false): State
       return beginPromptWait({
         ...s,
         activeTurnId: e.turnId ?? s.activeTurnId,
-        ask: e.ask,
+        ask: e.ask ? { ...e.ask, turnId: e.turnId ?? e.ask.turnId, runtimeEpoch: e.runtimeEpoch ?? e.ask.runtimeEpoch } : e.ask,
         promptArrivedAt: e.ask?.id === s.promptArrivedId ? s.promptArrivedAt : promptEventClock(),
         promptArrivedId: e.ask?.id,
         pendingPrompt: true,
@@ -1874,7 +1886,7 @@ function applyEvent(s: State, e: WireEvent, preserveToolPayloads = false): State
       return beginPromptWait({
         ...s,
         activeTurnId: e.turnId ?? s.activeTurnId,
-        mcpInteraction: e.mcpInteraction,
+        mcpInteraction: e.mcpInteraction ? { ...e.mcpInteraction, turnId: e.turnId ?? e.mcpInteraction.turnId, runtimeEpoch: e.runtimeEpoch ?? e.mcpInteraction.runtimeEpoch } : e.mcpInteraction,
         promptArrivedAt: e.mcpInteraction?.id === s.promptArrivedId ? s.promptArrivedAt : promptEventClock(),
         promptArrivedId: e.mcpInteraction?.id,
         pendingPrompt: true,
@@ -3923,44 +3935,32 @@ export function useController() {
   const approve = useCallback((id: string, allow: boolean, session: boolean, persist: boolean) => {
     if (!activeTabId) return;
     const tabId = activeTabId;
+    const promptState = statesRef.current.get(tabId);
     // Pin the failure callback to the prompt-id epoch the RPC was issued in:
     // if a controller rebuild lands while the call is in flight, a late
     // failure must not undo bookkeeping the NEW controller wrote for the same
     // numeric id (#6432 round 4).
     const epoch = statesRef.current.get(tabId)?.promptEpoch ?? 0;
     dispatchTo(tabId, { type: "clearApproval" });
-    app.ApproveTab(tabId, id, allow, session, persist).catch(() => {
-      // The backend never actually resolved this prompt — undo the optimistic
-      // tombstone and ask it to replay, so the approval card can come back
-      // instead of being silently lost forever (#6432 round 3).
-      dispatchTo(tabId, { type: "submit_prompt_failed", id, epoch });
-      replayPendingPromptsForActiveTab(tabId);
-    });
+    resolvePromptForTab(app, tabId, id, "approval", { allow, session, persist }, promptState?.approval?.turnId ?? promptState?.activeTurnId, promptState?.approval?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).catch((error) => handlePromptFailure(dispatchTo, tabId, id, epoch, error, "clearApproval"));
   }, [activeTabId, dispatchTo]);
 
   const resolvePlanDecision = useCallback((id: string, action: "start_execution" | "revise_plan" | "exit_plan") => {
     if (!activeTabId) return;
     const tabId = activeTabId;
+    const promptState = statesRef.current.get(tabId);
     const epoch = statesRef.current.get(tabId)?.promptEpoch ?? 0;
     dispatchTo(tabId, { type: "clearApproval" });
-    const request = typeof app.ResolvePlanDecisionTab === "function"
-      ? app.ResolvePlanDecisionTab(tabId, id, action)
-      : app.ApproveTab(tabId, id, action === "start_execution", false, false);
-    request.catch(() => {
-      dispatchTo(tabId, { type: "submit_prompt_failed", id, epoch });
-      replayPendingPromptsForActiveTab(tabId);
-    });
+    resolvePromptForTab(app, tabId, id, "plan", { action }, promptState?.approval?.turnId ?? promptState?.activeTurnId, promptState?.approval?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).catch((error) => handlePromptFailure(dispatchTo, tabId, id, epoch, error, "clearApproval"));
   }, [activeTabId, dispatchTo]);
 
   const resolveRecovery = useCallback((id: string, action: "continue" | "continue_task" | "revise" | "stop", feedback = "") => {
     if (!activeTabId) return;
     const tabId = activeTabId;
+    const promptState = statesRef.current.get(tabId);
     const epoch = statesRef.current.get(tabId)?.promptEpoch ?? 0;
     dispatchTo(tabId, { type: "clearApproval" });
-    app.ResolveRecoveryTab(tabId, id, action, feedback).catch(() => {
-      dispatchTo(tabId, { type: "submit_prompt_failed", id, epoch });
-      replayPendingPromptsForActiveTab(tabId);
-    });
+    resolvePromptForTab(app, tabId, id, "recovery", { action, feedback }, promptState?.approval?.turnId ?? promptState?.activeTurnId, promptState?.approval?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).catch((error) => handlePromptFailure(dispatchTo, tabId, id, epoch, error, "clearApproval"));
   }, [activeTabId, dispatchTo]);
 
   const answerQuestion = useCallback((id: string, answers: QuestionAnswer[]): Promise<void> => {
@@ -3968,7 +3968,7 @@ export function useController() {
     const tabId = activeTabId;
     const state = statesRef.current.get(tabId);
     const epoch = state?.promptEpoch ?? 0;
-    return answerPromptForActiveTurn(app, tabId, id, answers, state?.activeTurnId).then(
+    return answerPromptForActiveTurn(app, tabId, id, answers, state?.ask?.turnId ?? state?.activeTurnId, state?.ask?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).then(
       () => dispatchTo(tabId, { type: "ask_submit_succeeded", id, epoch }),
       (error) => {
         dispatchTo(tabId, { type: "local_notice", level: "warn", text: t("notice.askSubmitFailed", { error: errorMessage(error) }), preserveRuntime: true });
@@ -3982,10 +3982,9 @@ export function useController() {
     (id: string, action: "accept" | "decline" | "cancel", content?: Record<string, unknown>) => {
       if (!activeTabId) return;
       const tabId = activeTabId;
+      const promptState = statesRef.current.get(tabId);
       dispatchTo(tabId, { type: "clearAsk" });
-      app.AnswerMCPInteractionForTab(tabId, id, action, content ?? null).catch(() => {
-        replayPendingPromptsForActiveTab(tabId);
-      });
+      resolvePromptForTab(app, tabId, id, "mcp", { action, content: content ?? null }, promptState?.mcpInteraction?.turnId ?? promptState?.activeTurnId, promptState?.mcpInteraction?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).catch((error) => handlePromptFailure(dispatchTo, tabId, id, promptState?.promptEpoch ?? 0, error));
     },
     [activeTabId, dispatchTo],
   );

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -2045,7 +2045,7 @@ export function reducer(s: State, a: Action): State {
         promptArrivedId: undefined,
         pendingUser: a.text,
         pendingSubmissionId: a.submissionId,
-        activeTurnId: undefined,
+        activeTurnId: s.turnActive ? s.activeTurnId : undefined,
         currentAssistant: undefined,
         assistantSegmentOrdinal: 0,
         live: undefined,
@@ -3190,9 +3190,9 @@ export function useController() {
     return tabs.find((tab) => tab.active) ?? tabs[0];
   }, []);
 
-  // snapshotAt is the promptEventClock() reading taken immediately before
-  // initiating the backend call that produced `tab`. The reducer uses it to
-  // ignore snapshots that predate a live approval/ask event (#6429).
+  // snapshotAt is the promptEventClock() reading taken after the backend call
+  // produced `tab`. The reducer uses it to ignore snapshots that predate a
+  // live approval/ask event (#6429).
   const dispatchRuntimeStatusForTab = useCallback((tabId: string, tab: RuntimeMetaSnapshot, snapshotAt?: number) => {
     const foregroundRunning = foregroundRunningFromRuntimeMeta(tab);
     const runtimeEpoch = tab.runtime?.epoch;
@@ -3213,7 +3213,7 @@ export function useController() {
       turnId: tab.turnId,
       turnStatus: tab.turnStatus,
       runtimeEpoch,
-      turnEventSeq: latestEventSeq,
+      turnEventSeq: tab.turnEventSeq,
       snapshotAt,
     });
     // backend_status reconciliation can clear a live prompt from frontend state.
@@ -3971,7 +3971,8 @@ export function useController() {
     return answerPromptForActiveTurn(app, tabId, id, answers, state?.ask?.turnId ?? state?.activeTurnId, state?.ask?.runtimeEpoch ?? runtimeEpochByTabRef.current.get(tabId)).then(
       () => dispatchTo(tabId, { type: "ask_submit_succeeded", id, epoch }),
       (error) => {
-        dispatchTo(tabId, { type: "local_notice", level: "warn", text: t("notice.askSubmitFailed", { error: errorMessage(error) }), preserveRuntime: true });
+        if (isStalePromptError(error)) dispatchTo(tabId, { type: "clearAsk" });
+        else dispatchTo(tabId, { type: "local_notice", level: "warn", text: t("notice.askSubmitFailed", { error: errorMessage(error) }), preserveRuntime: true });
         void reconcileRuntimeAfterRejectedMutation(tabId);
         throw error;
       },

--- a/desktop/turn_runtime_api.go
+++ b/desktop/turn_runtime_api.go
@@ -19,6 +19,24 @@ type TurnStartView struct {
 	SubmissionID string                    `json:"submissionId,omitempty"`
 }
 
+// validatePromptIdentity fences a decision to the runtime and turn that
+// rendered its card. It is intentionally shared by every decision surface;
+// callers must still resolve the prompt on the same controller instance.
+func (a *App) validatePromptIdentity(tabID, turnID, runtimeEpoch string) (control.SessionAPI, error) {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if ctrl == nil {
+		return nil, a.workspaceNotReadyErr(tab)
+	}
+	status := ctrl.RuntimeStatus()
+	if strings.TrimSpace(turnID) == "" || status.TurnID != strings.TrimSpace(turnID) {
+		return nil, fmt.Errorf("turn %q is not the active turn for tab %q", turnID, tabID)
+	}
+	if epoch := strings.TrimSpace(runtimeEpoch); epoch != "" && tab != nil && tab.sink != nil && tab.sink.runtimeEpochSnapshot() != epoch {
+		return nil, fmt.Errorf("runtime changed while resolving prompt for tab %q", tabID)
+	}
+	return ctrl, nil
+}
+
 // StartTurnForTab is the turn-id-aware replacement for SubmitToTab. Existing
 // Submit entry points remain compatibility wrappers during the protocol cutover.
 func (a *App) StartTurnForTab(tabID, input, submissionID string) (TurnStartView, error) {

--- a/docs/DESKTOP_PROMPT_IDENTITY.md
+++ b/docs/DESKTOP_PROMPT_IDENTITY.md
@@ -1,0 +1,25 @@
+# Desktop prompt identity
+
+Desktop decision cards are owned by the controller that created them. Every
+new prompt request carries a prompt id, the owning turn id, and the runtime
+epoch visible to the tab. The kind identifies the decision surface: `ask`,
+`approval`, `plan`, `recovery`, or `mcp`.
+
+The frontend submits these values through `ResolvePromptForTab`. The controller
+checks the runtime epoch, active turn, prompt owner, and pending state under its
+exact-resolution boundary before persisting `PromptAnswered` and waking the
+original waiter. A stale turn or runtime is rejected without routing the answer
+to a replacement controller. Failed persistence restores the prompt to its
+pending state so the user can retry.
+
+Prompt requests and lifecycle events expose `promptId`, `promptKind`, and
+`turnId`. Desktop event envelopes carry the tab runtime epoch. Events without a
+turn identity are marked `promptLegacy` and are accepted only by compatibility
+paths.
+
+Older Wails methods such as `AnswerQuestionForTab`, `ApproveTab`, and
+`ResolveRecoveryTab` remain available for older clients. New frontend code uses
+`ResolvePromptForTab` and does not silently downgrade to an unfenced method.
+When a stale response is received, the card is removed from the active decision
+surface and one tab-scoped prompt replay is requested; only a new pending
+identity can re-arm a card.

--- a/docs/DESKTOP_PROMPT_IDENTITY.zh-CN.md
+++ b/docs/DESKTOP_PROMPT_IDENTITY.zh-CN.md
@@ -1,0 +1,20 @@
+# Desktop 交互卡片身份
+
+Desktop 决策卡片由创建它的 controller 所有。每个新的交互请求都携带
+prompt ID、所属 turn ID，以及 tab 可见的 runtime epoch。`kind` 标识交互类型：
+`ask`、`approval`、`plan`、`recovery` 或 `mcp`。
+
+前端通过 `ResolvePromptForTab` 提交这些字段。controller 在 exact resolve
+边界内校验 runtime epoch、active turn、prompt owner 和 pending 状态，然后
+持久化 `PromptAnswered` 并唤醒原始等待方。旧 turn 或旧 runtime 的提交会被
+拒绝，不会被路由到替换后的 controller。持久化失败时 prompt 会恢复为
+pending，用户可以重试。
+
+prompt 请求和生命周期事件会暴露 `promptId`、`promptKind` 和 `turnId`。
+Desktop 事件 envelope 会携带 tab 的 runtime epoch。缺少 turn identity 的旧
+事件会标记为 `promptLegacy`，只能通过兼容路径处理。
+
+`AnswerQuestionForTab`、`ApproveTab` 和 `ResolveRecoveryTab` 等旧 Wails 方法
+仍为旧客户端保留。新前端统一使用 `ResolvePromptForTab`，不会静默降级到
+没有 fence 的方法。收到 stale 响应后，旧卡片会从当前决策面移除，并按 tab
+请求一次 prompt replay；只有新的 pending identity 才能重新显示卡片。

--- a/internal/control/approval.go
+++ b/internal/control/approval.go
@@ -44,6 +44,7 @@ func (c *Controller) approveChecked(id string, allow, session, persist bool) err
 	if !ok || pending.reply == nil {
 		return nil
 	}
+	c.promptOwner.Remove(id)
 	outcome := "deny"
 	if pending.tool == planApprovalTool {
 		outcome = string(PlanDecisionRevisePlan)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2557,6 +2557,7 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 
 	c.approval.promptEmitMu.Lock()
 	turnID, _, _, _ = c.turnEventRuntimeStatus()
+	_, runtimeEpoch = c.promptIdentitySnapshot()
 	if identity := c.bindOwnedPromptRouting(id, turnID, runtimeEpoch); identity.TurnID != "" {
 		turnID = identity.TurnID
 	}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2557,6 +2557,9 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 
 	c.approval.promptEmitMu.Lock()
 	turnID, _, _, _ = c.turnEventRuntimeStatus()
+	if identity := c.bindOwnedPromptRouting(id, turnID, runtimeEpoch); identity.TurnID != "" {
+		turnID = identity.TurnID
+	}
 	if err := event.EmitChecked(c.sink, event.Event{Kind: event.AskRequest, TurnID: turnID, ItemID: id, Ask: event.Ask{ID: id, Questions: questions, TurnID: turnID}}); err != nil {
 		c.approval.promptEmitMu.Unlock()
 		c.cancelOwnedPrompt(id)
@@ -6317,6 +6320,10 @@ func (c *Controller) requestApprovalDecisionWithOptions(ctx context.Context, too
 func (c *Controller) approvalRequestEvent(approval event.Approval) event.Event {
 	if approval.TurnID == "" {
 		approval.TurnID, _, _, _ = c.turnEventRuntimeStatus()
+	}
+	_, runtimeEpoch := c.promptIdentitySnapshot()
+	if identity := c.bindOwnedPromptRouting(approval.ID, approval.TurnID, runtimeEpoch); identity.TurnID != "" {
+		approval.TurnID = identity.TurnID
 	}
 	return event.Event{Kind: event.ApprovalRequest, TurnID: approval.TurnID, ItemID: approval.ID, Approval: approval}
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -95,10 +95,15 @@ var errNoSessionPath = errors.New("session has content but no session path; conv
 // Controller drives one chat session. Construct with New; drive with the command
 // methods; observe through the Sink passed in Options.
 type Controller struct {
-	runner       agent.Runner
-	executor     *agent.Agent
-	guardianSess *guardian.Session // nil when guardian is disabled
-	guardianPath string            // persisted guardian session file ("" when disabled)
+	// promptResolveMu serializes exact prompt decisions on one controller. It
+	// prevents two UI submissions from racing through separate prompt managers.
+	promptResolveMu    sync.Mutex
+	promptRuntimeEpoch string
+	promptOwner        PendingPromptOwner
+	runner             agent.Runner
+	executor           *agent.Agent
+	guardianSess       *guardian.Session // nil when guardian is disabled
+	guardianPath       string            // persisted guardian session file ("" when disabled)
 	// recoveryGate is the shared Auto Guard state for this controller.
 	// nil when the feature is not wired for this controller.
 	recoveryGate *recovery.Gate
@@ -2125,6 +2130,12 @@ func (c *Controller) RunSubagentProfile(ctx context.Context, name, task string, 
 // Cancel aborts the in-flight turn. A goroutine blocked awaiting approval
 // unblocks via the cancelled context.
 func (c *Controller) Cancel() {
+	c.promptResolveMu.Lock()
+	defer c.promptResolveMu.Unlock()
+	c.cancelLocked()
+}
+
+func (c *Controller) cancelLocked() {
 	c.mu.Lock()
 	cancel := c.cancel
 	if cancel != nil {
@@ -2133,6 +2144,7 @@ func (c *Controller) Cancel() {
 	c.mu.Unlock()
 	if cancel != nil {
 		c.emitTurnStatus(event.TurnCancelling)
+		c.promptOwner.CancelAll()
 		c.approval.clearAll()
 		cancel()
 		return
@@ -2533,17 +2545,21 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 	// Registering after the lock left a queued question invisible everywhere:
 	// no event, absent from the snapshot, unreachable by ReplayPendingPrompts.
 	id, reply := c.approval.registerAsk(questions)
+	turnID, _, _, _ := c.turnEventRuntimeStatus()
+	_, runtimeEpoch := c.promptIdentitySnapshot()
+	_ = c.promptOwner.Register(PromptIdentity{PromptID: id, TurnID: turnID, RuntimeEpoch: runtimeEpoch, Kind: PromptAsk})
 
 	if !c.lockPromptFor(ctx, "question") {
-		c.approval.cancelAsk(id)
+		c.cancelOwnedPrompt(id)
 		return nil, ctx.Err()
 	}
 	defer c.approval.promptMu.Unlock()
 
 	c.approval.promptEmitMu.Lock()
-	if err := event.EmitChecked(c.sink, event.Event{Kind: event.AskRequest, ItemID: id, Ask: event.Ask{ID: id, Questions: questions}}); err != nil {
+	turnID, _, _, _ = c.turnEventRuntimeStatus()
+	if err := event.EmitChecked(c.sink, event.Event{Kind: event.AskRequest, TurnID: turnID, ItemID: id, Ask: event.Ask{ID: id, Questions: questions, TurnID: turnID}}); err != nil {
 		c.approval.promptEmitMu.Unlock()
-		c.approval.cancelAsk(id)
+		c.cancelOwnedPrompt(id)
 		return nil, fmt.Errorf("persist ask request: %w", err)
 	}
 	c.approval.markAskEmitted(id)
@@ -2556,7 +2572,7 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 	case ans := <-reply:
 		return ans, nil
 	case <-waitCtx.Done():
-		c.approval.cancelAsk(id)
+		c.cancelOwnedPrompt(id)
 		return nil, waitCtx.Err()
 	}
 }
@@ -2570,6 +2586,12 @@ func (c *Controller) AnswerQuestion(id string, answers []event.AskAnswer) {
 // AnswerQuestionChecked persists the prompt transition before releasing the
 // agent loop. A failed ledger write leaves the prompt pending and retryable.
 func (c *Controller) AnswerQuestionChecked(id string, answers []event.AskAnswer) error {
+	c.promptResolveMu.Lock()
+	defer c.promptResolveMu.Unlock()
+	return c.answerQuestionCheckedLocked(id, answers)
+}
+
+func (c *Controller) answerQuestionCheckedLocked(id string, answers []event.AskAnswer) error {
 	pending, ok, err := c.approval.resolveAskAfter(id, func(p pendingAsk) error {
 		return c.emitTurnEventChecked(event.Event{Kind: event.PromptAnswered, ItemID: id, Status: event.TurnInProgress})
 	})
@@ -2577,6 +2599,7 @@ func (c *Controller) AnswerQuestionChecked(id string, answers []event.AskAnswer)
 		return err
 	}
 	if ok {
+		c.promptOwner.Remove(id)
 		// An answer batch with no selections is the explicit "skip and continue
 		// chat" path. End the current turn instead of feeding a prose dismissal
 		// back to the model and trusting it not to ask again (#6869).
@@ -2585,7 +2608,7 @@ func (c *Controller) AnswerQuestionChecked(id string, answers []event.AskAnswer)
 			activeTurn := c.cancel != nil
 			c.mu.Unlock()
 			if activeTurn {
-				c.Cancel()
+				c.cancelLocked()
 				return nil
 			}
 		}
@@ -2694,13 +2717,22 @@ func (c *Controller) emitPendingPrompts(sink event.Sink, approvals []event.Appro
 		return
 	}
 	for _, a := range approvals {
+		if identity, ok := c.promptOwner.Identity(a.ID); ok {
+			a.TurnID = identity.TurnID
+		}
 		sink.Emit(c.approvalRequestEvent(a))
 	}
 	for _, a := range asks {
-		sink.Emit(event.Event{Kind: event.AskRequest, ItemID: a.ID, Ask: a})
+		if identity, ok := c.promptOwner.Identity(a.ID); ok {
+			a.TurnID = identity.TurnID
+		}
+		sink.Emit(event.Event{Kind: event.AskRequest, TurnID: a.TurnID, ItemID: a.ID, Ask: a})
 	}
 	for _, i := range interactions {
-		sink.Emit(event.Event{Kind: event.MCPInteractionRequest, ItemID: i.ID, MCPInteraction: i})
+		if identity, ok := c.promptOwner.Identity(i.ID); ok {
+			i.TurnID = identity.TurnID
+		}
+		sink.Emit(event.Event{Kind: event.MCPInteractionRequest, TurnID: i.TurnID, ItemID: i.ID, MCPInteraction: i})
 	}
 }
 
@@ -5524,8 +5556,13 @@ func (c *Controller) close(fireSessionEnd bool, jobsMode closeJobsMode) {
 		if cancel != nil {
 			// clearAll deliberately does not signal waiters. Pair it with the
 			// foreground cancellation so approval/ask waits always unblock.
+			c.promptResolveMu.Lock()
+			c.promptOwner.CancelAll()
 			c.approval.clearAll()
+			c.promptResolveMu.Unlock()
 			cancel()
+		} else {
+			c.promptOwner.Clear()
 		}
 		if fireSessionEnd && started {
 			c.hooks.SessionEnd(context.Background(), "other")
@@ -6239,19 +6276,25 @@ func (c *Controller) requestApprovalDecisionWithOptions(ctx context.Context, too
 	c.approval.promptEmitMu.Lock()
 	var id string
 	var reply chan approvalReply
+	kind := ""
 	if opts.fresh || opts.requireHuman || tool == planApprovalTool {
-		kind := ""
 		if tool == planApprovalTool {
 			kind = "plan"
 		}
 		id, reply = c.approval.registerDecisionKindWithInput(tool, subject, reason, args, opts.fresh, opts.requireHuman, kind, nil)
+		ownerKind := PromptApproval
+		if kind == "plan" {
+			ownerKind = PromptPlan
+		}
+		c.registerOwnedPrompt(id, ownerKind)
 	} else {
 		id, reply = c.approval.registerWithInput(tool, subject, reason, args)
+		c.registerOwnedPrompt(id, PromptApproval)
 	}
 
-	if err := event.EmitChecked(c.sink, c.approvalRequestEvent(event.Approval{ID: id, Tool: tool, Subject: subject, Reason: reason, RawInput: append(json.RawMessage(nil), args...), Fresh: opts.fresh})); err != nil {
+	if err := event.EmitChecked(c.sink, c.approvalRequestEvent(event.Approval{ID: id, Tool: tool, Subject: subject, Reason: reason, RawInput: append(json.RawMessage(nil), args...), Fresh: opts.fresh, Kind: kind})); err != nil {
 		c.approval.promptEmitMu.Unlock()
-		c.approval.cancel(id)
+		c.cancelOwnedPrompt(id)
 		return approvalReply{}, fmt.Errorf("persist approval request: %w", err)
 	}
 	c.approval.promptEmitMu.Unlock()
@@ -6266,13 +6309,16 @@ func (c *Controller) requestApprovalDecisionWithOptions(ctx context.Context, too
 	case r := <-reply:
 		return r, nil
 	case <-waitCtx.Done():
-		c.approval.cancel(id)
+		c.cancelOwnedPrompt(id)
 		return approvalReply{}, waitCtx.Err()
 	}
 }
 
 func (c *Controller) approvalRequestEvent(approval event.Approval) event.Event {
-	return event.Event{Kind: event.ApprovalRequest, ItemID: approval.ID, Approval: approval}
+	if approval.TurnID == "" {
+		approval.TurnID, _, _, _ = c.turnEventRuntimeStatus()
+	}
+	return event.Event{Kind: event.ApprovalRequest, TurnID: approval.TurnID, ItemID: approval.ID, Approval: approval}
 }
 
 func (c *Controller) emitRememberResult(r RememberResult) {

--- a/internal/control/mcp_interaction.go
+++ b/internal/control/mcp_interaction.go
@@ -150,6 +150,10 @@ func (c *Controller) Interact(ctx context.Context, req mcpinteraction.Request) (
 		URL:             req.URL, ElicitationID: req.ElicitationID,
 	}
 	payload.TurnID, _, _, _ = c.turnEventRuntimeStatus()
+	_, runtimeEpoch := c.promptIdentitySnapshot()
+	if identity := c.bindOwnedPromptRouting(id, payload.TurnID, runtimeEpoch); identity.TurnID != "" {
+		payload.TurnID = identity.TurnID
+	}
 	if err := event.EmitChecked(c.sink, event.Event{Kind: event.MCPInteractionRequest, TurnID: payload.TurnID, ItemID: id, MCPInteraction: payload}); err != nil {
 		c.approval.promptEmitMu.Unlock()
 		c.cancelOwnedPrompt(id)

--- a/internal/control/mcp_interaction.go
+++ b/internal/control/mcp_interaction.go
@@ -135,9 +135,10 @@ func (a *approvalManager) snapshotMCPInteractions() []event.MCPInteraction {
 // ride the resolve call only — nothing is logged from here.
 func (c *Controller) Interact(ctx context.Context, req mcpinteraction.Request) (mcpinteraction.Result, error) {
 	id, reply := c.approval.registerMCPInteraction(req)
+	c.registerOwnedPrompt(id, PromptMCP)
 
 	if !c.lockPromptFor(ctx, "mcp interaction") {
-		c.approval.cancelMCPInteraction(id)
+		c.cancelOwnedPrompt(id)
 		return mcpinteraction.Result{Action: mcpinteraction.ActionCancel}, ctx.Err()
 	}
 	defer c.approval.promptMu.Unlock()
@@ -148,9 +149,10 @@ func (c *Controller) Interact(ctx context.Context, req mcpinteraction.Request) (
 		RequestedSchema: append([]byte(nil), req.RequestedSchema...),
 		URL:             req.URL, ElicitationID: req.ElicitationID,
 	}
-	if err := event.EmitChecked(c.sink, event.Event{Kind: event.MCPInteractionRequest, ItemID: id, MCPInteraction: payload}); err != nil {
+	payload.TurnID, _, _, _ = c.turnEventRuntimeStatus()
+	if err := event.EmitChecked(c.sink, event.Event{Kind: event.MCPInteractionRequest, TurnID: payload.TurnID, ItemID: id, MCPInteraction: payload}); err != nil {
 		c.approval.promptEmitMu.Unlock()
-		c.approval.cancelMCPInteraction(id)
+		c.cancelOwnedPrompt(id)
 		return mcpinteraction.Result{Action: mcpinteraction.ActionCancel}, fmt.Errorf("persist elicitation request: %w", err)
 	}
 	c.approval.markMCPInteractionEmitted(id)
@@ -163,7 +165,7 @@ func (c *Controller) Interact(ctx context.Context, req mcpinteraction.Request) (
 	case res := <-reply:
 		return res, nil
 	case <-waitCtx.Done():
-		c.approval.cancelMCPInteraction(id)
+		c.cancelOwnedPrompt(id)
 		return mcpinteraction.Result{Action: mcpinteraction.ActionCancel}, waitCtx.Err()
 	}
 }
@@ -177,6 +179,12 @@ func (c *Controller) AnswerMCPInteraction(id, action string, content map[string]
 // AnswerMCPInteractionChecked persists the prompt transition before releasing
 // the blocked MCP call, so a crashed frontend cannot lose an answered decision.
 func (c *Controller) AnswerMCPInteractionChecked(id, action string, content map[string]any) error {
+	c.promptResolveMu.Lock()
+	defer c.promptResolveMu.Unlock()
+	return c.answerMCPInteractionCheckedLocked(id, action, content)
+}
+
+func (c *Controller) answerMCPInteractionCheckedLocked(id, action string, content map[string]any) error {
 	switch action {
 	case mcpinteraction.ActionAccept, mcpinteraction.ActionDecline, mcpinteraction.ActionCancel:
 	default:
@@ -192,6 +200,7 @@ func (c *Controller) AnswerMCPInteractionChecked(id, action string, content map[
 		return err
 	}
 	if ok {
+		c.promptOwner.Remove(id)
 		c.recordMCPInteractionReceipt(id, pending, action)
 		pending.reply <- mcpinteraction.Result{Action: action, Content: content}
 	}

--- a/internal/control/plan_decision.go
+++ b/internal/control/plan_decision.go
@@ -16,6 +16,12 @@ func (c *Controller) ResolvePlanDecision(id string, action PlanDecisionAction) e
 // ResolvePlanDecisionWithFeedback durably stages revision guidance before the
 // approval is removed. A persistence failure leaves the card pending for retry.
 func (c *Controller) ResolvePlanDecisionWithFeedback(id string, action PlanDecisionAction, feedback string) error {
+	c.promptResolveMu.Lock()
+	defer c.promptResolveMu.Unlock()
+	return c.resolvePlanDecisionWithFeedbackLocked(id, action, feedback)
+}
+
+func (c *Controller) resolvePlanDecisionWithFeedbackLocked(id string, action PlanDecisionAction, feedback string) error {
 	if c == nil {
 		return fmt.Errorf("controller is nil")
 	}
@@ -56,6 +62,7 @@ func (c *Controller) ResolvePlanDecisionWithFeedback(id string, action PlanDecis
 		rollback()
 		return nil
 	}
+	c.promptOwner.Remove(id)
 	pending.kind = "plan"
 	c.recordDecisionReceipt(pending, string(action))
 	pending.reply <- approvalReply{allow: action == PlanDecisionStartExecution}

--- a/internal/control/prompt_identity.go
+++ b/internal/control/prompt_identity.go
@@ -114,6 +114,26 @@ func (o *PendingPromptOwner) Restore(identity PromptIdentity) {
 		o.pending[identity.PromptID] = p
 	}
 }
+
+// BindRouting fills routing fields that were not available when a prompt was
+// queued behind another prompt. It never rewrites a captured identity: once a
+// turn or runtime epoch is known, a later event must use that same value.
+func (o *PendingPromptOwner) BindRouting(id, turnID, runtimeEpoch string) (PromptIdentity, bool) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	prompt, ok := o.pending[id]
+	if !ok {
+		return PromptIdentity{}, false
+	}
+	if prompt.Identity.TurnID == "" && turnID != "" {
+		prompt.Identity.TurnID = turnID
+	}
+	if prompt.Identity.RuntimeEpoch == "" && runtimeEpoch != "" {
+		prompt.Identity.RuntimeEpoch = runtimeEpoch
+	}
+	o.pending[id] = prompt
+	return prompt.Identity, true
+}
 func (o *PendingPromptOwner) Resolve(identity PromptIdentity, answer PromptAnswer) error {
 	if err := o.BeginResolve(identity); err != nil {
 		return err
@@ -233,6 +253,17 @@ func (c *Controller) registerOwnedPrompt(id string, kind PromptKind) {
 	_ = c.promptOwner.RegisterPrompt(PendingPrompt{Identity: identity, State: PromptPending, Resolve: resolve, Cancel: cancel})
 }
 
+// bindOwnedPromptRouting completes an identity immediately before its request
+// event is emitted. This closes the startup window where the prompt is queued
+// before the turn ledger has published its active turn or runtime epoch.
+func (c *Controller) bindOwnedPromptRouting(id, turnID, runtimeEpoch string) PromptIdentity {
+	if c == nil {
+		return PromptIdentity{}
+	}
+	identity, _ := c.promptOwner.BindRouting(id, turnID, runtimeEpoch)
+	return identity
+}
+
 func (c *Controller) PendingPromptIdentities() []PromptIdentity { return c.promptOwner.Identities() }
 
 func (c *Controller) cancelOwnedPrompt(id string) {
@@ -288,7 +319,7 @@ func (c *Controller) ResolvePromptExact(identity PromptIdentity, answer PromptAn
 	if closed {
 		return ErrPromptNotPending
 	}
-	if identity.RuntimeEpoch != "" && identity.RuntimeEpoch != c.promptRuntimeEpoch {
+	if c.promptRuntimeEpoch != "" && (identity.RuntimeEpoch == "" || identity.RuntimeEpoch != c.promptRuntimeEpoch) {
 		return ErrPromptStaleRuntime
 	}
 	turnID, _, _, _ := c.turnEventRuntimeStatus()
@@ -304,6 +335,9 @@ func (c *Controller) ResolvePromptExact(identity PromptIdentity, answer PromptAn
 	}
 	if owned.TurnID != identity.TurnID || owned.Kind != identity.Kind {
 		return ErrPromptStaleTurn
+	}
+	if owned.RuntimeEpoch != identity.RuntimeEpoch {
+		return ErrPromptStaleRuntime
 	}
 	return c.promptOwner.Resolve(identity, answer)
 }

--- a/internal/control/prompt_identity.go
+++ b/internal/control/prompt_identity.go
@@ -1,0 +1,309 @@
+package control
+
+import (
+	"errors"
+	"fmt"
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"sort"
+	"sync"
+)
+
+type PendingPromptOwner struct {
+	mu       sync.Mutex
+	pending  map[string]PendingPrompt
+	resolved map[string]PromptIdentity
+}
+
+type PendingPromptState string
+
+const (
+	PromptPending   PendingPromptState = "pending"
+	PromptResolving PendingPromptState = "resolving"
+)
+
+type PendingPrompt struct {
+	Identity PromptIdentity
+	State    PendingPromptState
+	Resolve  func(PromptAnswer) error
+	Cancel   func() error
+}
+
+func (o *PendingPromptOwner) RegisterPrompt(prompt PendingPrompt) error {
+	identity := prompt.Identity
+	if identity.PromptID == "" {
+		return ErrPromptNotPending
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.pending == nil {
+		o.pending = make(map[string]PendingPrompt)
+	}
+	if o.resolved == nil {
+		o.resolved = make(map[string]PromptIdentity)
+	}
+	if _, exists := o.pending[identity.PromptID]; exists {
+		return fmt.Errorf("prompt %q already registered", identity.PromptID)
+	}
+	if prompt.State == "" {
+		prompt.State = PromptPending
+	}
+	o.pending[identity.PromptID] = prompt
+	return nil
+}
+
+func (o *PendingPromptOwner) Register(identity PromptIdentity) error {
+	return o.RegisterPrompt(PendingPrompt{Identity: identity, State: PromptPending})
+}
+func (o *PendingPromptOwner) Identity(id string) (PromptIdentity, bool) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	v, ok := o.pending[id]
+	return v.Identity, ok
+}
+func (o *PendingPromptOwner) Prompt(id string) (PendingPrompt, bool) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	p, ok := o.pending[id]
+	return p, ok
+}
+func (o *PendingPromptOwner) Remove(id string) { o.mu.Lock(); delete(o.pending, id); o.mu.Unlock() }
+func (o *PendingPromptOwner) RemoveKind(kind PromptKind) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	for id, prompt := range o.pending {
+		if prompt.Identity.Kind == kind {
+			delete(o.pending, id)
+		}
+	}
+}
+func (o *PendingPromptOwner) MarkResolved(identity PromptIdentity) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	delete(o.pending, identity.PromptID)
+	if o.resolved == nil {
+		o.resolved = make(map[string]PromptIdentity)
+	}
+	o.resolved[identity.PromptID] = identity
+}
+func (o *PendingPromptOwner) BeginResolve(identity PromptIdentity) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	p, ok := o.pending[identity.PromptID]
+	if !ok {
+		if _, resolved := o.resolved[identity.PromptID]; resolved {
+			return ErrPromptAlreadyResolved
+		}
+		return ErrPromptNotPending
+	}
+	if p.Identity != identity {
+		return ErrPromptStaleTurn
+	}
+	if p.State == PromptResolving {
+		return ErrPromptAlreadyResolved
+	}
+	p.State = PromptResolving
+	o.pending[identity.PromptID] = p
+	return nil
+}
+func (o *PendingPromptOwner) Restore(identity PromptIdentity) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if p, ok := o.pending[identity.PromptID]; ok && p.Identity == identity {
+		p.State = PromptPending
+		o.pending[identity.PromptID] = p
+	}
+}
+func (o *PendingPromptOwner) Resolve(identity PromptIdentity, answer PromptAnswer) error {
+	if err := o.BeginResolve(identity); err != nil {
+		return err
+	}
+	prompt, ok := o.Prompt(identity.PromptID)
+	if !ok || prompt.Resolve == nil {
+		o.Restore(identity)
+		return ErrPromptNotPending
+	}
+	err := prompt.Resolve(answer)
+	if err != nil {
+		o.Restore(identity)
+		return err
+	}
+	if _, pending := o.Identity(identity.PromptID); pending {
+		o.Restore(identity)
+		return ErrPromptNotPending
+	}
+	o.MarkResolved(identity)
+	return nil
+}
+func (o *PendingPromptOwner) WasResolved(id string) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	_, ok := o.resolved[id]
+	return ok
+}
+func (o *PendingPromptOwner) Clear() {
+	o.mu.Lock()
+	o.pending = make(map[string]PendingPrompt)
+	o.resolved = make(map[string]PromptIdentity)
+	o.mu.Unlock()
+}
+func (o *PendingPromptOwner) CancelAll() {
+	o.mu.Lock()
+	cancels := make([]func() error, 0, len(o.pending))
+	for _, prompt := range o.pending {
+		if prompt.Cancel != nil {
+			cancels = append(cancels, prompt.Cancel)
+		}
+	}
+	o.pending = make(map[string]PendingPrompt)
+	o.mu.Unlock()
+	for _, cancel := range cancels {
+		_ = cancel()
+	}
+}
+func (o *PendingPromptOwner) Identities() []PromptIdentity {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	out := make([]PromptIdentity, 0, len(o.pending))
+	for _, prompt := range o.pending {
+		out = append(out, prompt.Identity)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].PromptID < out[j].PromptID })
+	return out
+}
+
+// PromptKind identifies the interactive surface that owns a pending decision.
+type PromptKind string
+
+const (
+	PromptAsk      PromptKind = "ask"
+	PromptApproval PromptKind = "approval"
+	PromptPlan     PromptKind = "plan"
+	PromptRecovery PromptKind = "recovery"
+	PromptMCP      PromptKind = "mcp"
+)
+
+// PromptIdentity is the immutable identity captured when a decision card is
+// emitted. Turn and runtime fences prevent a delayed UI action crossing a
+// controller replacement.
+type PromptIdentity struct {
+	PromptID     string
+	TurnID       string
+	RuntimeEpoch string
+	Kind         PromptKind
+}
+
+func (c *Controller) promptIdentitySnapshot() (string, string) {
+	c.promptResolveMu.Lock()
+	defer c.promptResolveMu.Unlock()
+	turnID, _, _, _ := c.turnEventRuntimeStatus()
+	return turnID, c.promptRuntimeEpoch
+}
+
+func (c *Controller) registerOwnedPrompt(id string, kind PromptKind) {
+	turn, epoch := c.promptIdentitySnapshot()
+	identity := PromptIdentity{PromptID: id, TurnID: turn, RuntimeEpoch: epoch, Kind: kind}
+	resolve := func(answer PromptAnswer) error {
+		switch kind {
+		case PromptAsk:
+			return c.answerQuestionCheckedLocked(id, answer.Questions)
+		case PromptApproval:
+			return c.resolveApprovalLocked(id, answer.Allow, scopeFromApprove(answer.Allow, answer.Session, answer.Persist))
+		case PromptPlan:
+			return c.resolvePlanDecisionWithFeedbackLocked(id, PlanDecisionAction(answer.Action), answer.Feedback)
+		case PromptRecovery:
+			return c.resolveRecoveryLocked(id, agent.RecoveryAction(answer.Action), answer.Feedback)
+		case PromptMCP:
+			return c.answerMCPInteractionCheckedLocked(id, answer.Action, answer.Content)
+		default:
+			return ErrPromptNotPending
+		}
+	}
+	cancel := func() error {
+		switch kind {
+		case PromptAsk:
+			c.approval.cancelAsk(id)
+		case PromptApproval, PromptPlan, PromptRecovery:
+			c.approval.cancel(id)
+		case PromptMCP:
+			c.approval.cancelMCPInteraction(id)
+		}
+		return nil
+	}
+	_ = c.promptOwner.RegisterPrompt(PendingPrompt{Identity: identity, State: PromptPending, Resolve: resolve, Cancel: cancel})
+}
+
+func (c *Controller) PendingPromptIdentities() []PromptIdentity { return c.promptOwner.Identities() }
+
+func (c *Controller) cancelOwnedPrompt(id string) {
+	c.promptResolveMu.Lock()
+	defer c.promptResolveMu.Unlock()
+	c.cancelOwnedPromptLocked(id)
+}
+
+func (c *Controller) cancelOwnedPromptLocked(id string) {
+	if prompt, ok := c.promptOwner.Prompt(id); ok && prompt.Cancel != nil {
+		_ = prompt.Cancel()
+	} else {
+		c.approval.cancel(id)
+		c.approval.cancelAsk(id)
+		c.approval.cancelMCPInteraction(id)
+	}
+	c.promptOwner.Remove(id)
+}
+
+var (
+	ErrPromptStaleTurn       = errors.New("prompt belongs to a stale turn")
+	ErrPromptStaleRuntime    = errors.New("prompt belongs to a stale runtime")
+	ErrPromptAlreadyResolved = errors.New("prompt is already resolved")
+	ErrPromptNotPending      = errors.New("prompt is not pending")
+)
+
+// PromptAnswer is the transport-neutral union used by exact prompt resolve.
+type PromptAnswer struct {
+	Questions []event.AskAnswer
+	Allow     bool
+	Session   bool
+	Persist   bool
+	Action    string
+	Feedback  string
+	Content   map[string]any
+}
+
+// ResolvePromptExact is the single controller-owned decision boundary. The
+// specialized resolvers retain their validation and durable receipts; this
+// mutex makes their check-and-wake path single-writer for one controller.
+func (c *Controller) ResolvePromptExact(identity PromptIdentity, answer PromptAnswer) error {
+	if c == nil {
+		return ErrPromptNotPending
+	}
+	if identity.PromptID == "" || identity.TurnID == "" {
+		return ErrPromptNotPending
+	}
+	c.promptResolveMu.Lock()
+	defer c.promptResolveMu.Unlock()
+	c.mu.Lock()
+	closed := c.closed
+	c.mu.Unlock()
+	if closed {
+		return ErrPromptNotPending
+	}
+	if identity.RuntimeEpoch != "" && identity.RuntimeEpoch != c.promptRuntimeEpoch {
+		return ErrPromptStaleRuntime
+	}
+	turnID, _, _, _ := c.turnEventRuntimeStatus()
+	if turnID != identity.TurnID {
+		return ErrPromptStaleTurn
+	}
+	owned, ok := c.promptOwner.Identity(identity.PromptID)
+	if !ok {
+		if c.promptOwner.WasResolved(identity.PromptID) {
+			return ErrPromptAlreadyResolved
+		}
+		return ErrPromptNotPending
+	}
+	if owned.TurnID != identity.TurnID || owned.Kind != identity.Kind {
+		return ErrPromptStaleTurn
+	}
+	return c.promptOwner.Resolve(identity, answer)
+}

--- a/internal/control/prompt_identity_test.go
+++ b/internal/control/prompt_identity_test.go
@@ -39,6 +39,16 @@ func TestResolvePromptExactRejectsStaleRuntime(t *testing.T) {
 	}
 }
 
+func TestResolvePromptExactRejectsLegacyIdentityAfterRuntimeEpochIsSet(t *testing.T) {
+	c := New(Options{})
+	t.Cleanup(c.Close)
+	c.SetTurnEventRoutingMetadata("runtime-current", "")
+	err := c.ResolvePromptExact(PromptIdentity{PromptID: "legacy", TurnID: "turn-any", Kind: PromptAsk}, PromptAnswer{})
+	if !errors.Is(err, ErrPromptStaleRuntime) {
+		t.Fatalf("legacy exact resolve error = %v, want ErrPromptStaleRuntime", err)
+	}
+}
+
 func TestResolvePromptExactRejectsClosedController(t *testing.T) {
 	c := New(Options{})
 	c.Close()
@@ -108,6 +118,22 @@ func TestPendingPromptOwnerResolveRestoresAfterFailure(t *testing.T) {
 	pending, ok := owner.Identity(id.PromptID)
 	if !ok || pending != id {
 		t.Fatalf("failed resolve did not restore pending identity: %+v %v", pending, ok)
+	}
+}
+
+func TestPendingPromptOwnerBindsMissingRoutingOnce(t *testing.T) {
+	var owner PendingPromptOwner
+	id := PromptIdentity{PromptID: "p-bind", Kind: PromptAsk}
+	if err := owner.Register(id); err != nil {
+		t.Fatal(err)
+	}
+	bound, ok := owner.BindRouting(id.PromptID, "turn-1", "runtime-1")
+	if !ok || bound.TurnID != "turn-1" || bound.RuntimeEpoch != "runtime-1" {
+		t.Fatalf("bound identity = %+v, %v", bound, ok)
+	}
+	again, ok := owner.BindRouting(id.PromptID, "turn-2", "runtime-2")
+	if !ok || again != bound {
+		t.Fatalf("routing identity was rewritten: first=%+v second=%+v ok=%v", bound, again, ok)
 	}
 }
 

--- a/internal/control/prompt_identity_test.go
+++ b/internal/control/prompt_identity_test.go
@@ -1,0 +1,125 @@
+package control
+
+import (
+	"errors"
+	"reasonix/internal/event"
+	"sync"
+	"testing"
+)
+
+func TestResolvePromptExactRejectsStaleTurnBeforeDispatch(t *testing.T) {
+	c := New(Options{})
+	t.Cleanup(c.Close)
+	err := c.ResolvePromptExact(PromptIdentity{
+		PromptID: "prompt-1", TurnID: "turn-stale", Kind: PromptAsk,
+	}, PromptAnswer{})
+	if !errors.Is(err, ErrPromptStaleTurn) {
+		t.Fatalf("ResolvePromptExact error = %v, want ErrPromptStaleTurn", err)
+	}
+}
+
+func TestResolvePromptExactRejectsIncompleteIdentity(t *testing.T) {
+	c := New(Options{})
+	t.Cleanup(c.Close)
+	err := c.ResolvePromptExact(PromptIdentity{PromptID: "prompt-1", Kind: PromptAsk}, PromptAnswer{})
+	if !errors.Is(err, ErrPromptNotPending) {
+		t.Fatalf("ResolvePromptExact error = %v, want ErrPromptNotPending", err)
+	}
+}
+
+func TestResolvePromptExactRejectsStaleRuntime(t *testing.T) {
+	c := New(Options{})
+	t.Cleanup(c.Close)
+	c.SetTurnEventRoutingMetadata("runtime-current", "")
+	err := c.ResolvePromptExact(PromptIdentity{
+		PromptID: "prompt-1", TurnID: "turn-any", RuntimeEpoch: "runtime-old", Kind: PromptAsk,
+	}, PromptAnswer{})
+	if !errors.Is(err, ErrPromptStaleRuntime) {
+		t.Fatalf("ResolvePromptExact error = %v, want ErrPromptStaleRuntime", err)
+	}
+}
+
+func TestResolvePromptExactRejectsClosedController(t *testing.T) {
+	c := New(Options{})
+	c.Close()
+	err := c.ResolvePromptExact(PromptIdentity{PromptID: "p", TurnID: "t", Kind: PromptAsk}, PromptAnswer{})
+	if !errors.Is(err, ErrPromptNotPending) {
+		t.Fatalf("closed resolver error = %v", err)
+	}
+}
+
+func TestPendingPromptOwnerTracksResolvedIdentity(t *testing.T) {
+	var owner PendingPromptOwner
+	id := PromptIdentity{PromptID: "p", TurnID: "t", Kind: PromptAsk}
+	if err := owner.Register(id); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := owner.Identity("p"); !ok || got != id {
+		t.Fatalf("registered identity = %+v, %v", got, ok)
+	}
+	owner.MarkResolved(id)
+	if _, ok := owner.Identity("p"); ok {
+		t.Fatal("resolved prompt remains pending")
+	}
+	if !owner.WasResolved("p") {
+		t.Fatal("resolved prompt was not recorded")
+	}
+}
+
+func TestPendingPromptOwnerRejectsConcurrentResolveReservation(t *testing.T) {
+	var owner PendingPromptOwner
+	id := PromptIdentity{PromptID: "p", TurnID: "t", Kind: PromptMCP}
+	if err := owner.Register(id); err != nil {
+		t.Fatal(err)
+	}
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() { defer wg.Done(); <-start; results <- owner.BeginResolve(id) }()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	var success, already int
+	for err := range results {
+		if err == nil {
+			success++
+		}
+		if errors.Is(err, ErrPromptAlreadyResolved) {
+			already++
+		}
+	}
+	if success != 1 || already != 1 {
+		t.Fatalf("resolve reservations = success %d already %d", success, already)
+	}
+}
+
+func TestPendingPromptOwnerResolveRestoresAfterFailure(t *testing.T) {
+	var owner PendingPromptOwner
+	id := PromptIdentity{PromptID: "p-fail", TurnID: "t", Kind: PromptAsk}
+	if err := owner.RegisterPrompt(PendingPrompt{Identity: id, Resolve: func(PromptAnswer) error { return errors.New("persist failed") }}); err != nil {
+		t.Fatal(err)
+	}
+	if err := owner.Resolve(id, PromptAnswer{}); err == nil || err.Error() != "persist failed" {
+		t.Fatalf("resolve error = %v", err)
+	}
+	pending, ok := owner.Identity(id.PromptID)
+	if !ok || pending != id {
+		t.Fatalf("failed resolve did not restore pending identity: %+v %v", pending, ok)
+	}
+}
+
+func TestPromptAnsweredEventInheritsOwnerTurnID(t *testing.T) {
+	var got event.Event
+	c := New(Options{Sink: event.FuncSink(func(e event.Event) { got = e })})
+	t.Cleanup(c.Close)
+	c.promptOwner.Register(PromptIdentity{PromptID: "p-event", TurnID: "turn-event", Kind: PromptAsk})
+	if err := c.emitTurnEventChecked(event.Event{Kind: event.PromptAnswered, ItemID: "p-event"}); err != nil {
+		t.Fatal(err)
+	}
+	if got.TurnID != "turn-event" {
+		t.Fatalf("PromptAnswered turn id = %q", got.TurnID)
+	}
+}

--- a/internal/control/prompt_identity_test.go
+++ b/internal/control/prompt_identity_test.go
@@ -86,8 +86,7 @@ func TestPendingPromptOwnerRejectsConcurrentResolveReservation(t *testing.T) {
 	results := make(chan error, 2)
 	var wg sync.WaitGroup
 	for range 2 {
-		wg.Add(1)
-		go func() { defer wg.Done(); <-start; results <- owner.BeginResolve(id) }()
+		wg.Go(func() { <-start; results <- owner.BeginResolve(id) })
 	}
 	close(start)
 	wg.Wait()

--- a/internal/control/recovery.go
+++ b/internal/control/recovery.go
@@ -17,6 +17,12 @@ import (
 // action is continue|continue_task|revise. For revise, feedback is returned in the
 // blocked tool result so the same agent sees it exactly once before retrying.
 func (c *Controller) ResolveRecovery(id string, action agent.RecoveryAction, feedback string) error {
+	c.promptResolveMu.Lock()
+	defer c.promptResolveMu.Unlock()
+	return c.resolveRecoveryLocked(id, action, feedback)
+}
+
+func (c *Controller) resolveRecoveryLocked(id string, action agent.RecoveryAction, feedback string) error {
 	if c == nil {
 		return fmt.Errorf("controller is nil")
 	}
@@ -64,6 +70,7 @@ func (c *Controller) ResolveRecovery(id string, action agent.RecoveryAction, fee
 	}); err != nil {
 		return err
 	}
+	c.promptOwner.Remove(id)
 
 	// Also resolve any matching approvalManager entry so legacy Approve paths
 	// and ReplayPending do not keep a stale prompt.
@@ -157,6 +164,7 @@ func (c *Controller) loadRecoveryState(path string) {
 		return
 	}
 	c.approval.clearKind(recovery.ApprovalKindRecovery)
+	c.promptOwner.RemoveKind(PromptRecovery)
 	c.mu.Lock()
 	gate := c.recoveryGate
 	c.mu.Unlock()
@@ -193,6 +201,7 @@ func (c *Controller) carryRecoveryState(path string) {
 		return
 	}
 	c.approval.clearKind(recovery.ApprovalKindRecovery)
+	c.promptOwner.RemoveKind(PromptRecovery)
 	c.mu.Lock()
 	gate := c.recoveryGate
 	c.mu.Unlock()
@@ -214,6 +223,7 @@ func (c *Controller) CarryRecoveryFrom(prev *Controller) {
 		return
 	}
 	c.approval.clearKind(recovery.ApprovalKindRecovery)
+	c.promptOwner.RemoveKind(PromptRecovery)
 	prev.mu.Lock()
 	prevGate := prev.recoveryGate
 	prev.mu.Unlock()
@@ -315,6 +325,7 @@ func (c *Controller) emitRecoveryPrompt(ctx context.Context, taskID string, pend
 		recovery.ApprovalKindRecovery,
 		ev.Recovery,
 	)
+	c.registerOwnedPrompt(id, PromptRecovery)
 	ev.ID = id
 	c.mu.Lock()
 	gate := c.recoveryGate
@@ -330,12 +341,12 @@ func (c *Controller) emitRecoveryPrompt(ctx context.Context, taskID string, pend
 		select {
 		case <-reply:
 		case <-ctx.Done():
-			c.approval.cancel(id)
+			c.cancelOwnedPrompt(id)
 		}
 	}()
 
 	if err := event.EmitChecked(c.sink, c.approvalRequestEvent(ev)); err != nil {
-		c.approval.cancel(id)
+		c.cancelOwnedPrompt(id)
 		if gate != nil {
 			gate.UnbindApprovalID(taskID, id)
 		}

--- a/internal/control/turn_events.go
+++ b/internal/control/turn_events.go
@@ -394,7 +394,10 @@ func (c *Controller) failTurnEventLedger(err error) {
 	}
 	c.mu.Unlock()
 	if cancel != nil {
+		c.promptResolveMu.Lock()
+		c.promptOwner.CancelAll()
 		c.approval.clearAll()
+		c.promptResolveMu.Unlock()
 		cancel()
 	}
 }
@@ -413,12 +416,25 @@ func (c *Controller) emitTurnEventChecked(e event.Event) error {
 	if c == nil {
 		return nil
 	}
+	if e.ItemID != "" && e.TurnID == "" {
+		if identity, ok := c.promptOwner.Identity(e.ItemID); ok {
+			e.TurnID = identity.TurnID
+			e.PromptKind = string(identity.Kind)
+		}
+	} else if e.ItemID != "" && e.PromptKind == "" {
+		if identity, ok := c.promptOwner.Identity(e.ItemID); ok {
+			e.PromptKind = string(identity.Kind)
+		}
+	}
 	return event.EmitChecked(c.sink, e)
 }
 
 // SetTurnEventRoutingMetadata attaches desktop routing identity to lifecycle
 // envelopes only. It never changes provider-visible prompts or tool schemas.
 func (c *Controller) SetTurnEventRoutingMetadata(runtimeEpoch, submissionID string) {
+	c.promptResolveMu.Lock()
+	c.promptRuntimeEpoch = runtimeEpoch
+	c.promptResolveMu.Unlock()
 	if ledger := c.turnEventLedger(); ledger != nil {
 		ledger.RequireProjectionAck(true)
 		ledger.SetRoutingMetadata(runtimeEpoch, submissionID)

--- a/internal/control/write_access.go
+++ b/internal/control/write_access.go
@@ -186,6 +186,7 @@ func (c *Controller) requestWriteAccessDecision(ctx context.Context, toolName, s
 
 	c.approval.promptEmitMu.Lock()
 	id, reply := c.approval.registerWriteAccess(toolName, subject, reason, args, payload)
+	c.registerOwnedPrompt(id, PromptApproval)
 	approval := event.Approval{
 		ID:          id,
 		Tool:        toolName,
@@ -206,13 +207,19 @@ func (c *Controller) requestWriteAccessDecision(ctx context.Context, toolName, s
 	case r := <-reply:
 		return r, nil
 	case <-waitCtx.Done():
-		c.approval.cancel(id)
+		c.cancelOwnedPrompt(id)
 		return approvalReply{}, waitCtx.Err()
 	}
 }
 
 // ResolveApproval answers a pending approval with an explicit scope.
 func (c *Controller) ResolveApproval(id string, allow bool, scope sandbox.ApprovalScope) error {
+	c.promptResolveMu.Lock()
+	defer c.promptResolveMu.Unlock()
+	return c.resolveApprovalLocked(id, allow, scope)
+}
+
+func (c *Controller) resolveApprovalLocked(id string, allow bool, scope sandbox.ApprovalScope) error {
 	if c == nil {
 		return fmt.Errorf("controller is nil")
 	}
@@ -228,7 +235,7 @@ func (c *Controller) ResolveApproval(id string, allow bool, scope sandbox.Approv
 		if allow {
 			action = agent.RecoveryActionContinue
 		}
-		return c.ResolveRecovery(id, action, "")
+		return c.resolveRecoveryLocked(id, action, "")
 	}
 	pending := c.approval.peek(id)
 	if pending.reply == nil {
@@ -246,6 +253,7 @@ func (c *Controller) ResolveApproval(id string, allow bool, scope sandbox.Approv
 		if !ok {
 			return fmt.Errorf("approval %q is no longer pending", id)
 		}
+		c.promptOwner.Remove(id)
 		return c.resolveWriteAccess(pending, allow, scope)
 	}
 	session := allow && (scope == sandbox.ApprovalScopeSession || scope == sandbox.ApprovalScopeProject)

--- a/internal/event/approval.go
+++ b/internal/event/approval.go
@@ -18,6 +18,7 @@ type Approval struct {
 	Kind        string
 	Recovery    *RecoveryApproval
 	WriteAccess *WriteAccessApproval
+	TurnID      string
 }
 
 // ApprovalKindWriteAccess is the Approval.Kind value for directory expansion.

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -327,6 +327,7 @@ type AskQuestion struct {
 type Ask struct {
 	ID        string
 	Questions []AskQuestion
+	TurnID    string
 }
 
 // MCPInteraction carries one MCPInteractionRequest: a server-initiated
@@ -341,6 +342,7 @@ type MCPInteraction struct {
 	RequestedSchema json.RawMessage
 	URL             string
 	ElicitationID   string
+	TurnID          string
 }
 
 // Extension surface kind values carried by ExtensionSurfacePayload.Kind. They
@@ -506,6 +508,7 @@ const (
 // for Kind; the others are zero.
 type Event struct {
 	Kind             Kind
+	PromptKind       string                    // interactive prompt kind for lifecycle events
 	TurnID           string                    // stable id of the owning top-level turn
 	Sequence         uint64                    // monotonic session-local event sequence
 	Status           TurnStatus                // lifecycle state after this event

--- a/internal/eventwire/approval.go
+++ b/internal/eventwire/approval.go
@@ -12,6 +12,7 @@ type Approval struct {
 	Kind        string               `json:"kind,omitempty"` // tool | plan | recovery | write_access
 	Recovery    *RecoveryApproval    `json:"recovery,omitempty"`
 	WriteAccess *WriteAccessApproval `json:"write_access,omitempty"`
+	TurnID      string               `json:"turnId,omitempty"`
 }
 
 type WriteAccessApproval struct {
@@ -40,7 +41,7 @@ type RecoveryApproval struct {
 }
 
 func toWireApproval(a event.Approval) *Approval {
-	w := &Approval{ID: a.ID, Tool: a.Tool, Subject: a.Subject, Reason: a.Reason, Fresh: a.Fresh, Kind: a.Kind}
+	w := &Approval{ID: a.ID, Tool: a.Tool, Subject: a.Subject, Reason: a.Reason, Fresh: a.Fresh, Kind: a.Kind, TurnID: a.TurnID}
 	if wa := event.NormalizeWriteAccessApproval(a.WriteAccess); wa != nil {
 		w.WriteAccess = &WriteAccessApproval{
 			Directories: append([]string{}, wa.Directories...), DisplayDirectories: append([]string{}, wa.DisplayDirectories...),

--- a/internal/eventwire/wire.go
+++ b/internal/eventwire/wire.go
@@ -14,6 +14,9 @@ import (
 // offload via content refs without changing provider-visible semantics.
 type Event struct {
 	Kind             string                           `json:"kind"`
+	PromptID         string                           `json:"promptId,omitempty"`
+	PromptKind       string                           `json:"promptKind,omitempty"`
+	PromptLegacy     bool                             `json:"promptLegacy,omitempty"`
 	TurnID           string                           `json:"turnId,omitempty"`
 	Sequence         uint64                           `json:"seq,omitempty"`
 	Status           string                           `json:"status,omitempty"`
@@ -132,7 +135,30 @@ type StreamAttempt struct {
 
 // ToWire converts a typed runtime event into the shared frontend JSON contract.
 func ToWire(e event.Event) Event {
-	w := Event{Kind: kindNames[e.Kind], TurnID: e.TurnID, Sequence: e.Sequence, Status: string(e.Status), Text: e.Text, Detail: e.Detail, Reasoning: e.Reasoning, ItemID: e.ItemID, SessionPath: e.SessionPath, SessionReset: e.SessionReset}
+	w := Event{Kind: kindNames[e.Kind], PromptKind: e.PromptKind, TurnID: e.TurnID, Sequence: e.Sequence, Status: string(e.Status), Text: e.Text, Detail: e.Detail, Reasoning: e.Reasoning, ItemID: e.ItemID, SessionPath: e.SessionPath, SessionReset: e.SessionReset}
+	if e.ItemID != "" {
+		promptEvent := false
+		switch e.Kind {
+		case event.AskRequest:
+			promptEvent = true
+			w.PromptKind = "ask"
+		case event.ApprovalRequest:
+			promptEvent = true
+			w.PromptKind = e.Approval.Kind
+			if w.PromptKind == "" {
+				w.PromptKind = "approval"
+			}
+		case event.MCPInteractionRequest:
+			promptEvent = true
+			w.PromptKind = "mcp"
+		case event.PromptAnswered:
+			promptEvent = true
+		}
+		if promptEvent {
+			w.PromptID = e.ItemID
+			w.PromptLegacy = e.TurnID == ""
+		}
+	}
 	if len(e.MemoryCitations) > 0 {
 		w.MemoryCitations = ToWireMemoryCitations(e.MemoryCitations)
 	}
@@ -358,6 +384,7 @@ type AskQuestion struct {
 type Ask struct {
 	ID        string        `json:"id"`
 	Questions []AskQuestion `json:"questions"`
+	TurnID    string        `json:"turnId,omitempty"`
 }
 
 // MCPInteraction is the JSON form of an event.MCPInteraction: one
@@ -372,6 +399,7 @@ type MCPInteraction struct {
 	RequestedSchema json.RawMessage `json:"requestedSchema,omitempty"`
 	URL             string          `json:"url,omitempty"`
 	ElicitationID   string          `json:"elicitationId,omitempty"`
+	TurnID          string          `json:"turnId,omitempty"`
 }
 
 // applyNotice fills the Notice-specific wire fields.
@@ -391,7 +419,7 @@ func (w *Event) applyNotice(e event.Event) {
 func ToWireMCPInteraction(i event.MCPInteraction) *MCPInteraction {
 	return &MCPInteraction{
 		ID: i.ID, Server: i.Server, Mode: i.Mode, Message: i.Message,
-		RequestedSchema: i.RequestedSchema, URL: i.URL, ElicitationID: i.ElicitationID,
+		RequestedSchema: i.RequestedSchema, URL: i.URL, ElicitationID: i.ElicitationID, TurnID: i.TurnID,
 	}
 }
 
@@ -573,7 +601,7 @@ func ToWireAsk(a event.Ask) *Ask {
 		}
 		qs[i] = AskQuestion{ID: q.ID, Header: q.Header, Prompt: q.Prompt, Options: opts, Multi: q.Multi}
 	}
-	return &Ask{ID: a.ID, Questions: qs}
+	return &Ask{ID: a.ID, Questions: qs, TurnID: a.TurnID}
 }
 
 // ToWireCacheDiagnostics converts cache diagnostics into their JSON wire form.

--- a/internal/eventwire/wire_test.go
+++ b/internal/eventwire/wire_test.go
@@ -452,8 +452,8 @@ func TestToWireInteractionAndLifecyclePayloads(t *testing.T) {
 	}{
 		{
 			name: "approval",
-			in:   event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: "a1", Tool: "bash", Subject: "rm"}},
-			want: []string{`"kind":"approval_request"`, `"approval":{"id":"a1","tool":"bash","subject":"rm"}`},
+			in:   event.Event{Kind: event.ApprovalRequest, TurnID: "turn-a", ItemID: "a1", Approval: event.Approval{ID: "a1", Tool: "bash", Subject: "rm", TurnID: "turn-a"}},
+			want: []string{`"kind":"approval_request"`, `"promptId":"a1"`, `"promptKind":"approval"`, `"turnId":"turn-a"`, `"approval":{"id":"a1"`, `"tool":"bash"`, `"subject":"rm"`},
 		},
 		{
 			name: "fresh approval",
@@ -489,14 +489,15 @@ func TestToWireInteractionAndLifecyclePayloads(t *testing.T) {
 		},
 		{
 			name: "ask",
-			in: event.Event{Kind: event.AskRequest, Ask: event.Ask{
-				ID: "ask-1",
+			in: event.Event{Kind: event.AskRequest, TurnID: "turn-q", ItemID: "ask-1", Ask: event.Ask{
+				ID:     "ask-1",
+				TurnID: "turn-q",
 				Questions: []event.AskQuestion{{
 					ID: "q1", Header: "Pick", Prompt: "Choose", Multi: true,
 					Options: []event.AskOption{{Label: "A", Description: "Alpha"}, {Label: "B"}},
 				}},
 			}},
-			want: []string{`"kind":"ask_request"`, `"ask":{"id":"ask-1"`, `"header":"Pick"`, `"description":"Alpha"`, `"multi":true`},
+			want: []string{`"kind":"ask_request"`, `"promptId":"ask-1"`, `"promptKind":"ask"`, `"turnId":"turn-q"`, `"ask":{"id":"ask-1"`, `"header":"Pick"`, `"description":"Alpha"`, `"multi":true`},
 		},
 		{
 			name: "compaction",
@@ -529,5 +530,12 @@ func TestToWireInteractionAndLifecyclePayloads(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPromptWireMarksLegacyIdentity(t *testing.T) {
+	w := ToWire(event.Event{Kind: event.AskRequest, ItemID: "legacy-ask", Ask: event.Ask{ID: "legacy-ask"}})
+	if !w.PromptLegacy || w.PromptID != "legacy-ask" || w.PromptKind != "ask" {
+		t.Fatalf("legacy prompt wire identity = %+v", w)
 	}
 }

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -900,7 +900,7 @@
     "internal/control/controller.go": {
       "complexity": 12,
       "essay": 91,
-      "file-size": 5564,
+      "file-size": 5565,
       "function-size": 84,
       "narrative": 4,
       "struct-state": 17

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -147,7 +147,7 @@
       "file-size": 180
     },
     "desktop/frontend/src/lib/bridge.ts": {
-      "file-size": 4977
+      "file-size": 4979
     },
     "desktop/frontend/src/lib/crash.ts": {
       "file-size": 225
@@ -895,15 +895,15 @@
     },
     "internal/control/approval.go": {
       "essay": 5,
-      "file-size": 75
+      "file-size": 76
     },
     "internal/control/controller.go": {
       "complexity": 12,
       "essay": 91,
-      "file-size": 5515,
+      "file-size": 5547,
       "function-size": 84,
       "narrative": 4,
-      "struct-state": 16
+      "struct-state": 17
     },
     "internal/control/controller_test.go": {
       "essay": 1,
@@ -989,7 +989,9 @@
       "narrative": 1
     },
     "internal/eventwire/wire.go": {
-      "file-size": 3
+      "complexity": 6,
+      "file-size": 31,
+      "function-size": 10
     },
     "internal/evidence/evidence.go": {
       "complexity": 6,

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -147,7 +147,7 @@
       "file-size": 180
     },
     "desktop/frontend/src/lib/bridge.ts": {
-      "file-size": 4979
+      "file-size": 4997
     },
     "desktop/frontend/src/lib/crash.ts": {
       "file-size": 225
@@ -156,7 +156,7 @@
       "file-size": 264
     },
     "desktop/frontend/src/lib/types.ts": {
-      "file-size": 1599
+      "file-size": 1620
     },
     "desktop/frontend/src/lib/useController.ts": {
       "file-size": 4248
@@ -900,7 +900,7 @@
     "internal/control/controller.go": {
       "complexity": 12,
       "essay": 91,
-      "file-size": 5547,
+      "file-size": 5564,
       "function-size": 84,
       "narrative": 4,
       "struct-state": 17
@@ -989,9 +989,9 @@
       "narrative": 1
     },
     "internal/eventwire/wire.go": {
-      "complexity": 6,
+      "complexity": 4,
       "file-size": 31,
-      "function-size": 10
+      "function-size": 9
     },
     "internal/evidence/evidence.go": {
       "complexity": 6,

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -159,7 +159,7 @@
       "file-size": 1620
     },
     "desktop/frontend/src/lib/useController.ts": {
-      "file-size": 4248
+      "file-size": 4263
     },
     "desktop/heartbeat.go": {
       "essay": 7


### PR DESCRIPTION
## Problem
A delayed Ask or decision-card response could outlive the turn or controller that created it. The desktop then showed `turn ... is not the active turn`, could repeat stale submissions after a reconnect, or rely on an unfenced compatibility route.

## Root cause
Prompt ownership was split across the Ask, approval, Recovery, and MCP managers while the frontend cached turn identity independently. The check, durable `PromptAnswered` write, and waiter wake-up were not represented by one controller-owned identity boundary.

## Fix
- Add a controller-owned pending prompt owner for Ask, approval, Plan, Recovery, and MCP cards.
- Bind each prompt to `promptId`, `turnId`, `runtimeEpoch`, and `kind`, complete missing routing metadata immediately before emission, and carry that identity through prompt and lifecycle event wire payloads.
- Add `ResolvePromptForTab`, backed by controller-side exact resolution, closed-controller checks, runtime/turn fences, resolving reservations, persistence rollback, and serialized cancellation.
- Make new frontend decision paths submit the card identity through the exact API. Ask refreshes the authoritative turn from `ListTabs()` immediately before submit; other cards retain their captured turn/epoch. Stale responses expire only the matching prompt identity/epoch, preserve sibling cards, and deduplicate tab-scoped replay; new frontend code does not silently fall back to an unfenced API.
- Preserve the active turn identity while a queued follow-up is submitted, and keep missing backend event sequence metadata out of sequence deduplication so the authoritative status snapshot can restore idle/running state.
- Add browser mock coverage, deterministic owner/resolution tests, identity wire tests, bilingual protocol documentation, and the minimal `external-opener` base-test fixture repair needed for the current main-v2 test suite.

## Verification
- `go test ./...`
- `go test -race ./internal/control`
- `(cd desktop && go test .)`
- `(cd desktop && go test -race .)`
- `go vet ./...`
- `(cd desktop && go vet ./...)`
- `pnpm typecheck`
- `pnpm test:typecheck`
- `pnpm test:all` (267 suites)
- `pnpm build`
- `go run ./tools/repolint`
- `git diff --check`

The bundle guard keeps the smallest measured ceilings for this protocol increment: 468.2 KiB measured initial JavaScript gzip under a 468.3 KiB ceiling, and 2496.4 KiB measured initial raw JavaScript plus CSS under a 2496.5 KiB ceiling.

## Compatibility and cache
Old Wails decision methods remain available for older clients. The new frontend uses only the exact prompt API. The change does not alter provider-visible prompt text, tool schemas, memory serialization, or request bytes.

Cache-impact: low — Desktop prompt routing and event metadata only; provider-visible bytes are unchanged.
Cache-guard: frontend type/build checks plus root and Desktop test suites; no provider serialization path was changed.
System-prompt-review: not applicable — no system prompt or provider request construction changed.
Documentation-impact: updated - added English and Simplified Chinese Desktop prompt identity documentation covering the exact API, stale lifecycle, and compatibility behavior.

Review: current head is rebased onto `main-v2` and reviewed for stale-card routing, controller replacement, legacy API fallback, prompt ownership, persistence rollback, and prompt/cache serialization boundaries.



