### PR TITLE
feat(turnevent): head reference on turn envelopes / 回合账本携带 head 引用

### DIFF
--- a/desktop/turn_runtime_api.go
+++ b/desktop/turn_runtime_api.go
@@ -164,6 +164,8 @@ type TurnEventReplayView struct {
 	ResetRequired      bool                 `json:"resetRequired"`
 	TranscriptRevision int64                `json:"transcriptRevision,omitempty"`
 	TranscriptDigest   string               `json:"transcriptDigest,omitempty"`
+	HeadID             string               `json:"headId,omitempty"`
+	LeafMessageID      string               `json:"leafMessageId,omitempty"`
 	RuntimeEpoch       string               `json:"runtimeEpoch,omitempty"`
 }
 
@@ -201,6 +203,7 @@ func (a *App) TurnEventsForTab(tabID string, afterSeq uint64) (TurnEventReplayVi
 		LatestSequence: replay.LatestSequence, NextAfterSequence: replay.NextAfterSequence,
 		HasMore: replay.HasMore, ResetRequired: replay.ResetRequired,
 		TranscriptRevision: replay.TranscriptRevision, TranscriptDigest: replay.TranscriptDigest,
+		HeadID: replay.HeadID, LeafMessageID: replay.LeafMessageID,
 		RuntimeEpoch: epoch,
 	}, err
 }

--- a/internal/control/turn_events.go
+++ b/internal/control/turn_events.go
@@ -192,6 +192,11 @@ func (s *turnEventSink) persistAndPublish(e event.Event) error {
 			} else {
 				ledger.SetTranscriptSnapshot(int64(session.TranscriptVersion()), digest)
 			}
+			if ref, ok := session.Head(); ok {
+				ledger.SetTranscriptHead(ref.HeadID, session.LeafID())
+			} else {
+				ledger.SetTranscriptHead("", "")
+			}
 		}
 	case event.TurnStatusChanged:
 		// The emitter supplied the exact transition in e.Status.

--- a/internal/control/turn_events_head_test.go
+++ b/internal/control/turn_events_head_test.go
@@ -1,0 +1,64 @@
+package control
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// TestTurnDoneStampsHeadReferenceForSchemaTwo pins that the terminal turn
+// envelope names the head and leaf message the turn ended on, so projection
+// acks and orphan repair can identify the transcript position without a
+// revision/digest pair.
+func TestTurnDoneStampsHeadReferenceForSchemaTwo(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	reply := [][]provider.Chunk{{{Type: provider.ChunkText, Text: "ok"}, {Type: provider.ChunkDone}}}
+	exec := agent.New(&recordingProvider{streams: reply}, tool.NewRegistry(), agent.NewSession("SYS"), agent.Options{}, event.Discard)
+	done := make(chan event.Event, 4)
+	c := New(Options{Runner: exec, Executor: exec, SystemPrompt: "SYS", SessionDir: dir, SessionPath: path, Label: "test",
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.TurnDone {
+				done <- e
+			}
+		})})
+	t.Cleanup(c.Close)
+	// The first turn's save creates the schema-2 log; the second turn ends on it.
+	for _, input := range []string{"first", "second"} {
+		c.Submit(input)
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("turn %q did not finish", input)
+		}
+	}
+	records, err := c.TurnEventsAfter(0)
+	if err != nil {
+		t.Fatalf("TurnEventsAfter: %v", err)
+	}
+	var terminal int
+	for i, record := range slices.Backward(records) {
+		if record.Kind == "turn_done" {
+			terminal = i
+			break
+		}
+	}
+	ref, ok := exec.Session().Head()
+	if !ok {
+		t.Fatal("session must be schema 2 after two saved turns")
+	}
+	got := records[terminal]
+	if got.HeadID != ref.HeadID || got.LeafMessageID == "" || got.LeafMessageID != exec.Session().LeafID() {
+		t.Fatalf("terminal envelope head=%q leaf=%q, want head %q leaf %q", got.HeadID, got.LeafMessageID, ref.HeadID, exec.Session().LeafID())
+	}
+	view, err := c.TurnEventReplay(0)
+	if err != nil || view.HeadID != ref.HeadID || view.LeafMessageID != got.LeafMessageID {
+		t.Fatalf("replay view = %+v err=%v", view, err)
+	}
+}

--- a/internal/turnevent/ledger.go
+++ b/internal/turnevent/ledger.go
@@ -61,6 +61,8 @@ type Envelope struct {
 	Status             event.TurnStatus `json:"status"`
 	TranscriptRevision int64            `json:"transcriptRevision,omitempty"`
 	TranscriptDigest   string           `json:"transcriptDigest,omitempty"`
+	HeadID             string           `json:"headId,omitempty"`
+	LeafMessageID      string           `json:"leafMessageId,omitempty"`
 	CreatedAt          int64            `json:"createdAt"`
 	Event              eventwire.Event  `json:"event"`
 }
@@ -78,6 +80,8 @@ type TerminalSummary struct {
 	DurationMs         int64            `json:"durationMs,omitempty"`
 	TranscriptRevision int64            `json:"transcriptRevision,omitempty"`
 	TranscriptDigest   string           `json:"transcriptDigest,omitempty"`
+	HeadID             string           `json:"headId,omitempty"`
+	LeafMessageID      string           `json:"leafMessageId,omitempty"`
 }
 
 // ReplayView is a bounded page plus the retained-history contract a frontend
@@ -91,6 +95,8 @@ type ReplayView struct {
 	ResetRequired      bool       `json:"resetRequired"`
 	TranscriptRevision int64      `json:"transcriptRevision,omitempty"`
 	TranscriptDigest   string     `json:"transcriptDigest,omitempty"`
+	HeadID             string     `json:"headId,omitempty"`
+	LeafMessageID      string     `json:"leafMessageId,omitempty"`
 	RuntimeEpoch       string     `json:"runtimeEpoch,omitempty"`
 }
 
@@ -125,17 +131,14 @@ type checkpointRecord struct {
 	LastStatus                 event.TurnStatus  `json:"lastStatus,omitempty"`
 	TranscriptRevision         int64             `json:"transcriptRevision,omitempty"`
 	TranscriptDigest           string            `json:"transcriptDigest,omitempty"`
+	HeadID                     string            `json:"headId,omitempty"`
+	LeafMessageID              string            `json:"leafMessageId,omitempty"`
 	TerminalSummaries          []TerminalSummary `json:"terminalSummaries"`
 }
 
 type routingMetadata struct {
 	runtimeEpoch string
 	submissionID string
-}
-
-type transcriptSnapshot struct {
-	revision int64
-	digest   string
 }
 
 // MetricsSnapshot contains counters only; no event content, ids or paths leave
@@ -255,7 +258,7 @@ func Open(sessionPath, sessionID string) (*Ledger, error) {
 			if rec.SubmissionID != "" {
 				l.submissionTurns[rec.SubmissionID] = rec.TurnID
 			}
-			l.transcript = transcriptSnapshot{revision: rec.TranscriptRevision, digest: rec.TranscriptDigest}
+			l.transcript = transcriptSnapshot{revision: rec.TranscriptRevision, digest: rec.TranscriptDigest, headID: rec.HeadID, leafID: rec.LeafMessageID}
 		}
 		if rec.Event.Tool != nil && rec.Event.Tool.ID != "" {
 			switch rec.Kind {
@@ -387,15 +390,6 @@ func (l *Ledger) TurnIDForSubmission(submissionID string) string {
 	return l.submissionTurns[submissionID]
 }
 
-func (l *Ledger) SetTranscriptSnapshot(revision int64, digest string) {
-	if l == nil {
-		return
-	}
-	l.mu.Lock()
-	l.transcript = transcriptSnapshot{revision: revision, digest: digest}
-	l.mu.Unlock()
-}
-
 // ObserveRawEvent counts provider stream pressure before the coalescer. It
 // intentionally records no content or routing identity.
 func (l *Ledger) ObserveRawEvent(e event.Event) {
@@ -504,7 +498,8 @@ func (l *Ledger) appendLocked(e event.Event, status event.TurnStatus) (event.Eve
 		RuntimeEpoch: l.routing.runtimeEpoch, SubmissionID: l.routing.submissionID,
 		Source: e.Source,
 		Kind:   kind, Status: status, TranscriptRevision: l.transcript.revision,
-		TranscriptDigest: l.transcript.digest, CreatedAt: time.Now().UnixMilli(), Event: w,
+		TranscriptDigest: l.transcript.digest, HeadID: l.transcript.headID, LeafMessageID: l.transcript.leafID,
+		CreatedAt: time.Now().UnixMilli(), Event: w,
 	}
 	var line []byte
 	if l.writeVersion == legacySchemaVersion {
@@ -664,18 +659,7 @@ func (l *Ledger) terminalSequenceLocked(turnID string) uint64 {
 }
 
 func (l *Ledger) addSummaryLocked(rec Envelope, outcome string) {
-	started := l.turnStarted
-	finished := rec.CreatedAt
-	summary := TerminalSummary{
-		TurnID: rec.TurnID, TerminalSequence: rec.Sequence, Status: rec.Status, Outcome: outcome,
-		RuntimeEpoch: rec.RuntimeEpoch, SubmissionID: rec.SubmissionID,
-		StartedAt: started, FinishedAt: finished, TranscriptRevision: rec.TranscriptRevision,
-		TranscriptDigest: rec.TranscriptDigest,
-	}
-	if started > 0 && finished >= started {
-		summary.DurationMs = finished - started
-	}
-	l.summaries = appendTerminalSummary(l.summaries, summary)
+	l.summaries = appendTerminalSummary(l.summaries, terminalSummaryFor(rec, outcome, l.turnStarted))
 }
 
 // Replay returns a bounded page without rereading the whole sidecar. Open owns
@@ -704,6 +688,7 @@ func (l *Ledger) Replay(after uint64) (ReplayView, error) {
 	}
 	view.TranscriptRevision = l.transcript.revision
 	view.TranscriptDigest = l.transcript.digest
+	view.HeadID, view.LeafMessageID = l.transcript.headID, l.transcript.leafID
 	view.RuntimeEpoch = l.routing.runtimeEpoch
 	effective := after
 	if effective < l.compactedThrough || effective > latest {
@@ -856,6 +841,7 @@ func (l *Ledger) compactLocked(force bool) error {
 		CompactedThroughSequence: cutoff, ProjectionCommittedThrough: cutoff,
 		LastTurnID: last.TurnID, LastStatus: last.Status,
 		TranscriptRevision: last.TranscriptRevision, TranscriptDigest: last.TranscriptDigest,
+		HeadID: last.HeadID, LeafMessageID: last.LeafMessageID,
 		TerminalSummaries: append([]TerminalSummary(nil), l.summaries...),
 	}
 	if checkpoint.TerminalSummaries == nil {
@@ -1026,7 +1012,7 @@ func (l *Ledger) readAndRepairLocked() (parsedLedger, error) {
 				}
 				result.compactedThrough = checkpoint.CompactedThroughSequence
 				result.projectionCommitted = checkpoint.ProjectionCommittedThrough
-				result.checkpoint = transcriptSnapshot{revision: checkpoint.TranscriptRevision, digest: checkpoint.TranscriptDigest}
+				result.checkpoint = transcriptSnapshot{revision: checkpoint.TranscriptRevision, digest: checkpoint.TranscriptDigest, headID: checkpoint.HeadID, leafID: checkpoint.LeafMessageID}
 				result.summaries = append(result.summaries, checkpoint.TerminalSummaries...)
 				expectedSeq = checkpoint.CompactedThroughSequence + 1
 			case "event":
@@ -1071,18 +1057,7 @@ damaged:
 		if !rec.Status.Terminal() {
 			continue
 		}
-		started := startedByTurn[rec.TurnID]
-		summary := TerminalSummary{
-			TurnID: rec.TurnID, TerminalSequence: rec.Sequence, Status: rec.Status,
-			Outcome:      rec.Event.Outcome,
-			RuntimeEpoch: rec.RuntimeEpoch, SubmissionID: rec.SubmissionID,
-			StartedAt: started, FinishedAt: rec.CreatedAt, TranscriptRevision: rec.TranscriptRevision,
-			TranscriptDigest: rec.TranscriptDigest,
-		}
-		if started > 0 && rec.CreatedAt >= started {
-			summary.DurationMs = rec.CreatedAt - started
-		}
-		result.summaries = appendTerminalSummary(result.summaries, summary)
+		result.summaries = appendTerminalSummary(result.summaries, terminalSummaryFor(rec, rec.Event.Outcome, startedByTurn[rec.TurnID]))
 	}
 	return result, nil
 }

--- a/internal/turnevent/transcript_ref.go
+++ b/internal/turnevent/transcript_ref.go
@@ -1,0 +1,47 @@
+package turnevent
+
+// transcriptSnapshot is the transcript identity stamped on every envelope: the
+// schema-1 revision/digest pair, and for schema-2 sessions the head and leaf
+// message the turn ended on, which is known before the save lands.
+type transcriptSnapshot struct {
+	revision int64
+	digest   string
+	headID   string
+	leafID   string
+}
+
+func (l *Ledger) SetTranscriptSnapshot(revision int64, digest string) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	l.transcript.revision, l.transcript.digest = revision, digest
+	l.mu.Unlock()
+}
+
+// SetTranscriptHead records the schema-2 head position the next envelopes
+// describe. An empty head id clears it (schema-1 session).
+func (l *Ledger) SetTranscriptHead(headID, leafID string) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	l.transcript.headID, l.transcript.leafID = headID, leafID
+	l.mu.Unlock()
+}
+
+// terminalSummaryFor folds a terminal envelope into the summary a checkpoint
+// keeps once its events are compacted away.
+func terminalSummaryFor(rec Envelope, outcome string, started int64) TerminalSummary {
+	summary := TerminalSummary{
+		TurnID: rec.TurnID, TerminalSequence: rec.Sequence, Status: rec.Status, Outcome: outcome,
+		RuntimeEpoch: rec.RuntimeEpoch, SubmissionID: rec.SubmissionID,
+		StartedAt: started, FinishedAt: rec.CreatedAt,
+		TranscriptRevision: rec.TranscriptRevision, TranscriptDigest: rec.TranscriptDigest,
+		HeadID: rec.HeadID, LeafMessageID: rec.LeafMessageID,
+	}
+	if started > 0 && rec.CreatedAt >= started {
+		summary.DurationMs = rec.CreatedAt - started
+	}
+	return summary
+}

--- a/internal/turnevent/transcript_ref_test.go
+++ b/internal/turnevent/transcript_ref_test.go
@@ -1,0 +1,90 @@
+package turnevent
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+func TestEnvelopesCarryHeadReferenceAcrossCompaction(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	l, err := Open(path, "session")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	turnID, err := l.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	l.SetTranscriptSnapshot(3, "digest")
+	l.SetTranscriptHead("main", "01LEAF")
+	if _, ok, err := l.Append(event.Event{Kind: event.TurnStarted}, event.TurnInProgress); err != nil || !ok {
+		t.Fatalf("started: ok=%v err=%v", ok, err)
+	}
+	done, ok, err := l.Append(event.Event{Kind: event.TurnDone}, event.TurnCompleted)
+	if err != nil || !ok {
+		t.Fatalf("done: ok=%v err=%v", ok, err)
+	}
+	recs, err := l.EventsAfter(0)
+	if err != nil || len(recs) != 2 {
+		t.Fatalf("EventsAfter: %v (%d records)", err, len(recs))
+	}
+	if rec := recs[1]; rec.HeadID != "main" || rec.LeafMessageID != "01LEAF" || rec.TranscriptRevision != 3 {
+		t.Fatalf("terminal envelope = %+v, want head reference beside the schema-1 identity", rec)
+	}
+	view, err := l.Replay(0)
+	if err != nil || view.HeadID != "main" || view.LeafMessageID != "01LEAF" {
+		t.Fatalf("replay view = %+v err=%v", view, err)
+	}
+	if err := l.Compact(); err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	reopened, err := Open(path, "session")
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	summaries := reopened.summaries
+	if len(summaries) != 1 || summaries[0].TurnID != turnID || summaries[0].HeadID != "main" || summaries[0].LeafMessageID != "01LEAF" {
+		t.Fatalf("summaries after checkpoint = %+v", summaries)
+	}
+	view, err = reopened.Replay(done.Sequence)
+	if err != nil || view.HeadID != "main" || view.LeafMessageID != "01LEAF" {
+		t.Fatalf("replay after reopen = %+v err=%v", view, err)
+	}
+	// A schema-1 session clears the head without touching the revision pair.
+	reopened.SetTranscriptHead("", "")
+	if _, err := reopened.Begin(); err != nil {
+		t.Fatal(err)
+	}
+	next, ok, err := reopened.Append(event.Event{Kind: event.TurnDone}, event.TurnCompleted)
+	if err != nil || !ok {
+		t.Fatalf("schema-1 append ok=%v err=%v", ok, err)
+	}
+	recs, err = reopened.EventsAfter(next.Sequence - 1)
+	if err != nil || len(recs) != 1 || recs[0].HeadID != "" || recs[0].LeafMessageID != "" {
+		t.Fatalf("schema-1 envelope = %+v err=%v", recs, err)
+	}
+}
+
+func TestEnvelopeWithoutHeadFieldsDecodesEmpty(t *testing.T) {
+	var rec Envelope
+	if err := json.Unmarshal([]byte(`{"schemaVersion":2,"sessionId":"s","turnId":"t","seq":1,"kind":"turn_done","status":"completed","transcriptRevision":4,"transcriptDigest":"d","createdAt":1,"event":{}}`), &rec); err != nil {
+		t.Fatal(err)
+	}
+	if rec.HeadID != "" || rec.LeafMessageID != "" || rec.TranscriptRevision != 4 {
+		t.Fatalf("legacy envelope = %+v", rec)
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(b, []byte("headId")) || bytes.Contains(b, []byte("leafMessageId")) {
+		t.Fatalf("empty head fields must stay omitted: %s", b)
+	}
+}


### PR DESCRIPTION
## Summary

Fifth PR of the append-only DAG session log series (#8451 / #8452), after #9908, #9910, #9912, and #9913. The turn-event ledger now names the schema-2 head position a turn ended on.

- `Envelope`, `TerminalSummary`, `ReplayView`, and the checkpoint record gain `headId` and `leafMessageId` (omitempty) beside the existing `transcriptRevision` / `transcriptDigest` pair. The controller sets them at `TurnDone` from `Session.Head()` and the in-memory leaf id, which is known before the save lands; schema-1 sessions clear them.
- The head reference survives compaction: the checkpoint record carries it and terminal summaries are rebuilt with it on reopen.
- The desktop `TurnEventReplayView` forwards the two fields; the frontend types pick them up in the desktop PR.
- `transcriptSnapshot`, `SetTranscriptSnapshot`, and a shared `terminalSummaryFor` moved into `internal/turnevent/transcript_ref.go`, which also removes the duplicated summary construction; `ledger.go` shrinks by 25 lines.

## Verification

- `go test ./internal/turnevent/ ./internal/control/` (+ `-race` on the new tests); `go test ./...`; `cd desktop && go test ./...`.
- New tests: envelopes and the replay view carry the head reference, it survives `Compact` + reopen in the terminal summaries, a schema-1 turn clears it; an envelope written without the fields decodes to empty values and re-encodes without them; a two-turn controller run on a schema-2 session stamps the terminal envelope and replay view with the session's head and leaf.
- `gofmt`, `go vet`, `make lint` clean.

## Compatibility

| Field or format | Old-data behavior | New-reader behavior | Previous-reader behavior | Conclusion |
| --- | --- | --- | --- | --- |
| `turns.jsonl` envelope / checkpoint `headId`, `leafMessageId` | absent → empty strings | used when present | ignored (unknown fields); schema version unchanged | compatible |
| `transcriptRevision` / `transcriptDigest` | unchanged | unchanged | unchanged | compatible |
| desktop `TurnEventReplayView.headId` / `leafMessageId` | n/a | optional fields | frontend ignores unknown keys | compatible |

Cache-impact: none - the ledger is a local sidecar; no provider-visible bytes change
Cache-guard: existing guard rationale - internal/turnevent never feeds provider requests; go test ./internal/turnevent/ pins the sidecar shape
Documentation-impact: none - the ledger fields are internal until the desktop PR consumes them; docs/TURN_RELIABILITY.md is updated in the final docs PR of the series
