### PR TITLE
fix: restore prompt answers and recovery / 修复提问提交与状态恢复

### DIFF
--- a/desktop/frontend/src/__tests__/ask-card-identity.test.tsx
+++ b/desktop/frontend/src/__tests__/ask-card-identity.test.tsx
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import type { QuestionAnswer, WireAsk } from "../lib/types";
+
+const dom = new JSDOM('<div id="root"></div>', { url: "http://localhost/", pretendToBeVisual: true });
+Object.assign(globalThis, {
+  window: dom.window, document: dom.window.document, Element: dom.window.Element,
+  HTMLElement: dom.window.HTMLElement, Node: dom.window.Node, localStorage: dom.window.localStorage,
+  IS_REACT_ACT_ENVIRONMENT: true,
+});
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+const { default: React, act } = await import("react");
+const { createRoot } = await import("react-dom/client");
+const { AskCard } = await import("../components/AskCard");
+const { LocaleProvider } = await import("../lib/i18n");
+const root = createRoot(document.getElementById("root")!);
+const answers: QuestionAnswer[][] = [];
+const ask: WireAsk = {
+  id: "1", runtimeEpoch: "runtime-a", turnId: "turn-a",
+  questions: [{ id: "q1", prompt: "Choose", options: [{ label: "Option A" }, { label: "Option B" }] }],
+};
+async function render(next: WireAsk | null, scope = "tab-a") {
+  await act(async () => root.render(<LocaleProvider>{next && <AskCard ask={next} draftScope={scope}
+    onAnswer={(_id, value) => { answers.push(value); }} onStop={() => {}} />}</LocaleProvider>));
+}
+function input() { return document.querySelector<HTMLInputElement>(".ask-shelf__custom")!; }
+async function type(text: string) {
+  await act(async () => input().focus()); // Keyboard focus does not click the custom row.
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, "value")!.set!.call(input(), text);
+    input().dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+  });
+}
+
+await render(ask);
+await type("Keyboard answer");
+await act(async () => input().dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+assert.deepEqual(answers, [[{ questionId: "q1", selected: ["Keyboard answer"] }]]);
+console.log("  PASS  keyboard focus and Enter submit the custom answer exactly once");
+
+await render(null);
+await render(ask);
+assert.equal(input().value, "", "successful submission clears its draft");
+await type("Keep this draft");
+await render(null);
+await render({ ...ask });
+assert.equal(input().value, "Keep this draft", "same prompt survives unmount and replay");
+
+await render({ ...ask, runtimeEpoch: "runtime-b" });
+assert.equal(input().value, "", "runtime replacement resets a mounted card even with the same prompt and turn IDs");
+await type("Runtime B draft");
+await render({ ...ask, runtimeEpoch: "runtime-b", turnId: "turn-b" });
+assert.equal(input().value, "", "new turn cannot inherit the previous turn's draft");
+await render(null);
+await render({ ...ask, runtimeEpoch: "runtime-c" });
+assert.equal(input().value, "", "a replacement runtime cannot inherit an unmounted card's draft");
+await render(ask, "tab-b");
+assert.equal(input().value, "", "tabs have separate drafts");
+await render(ask);
+assert.equal(input().value, "Keep this draft", "switching back restores only the original prompt's draft");
+console.log("  PASS  drafts follow tab, runtime, turn, and prompt identity across replay and replacement");
+await act(async () => root.unmount());
+dom.window.close();

--- a/desktop/frontend/src/__tests__/runtime-status-freshness.test.ts
+++ b/desktop/frontend/src/__tests__/runtime-status-freshness.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { initialState, reducer, promptEventClock } from "../lib/useController";
+import { findTabAfterSubmitFailure } from "../lib/turnSubmissionFailure";
+import type { TabMeta } from "../lib/types";
+
+const idle = { type: "backend_status", running: false, pendingPrompt: false, backgroundJobs: 0,
+  cancelRequested: false, cancellable: false, runtimeEpoch: "epoch-a", turnEventSeq: 7 } as const;
+const now = promptEventClock();
+const baseline = reducer(initialState, { ...idle, snapshotAt: now });
+const optimistic = reducer(baseline, { type: "user", text: "hello", seq: 0, submissionId: "send" });
+const rejected = reducer(optimistic, { type: "turn_submit_rejected", submissionId: "send", error: "not ready" });
+assert.equal(reducer(rejected, { ...idle, snapshotAt: now }), rejected, "pre-submit snapshot cannot undo a later lifecycle event");
+const fresh = promptEventClock() + 1;
+const settled = reducer(rejected, { ...idle, snapshotAt: fresh });
+assert.equal(settled.running, false, "same-sequence fresh idle clears a rejected optimistic send");
+assert.equal(settled.cancellable, false);
+assert.equal(reducer(settled, { ...idle, running: true, cancellable: true, snapshotAt: now }), settled, "out-of-order equal-sequence response cannot restore running");
+assert.equal(reducer(settled, { ...idle, running: true, cancellable: true, snapshotAt: fresh }), settled, "duplicate snapshot is ignored");
+assert.equal(reducer(settled, { ...idle, running: true, cancellable: true }), settled, "equal sequence without freshness cannot override state");
+assert.equal(reducer(settled, { ...idle, running: true, cancellable: true, turnEventSeq: 6, snapshotAt: fresh + 1 }), settled, "older backend sequence is always stale");
+const active = reducer(settled, { ...idle, running: true, cancellable: true, turnEventSeq: 8, snapshotAt: fresh + 2 });
+assert.equal(active.running, true, "newer backend event still advances state");
+const replaced = reducer(active, { ...idle, runtimeEpoch: "epoch-b", turnEventSeq: 1, snapshotAt: fresh + 3 });
+assert.equal(replaced.running, false, "new runtime may restart its event sequence");
+
+let clock = 100;
+let finishRead: (tabs: TabMeta[]) => void = () => {};
+const read = findTabAfterSubmitFailure({ ListTabs: () => new Promise((resolve) => { finishRead = resolve; }) }, "tab", [0], () => clock);
+// A newer lifecycle event arrives while the older status read is in flight.
+clock = 200;
+finishRead([{ id: "tab", running: false }] as TabMeta[]);
+const snapshot = await read;
+assert.ok(snapshot && snapshot[1] < 150, "reconciliation carries read-start time, not response time");
+const newerTurn = { ...rejected, turnLifecycleObservedAt: 150 };
+assert.equal(reducer(newerTurn, { ...idle, snapshotAt: snapshot[1] }), newerTurn, "delayed failed-send reconciliation cannot clear a newer turn");
+console.log("  PASS  runtime snapshots use event order and read freshness without trapping optimistic state");

--- a/desktop/frontend/src/__tests__/session-recovery-runtime-failure.test.ts
+++ b/desktop/frontend/src/__tests__/session-recovery-runtime-failure.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { JSDOM } from "jsdom";
+import type { AppBindings } from "../lib/bridge";
+import type { SessionRecoveryEvent } from "../lib/types";
+
+const dom = new JSDOM("", { url: "http://localhost/" });
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+const handlers = new Map<string, (...data: unknown[]) => void>();
+window.runtime = {
+  EventsOn: (name, handler) => { handlers.set(name, handler); return () => handlers.delete(name); },
+  BrowserOpenURL: () => {},
+};
+let reconcileCalls = 0;
+let reads = 0;
+let rejectReconcile: (error: Error) => void = () => {};
+window.go = { main: { App: {
+  ReconcileRecoveryVersions: () => {
+    reconcileCalls += 1;
+    return new Promise((_resolve, reject) => { rejectReconcile = reject; });
+  },
+  GetRecoveryLineage: async () => {
+    reads += 1;
+    return { groupId: "root", state: "diverged", branchCount: 2, unresolved: 1, cleanupEligible: 0, members: [] };
+  },
+} as unknown as AppBindings } };
+const { startSessionRecoveryRuntime } = await import("../lib/sessionRecoveryRuntime");
+const { setFrontendDiagnosticSink } = await import("../lib/frontendDiagnosticBridge");
+const diagnostics: unknown[] = [];
+setFrontendDiagnosticSink((_source, type, fields) => diagnostics.push({ type, fields }));
+const unhandled: unknown[] = [];
+const onUnhandled = (error: unknown) => unhandled.push(error);
+process.on("unhandledRejection", onUnhandled);
+let recovered = 0;
+const stop = startSessionRecoveryRuntime({ onRecovered: () => { recovered += 1; }, onDiverged: () => {} });
+const event: SessionRecoveryEvent = {
+  recoveryPath: "/sessions/fork.jsonl", scope: "global", topicId: "topic",
+  recoveryParentId: "root", recoveryReason: "snapshot_conflict",
+};
+handlers.get("session:recovered")!(event);
+handlers.get("session:recovered")!(event);
+assert.equal(reconcileCalls, 1, "duplicate recovery is deduplicated");
+rejectReconcile(new Error("session version lineage is unavailable: /private/session/path"));
+await setImmediate(); // Let Node report any unhandled promise rejection.
+assert.deepEqual(unhandled, [], "a failed background reconcile must not escape to the crash handler");
+assert.equal(JSON.stringify(diagnostics).includes("/private/session/path"), false, "diagnostics omit raw backend errors");
+handlers.get("project-tree:changed-v2")!({ revision: 2, roots: [""], reason: "reconcile" });
+await setImmediate();
+assert.equal(reads, 1, "a later catalog revision still classifies the pending recovery");
+handlers.get("session:recovered")!({ ...event, recoveryPath: "/sessions/next-fork.jsonl" });
+assert.equal(reconcileCalls, 2, "failure releases the topic's in-flight guard");
+assert.equal(recovered, 2, "new recovery events remain usable after failure");
+stop();
+rejectReconcile(new Error("stopped coordinator failure"));
+await setImmediate();
+assert.deepEqual(unhandled, [], "rejections after disposal are also contained");
+assert.equal(handlers.size, 0);
+process.off("unhandledRejection", onUnhandled);
+dom.window.close();
+console.log("  PASS  failed recovery reconciliation stays local and preserves catalog-driven classification");

--- a/desktop/frontend/src/__tests__/use-controller-send-fallback.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-send-fallback.test.tsx
@@ -294,6 +294,26 @@ eq(controller?.state.ask, undefined, "stale Ask submission expires the old card"
 rejectAnswer = false;
 rejectAnswerMessage = "prompt write failed";
 
+// Pre-admission rejection does not append a backend event. A fresh idle read
+// with the same sequence must still undo each optimistic submission.
+rejectSubmit = true;
+backendTab = tabMeta({ running: false, pendingPrompt: false, turnEventSeq: 700 });
+await act(async () => {
+  for (const handler of eventHandlers) handler({ kind: "turn_done", tabId: "tab-send" } as WireEvent);
+  await controller?.send("seed idle status after rejected submit");
+  await flushPromises();
+  await flushPromises();
+});
+eq(controller?.state.runtimeStatusSeq, 700, "baseline stores the backend sequence");
+eq(controller?.state.running, false, "first rejection settles to authoritative idle");
+await act(async () => {
+  await controller?.send("second pre-admission rejection");
+  await flushPromises();
+  await flushPromises();
+});
+eq(controller?.state.running, false, "same-sequence idle settles a new failed submit");
+eq(controller?.state.cancellable, false, "same-sequence idle removes the stale Stop action");
+
 await act(async () => {
   root.unmount();
 });

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -11,7 +11,8 @@ import {
 } from "./PromptShelf";
 
 const askDrafts = new Map<string, AskDraft>();
-const askDraftKey = (scope: string, id: string) => `${scope}:${id}`;
+const askDraftKey = (scope: string, ask: WireAsk) =>
+  JSON.stringify([scope, ask.runtimeEpoch ?? "", ask.turnId ?? "", ask.id]);
 type AnswerMode = "option" | "custom";
 type AskDraft = {
   sel: Record<string, string[]>;
@@ -21,41 +22,45 @@ type AskDraft = {
   selectedIndex: number;
 };
 
-function readAskDraft(scope: string, id: string): AskDraft | undefined {
-  const draft = askDrafts.get(askDraftKey(scope, id));
+function readAskDraft(key: string): AskDraft | undefined {
+  const draft = askDrafts.get(key);
   return draft ? { ...draft, sel: { ...draft.sel }, custom: { ...draft.custom }, answerMode: { ...draft.answerMode } } : undefined;
 }
 
-function clearAskDraft(scope: string, id: string): void {
-  askDrafts.delete(askDraftKey(scope, id));
+function clearAskDraft(key: string): void {
+  askDrafts.delete(key);
 }
 
 // AskCard renders the `ask` tool as a decision shelf near the composer. It
 // walks multi-question asks one at a time. Single-select choices advance to
 // the next question immediately; multi-select and custom answers wait for an
 // explicit confirm, and the final question still requires submission.
-export function AskCard({
-  ask,
-  onAnswer,
-  draftScope = "default",
-  onStop,
-}: {
+type AskCardProps = {
   ask: WireAsk;
   onAnswer: (id: string, answers: QuestionAnswer[]) => void | Promise<void>;
   onDismiss?: () => void | Promise<void>;
   draftScope?: string;
   onStop: () => void;
-}) {
+};
+
+export function AskCard(props: AskCardProps) {
+  const draftKey = askDraftKey(props.draftScope ?? "default", props.ask);
+  // The same identity owns both cached drafts and live component state. A
+  // controller can reuse prompt IDs, so changing runtime or turn remounts it.
+  return <AskCardBody key={draftKey} {...props} draftKey={draftKey} />;
+}
+
+function AskCardBody({ ask, onAnswer, onStop, draftKey }: AskCardProps & { draftKey: string }) {
   const t = useT();
   // Per-question state: selected option labels, and an optional typed answer.
-  const [sel, setSel] = useState<Record<string, string[]>>(() => readAskDraft(draftScope, ask.id)?.sel ?? {});
-  const [custom, setCustom] = useState<Record<string, string>>(() => readAskDraft(draftScope, ask.id)?.custom ?? {});
-  const [answerMode, setAnswerMode] = useState<Record<string, AnswerMode>>(() => readAskDraft(draftScope, ask.id)?.answerMode ?? {});
+  const [sel, setSel] = useState<Record<string, string[]>>(() => readAskDraft(draftKey)?.sel ?? {});
+  const [custom, setCustom] = useState<Record<string, string>>(() => readAskDraft(draftKey)?.custom ?? {});
+  const [answerMode, setAnswerMode] = useState<Record<string, AnswerMode>>(() => readAskDraft(draftKey)?.answerMode ?? {});
   const [customOpen, setCustomOpen] = useState(false);
-  const [active, setActive] = useState(() => readAskDraft(draftScope, ask.id)?.active ?? 0);
+  const [active, setActive] = useState(() => readAskDraft(draftKey)?.active ?? 0);
   // Extra decision row after option labels: custom answer. Skip is a
   // secondary footer action rather than an answer choice.
-  const [selectedIndex, setSelectedIndex] = useState(() => readAskDraft(draftScope, ask.id)?.selectedIndex ?? 0);
+  const [selectedIndex, setSelectedIndex] = useState(() => readAskDraft(draftKey)?.selectedIndex ?? 0);
   const [expandedDescriptionId, setExpandedDescriptionId] = useState<string | null>(null);
   const [descriptionTruncated, setDescriptionTruncated] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -87,25 +92,15 @@ export function AskCard({
 
   useEffect(() => {
     shelfRef.current?.focus();
-    initializedActiveRef.current = false;
-    const draft = readAskDraft(draftScope, ask.id);
-    setSel(draft?.sel ?? {});
-    setCustom(draft?.custom ?? {});
-    setAnswerMode(draft?.answerMode ?? {});
-    setCustomOpen(false);
-    setActive(draft?.active ?? 0);
-    setSelectedIndex(draft?.selectedIndex ?? 0);
-    setSubmitting(false);
-    setCollapsed(false);
-  }, [ask.id, draftScope]);
+  }, []);
 
   useEffect(() => {
     try {
-      askDrafts.set(askDraftKey(draftScope, ask.id), { sel: { ...sel }, custom: { ...custom }, answerMode: { ...answerMode }, active, selectedIndex });
+      askDrafts.set(draftKey, { sel: { ...sel }, custom: { ...custom }, answerMode: { ...answerMode }, active, selectedIndex });
     } catch {
       // Draft storage is best effort; the live pending ask remains authoritative.
     }
-  }, [active, answerMode, ask.id, custom, draftScope, selectedIndex, sel]);
+  }, [active, answerMode, custom, draftKey, selectedIndex, sel]);
 
   useEffect(() => {
     setCustomOpen(false);
@@ -155,7 +150,7 @@ export function AskCard({
     if (submitting) return;
     if (isLast) {
       submitAction(() => Promise.resolve(onAnswer(ask.id, answersFrom(nextSel, nextCustom))).then(() => {
-        clearAskDraft(draftScope, ask.id);
+        clearAskDraft(draftKey);
       }));
       return;
     }
@@ -175,6 +170,7 @@ export function AskCard({
   };
 
   const setTyped = (question: WireAskQuestion, text: string) => {
+    setSelectedIndex(customRowIndex);
     setAnswerMode((m) => ({ ...m, [question.id]: "custom" }));
     setCustom((c) => ({ ...c, [question.id]: text }));
     if (text.trim()) setSel((s) => ({ ...s, [question.id]: [] }));
@@ -186,7 +182,7 @@ export function AskCard({
   };
 
   const stopAsk = () => {
-    clearAskDraft(draftScope, ask.id);
+    clearAskDraft(draftKey);
     onStop();
   };
 
@@ -202,7 +198,7 @@ export function AskCard({
       return;
     }
     submitAction(() => Promise.resolve(onAnswer(ask.id, answersFrom(nextSel, nextCustom))).then(() => {
-      clearAskDraft(draftScope, ask.id);
+      clearAskDraft(draftKey);
     }));
   };
 
@@ -398,6 +394,7 @@ export function AskCard({
               placeholder={t("ask.customPlaceholder")}
               value={answerMode[q.id] === "custom" ? custom[q.id] ?? "" : ""}
               disabled={submitting}
+              onFocus={() => setSelectedIndex(customRowIndex)}
               onChange={(e) => setTyped(q, e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === "Enter" && canConfirm()) {

--- a/desktop/frontend/src/lib/runtimeStatusFreshness.ts
+++ b/desktop/frontend/src/lib/runtimeStatusFreshness.ts
@@ -1,0 +1,23 @@
+type RuntimeStatusState = {
+  runtimeStatusEpoch?: string;
+  runtimeStatusSeq?: number;
+  runtimeStatusSnapshotAt?: number;
+};
+type RuntimeStatusSnapshot = {
+  runtimeEpoch?: string;
+  turnEventSeq?: number;
+  snapshotAt?: number;
+};
+
+export function runtimeStatusSnapshotIsStale(state: RuntimeStatusState, snapshot: RuntimeStatusSnapshot): boolean {
+  const incomingEpoch = snapshot.runtimeEpoch?.trim();
+  const storedEpoch = state.runtimeStatusEpoch?.trim();
+  if (incomingEpoch && storedEpoch && incomingEpoch !== storedEpoch) return false;
+  if (snapshot.turnEventSeq === undefined || state.runtimeStatusSeq === undefined) return false;
+  if (snapshot.turnEventSeq < state.runtimeStatusSeq) return true;
+  // A rejected optimistic send need not append a backend event. A fresh read
+  // at the same sequence can reconcile it; duplicate and out-of-order reads
+  // cannot override a more recent snapshot.
+  return snapshot.turnEventSeq === state.runtimeStatusSeq && (snapshot.snapshotAt === undefined ||
+    (state.runtimeStatusSnapshotAt !== undefined && snapshot.snapshotAt <= state.runtimeStatusSnapshotAt));
+}

--- a/desktop/frontend/src/lib/sessionRecoveryRuntime.ts
+++ b/desktop/frontend/src/lib/sessionRecoveryRuntime.ts
@@ -69,6 +69,13 @@ export function startSessionRecoveryRuntime(options: SessionRecoveryRuntimeOptio
         workspaceRoot: event.workspaceRoot,
         topicId,
         path: event.recoveryPath,
+      }).catch(() => {
+        // Background reconciliation can race catalog rebuilds. Keep the
+        // recovery pending for classification on a later catalog revision;
+        // raw backend errors can contain private session paths.
+        if (!stopped) recordFrontendDiagnostic("runtime", "session.recovery-reconcile", {
+          status: "error", reason: "reconcile_failed",
+        });
       }).finally(() => reconciling.delete(reconcileKey));
     }
   });

--- a/desktop/frontend/src/lib/turnSubmissionFailure.ts
+++ b/desktop/frontend/src/lib/turnSubmissionFailure.ts
@@ -72,12 +72,11 @@ export async function findTabAfterSubmitFailure(
   for (const delay of delays) {
     if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
     try {
-      const tab = asArray(await binding.ListTabs()).find((candidate) => candidate.id === tabId);
-      // Sample after the authoritative read. A synchronous bridge may resolve
-      // within the same monotonic tick as the initiating lifecycle event; the
-      // tiny deterministic advance records that the read has completed without
-      // weakening the reducer's tie guard.
+      // Fence at read start, so a delayed response cannot override a turn or
+      // prompt observed while it was in flight. Preserve a sub-tick advance
+      // for synchronous bridges called in the initiating event's clock tick.
       const snapshotAt = clock() + 0.001;
+      const tab = asArray(await binding.ListTabs()).find((candidate) => candidate.id === tabId);
       return [tab, snapshotAt] as const;
     } catch {
       // The caller's stale-turn watchdog remains the long-tail backstop.

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1,6 +1,7 @@
 // useController is the frontend's state machine over the agent event stream. It keeps
 // per-tab output, tool state, and approvals while the user switches tabs; components
 // render the active tab's state.
+import { runtimeStatusSnapshotIsStale } from "./runtimeStatusFreshness";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { asArray } from "./array";
 import { compactArchivedToolItems } from "./archivedToolItems";
@@ -429,7 +430,7 @@ export interface State {
   turnDoneAt: number;
   turnLifecycleObservedAt?: number;
   /** Last runtime snapshot sequence accepted for this tab/epoch. */
-  runtimeStatusEpoch?: string; runtimeStatusSeq?: number;
+  runtimeStatusEpoch?: string; runtimeStatusSeq?: number; runtimeStatusSnapshotAt?: number;
   // Completion tokens accumulated across executor usage events within the
   // current turn. ReasoningTokens is a subset of CompletionTokens.
   turnOutputTokens: number;
@@ -2103,11 +2104,10 @@ export function reducer(s: State, a: Action): State {
     case "backend_status": {
       const incomingEpoch = a.runtimeEpoch?.trim();
       const storedEpoch = s.runtimeStatusEpoch?.trim();
-      if (!(incomingEpoch && storedEpoch && incomingEpoch !== storedEpoch) && a.turnEventSeq !== undefined && s.runtimeStatusSeq !== undefined && a.turnEventSeq <= s.runtimeStatusSeq) {
-        return s;
-      }
+      if (runtimeStatusSnapshotIsStale(s, a)) return s;
       // Reject snapshots that began before newer prompt or turn lifecycle evidence.
       if (runtimeSnapshotPredatesPrompt(s, a.snapshotAt) || snapshotPredatesTurnLifecycle(s.turnLifecycleObservedAt, a.snapshotAt)) return s;
+      const runtimeStatus = { runtimeStatusEpoch: incomingEpoch ?? storedEpoch, runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq, runtimeStatusSnapshotAt: a.snapshotAt };
       const pendingPrompt = Boolean(a.pendingPrompt);
       const backgroundJobs = Math.max(0, a.backgroundJobs ?? s.backgroundJobs ?? 0);
       const cancelRequested = Boolean(a.cancelRequested);
@@ -2130,11 +2130,11 @@ export function reducer(s: State, a: Action): State {
         activeTurnId === s.activeTurnId &&
         !clearsRetry
       ) return incomingEpoch || a.turnEventSeq !== undefined
-        ? { ...s, runtimeStatusEpoch: incomingEpoch ?? storedEpoch, runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq } : s;
+        ? { ...s, ...runtimeStatus } : s;
       if (foregroundRunning) {
         return {
           ...s,
-          runtimeStatusEpoch: incomingEpoch ?? storedEpoch, runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq,
+          ...runtimeStatus,
           running: true,
           turnActive: true,
           pendingPrompt,
@@ -2154,7 +2154,7 @@ export function reducer(s: State, a: Action): State {
       }));
       return endPromptWait({
         ...telemetry,
-        runtimeStatusEpoch: incomingEpoch ?? storedEpoch, runtimeStatusSeq: a.turnEventSeq ?? s.runtimeStatusSeq,
+        ...runtimeStatus,
         items: finalized,
         running: false,
         turnActive: false,

--- a/internal/control/ask_exact_integration_test.go
+++ b/internal/control/ask_exact_integration_test.go
@@ -1,0 +1,156 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+)
+
+func TestAskExactResolutionDeliversOnceAfterReplay(t *testing.T) {
+	dir := t.TempDir()
+	asks := make(chan event.Event, 1)
+	answers := make(chan []event.AskAnswer, 1)
+	release := make(chan struct{})
+	c := New(Options{
+		SessionDir: dir, SessionPath: filepath.Join(dir, "session.jsonl"),
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.AskRequest {
+				asks <- e
+			}
+		}),
+	})
+	t.Cleanup(func() { c.Cancel(); waitIdle(t, c); c.Close() })
+	c.SetTurnEventRoutingMetadata("runtime-ask", "")
+	c.runGuarded(func(ctx context.Context) error {
+		got, err := c.Ask(ctx, askProbeQuestions())
+		if err != nil {
+			return err
+		}
+		answers <- got
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return nil
+	})
+	var request event.Event
+	select {
+	case request = <-asks:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Ask was not published")
+	}
+	identity := PromptIdentity{PromptID: request.Ask.ID, TurnID: request.TurnID, RuntimeEpoch: "runtime-ask", Kind: PromptAsk}
+	if identity.TurnID == "" || identity.TurnID != c.RuntimeStatus().TurnID {
+		t.Fatalf("Ask has no current turn identity: %+v", identity)
+	}
+	var replay event.Event
+	c.ReplayPendingPromptsTo(event.FuncSink(func(e event.Event) { replay = e }))
+	if replay.Ask.ID != identity.PromptID || replay.TurnID != identity.TurnID {
+		t.Fatalf("replayed Ask changed identity: %+v", replay)
+	}
+	want := []event.AskAnswer{{QuestionID: request.Ask.Questions[0].ID, Selected: []string{"custom answer"}}}
+	answer := PromptAnswer{Questions: want}
+	stale := identity
+	stale.RuntimeEpoch = "old-runtime"
+	if err := c.ResolvePromptExact(stale, answer); !errors.Is(err, ErrPromptStaleRuntime) {
+		t.Fatalf("stale runtime = %v", err)
+	}
+	stale = identity
+	stale.TurnID = "old-turn"
+	if err := c.ResolvePromptExact(stale, answer); !errors.Is(err, ErrPromptStaleTurn) {
+		t.Fatalf("stale turn = %v", err)
+	}
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Go(func() { <-start; results <- c.ResolvePromptExact(identity, answer) })
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	var succeeded, duplicate int
+	for err := range results {
+		switch {
+		case err == nil:
+			succeeded++
+		case errors.Is(err, ErrPromptAlreadyResolved):
+			duplicate++
+		default:
+			t.Fatalf("current Ask answer rejected: %v", err)
+		}
+	}
+	if succeeded != 1 || duplicate != 1 {
+		t.Fatalf("answer results: %d successes, %d duplicates", succeeded, duplicate)
+	}
+	select {
+	case got := <-answers:
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("Ask returned %+v, want %+v", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("accepted answer did not unblock Ask")
+	}
+	if pending := c.PendingPromptIdentities(); len(pending) != 0 {
+		t.Fatalf("resolved Ask remains pending: %+v", pending)
+	}
+	records, err := c.TurnEventsAfter(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	answered := 0
+	for _, record := range records {
+		if record.Kind == "prompt_answered" {
+			answered++
+		}
+	}
+	if answered != 1 {
+		t.Fatalf("durable answers = %d, want exactly one", answered)
+	}
+	close(release)
+	waitIdle(t, c)
+}
+
+func TestAskExactSkipCancelsTurn(t *testing.T) {
+	dir := t.TempDir()
+	asks := make(chan event.Event, 1)
+	done := make(chan event.Event, 1)
+	c := New(Options{
+		SessionDir: dir, SessionPath: filepath.Join(dir, "session.jsonl"),
+		Sink: event.FuncSink(func(e event.Event) {
+			switch e.Kind {
+			case event.AskRequest:
+				asks <- e
+			case event.TurnDone:
+				done <- e
+			}
+		}),
+	})
+	t.Cleanup(func() { c.Cancel(); waitIdle(t, c); c.Close() })
+	c.runner = &askBlockingRunner{c: c}
+	c.SetTurnEventRoutingMetadata("runtime-skip", "")
+	c.Send("ask user")
+	var request event.Event
+	select {
+	case request = <-asks:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Ask was not published")
+	}
+	identity := PromptIdentity{PromptID: request.Ask.ID, TurnID: request.TurnID, RuntimeEpoch: "runtime-skip", Kind: PromptAsk}
+	if err := c.ResolvePromptExact(identity, PromptAnswer{}); err != nil {
+		t.Fatalf("skip Ask: %v", err)
+	}
+	if terminal := waitTurnDoneEvent(t, done); !terminal.Cancelled {
+		t.Fatalf("empty answer did not cancel the turn: %+v", terminal)
+	}
+	waitIdle(t, c)
+	if c.PendingPrompt() || len(c.PendingPromptIdentities()) != 0 {
+		t.Fatal("skipped Ask remains pending")
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2545,9 +2545,7 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 	// Registering after the lock left a queued question invisible everywhere:
 	// no event, absent from the snapshot, unreachable by ReplayPendingPrompts.
 	id, reply := c.approval.registerAsk(questions)
-	turnID, _, _, _ := c.turnEventRuntimeStatus()
-	_, runtimeEpoch := c.promptIdentitySnapshot()
-	_ = c.promptOwner.Register(PromptIdentity{PromptID: id, TurnID: turnID, RuntimeEpoch: runtimeEpoch, Kind: PromptAsk})
+	c.registerOwnedPrompt(id, PromptAsk)
 
 	if !c.lockPromptFor(ctx, "question") {
 		c.cancelOwnedPrompt(id)
@@ -2556,8 +2554,8 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 	defer c.approval.promptMu.Unlock()
 
 	c.approval.promptEmitMu.Lock()
-	turnID, _, _, _ = c.turnEventRuntimeStatus()
-	_, runtimeEpoch = c.promptIdentitySnapshot()
+	turnID, _, _, _ := c.turnEventRuntimeStatus()
+	_, runtimeEpoch := c.promptIdentitySnapshot()
 	if identity := c.bindOwnedPromptRouting(id, turnID, runtimeEpoch); identity.TurnID != "" {
 		turnID = identity.TurnID
 	}

--- a/internal/control/prompt_ledger_failure_test.go
+++ b/internal/control/prompt_ledger_failure_test.go
@@ -1,0 +1,158 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/mcpinteraction"
+	"reasonix/internal/turnevent"
+)
+
+func blockPromptTestLedger(t *testing.T, c *Controller, root string) {
+	t.Helper()
+	ledger := c.turnEventLedger()
+	if ledger == nil {
+		t.Fatal("controller did not open a turn ledger")
+	}
+	if err := ledger.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(root, []byte("block future WAL opens"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func awaitPromptLedgerTest[T any](t *testing.T, ch <-chan T, description string) T {
+	t.Helper()
+	select {
+	case result := <-ch:
+		return result
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+		var zero T
+		return zero
+	}
+}
+
+func TestCancelLedgerFailureReturnsAndCancelsTurn(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "session-dir")
+	started := make(chan context.Context, 1)
+	finished := make(chan error, 1)
+	c := New(Options{SessionDir: root, SessionPath: filepath.Join(root, "session.jsonl")})
+	t.Cleanup(c.Close)
+	c.runGuarded(func(ctx context.Context) error {
+		started <- ctx
+		<-ctx.Done()
+		finished <- ctx.Err()
+		return ctx.Err()
+	})
+	ctx := awaitPromptLedgerTest(t, started, "turn start")
+	blockPromptTestLedger(t, c, root)
+	returned := make(chan struct{})
+	go func() {
+		c.Cancel()
+		close(returned)
+	}()
+	awaitPromptLedgerTest(t, returned, "Cancel to return after WAL failure")
+	awaitPromptLedgerTest(t, ctx.Done(), "turn context cancellation")
+	if err := awaitPromptLedgerTest(t, finished, "cancelled turn body"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("turn error = %v, want context cancellation", err)
+	}
+	if err := c.turnEventLedgerError(); !errors.Is(err, turnevent.ErrTurnLedgerUnavailable) {
+		t.Fatalf("ledger error = %v, want storage failure", err)
+	}
+	waitIdle(t, c)
+}
+
+func TestResolvePromptExactLedgerFailureCancelsWithoutAnswer(t *testing.T) {
+	tests := []struct {
+		name   string
+		kind   PromptKind
+		answer PromptAnswer
+		wait   func(context.Context, *Controller) (bool, error)
+	}{
+		{
+			name: "ask", kind: PromptAsk,
+			answer: PromptAnswer{Questions: []event.AskAnswer{{QuestionID: "q1", Selected: []string{"A"}}}},
+			wait: func(ctx context.Context, c *Controller) (bool, error) {
+				answers, err := c.Ask(ctx, askProbeQuestions())
+				return len(answers) != 0, err
+			},
+		},
+		{
+			name: "approval", kind: PromptApproval, answer: PromptAnswer{Allow: true},
+			wait: func(ctx context.Context, c *Controller) (bool, error) {
+				allow, _, err := c.requestApprovalWithReason(ctx, "bash", "echo test", nil, "test")
+				return allow, err
+			},
+		},
+		{
+			name: "mcp", kind: PromptMCP, answer: PromptAnswer{Action: mcpinteraction.ActionAccept},
+			wait: func(ctx context.Context, c *Controller) (bool, error) {
+				result, err := c.Interact(ctx, mcpinteraction.Request{Server: "test", Mode: "form", Message: "Confirm?"})
+				return result.Action == mcpinteraction.ActionAccept, err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), "session-dir")
+			requests := make(chan event.Event, 1)
+			started := make(chan context.Context, 1)
+			type outcome struct {
+				answered bool
+				err      error
+			}
+			finished := make(chan outcome, 1)
+			c := New(Options{
+				SessionDir: root, SessionPath: filepath.Join(root, "session.jsonl"),
+				Sink: event.FuncSink(func(e event.Event) {
+					switch e.Kind {
+					case event.AskRequest, event.ApprovalRequest, event.MCPInteractionRequest:
+						requests <- e
+					}
+				}),
+			})
+			t.Cleanup(c.Close)
+			c.SetTurnEventRoutingMetadata("ledger-failure-test", "")
+			c.runGuarded(func(ctx context.Context) error {
+				started <- ctx
+				answered, err := tt.wait(ctx, c)
+				finished <- outcome{answered: answered, err: err}
+				return err
+			})
+			ctx := awaitPromptLedgerTest(t, started, "turn start")
+			request := awaitPromptLedgerTest(t, requests, "prompt publication")
+			identity := PromptIdentity{PromptID: request.ItemID, TurnID: request.TurnID, RuntimeEpoch: "ledger-failure-test", Kind: tt.kind}
+			blockPromptTestLedger(t, c, root)
+			resolved := make(chan error, 1)
+			go func() { resolved <- c.ResolvePromptExact(identity, tt.answer) }()
+			if err := awaitPromptLedgerTest(t, resolved, "failed resolution to return"); !errors.Is(err, turnevent.ErrTurnLedgerUnavailable) {
+				t.Fatalf("ResolvePromptExact error = %v, want storage failure", err)
+			}
+			awaitPromptLedgerTest(t, ctx.Done(), "turn context cancellation")
+			result := awaitPromptLedgerTest(t, finished, "prompt waiter cancellation")
+			if result.answered || !errors.Is(result.err, context.Canceled) {
+				t.Fatalf("prompt outcome = %+v, want cancellation without an answer", result)
+			}
+			if pending := c.PendingPromptIdentities(); len(pending) != 0 {
+				t.Fatalf("failed turn left pending identities: %+v", pending)
+			}
+			if c.PendingPrompt() {
+				t.Fatal("failed turn left a pending approval or question")
+			}
+			if err := c.ResolvePromptExact(identity, tt.answer); err == nil {
+				t.Fatal("prompt accepted a later answer after ledger failure")
+			}
+			waitIdle(t, c)
+		})
+	}
+}

--- a/internal/control/turn_events.go
+++ b/internal/control/turn_events.go
@@ -394,10 +394,11 @@ func (c *Controller) failTurnEventLedger(err error) {
 	}
 	c.mu.Unlock()
 	if cancel != nil {
-		c.promptResolveMu.Lock()
+		// Cancel and prompt resolvers may hold promptResolveMu while this
+		// synchronous failure callback runs. Use the owners' internal locks to
+		// invalidate pending resolutions without reentering the submission lock.
 		c.promptOwner.CancelAll()
 		c.approval.clearAll()
-		c.promptResolveMu.Unlock()
 		cancel()
 	}
 }


### PR DESCRIPTION
Restore prompt answers and failure recovery after v1.38.0. Exact Ask answers previously failed as not pending, and an unwritable event ledger could deadlock cancellation or prompt resolution.

The controller now registers Ask through the shared prompt resolver and invalidates failed reservations without re-entering the submission mutex. Desktop fixes also preserve keyboard-entered custom answers, isolate Ask drafts by tab/runtime/turn/prompt identity, reconcile rejected submissions from fresh same-sequence snapshots, and contain background recovery errors. Failed-send status reads retain their request-start timestamp so delayed responses cannot clear newer turns.

Verification:
- `go test ./...` passed; owning control/eventwire/billing race suites and targeted Desktop runtime race tests passed.
- Added real-controller regressions for replay, stale identities, duplicate answers, skip, and WAL failures during cancellation and Ask/approval/MCP resolution.
- Frontend `pnpm test` passed all 271 discovered suites plus pretest checks; `pnpm test:typecheck`, `pnpm test:stream`, `pnpm test:remote`, and `pnpm build` passed.
- Real Chromium verified keyboard answer contents, runtime draft isolation, and absence of the global crash overlay after recovery rejection.
- `golangci-lint`, `go run ./tools/repolint`, Wails pin checks, and existing bundle budgets passed. Browser checks cover frontend behavior; native Windows/macOS shell interactions were not part of this change.

Documentation-impact: none - restores documented prompt, cancellation, and recovery behavior without adding settings or changing user-facing contracts.
Cache-impact: none - system prompts, tool schemas, provider serialization, and cache-prefix construction are unchanged.
Cache-guard: reviewed the controller registration/cleanup diff; go test -race ./internal/control ./internal/eventwire ./internal/billing.
