### PR TITLE
perf(agent): parallelize chunked compaction fragments and half-split on context-limit / 分块压缩片段并行化与超窗半切

### DIFF
--- a/internal/agent/session_extract.go
+++ b/internal/agent/session_extract.go
@@ -28,7 +28,14 @@ const (
 	// Adjacent chunks share this many bytes near their boundary so a fact
 	// spanning the cut is not lost between digests.
 	extractChunkOverlapBytes = 16 << 10
-	minMergeInputTokens      = 400
+
+	// extractFragmentConcurrency bounds the parallel fragment summaries.
+	// Fragments are independent LLM calls; running a few concurrently cuts the
+	// wall time of a 2M-token fold from tens of minutes to minutes while
+	// staying under provider rate limits (same 3-4 in-flight budget the
+	// subagent dispatch discipline uses).
+	extractFragmentConcurrency = 4
+	minMergeInputTokens        = 400
 	// A chunked recovery owns the compaction lock and can issue multiple paid
 	// requests. Keep the exceptional path finite even when a provider repeatedly
 	// truncates a digest without making it smaller.
@@ -102,6 +109,7 @@ func extractMergeInstructionWithFocus(instructions string) string {
 
 type chunkedSummaryRun struct {
 	a     *Agent
+	mu    sync.Mutex
 	calls int
 	usage *provider.Usage
 }
@@ -111,6 +119,12 @@ func newChunkedSummaryRun(a *Agent) *chunkedSummaryRun {
 }
 
 func (r *chunkedSummaryRun) requireCalls(required int) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.requireCallsLocked(required)
+}
+
+func (r *chunkedSummaryRun) requireCallsLocked(required int) error {
 	if required < 0 {
 		return fmt.Errorf("invalid chunked summary call reservation (%d)", required)
 	}
@@ -124,12 +138,20 @@ func (r *chunkedSummaryRun) summarize(ctx context.Context, fold []provider.Messa
 	if err := ctx.Err(); err != nil {
 		return foldSummary{}, err
 	}
-	if err := r.requireCalls(1 + reserveAfter); err != nil {
+	// Parallel fragment workers share one run: reserve, count, and usage
+	// accounting must be atomic or the maxChunkedSummaryCalls budget can be
+	// races past and usage entries lost.
+	r.mu.Lock()
+	if err := r.requireCallsLocked(1 + reserveAfter); err != nil {
+		r.mu.Unlock()
 		return foldSummary{}, err
 	}
 	r.calls++
+	r.mu.Unlock()
 	res, err := r.a.foldToSummary(ctx, fold, instructions)
+	r.mu.Lock()
 	r.usage = mergeSamplingUsage(r.usage, res.Usage)
+	r.mu.Unlock()
 	return res, err
 }
 
@@ -278,19 +300,60 @@ func (a *Agent) summarizeExtractChunks(ctx context.Context, chunks [][]provider.
 		}
 		report(done, total)
 	}
-	parts := make([]string, 0, len(chunks))
 	mergeInstructions := extractMergeInstructionWithFocus(instructions)
-	for i, chunk := range chunks {
-		fragInstructions := extractFragmentInstruction(i+1, len(chunks), instructions)
-		reserveAfter := len(chunks) - i - 1
-		if len(chunks) > 1 {
-			reserveAfter++
+	parts := make([]string, len(chunks))
+	// Fragments are independent LLM calls: summarize them with a bounded
+	// worker pool so a 2M-token fold stops paying N × per-fragment latency
+	// serially. Results are written by index to keep the merge order stable
+	// (oldest first); the first fragment failure cancels its siblings and
+	// becomes the returned error. The shared run budget stays exact: each
+	// worker reserves under the run lock with the same worst-case reserveAfter
+	// the serial loop used.
+	{
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		var errMu sync.Mutex
+		var firstErr error
+		fail := func(i int, err error) {
+			errMu.Lock()
+			defer errMu.Unlock()
+			if firstErr == nil {
+				firstErr = fmt.Errorf("fragment %d/%d: %w", i+1, len(chunks), err)
+			}
+			cancel() // stop sibling fragments early
 		}
-		res, err := a.extractFragmentResilient(ctx, chunk, fragInstructions, mergeInstructions, advance, run, reserveAfter)
-		if err != nil {
-			return "", fmt.Errorf("fragment %d/%d: %w", i+1, len(chunks), err)
+		sem := make(chan struct{}, extractFragmentConcurrency)
+		var wg sync.WaitGroup
+		for i, chunk := range chunks {
+			wg.Add(1)
+			go func(i int, chunk []provider.Message) {
+				defer wg.Done()
+				select {
+				case sem <- struct{}{}:
+					defer func() { <-sem }()
+				case <-ctx.Done():
+					return // a sibling already failed; firstErr is recorded
+				}
+				fragInstructions := extractFragmentInstruction(i+1, len(chunks), instructions)
+				// The serial loop reserved the whole future plan per fragment
+				// (remaining fragments + merge), which is meaningless once
+				// fragments run out of order: a late-starting worker would find
+				// its reserve already spent by finished siblings. Each fragment
+				// reserves only itself here; half-split recursion and every
+				// merge step still reserve their own calls, and the
+				// maxChunkedSummaryCalls budget keeps the worst case finite.
+				res, err := a.extractFragmentResilient(ctx, chunk, fragInstructions, mergeInstructions, advance, run, 0)
+				if err != nil {
+					fail(i, err)
+					return
+				}
+				parts[i] = res
+			}(i, chunk)
 		}
-		parts = append(parts, res)
+		wg.Wait()
+		if firstErr != nil {
+			return "", firstErr
+		}
 	}
 	text, err := a.mergeFragmentsWithRun(ctx, parts, mergeInstructions, run, 0)
 	if err != nil {
@@ -313,7 +376,13 @@ func (a *Agent) extractFragmentResilient(ctx context.Context, chunk []provider.M
 	if err == nil {
 		return strings.TrimSpace(res.Text), nil
 	}
-	retriable := errors.Is(err, errSummaryOutputTruncated) || errors.Is(err, ErrCompactionRequired)
+	// A context-limit rejection means the fragment itself overflowed the
+	// summarizer window — halving it is exactly the fix (the same reasoning as
+	// output truncation: smaller fragments, smaller requests). Without this,
+	// one oversized fragment fails the whole chunked fold on small-window
+	// gateways even though its halves would fit.
+	retriable := errors.Is(err, errSummaryOutputTruncated) || errors.Is(err, ErrCompactionRequired) ||
+		provider.AsContextLimitError(err) != nil
 	leftChunk, rightChunk, splittable := splitExtractFragment(chunk)
 	if !retriable || !splittable {
 		return "", err
@@ -365,7 +434,10 @@ func (a *Agent) mergeGroup(ctx context.Context, group []string, instructions str
 		return strings.TrimSpace(merged.Text), nil
 	}
 	mergeErr := err
-	retriable := errors.Is(err, errSummaryOutputTruncated) || errors.Is(err, ErrCompactionRequired)
+	// Same reasoning as fragment half-splitting: a merge group that overflows
+	// the window shrinks into sub-groups that fit (depth-capped below).
+	retriable := errors.Is(err, errSummaryOutputTruncated) || errors.Is(err, ErrCompactionRequired) ||
+		provider.AsContextLimitError(err) != nil
 	if !retriable || len(group) < 2 {
 		return "", err
 	}

--- a/internal/agent/session_extract_test.go
+++ b/internal/agent/session_extract_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
@@ -125,14 +126,18 @@ func indexOfMessage(msgs []provider.Message, target provider.Message) int {
 // message count is recorded so merge-grouping tests can assert the merge
 // request never carried the whole fragment set.
 type extractStubProvider struct {
-	mu        sync.Mutex
-	calls     int
-	failFirst int
-	streamErr error
-	reply     string
-	msgLens   []int
-	reqEsts   []int
-	requests  []provider.Request
+	mu          sync.Mutex
+	calls       int
+	failFirst   int
+	limitFirst  int // first N calls fail with a trusted provider.ContextLimitError
+	streamErr   error
+	reply       string
+	msgLens     []int
+	reqEsts     []int
+	requests    []provider.Request
+	inFlight    int           // live concurrency, for parallel-fragment assertions
+	maxInFlight int           // peak concurrency observed across the whole run
+	holdUntil   chan struct{} // when non-nil, normal replies hold until it closes
 }
 
 func (p *extractStubProvider) Name() string { return "extract-stub" }
@@ -140,6 +145,10 @@ func (p *extractStubProvider) Name() string { return "extract-stub" }
 func (p *extractStubProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
 	p.mu.Lock()
 	p.calls++
+	p.inFlight++
+	if p.inFlight > p.maxInFlight {
+		p.maxInFlight = p.inFlight
+	}
 	p.msgLens = append(p.msgLens, len(req.Messages))
 	p.reqEsts = append(p.reqEsts, estimateMessagesTokens(req.Messages))
 	requestCopy := req
@@ -148,9 +157,15 @@ func (p *extractStubProvider) Stream(_ context.Context, req provider.Request) (<
 	n := p.calls
 	p.mu.Unlock()
 	ch := make(chan provider.Chunk, 3)
+	done := func() {
+		p.mu.Lock()
+		p.inFlight--
+		p.mu.Unlock()
+		close(ch)
+	}
 	if p.streamErr != nil {
 		ch <- provider.Chunk{Type: provider.ChunkError, Err: p.streamErr}
-		close(ch)
+		done()
 		return ch, nil
 	}
 	if n <= p.failFirst {
@@ -159,16 +174,30 @@ func (p *extractStubProvider) Stream(_ context.Context, req provider.Request) (<
 			FinishReason: "length", RequestCount: 1,
 		}}
 		ch <- provider.Chunk{Type: provider.ChunkDone}
-		close(ch)
+		done()
+		return ch, nil
+	}
+	if n <= p.limitFirst {
+		ch <- provider.Chunk{Type: provider.ChunkError, Err: &provider.ContextLimitError{
+			APIError:         &provider.APIError{Provider: p.Name(), Status: 400, Body: "prompt too long"},
+			WindowTokens:     128_000,
+			RequestedTokens:  300_000,
+			PromptTokens:     290_000,
+			CompletionTokens: 10_000,
+		}}
+		done()
 		return ch, nil
 	}
 	ch <- provider.Chunk{Type: provider.ChunkText, Text: p.reply}
+	if p.holdUntil != nil {
+		<-p.holdUntil
+	}
 	ch <- provider.Chunk{Type: provider.ChunkUsage, Usage: &provider.Usage{
 		PromptTokens: 10, CompletionTokens: 2, TotalTokens: 12,
 		CacheHitTokens: 3, CacheMissTokens: 7, RequestCount: 1,
 	}}
 	ch <- provider.Chunk{Type: provider.ChunkDone}
-	close(ch)
+	done()
 	return ch, nil
 }
 
@@ -526,5 +555,79 @@ func TestCompactFallsBackToChunkedSummaryOnTruncation(t *testing.T) {
 	}
 	if prov.calls < 4 {
 		t.Fatalf("provider calls = %d, want the failed single request plus chunks and merge (>=4)", prov.calls)
+	}
+}
+
+// A context-limit rejection on one fragment must half-split it (the fragment
+// overflowed the summarizer window; its halves fit) instead of failing the
+// whole chunked fold — small-window gateways depend on this.
+func TestChunkedFoldSummaryHalfSplitsOnContextLimitFragment(t *testing.T) {
+	prov := &extractStubProvider{limitFirst: 1, reply: "digest"}
+	a := New(prov, tool.NewRegistry(), extractStubSession(), Options{}, event.Discard)
+	res, err := a.chunkedFoldSummary(context.Background(), a.Session().Snapshot(), compactionInstruction, nil)
+	if err != nil {
+		t.Fatalf("chunkedFoldSummary: %v", err)
+	}
+	if strings.TrimSpace(res.Text) == "" {
+		t.Fatal("empty summary after context-limit split recovery")
+	}
+	if prov.calls != 4 {
+		t.Fatalf("provider calls = %d, want 4 (limit, two halves, merge)", prov.calls)
+	}
+}
+
+// Fragments are independent LLM calls and run with bounded parallelism: the
+// pool saturates at extractFragmentConcurrency without exceeding it, and the
+// merge still receives the digests in oldest-first order.
+func TestChunkedFoldSummaryRunsFragmentsInParallel(t *testing.T) {
+	msgs := make([]provider.Message, 40)
+	for i := range msgs {
+		msgs[i] = extractTestMsg(48<<10, fmt.Sprintf("<%06d>", i))
+	}
+	hold := make(chan struct{})
+	prov := &extractStubProvider{reply: "digest", holdUntil: hold}
+	a := New(prov, tool.NewRegistry(), extractStubSession(), Options{}, event.Discard)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := a.chunkedFoldSummary(context.Background(), msgs, compactionInstruction, nil)
+		done <- err
+	}()
+
+	// Wait until the pool saturates (fragment calls in flight) before the
+	// barrier releases; fragments split exponentially on a 1.9MiB fold, so at
+	// least extractFragmentConcurrency of them exist. Note: do NOT break on
+	// inFlight==0 — at the very start no worker has entered Stream yet.
+	saturated := false
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		prov.mu.Lock()
+		calls := prov.calls
+		prov.mu.Unlock()
+		if calls >= extractFragmentConcurrency {
+			saturated = true
+			break
+		}
+		select {
+		case err := <-done:
+			t.Fatalf("chunkedFoldSummary finished before saturation (calls=%d): %v", calls, err)
+		case <-time.After(time.Millisecond):
+		}
+	}
+	if !saturated {
+		t.Fatal("fragment pool never saturated")
+	}
+	close(hold)
+	if err := <-done; err != nil {
+		t.Fatalf("chunkedFoldSummary: %v", err)
+	}
+	prov.mu.Lock()
+	peak, calls := prov.maxInFlight, prov.calls
+	prov.mu.Unlock()
+	if peak < 2 || peak > extractFragmentConcurrency {
+		t.Fatalf("peak fragment concurrency = %d, want 2..%d", peak, extractFragmentConcurrency)
+	}
+	if calls < 5 { // >=4 fragments + the merge request
+		t.Fatalf("provider calls = %d, want >=5", calls)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #9878 / #9882, observed while compacting a real 2M-token session end to end (the fix PR works; this one makes it fast and small-window-proof):

1. **Parallel fragment summaries** (`internal/agent/session_extract.go`): `summarizeExtractChunks` summarized fragments strictly serially, paying N × per-fragment latency — a 2M-token fold spent tens of minutes on a thinking model. Fragments are independent LLM calls: run them with a bounded worker pool (4 in flight, the rate-limit-safe budget our subagent dispatch discipline uses). Results are written by index so the merge keeps the oldest-first order; the first fragment failure cancels its siblings and is returned as-is.
   - The shared `chunkedSummaryRun` gains a mutex so parallel workers keep the `maxChunkedSummaryCalls` budget and usage accounting exact.
   - Fragment reservations drop the serial loop's future-plan reserve (`remaining fragments + merge`): out of order it is meaningless — a late-starting worker finds its reserve already spent by finished siblings (observed: `fragment 5/63: budget exhausted (64): 13 used, 59 required` with an index-based reserve). Each fragment now reserves only itself; half-split recursion and every merge step still reserve their own calls against the same hard budget, so the worst case stays finite.
2. **Context-limit half-splitting**: `extractFragmentResilient` and `mergeGroup` retried only output truncation and hard compaction requirements, so a fragment or merge group that overflowed the summarizer window failed the whole chunked fold instead of splitting into pieces that fit — fatal on small-window gateways (GLM) where every retry of the same size overflows again. A trusted `ContextLimitError` now triggers the same bounded half-split (fragment depth capped by the message count, merge depth by `maxChunkedMergeDepth`).

## Testing

- New `TestChunkedFoldSummaryRunsFragmentsInParallel`: 1.9MiB fold, peak stub concurrency saturates at 4 without exceeding it, merge order and call counts intact.
- New `TestChunkedFoldSummaryHalfSplitsOnContextLimitFragment`: a context-limit rejection on the root fragment half-splits and recovers (4 calls: limit, two halves, merge).
- `go test ./internal/agent/ -count=1` fully green including all existing chunked tests (truncation splits, transport no-retry, single-message cannot-split, merge grouping/budget, fallback focus/telemetry).

## Cache Impact / 缓存影响

Cache-impact: none - parallelism and half-split scheduling live inside the chunked compaction fallback; no promptCacheKey, projection key, or cache-key derivation changes. / 仅分块压缩回退内部的调度与预算，不触及 promptCacheKey/会话投影/缓存键逻辑。
Cache-guard: `go test ./internal/agent/ -run 'TestChunkedFoldSummary|TestMergeFragments|TestChunkedSummaryRun' -count=1` / 分块压缩路径定点回归守护。
Documentation-impact: none - internal-only perf/robustness change, no docs or config surface changed.
System-prompt-review: none - no system prompt text changes.

Refs: #9878, #9882 (context-limit recognition + thinking-model summary fix), #9082, #9572
