### PR TITLE
fix(desktop): preserve settings component layout ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,7 @@ jobs:
           pnpm --dir frontend test:todo-visibility
           pnpm --dir frontend test:app-lifecycle
           PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend test:app-browser
+          PLAYWRIGHT_BROWSERS_PATH=.pw-browsers REASONIX_SETTINGS_BROWSERS=chromium,webkit pnpm --dir frontend test:settings-browser
           pnpm --dir frontend test:all
           pnpm --dir frontend test:transcript
           xvfb-run -a env REASONIX_TRANSCRIPT_NATIVE_THUMB=1 pnpm --dir frontend test:transcript-browser
@@ -606,6 +607,12 @@ jobs:
         run: |
           pnpm --dir frontend exec playwright install chromium
           pnpm --dir frontend test:transcript-browser
+
+      - name: Test settings layout on Windows
+        timeout-minutes: 5
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/desktop/frontend/.pw-browsers
+        run: pnpm --dir frontend test:settings-browser
 
       - name: Test WebView2 native transcript and composer scrolling
         timeout-minutes: 5

--- a/desktop/frontend/bench/settings-layout.mjs
+++ b/desktop/frontend/bench/settings-layout.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { startPreviewServer } from "./vite-preview-server.mjs";
+import { chooseAppLayout } from "./app-page-actions.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+process.env.PLAYWRIGHT_BROWSERS_PATH = !process.env.PLAYWRIGHT_BROWSERS_PATH || process.env.PLAYWRIGHT_BROWSERS_PATH === ".pw-browsers"
+  ? path.join(root, ".pw-browsers") : process.env.PLAYWRIGHT_BROWSERS_PATH;
+const engines = await import("playwright");
+const port = Number(process.env.REASONIX_SETTINGS_PORT ?? 4679);
+const preview = await startPreviewServer(root, port);
+const themes = ["graphite", "aurora", "slate", "carbon", "nocturne", "amber"];
+const sizes = [1600, 1100, 900, 700, 400];
+let cases = 0;
+
+async function settle(page) {
+  await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+}
+
+function geometry() {
+  const rect = el => {
+    const r = el.getBoundingClientRect();
+    return { left: r.left, right: r.right, top: r.top, bottom: r.bottom };
+  };
+  const group = document.querySelector(".model-preferences");
+  const head = group?.querySelector(".model-assignment-head");
+  const general = document.querySelector(".settings-page--general");
+  return {
+    pageWidth: general?.clientWidth,
+    generalContainer: general && getComputedStyle(general).containerName,
+    soundColumns: general && [...general.querySelectorAll(".settings-sound-row")].map(row => getComputedStyle(row).gridTemplateColumns.split(" ").length),
+    statusColumns: general && getComputedStyle(general.querySelector(".status-bar-items-setting")).gridTemplateColumns.split(" ").length,
+    width: group?.clientWidth,
+    headVisible: head && getComputedStyle(head).display !== "none",
+    headers: head && [...head.children].map(rect),
+    rows: group && [...group.querySelectorAll(".model-assignment-row")].map(row => ({
+      bounds: rect(row),
+      label: rect(row.querySelector(".settings-field__copy")),
+      picker: rect(row.querySelector(".settings-model-picker")),
+      connection: rect(row.querySelector(".model-assignment-connection")),
+      columns: getComputedStyle(row).gridTemplateColumns.split(" ").length,
+    })),
+  };
+}
+
+try {
+  for (const engineName of (process.env.REASONIX_SETTINGS_BROWSERS ?? "chromium").split(",")) {
+    const browser = await engines[engineName].launch({ headless: true });
+    try {
+      const page = await browser.newPage({ locale: "en-US", viewport: { width: 1600, height: 1100 } });
+      const errors = [];
+      page.on("pageerror", error => errors.push(error.message));
+      await page.goto(`http://127.0.0.1:${port}/?mock=deepseek_upgrade&bench=1`, { waitUntil: "domcontentloaded" });
+      await page.locator("textarea.composer__input:not([aria-hidden=true])").waitFor();
+      for (const layout of [["Creation", "app--creation"], ["Workbench", "app--workbench"]]) {
+        await page.setViewportSize({ width: 1600, height: 1100 });
+        await page.evaluate(() => { document.documentElement.style.zoom = "1"; });
+        await chooseAppLayout(page, ...layout);
+        await page.locator('button:has(svg.lucide-settings)').last().click();
+        await page.locator(".settings-page--general").waitFor();
+        await page.getByRole("button", { name: "Expand sound settings", exact: true }).click();
+        for (const width of sizes) {
+          await page.setViewportSize({ width, height: 1100 });
+          await settle(page);
+          const g = await page.evaluate(geometry);
+          assert.equal(g.generalContainer, "settings-general", "general page retains its responsive container");
+          if (g.pageWidth <= 440) {
+            assert.ok(g.soundColumns.length > 0, "sound controls are present");
+            assert.ok(g.soundColumns.every(columns => columns === 1), "narrow sound controls stack within the general page");
+          }
+          assert.equal(g.statusColumns, 1, `status bar editor owns one full-width column at ${width}px`);
+        }
+        console.log(`PASS ${engineName}/${layout[0]} general settings`);
+        await page.setViewportSize({ width: 1600, height: 1100 });
+        await page.getByRole("button", { name: "Model preferences", exact: true }).click();
+        await page.locator(".model-assignment-row").first().waitFor();
+        for (const theme of themes) {
+          for (const zoom of [1, 1.5]) {
+            await page.evaluate(({ theme, zoom }) => {
+              document.documentElement.dataset.themeStyle = theme;
+              document.documentElement.style.zoom = String(zoom);
+            }, { theme, zoom });
+            for (const width of sizes) {
+              await page.setViewportSize({ width, height: 1100 });
+              await settle(page);
+              const g = await page.evaluate(geometry);
+              const context = `${engineName}/${layout[0]}/${theme}/${width}px/${zoom}x`;
+              assert.equal(g.rows.length, 4, `${context}: all assignments remain visible`);
+              const columns = g.width > 780 ? 3 : g.width > 440 ? 2 : 1;
+              assert.equal(g.headVisible, columns === 3, `${context}: header follows content width`);
+              for (const row of g.rows) {
+                assert.equal(row.columns, columns, `${context}: assignment owns its columns`);
+                assert.ok(row.picker.left >= row.bounds.left - 1 && row.picker.right <= row.bounds.right + 1, `${context}: picker stays within row`);
+                assert.ok(row.connection.right <= row.bounds.right + 1, `${context}: connection stays within row`);
+                if (columns === 3) {
+                  assert.ok(Math.abs(row.picker.left - g.headers[1].left) < 2, `${context}: model aligns with header`);
+                  assert.ok(Math.abs(row.connection.left - g.headers[2].left) < 2, `${context}: connection aligns with header`);
+                  assert.ok(row.connection.top < row.picker.bottom && row.connection.bottom > row.picker.top, `${context}: connection stays on same row`);
+                } else {
+                  assert.ok(row.connection.top >= row.picker.bottom - 1, `${context}: connection follows its model`);
+                  assert.ok(Math.abs(row.connection.left - row.picker.left) < 2, `${context}: stacked connection aligns with model`);
+                }
+              }
+              cases++;
+            }
+          }
+        }
+        await page.evaluate(() => { document.documentElement.style.zoom = "1"; });
+        await page.setViewportSize({ width: 1600, height: 1100 });
+        const picker = page.locator(".model-assignment-row .settings-model-picker__trigger").first();
+        await picker.click();
+        await page.locator(".settings-model-picker__menu").waitFor();
+        await page.keyboard.press("Escape");
+        await page.locator(".settings-model-picker__menu").waitFor({ state: "detached" });
+        console.log(`PASS ${engineName}/${layout[0]} assignments and picker`);
+        await page.locator(".settings-screen .management-screen__back").click();
+      }
+      assert.deepEqual(errors, [], `${engineName}: no runtime errors`);
+    } finally { await browser.close(); }
+  }
+  console.log(`PASS settings layout: ${cases} real-page theme/layout/width/zoom cases plus general settings and picker interaction`);
+} finally { await new Promise((resolve, reject) => preview.httpServer.close(error => error ? reject(error) : resolve())); }

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -20,6 +20,7 @@
     "test:task-monitor": "tsx src/components/TaskMonitorPanel.test.tsx && tsx src/__tests__/task-monitor-navigation.test.ts",
     "test:mcp-app": "tsx src/__tests__/mcp-app-protocol.test.ts",
     "test:workspace": "tsx src/__tests__/keyed-resource.test.ts && tsx src/__tests__/workspace-tree-memory.test.ts && tsx src/__tests__/workspace-refresh-store.test.ts && tsx src/__tests__/workspace-selection-isolation.test.tsx && tsx src/__tests__/workspace-changes-errors.test.tsx && tsx src/__tests__/workspace-turn-verification.test.tsx && tsx src/__tests__/workspace-preview-css.test.ts && tsx src/__tests__/workspace-context-menu.test.tsx && tsx src/__tests__/workspace-resize-interaction.test.tsx && tsx src/__tests__/workspace-panel-swr-contract.test.ts",
+    "test:settings-browser": "node bench/settings-layout.mjs",
     "test:settings-responsive": "tsx src/__tests__/settings-responsive-layout.test.ts",
     "test:stream": "tsx src/__tests__/raf-batch.test.ts && tsx src/__tests__/stream-delta-batch.test.ts && tsx src/__tests__/use-controller-stream-progress.test.ts",
     "test:motion": "node scripts/check-motion-ci-contract.mjs && node scripts/check-waapi-contract.mjs --self-test && tsx src/__tests__/native-motion.test.tsx && tsx src/__tests__/approval-animation.test.tsx",

--- a/desktop/frontend/src/components/SettingsPanel.css
+++ b/desktop/frontend/src/components/SettingsPanel.css
@@ -706,10 +706,11 @@
 .settings-subagent-advanced > summary { cursor: pointer; color: var(--fg-dim); padding: 12px 0; }
 
 /* Settings templates: geometry is shared; only task layout varies. */
+/* Defaults must yield to component layouts and named page containers. */
+:where(.settings-center .settings-page[data-layout]) { container: settings-page / inline-size; }
 :root .settings-center .settings-page[data-layout] {
   --settings-space: 24px;
   --settings-control-height: 40px;
-  container: settings-page / inline-size;
   max-width: none;
   color: var(--fg);
 }
@@ -735,13 +736,12 @@
   font-weight: 650;
   line-height: 1.5;
 }
-:root .settings-center .settings-page[data-layout] .settings-field {
+:where(.settings-center .settings-page[data-layout]) .settings-field {
   grid-template-columns: minmax(160px, .8fr) minmax(0, 1.2fr);
   gap: 24px;
   padding: 16px 0;
-  align-items: center;
 }
-:root .settings-center .settings-page[data-layout] .settings-field--wide-copy { grid-template-columns: minmax(0, 1fr) auto; }
+:where(.settings-center .settings-page[data-layout]) .settings-field--wide-copy { grid-template-columns: minmax(0, 1fr) auto; }
 :root .settings-center .settings-page[data-layout] :is(.settings-field__copy, .settings-field__control) { min-width: 0; }
 :root .settings-center .settings-page[data-layout] .settings-field__hint-line {
   white-space: normal;
@@ -818,7 +818,7 @@
 :root .settings-center .settings-page--storage .settings-field__control input[readonly] { background: transparent; border-color: transparent; font-family: var(--font-mono, monospace); }
 :root .settings-center .settings-center__navitem:not(.settings-center__navitem--active):hover { background: color-mix(in srgb, var(--fg) 3%, transparent); }
 @container settings-page (max-width: 680px) {
-  :root .settings-center .settings-page[data-layout] .settings-field { grid-template-columns: minmax(0, 1fr); gap: 8px; }
+  :where(.settings-center .settings-page[data-layout]) .settings-field { grid-template-columns: minmax(0, 1fr); gap: 8px; }
   :root .settings-center .settings-page--bots .bot-channel-manager { grid-template-columns: minmax(0, 1fr); }
   :root .settings-center .settings-page--bots .bot-channel-tabs { border: 0; padding: 0; display: flex; overflow-x: auto; }
   :root .settings-center .settings-page--bots .bot-channel-tab { flex: 0 0 160px; }
@@ -831,14 +831,14 @@
 :root .settings-center .settings-page[data-layout] .settings-path-value input { flex: 1; min-width: 0; }
 
 /* Model preferences: one assignment matrix, then compact runtime controls. */
-.model-preferences { width: 100%; max-width: 1120px; margin: 0 auto; }
+.model-preferences { container: model-preferences / inline-size; --model-assignment-columns: minmax(140px, 1fr) minmax(220px, 1.5fr) minmax(140px, .8fr); width: 100%; max-width: 1120px; margin: 0 auto; }
 .model-preferences .settings-section { background: transparent; border: 0; box-shadow: none; padding: 0; margin: 0; border-radius: 0; }
 .model-preferences .settings-section + .settings-section { margin-top: 20px; }
 .model-preferences .settings-section__head { padding: 0 0 16px; margin: 0; }
 .model-preferences .settings-section__title { font-size: 16px; }
 .model-preferences .settings-section__body { padding: 0; }
 .model-preferences .settings-field { padding: 16px 0; min-height: 0; gap: 24px; }
-.model-assignment-head, .model-preferences .model-assignment-row { display: grid; grid-template-columns: minmax(140px, 1fr) minmax(220px, 1.5fr) minmax(140px, .8fr); gap: 24px; align-items: center; border-bottom: 1px solid var(--border); }
+.model-assignment-head, .model-preferences .model-assignment-row { display: grid; grid-template-columns: var(--model-assignment-columns); gap: 24px; align-items: center; border-bottom: 1px solid var(--border); }
 .model-assignment-head { padding: 12px 0; font-size: 13px; color: var(--fg-dim); }
 .model-preferences .model-assignment-row .settings-field__control { display: contents; }
 .model-assignment-row .settings-model-picker { min-width: 0; width: 100%; }
@@ -853,8 +853,13 @@
 .model-preferences .compact-ratio-preset__caption, .model-preferences .compact-ratio-current { display: none; }
 .model-preferences .compact-ratio-presets .set-seg__btn { min-height: 40px; padding: 8px 16px; }
 .model-preferences .compact-ratio-summary { justify-content: flex-end; }
-@media (max-width: 900px) {
+@container model-preferences (max-width: 780px) {
  .model-assignment-head { display: none; }
  .model-preferences .model-assignment-row { grid-template-columns: minmax(120px, .7fr) minmax(160px, 1fr); gap: 8px 16px; }
  .model-assignment-connection { grid-column: 2; }
+}
+
+@container model-preferences (max-width: 440px) {
+ .model-preferences .model-assignment-row { grid-template-columns: minmax(0, 1fr); }
+ .model-assignment-connection { grid-column: 1; }
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -31776,8 +31776,7 @@ body > .mermaid-diagram--fullscreen {
   display: none;
 }
 
-.app--creation .settings-field,
-:root[data-theme-style] .app--creation .settings-field {
+:where(.app--creation) .settings-field {
   grid-template-columns: minmax(150px, 200px) minmax(260px, 1fr);
   gap: 18px;
   padding: 10px 0;
@@ -31785,15 +31784,13 @@ body > .mermaid-diagram--fullscreen {
 }
 
 /* 机器人详情卡片内 settings-field 不受 Creation 全局覆盖 — 保持紧凑布局（仅复位溢出相关的 grid 属性） */
-.app--creation .bot-detail-card .settings-field,
-:root[data-theme-style] .app--creation .bot-detail-card .settings-field {
+:where(.app--creation) .bot-detail-card .settings-field {
   grid-template-columns: minmax(112px, 138px) minmax(0, 1fr);
   gap: 12px;
 }
 
 @media (max-width: 980px) {
-  .app--creation .bot-detail-card .settings-field,
-  :root[data-theme-style] .app--creation .bot-detail-card .settings-field {
+  :where(.app--creation) .bot-detail-card .settings-field {
     grid-template-columns: 1fr;
     gap: 8px;
   }
@@ -32016,8 +32013,7 @@ body > .mermaid-diagram--fullscreen {
     padding: 24px 22px;
   }
 
-  .app--creation .settings-field,
-  :root[data-theme-style] .app--creation .settings-field {
+  :where(.app--creation) .settings-field {
     grid-template-columns: 1fr;
     gap: 8px;
   }


### PR DESCRIPTION
## Summary

Fix the model assignment matrix in Settings: the connection label could wrap below the purpose while the header still showed three columns. Shared settings and Creation rules had higher specificity than the component's grid.

- Lower the specificity of shared layout defaults so component layouts retain ownership.
- Use the model preferences pane's available width for coordinated three-, two-, and one-column layouts.
- Restore the General page's named responsive container and full-width status bar editor, including narrow sound controls affected by the same cascade.
- Add real-page browser geometry and picker interaction checks to Linux (Chromium/WebKit) and Windows (Chromium) CI.

## Verification

- Frontend production build and existing bundle budgets passed.
- Settings browser gate: 240 combinations across Chromium/WebKit, Creation/Workbench, six themes, five viewport widths, and 100%/150% CSS zoom, plus General settings and picker interactions.
- Reapplying the original stylesheet to the same page makes the new container-ownership assertion fail.
- Frontend `pnpm test:all` passed (including type checking, discovery suites, remote UI tests, and performance contracts). Repository lint also passed.

Windows CI covers Chromium on Windows; this does not claim native WebView2 or OS DPI validation of a rebuilt installer. The existing test package is unchanged.

## Documentation impact

Documentation-impact: none - restores the existing settings layout and responsive behavior; configuration and documented workflows are unchanged.

## Cache impact

Cache-impact: none - CSS and browser regression coverage only; no provider requests, prompts, persistence, or cache keys change.
Cache-guard: not applicable to presentation-only changes.
System-prompt-review: N/A
