### PR TITLE
fix(release): emit Homebrew postflight_steps instead of deprecated postflight

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,12 +52,16 @@ homebrew_casks:
     commit_author:
       name: reasonix
       email: reasonix@deepseek.com
-    hooks:
-      post:
-        install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/reasonix"]
-          end
+    # Homebrew 6.x deprecates the `postflight` Ruby block that
+    # `hooks.post.install` emits. Use the declarative `postflight_steps`
+    # stanza instead; it runs the xattr command from the staged directory so
+    # no Homebrew-specific Ruby interpolation is needed.
+    custom_block: |
+      postflight_steps do
+        on_macos do
+          run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "reasonix"], chdir: :staged_path
+        end
+      end
 
 release:
   prerelease: auto


### PR DESCRIPTION
## Summary

GoReleaser's `homebrew_casks.hooks.post.install` emits the deprecated Homebrew
`postflight do ... end` block, so every `brew install`/`brew upgrade` of the
Reasonix cask prints:

```text
Warning: Calling `postflight` is deprecated! Use `postflight_steps` instead.
```

This replaces the raw Ruby hook with a `custom_block` that emits Homebrew's
declarative `postflight_steps` stanza. The `run` step uses `chdir: :staged_path`
instead of Ruby interpolation because the new install-steps DSL accepts base
path specs rather than executing arbitrary Ruby inside the cask. This also does
not depend on the new hook-steps fields being available from GoReleaser yet.

## Issues

Refs goreleaser/goreleaser#6870
Refs goreleaser/goreleaser#6873

## Verification

- The resulting `postflight_steps` block was loaded by Homebrew with no
  deprecation warning, and the `run`/`chdir` step was normalised to
  `{"base" => "staged_path"}` as expected.
- `.goreleaser.yaml` parses successfully with Ruby's YAML parser.

## Documentation impact

Documentation-impact: none - this only changes the Homebrew Cask generated by
the existing release pipeline; no user-visible CLI or configuration behavior
changes.

## Cache impact

Cache-impact: none - the release configuration change does not affect Reasonix
session state or cache keys.
Cache-guard: N/A - no cache-sensitive code paths are changed.
System-prompt-review: N/A
