### PR TITLE
perf(desktop): short-circuit same-level effort switches / 同档位思考强度切换短路

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -9865,6 +9865,19 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	defer a.runtimeRebuildMu.Unlock()
 	tab.turnStartMu.Lock()
 	defer tab.turnStartMu.Unlock()
+	// Same-level short circuit, before any attach/workspace side effects:
+	// switching to the depth this tab already runs must not pay for a full
+	// runtime rebuild (nor even re-enter the attach/workspace paths). tab.effort
+	// holds the depth the tab currently runs — seeded from the provider entry at
+	// attach time and rewritten by every effort/model switch.
+	if tab.effort != nil {
+		if entry, err := a.currentProviderEntryForTab(tabID); err == nil {
+			if effort, err := config.NormalizeEffort(entry, level); err == nil &&
+				strings.EqualFold(strings.TrimSpace(*tab.effort), effort) {
+				return nil
+			}
+		}
+	}
 	prevPath := a.reconciledSessionPathForTab(tab)
 	if prevPath == "" {
 		prevPath = a.currentSessionPathFor(tab)

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -3163,6 +3163,88 @@ func TestSetEffortForTabReanchorsDepthCapRecoveryBranch(t *testing.T) {
 	}
 }
 
+func TestSetEffortForTabSameLevelShortCircuit(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name:             "old",
+		Kind:             "openai",
+		BaseURL:          "https://example.invalid/v1",
+		Model:            "old-model",
+		APIKeyEnv:        "OLD_MODEL_KEY",
+		SupportedEfforts: []string{"low", "max"},
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	exec := agent.New(nil, nil, agent.NewSession("old system prompt"), agent.Options{}, event.Discard)
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.runtimeEvents.emit = func(context.Context, string, ...any) {}
+	tab := &WorkspaceTab{
+		ID:          "tab_effort_short_circuit",
+		Scope:       "global",
+		Ready:       true,
+		model:       "old/old-model",
+		disabledMCP: map[string]ServerView{},
+	}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	tab.Ctrl = control.New(control.Options{
+		Executor:    exec,
+		SessionDir:  dir,
+		SessionPath: filepath.Join(dir, "effort-short-circuit.jsonl"),
+		Label:       "old",
+		Sink:        tab.sink,
+	})
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		tab.Ctrl.Close()
+		tab.releaseSessionLease()
+	})
+
+	if err := app.SetEffortForTab(tab.ID, "max"); err != nil {
+		t.Fatalf("SetEffortForTab max: %v", err)
+	}
+	if tab.effort == nil || *tab.effort != "max" {
+		t.Fatalf("tab effort after switch = %v, want max", tab.effort)
+	}
+	// Let any post-rebuild async settle so the short-circuit assertion below
+	// compares against a quiescent tab.
+	time.Sleep(500 * time.Millisecond)
+	rebuilt := tab.Ctrl
+	t.Logf("before-second: ctrl=%p rebuilt=%p", tab.Ctrl, rebuilt)
+
+	// Same level again: the short circuit must keep the running controller
+	// instead of paying for a full runtime rebuild.
+	if err := app.SetEffortForTab(tab.ID, "max"); err != nil {
+		t.Fatalf("SetEffortForTab same level: %v", err)
+	}
+	t.Logf("after-second: ctrl=%p rebuilt=%p tab.effort=%v", tab.Ctrl, rebuilt, tab.effort)
+	if tab.Ctrl != rebuilt {
+		t.Fatal("same-level effort switch rebuilt the controller")
+	}
+
+	// A genuinely different depth still rebuilds.
+	if err := app.SetEffortForTab(tab.ID, "low"); err != nil {
+		t.Fatalf("SetEffortForTab low: %v", err)
+	}
+	if tab.Ctrl == rebuilt {
+		t.Fatal("different-level effort switch kept the controller")
+	}
+}
+
 func TestRemoveBuiltInProviderAccessRetargetsDefaultToRemainingAccess(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	setDesktopTestCredential(t, "MIMO_API_KEY", "sk-test")


### PR DESCRIPTION
## Summary

- Switching the reasoning effort to the level a tab already runs now returns immediately after the rebuild serialization locks instead of paying for the full build+swap path (session snapshot, lease re-arm, provider re-init, history carry, controller swap). This is the multi-second stall users see when re-picking the current depth in the effort menu.
- The short circuit runs **before** the attach/workspace side-effect paths, so a redundant switch cannot kick off background work either. `tab.effort` (seeded from the provider entry at attach time, rewritten by every effort/model switch) is the comparison source.

## Issues-Fixes

None. (Follow-up on a broader per-request effort redesign is being prepared separately; this is the safe incremental cut.)

## Verification

- `go build ./...` (root module) — clean.
- `go test . -run Effort -count=1` (desktop module) — ok.
- New `TestSetEffortForTabSameLevelShortCircuit`: same-level switch keeps the running controller, a genuinely different depth still rebuilds.
- Existing `TestSetEffortForTabReanchorsDepthCapRecoveryBranch` still passes — an earlier draft that skipped the pre-rebuild snapshot was reverted precisely because that snapshot carries the recovery-branch isolation semantics; this PR keeps it.

## Documentation-impact

None — user-visible behavior for distinct levels is unchanged.

## Cache-impact

None — same-level switches issue no request at all; distinct-level switches keep the exact rebuild path and therefore the same wire bytes.

## Cache-guard

Not applicable — no prompt/provider wire changes; the short circuit returns before any request is built.

## System-prompt-review

None — no system prompt or model-facing text changes.
