### PR TITLE
fix(agent): preserve cancellation at context admission / 修复上下文准备入口的取消语义

### DIFF
--- a/internal/agent/context_manager.go
+++ b/internal/agent/context_manager.go
@@ -72,6 +72,9 @@ func (m ContextManager) ObserveUsage(u *provider.Usage) {
 // nothing. At or above the trigger it runs one single-flight prune/summary
 // transaction, with at most two successful summary attempts under pressure.
 func (m ContextManager) Prepare(ctx context.Context, policy ContextPreparePolicy) (PreparedContext, error) {
+	if err := ctx.Err(); err != nil {
+		return PreparedContext{}, err
+	}
 	if policy.Trigger == "" {
 		policy.Trigger = CompactionTriggerPressure
 	}
@@ -80,6 +83,11 @@ func (m ContextManager) Prepare(ctx context.Context, policy ContextPreparePolicy
 	}
 	m.agent.sess.compactionRunMu.Lock()
 	defer m.agent.sess.compactionRunMu.Unlock()
+	// Cancellation may have arrived while another maintenance transaction held the lock.
+	// Reject it before any fast path or projection maintenance can run.
+	if err := ctx.Err(); err != nil {
+		return PreparedContext{}, err
+	}
 	return m.prepareOnce(ctx, policy)
 }
 

--- a/internal/agent/context_manager.go
+++ b/internal/agent/context_manager.go
@@ -72,6 +72,10 @@ func (m ContextManager) ObserveUsage(u *provider.Usage) {
 // nothing. At or above the trigger it runs one single-flight prune/summary
 // transaction, with at most two successful summary attempts under pressure.
 func (m ContextManager) Prepare(ctx context.Context, policy ContextPreparePolicy) (PreparedContext, error) {
+	// Legacy desktop callers can compact before their runtime context is installed.
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if err := ctx.Err(); err != nil {
 		return PreparedContext{}, err
 	}

--- a/internal/agent/context_manager_cancellation_test.go
+++ b/internal/agent/context_manager_cancellation_test.go
@@ -1,0 +1,129 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Sampling Err before signalling makes the lock-wait interleaving deterministic:
+// the first check returns nil even if cancellation arrives before it returns.
+type prepareEntryContext struct {
+	context.Context
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (c *prepareEntryContext) Err() error {
+	err := c.Context.Err()
+	c.once.Do(func() { close(c.entered) })
+	return err
+}
+
+func TestPrepareRejectsCancelledContextBeforeMaintenance(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		turns    int
+		deadline bool
+	}{
+		{"below threshold", 0, false},
+		{"above ceiling", 6, false},
+		{"expired deadline", 6, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := &failingSummaryProvider{}
+			a := agentOverForce(t, prov, foldableSessionOverForce(tc.turns))
+			before, err := json.Marshal(a.modelVisibleMessages())
+			if err != nil {
+				t.Fatal(err)
+			}
+			version := a.currentProjectionVersion()
+			canonical, canonicalVersion := a.sess.conversation.snapshotMessagesVersion()
+			canonicalBefore, err := json.Marshal(canonical)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			want := error(context.Canceled)
+			if tc.deadline {
+				cancel()
+				ctx, cancel = context.WithDeadline(context.Background(), time.Unix(1, 0))
+				want = context.DeadlineExceeded
+			} else {
+				cancel()
+			}
+			defer cancel()
+			trigger := CompactionTriggerOverflow
+			if tc.turns == 0 {
+				trigger = CompactionTriggerPressure
+			}
+			_, err = a.contextManager().Prepare(ctx, ContextPreparePolicy{Trigger: trigger})
+			if !errors.Is(err, want) {
+				t.Fatalf("Prepare error = %v, want %v", err, want)
+			}
+			after, err := json.Marshal(a.modelVisibleMessages())
+			if err != nil {
+				t.Fatal(err)
+			}
+			current, currentVersion := a.sess.conversation.snapshotMessagesVersion()
+			canonicalAfter, err := json.Marshal(current)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(before) != string(after) || version != a.currentProjectionVersion() || a.sess.compactionState.LastReceipt != nil {
+				t.Fatal("cancelled Prepare changed projection or receipt")
+			}
+			if string(canonicalBefore) != string(canonicalAfter) || canonicalVersion != currentVersion {
+				t.Fatal("cancelled Prepare changed canonical history")
+			}
+			if prov.calls != 0 {
+				t.Fatalf("cancelled Prepare called provider %d times", prov.calls)
+			}
+		})
+	}
+}
+
+func TestPrepareRejectsCancellationWhileWaitingForMaintenance(t *testing.T) {
+	prov := &failingSummaryProvider{}
+	a := agentOverForce(t, prov, foldableSessionOverForce(6))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	entry := &prepareEntryContext{Context: ctx, entered: make(chan struct{})}
+	a.sess.compactionRunMu.Lock()
+	result := make(chan error, 1)
+	go func() {
+		_, err := a.contextManager().Prepare(entry, ContextPreparePolicy{Trigger: CompactionTriggerOverflow})
+		result <- err
+	}()
+	select {
+	case <-entry.entered:
+	case <-time.After(5 * time.Second):
+		cancel()
+		a.sess.compactionRunMu.Unlock()
+		<-result
+		t.Fatal("Prepare did not check cancellation before waiting for maintenance")
+	}
+	cancel()
+	a.sess.compactionRunMu.Unlock()
+	if err := <-result; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Prepare error = %v, want cancellation", err)
+	}
+	if prov.calls != 0 || a.currentProjectionVersion() != 0 || a.sess.compactionState.LastReceipt != nil {
+		t.Fatal("cancelled waiter entered maintenance")
+	}
+}
+
+func TestPrepareAllowsLiveBelowThresholdContext(t *testing.T) {
+	prov := &failingSummaryProvider{}
+	a := agentOverForce(t, prov, foldableSessionOverForce(0))
+	prepared, err := a.contextManager().Prepare(context.Background(), ContextPreparePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prepared.Messages) == 0 || prov.calls != 0 || a.currentProjectionVersion() != 0 {
+		t.Fatal("live fast path changed")
+	}
+}

--- a/internal/agent/context_manager_cancellation_test.go
+++ b/internal/agent/context_manager_cancellation_test.go
@@ -127,3 +127,22 @@ func TestPrepareAllowsLiveBelowThresholdContext(t *testing.T) {
 		t.Fatal("live fast path changed")
 	}
 }
+
+func TestPreparePreservesLegacyNilContext(t *testing.T) {
+	for _, manual := range []bool{false, true} {
+		turns := 0
+		if manual {
+			turns = 6
+		}
+		a := agentOverForce(t, &fakeProvider{reply: "digest"}, foldableSessionOverForce(turns))
+		var err error
+		if manual {
+			err = a.CompactNow(nil, "")
+		} else {
+			err = a.PrepareContext(nil)
+		}
+		if err != nil {
+			t.Fatalf("manual=%v: %v", manual, err)
+		}
+	}
+}

--- a/internal/agent/context_manager_cancellation_test.go
+++ b/internal/agent/context_manager_cancellation_test.go
@@ -137,9 +137,9 @@ func TestPreparePreservesLegacyNilContext(t *testing.T) {
 		a := agentOverForce(t, &fakeProvider{reply: "digest"}, foldableSessionOverForce(turns))
 		var err error
 		if manual {
-			err = a.CompactNow(nil, "")
+			err = a.CompactNow(nil, "") //nolint:staticcheck // Exercise the legacy nil-context compatibility boundary.
 		} else {
-			err = a.PrepareContext(nil)
+			err = a.PrepareContext(nil) //nolint:staticcheck // Exercise the legacy nil-context compatibility boundary.
 		}
 		if err != nil {
 			t.Fatalf("manual=%v: %v", manual, err)


### PR DESCRIPTION
## Summary

A context preparation request cancelled before admission could return success through a no-maintenance fast path. This was exposed repeatedly by `TestCallerCancellationDoesNotDegrade` while validating the #9777 split; the missing admission checks also exist on `main-v2`.

Normalize the legacy absent-context input once at the shared entry, preserving desktop callers that compact before runtime context installation. Non-nil contexts remain unchanged. Check `ctx.Err()` before waiting for the maintenance lock and again after acquiring it, before reading or updating the context projection. This covers already-cancelled requests, expired deadlines, and cancellation while another maintenance transaction holds the lock. It does not promise interruption of mutex waiting or rollback of synchronous work after admission.

This independent repair keeps backend cancellation semantics out of the frontend child PRs #9895, #9896, and #9897.

## Verification

- The new below-threshold regression fails on the original implementation with `Prepare error = <nil>, want context canceled`.
- Focused cancellation tests pass five times under the race detector, including a channel-controlled lock-wait interleaving and a live fast-path control.
- Tests verify unchanged canonical history, projection version, receipt, and zero provider calls for rejected requests.
- Full root and desktop Go suites pass. Nil automatic/manual preparation and cancellation tests pass five times under the race detector. Full `internal/agent` race tests passed before the nil-context normalization; focused race tests cover that compatibility addition. The latest owning-package lint reports zero issues. Exact-head CI remains required before merge.
- Independent read-only review of the latest commit found no blocking cancellation, compatibility, or lock defect; mutex waiting is intentionally not made interruptible.

Documentation-impact: none - no user-facing configuration or supported behavior changes; cancelled operations now retain their cancellation error.
Cache-impact: none - only requests already cancelled at admission are rejected; live provider-visible messages, tools, prompt bytes, thresholds, and compaction policies are unchanged.
Cache-guard: cancellation regressions assert projection and canonical-history stability, and a live below-threshold control verifies the normal path.
System-prompt-review: not changed - no system prompt construction or serialization changes.
