### PR TITLE
feat(sessioncatalog): project schema-2 heads / 会话目录投影 schema 2 heads

### DIFF
--- a/docs/SESSION_CATALOG.md
+++ b/docs/SESSION_CATALOG.md
@@ -3,7 +3,7 @@
 Reasonix keeps session transcripts, event logs, metadata sidecars, and
 `desktop-projects.json` as the only authoritative session data. The desktop
 project tree reads a disposable SQLite projection from
-`<cache root>/session-catalog/v6.sqlite`; deleting that database never deletes
+`<cache root>/session-catalog/v8.sqlite`; deleting that database never deletes
 or changes a conversation. The earlier `v1.sqlite` through `v5.sqlite` caches
 are left in place so a concurrent or downgraded process cannot cross-write the
 projection. v6 introduces filesystem-aware path identity and is rebuilt from
@@ -60,7 +60,10 @@ The catalog stores only query projections:
 - topic ordering, aggregate counts, activity, recovery, health state, and
   workspace-root identity key; and
 - session access path plus path, directory, and workspace-root identity keys,
-  preview, counts, fingerprints, recovery, and health state.
+  preview, counts, fingerprints, recovery, and health state; and
+- for schema-2 event logs, the log format, the selected head, and one
+  `catalog_heads` row per head, taken from the kernel's head index sidecar and
+  the `BranchMeta` mirror rather than from replaying the log.
 
 Topic pages use a `(pinned, last_activity_at, topic_id)` keyset cursor. The
 default page size is 50 and the maximum is 200. Directory reconciliation commits

--- a/docs/SESSION_CATALOG.zh-CN.md
+++ b/docs/SESSION_CATALOG.zh-CN.md
@@ -2,7 +2,7 @@
 
 Reasonix 始终以会话 transcript、event log、metadata sidecar 和
 `desktop-projects.json` 作为唯一权威数据。桌面项目树读取位于
-`<缓存根目录>/session-catalog/v6.sqlite` 的一次性 SQLite 查询投影；删除该数据库
+`<缓存根目录>/session-catalog/v8.sqlite` 的一次性 SQLite 查询投影；删除该数据库
 不会删除或修改任何会话。早期的 `v1.sqlite` 至 `v5.sqlite` 缓存会保留，避免与仍在
 运行或降级后的旧版本进程交叉写同一投影。v6 引入文件系统感知的路径身份，首次启动
 会从权威文件重新建立；旧 v5 文件保留用于回滚，不会被新版本写入。同一 v6 索引的
@@ -47,7 +47,9 @@ catalog 只保存查询投影：
 - 项目排序、标题、颜色、置顶状态及 workspace root identity key；
 - topic 排序、聚合计数、活动时间、恢复、健康状态及 workspace root identity key；
 - session 访问路径及路径、目录和 workspace root identity key、preview、计数、指纹、
-  恢复和健康状态。
+  恢复和健康状态；
+- 对 schema 2 事件日志，还有日志格式、选中 head，以及每个 head 一行的
+  `catalog_heads`，来源是内核写出的 head 索引侧车与 `BranchMeta` 镜像，而不是重放日志。
 
 topic 分页使用 `(pinned, last_activity_at, topic_id)` keyset cursor。默认每页
 50 条，最多 200 条。目录对账每批最多提交 64 个 sidecar，并在让出调度前持久化

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -1997,6 +1997,7 @@ func ListSessionOrderWithRecoveryPreferenceResolver(dir string, resolve Recovery
 		versionKind := VersionNormal
 		versionState := VersionActive
 		parentConversationID := ""
+		var headMirror BranchMeta
 		parentVersionID := ""
 		recoveryPreferred := false
 		turns := 0
@@ -2034,6 +2035,7 @@ func ListSessionOrderWithRecoveryPreferenceResolver(dir string, resolve Recovery
 			contentDigest = meta.ContentDigest
 			listingRevision = meta.ListingRevision
 			listingContentDigest = meta.ListingContentDigest
+			headMirror = meta
 		}
 		// Old recovery files may lack Recovered meta; filename still proves
 		// automatic recovery lineage for catalog folding.
@@ -2072,6 +2074,9 @@ func ListSessionOrderWithRecoveryPreferenceResolver(dir string, resolve Recovery
 			ContentDigest:        contentDigest,
 			ListingRevision:      listingRevision,
 			ListingContentDigest: listingContentDigest,
+			HeadID:               headMirror.HeadID,
+			HeadCount:            headMirror.HeadCount,
+			LogSchema:            headMirror.LogSchema,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/internal/agent/session_dag_index.go
+++ b/internal/agent/session_dag_index.go
@@ -2,9 +2,12 @@ package agent
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"os"
 	"time"
+
+	"reasonix/internal/provider"
 
 	fileencoding "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/store"
@@ -96,4 +99,22 @@ func writeSessionDAGIndex(ctx context.Context, sessionPath string, st *sessionDA
 	}
 	b = append(b, '\n')
 	return atomicWriteFileContext(ctx, indexPath, ".session-event-index.*.tmp", "event-index", b, 0o600, false)
+}
+
+// refreshSessionEventIndexContext rewrites the event index in the schema the
+// log actually uses: a schema-2 log gets its head index replayed, a schema-1
+// log the listing index. A listing repair must never downgrade a head index.
+func refreshSessionEventIndexContext(ctx context.Context, sessionPath string, msgs []provider.Message, digest [sha256.Size]byte, revision int64) error {
+	probe, err := probeSessionEventLog(sessionPath)
+	if err != nil {
+		return err
+	}
+	if !probe.dag {
+		return writeSessionEventIndexContext(ctx, sessionPath, msgs, digest, revision)
+	}
+	st, err := replaySessionDAG(ctx, store.SessionEventLog(sessionPath), defaultSessionReplayLimits)
+	if err != nil {
+		return err
+	}
+	return writeSessionDAGIndex(ctx, sessionPath, st)
 }

--- a/internal/agent/session_listing_helpers.go
+++ b/internal/agent/session_listing_helpers.go
@@ -36,6 +36,11 @@ type SessionOrderInfo struct {
 	ContentDigest        string
 	ListingRevision      int64
 	ListingContentDigest string
+	// Schema-2 sessions mirror their selected head here so listings never
+	// replay the log; LogSchema is 0 for schema-1 sidecars.
+	HeadID    string
+	HeadCount int
+	LogSchema int
 }
 
 // RecoveryPreferenceResolver validates one explicit recovery preference while

--- a/internal/agent/session_listing_repair.go
+++ b/internal/agent/session_listing_repair.go
@@ -201,7 +201,7 @@ func repairSessionListingFromReplay(ctx context.Context, path string, meta Branc
 	if err := writeSessionMessagesContext(ctx, path, msgs); err != nil {
 		return SessionListingRepairResult{}, fmt.Errorf("write session display read model: %w", err)
 	}
-	if err := writeSessionEventIndexContext(ctx, path, msgs, state.Digest, meta.Revision); err != nil {
+	if err := refreshSessionEventIndexContext(ctx, path, msgs, state.Digest, meta.Revision); err != nil {
 		return SessionListingRepairResult{}, err
 	}
 	idx, err := BuildSessionDisplayIndexContext(ctx, msgs, meta.Revision, true, state.Digest)

--- a/internal/agent/session_listing_repair_dag_test.go
+++ b/internal/agent/session_listing_repair_dag_test.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"reasonix/internal/store"
+)
+
+// A listing repair replays the transcript and rewrites the event index; on a
+// schema-2 log that index is the head index and must stay schema 2.
+func TestListingRepairKeepsSchemaTwoHeadIndex(t *testing.T) {
+	path := dagTestSession(t)
+	dagSavedSession(t, path, "q1", "a1")
+	if err := os.Remove(store.SessionEventIndex(path)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(store.SessionDisplayIndex(path)); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpdateBranchMeta(path, false, func(meta *BranchMeta) error {
+		meta.ListingRevision, meta.ListingContentDigest = 0, ""
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := RepairSessionListingProjection(context.Background(), path)
+	if err != nil || result.Status != SessionListingRepairApplied {
+		t.Fatalf("repair = %+v err=%v", result, err)
+	}
+	idx, err := ReadSessionHeadIndex(path)
+	if err != nil || idx == nil || !idx.Current(path) || idx.SelectedHead != SessionMainHead || len(idx.Heads) != 1 {
+		t.Fatalf("head index after repair = %+v err=%v, want a current schema-2 index", idx, err)
+	}
+	if _, err := readSessionEventIndex(path); err == nil {
+		t.Fatal("repair must not write a schema-1 index over a schema-2 log")
+	}
+}

--- a/internal/sessioncatalog/catalog_test.go
+++ b/internal/sessioncatalog/catalog_test.go
@@ -287,7 +287,7 @@ func TestSchemaMigrationLedgerRecordsEveryVersion(t *testing.T) {
 		}
 		versions = append(versions, version)
 	}
-	if fmt.Sprint(versions) != "[1 2 3 4 5 6 7 8 9 10 11]" {
+	if fmt.Sprint(versions) != "[1 2 3 4 5 6 7 8 9 10 11 12]" {
 		t.Fatalf("schema migration ledger = %v", versions)
 	}
 }

--- a/internal/sessioncatalog/heads.go
+++ b/internal/sessioncatalog/heads.go
@@ -1,0 +1,121 @@
+package sessioncatalog
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"reasonix/internal/agent"
+)
+
+// HeadRecord is one head of a schema-2 session as the catalog projects it.
+// Rows come from the kernel's head index sidecar, never from replaying a log.
+type HeadRecord struct {
+	Path           string `json:"path"`
+	ID             string `json:"id"`
+	ParentHeadID   string `json:"parentHeadId,omitempty"`
+	Kind           string `json:"kind"`
+	Name           string `json:"name,omitempty"`
+	LeafMessageID  string `json:"leafMessageId,omitempty"`
+	WriterID       string `json:"writerId,omitempty"`
+	LastActivityAt int64  `json:"lastActivityAt,omitempty"`
+	Turns          int    `json:"turns"`
+	Preview        string `json:"preview,omitempty"`
+	Retired        bool   `json:"retired,omitempty"`
+	Selected       bool   `json:"selected,omitempty"`
+}
+
+// sessionHeadProjection is what recordFromOrder learns about a schema-2
+// session without opening its log: the sidecar mirror is always available,
+// the per-head rows only while the head index still matches the log.
+type sessionHeadProjection struct {
+	logFormat   int
+	headCount   int
+	selected    string
+	fingerprint string
+	heads       []HeadRecord
+	stale       bool
+}
+
+func projectSessionHeads(info agent.SessionOrderInfo) sessionHeadProjection {
+	if info.LogSchema < 2 {
+		return sessionHeadProjection{logFormat: 1}
+	}
+	out := sessionHeadProjection{logFormat: info.LogSchema, headCount: info.HeadCount, selected: info.HeadID}
+	idx, err := agent.ReadSessionHeadIndex(info.Path)
+	if err != nil || idx == nil || !idx.Current(info.Path) {
+		out.stale = true
+		return out
+	}
+	out.selected = idx.SelectedHead
+	out.headCount = len(idx.Heads)
+	out.heads = make([]HeadRecord, 0, len(idx.Heads))
+	for _, h := range idx.Heads {
+		out.heads = append(out.heads, HeadRecord{
+			Path: info.Path, ID: h.ID, ParentHeadID: h.ParentHead, Kind: h.Kind, Name: h.Name,
+			LeafMessageID: h.LeafID, WriterID: h.Writer, LastActivityAt: unixMilli(h.LastActivity),
+			Turns: h.Turns, Preview: h.Preview, Retired: h.Retired, Selected: h.ID == idx.SelectedHead,
+		})
+		if h.ID == idx.SelectedHead {
+			out.fingerprint = "|h:" + h.ID + ":" + h.LeafID
+		}
+	}
+	return out
+}
+
+// writeDirectoryRow lands one scanned session row and its head rows inside
+// the directory projection transaction.
+func (c *Catalog) writeDirectoryRow(ctx context.Context, tx *sql.Tx, stmt *sql.Stmt, record SessionRecord, pathKey, directoryKey string, generation int64) error {
+	if _, err := stmt.ExecContext(ctx, c.sessionRowValues(record, pathKey, directoryKey, generation)...); err != nil {
+		return err
+	}
+	return upsertHeadRows(ctx, tx, pathKey, record.heads)
+}
+
+// upsertHeadRows replaces the head rows of one session inside the projection
+// transaction. Stale projections keep the previous rows until the head index
+// is current again.
+func upsertHeadRows(ctx context.Context, tx *sql.Tx, pathKey string, heads []HeadRecord) error {
+	if heads == nil {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM catalog_heads WHERE path_key=?`, pathKey); err != nil {
+		return err
+	}
+	for _, h := range heads {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO catalog_heads(path_key,head_id,parent_head_id,kind,name,leaf_message_id,
+			writer_id,last_activity_at,turns,preview,retired,selected) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`,
+			pathKey, h.ID, h.ParentHeadID, h.Kind, h.Name, h.LeafMessageID, h.WriterID, h.LastActivityAt, h.Turns, h.Preview,
+			boolToInt(h.Retired), boolToInt(h.Selected)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ListHeads returns the projected heads of one session in creation order. A
+// schema-1 session has none and returns an empty slice.
+func (c *Catalog) ListHeads(ctx context.Context, path string) ([]HeadRecord, error) {
+	out := []HeadRecord{}
+	if c == nil || path == "" {
+		return out, nil
+	}
+	rows, err := c.db.QueryContext(ctx, `SELECT head_id,parent_head_id,kind,name,leaf_message_id,writer_id,last_activity_at,
+		turns,preview,retired,selected FROM catalog_heads WHERE path_key=? ORDER BY rowid`, c.pathKey(path))
+	if err != nil {
+		return out, fmt.Errorf("list session heads: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var h HeadRecord
+		var retired, selected int
+		if err := rows.Scan(&h.ID, &h.ParentHeadID, &h.Kind, &h.Name, &h.LeafMessageID, &h.WriterID, &h.LastActivityAt,
+			&h.Turns, &h.Preview, &retired, &selected); err != nil {
+			return out, err
+		}
+		h.Path = path
+		h.Retired, h.Selected = retired != 0, selected != 0
+		out = append(out, h)
+	}
+	return out, rows.Err()
+}

--- a/internal/sessioncatalog/heads_projection_test.go
+++ b/internal/sessioncatalog/heads_projection_test.go
@@ -1,0 +1,170 @@
+package sessioncatalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/projectiondb"
+	"reasonix/internal/provider"
+	"reasonix/internal/store"
+)
+
+func writeSchemaTwoSession(t *testing.T, path string) (*agent.Session, *agent.Session) {
+	t.Helper()
+	a := agent.NewSession("sys")
+	a.Add(provider.Message{Role: provider.RoleUser, Content: "q1"})
+	a.Add(provider.Message{Role: provider.RoleAssistant, Content: "a1"})
+	if err := a.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{Scope: "global", TopicID: "topic-heads", TopicTitle: "Heads"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	b, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.Add(provider.Message{Role: provider.RoleUser, Content: "q2 from a"})
+	if err := a.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	b.Add(provider.Message{Role: provider.RoleUser, Content: "q2 from b"})
+	if err := b.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	return a, b
+}
+
+func TestReconcileProjectsSchemaTwoHeadsFromTheIndex(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "heads.jsonl")
+	_, b := writeSchemaTwoSession(t, path)
+
+	catalog, err := Open(ctx, Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	if err := catalog.ReconcileDirectory(ctx, DirectoryTarget{Path: dir, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+	page, err := catalog.ListSessions(ctx, SessionPageRequest{Scope: "global", Limit: 10})
+	if err != nil || len(page.Items) != 1 {
+		t.Fatalf("sessions = %+v err=%v", page.Items, err)
+	}
+	rec := page.Items[0]
+	refB, _ := b.Head()
+	if rec.LogFormat != 2 || rec.HeadCount != 2 || rec.SelectedHeadID != refB.HeadID {
+		t.Fatalf("record = logFormat %d heads %d selected %q, want schema 2 with b's head selected (%q)", rec.LogFormat, rec.HeadCount, rec.SelectedHeadID, refB.HeadID)
+	}
+	if !strings.Contains(rec.ContentFingerprint, "|h:"+refB.HeadID+":") {
+		t.Fatalf("fingerprint %q must bind the selected head", rec.ContentFingerprint)
+	}
+	if rec.TurnsState != TurnsValid || rec.Recovered || rec.RecoveryRole != RecoveryRoleNormal || !rec.OrdinaryVisible {
+		t.Fatalf("schema-2 row must be an ordinary valid session: %+v", rec)
+	}
+	heads, err := catalog.ListHeads(ctx, path)
+	if err != nil || len(heads) != 2 {
+		t.Fatalf("heads = %+v err=%v", heads, err)
+	}
+	if heads[0].ID != agent.SessionMainHead || heads[0].Kind != agent.HeadKindMain || heads[0].Selected {
+		t.Fatalf("main head = %+v", heads[0])
+	}
+	if heads[1].ID != refB.HeadID || heads[1].Kind != agent.HeadKindConcurrent || !heads[1].Selected || heads[1].Turns != 2 || heads[1].Path != path {
+		t.Fatalf("concurrent head = %+v", heads[1])
+	}
+	if none, err := catalog.ListHeads(ctx, filepath.Join(dir, "missing.jsonl")); err != nil || none == nil || len(none) != 0 {
+		t.Fatalf("missing session heads = %#v err=%v, want empty slice", none, err)
+	}
+}
+
+func TestReconcileMarksStaleHeadIndexUnknownAndKeepsRows(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "heads.jsonl")
+	writeSchemaTwoSession(t, path)
+	catalog, err := Open(ctx, Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	if err := catalog.ReconcileDirectory(ctx, DirectoryTarget{Path: dir, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+	// A log that grew without its index (a writer died mid-save) is projected
+	// from the sidecar mirror and queued for repair; the head rows stay.
+	if err := os.Remove(store.SessionEventIndex(path)); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(store.SessionEventLog(path), os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("\n"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if err := catalog.ReconcileDirectory(ctx, DirectoryTarget{Path: dir, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+	page, err := catalog.ListSessions(ctx, SessionPageRequest{Scope: "global", Limit: 10})
+	if err != nil || len(page.Items) != 1 {
+		t.Fatalf("sessions = %+v err=%v", page.Items, err)
+	}
+	rec := page.Items[0]
+	if rec.LogFormat != 2 || rec.HeadCount != 2 || rec.SelectedHeadID == "" || rec.TurnsState != TurnsUnknown {
+		t.Fatalf("stale projection = %+v, want schema-2 mirror with unknown counts", rec)
+	}
+	if heads, err := catalog.ListHeads(ctx, path); err != nil || len(heads) != 2 {
+		t.Fatalf("head rows after stale index = %+v err=%v", heads, err)
+	}
+}
+
+func TestMigrationV12AddsHeadProjectionAndForcesRescan(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "catalog.sqlite")
+	handle, err := projectiondb.Open(ctx, projectiondb.OpenOptions{
+		Path: path, MemoryName: "session-catalog-v11-test", Migrations: sessionMigrations()[:11], RequireDisk: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`INSERT INTO catalog_directories(path,path_key,scope) VALUES('/Sessions','/sessions','global')`,
+		`INSERT INTO catalog_sessions(path,path_key,directory,directory_key,scope,topic_id) VALUES('/Sessions/Old.jsonl','/sessions/old.jsonl','/Sessions','/sessions','global','topic')`,
+	} {
+		if _, err := handle.DB.ExecContext(ctx, statement); err != nil {
+			_ = handle.DB.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := handle.DB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	catalog, err := Open(ctx, Options{Path: path, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	var directories, sessions, logFormat int
+	if err := catalog.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_directories`).Scan(&directories); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.db.QueryRowContext(ctx, `SELECT COUNT(*), MAX(log_format) FROM catalog_sessions`).Scan(&sessions, &logFormat); err != nil {
+		t.Fatal(err)
+	}
+	if directories != 0 || sessions != 1 || logFormat != 1 {
+		t.Fatalf("after v12: directories=%d sessions=%d log_format=%d, want rescan forced and rows kept as schema 1", directories, sessions, logFormat)
+	}
+	if heads, err := catalog.ListHeads(ctx, "/Sessions/Old.jsonl"); err != nil || len(heads) != 0 {
+		t.Fatalf("legacy row heads = %+v err=%v", heads, err)
+	}
+}

--- a/internal/sessioncatalog/lineage_test.go
+++ b/internal/sessioncatalog/lineage_test.go
@@ -445,8 +445,8 @@ func TestUpgradeMatrixV4RebuildKeepsSingleLogicalRowAndAuthority(t *testing.T) {
 		}
 	}
 	// v7 isolates the persistent v11 repair scheduler from older writers.
-	if !strings.HasSuffix(filepath.ToSlash(DefaultPath()), "session-catalog/v7.sqlite") && DefaultPath() != "" {
-		t.Fatalf("DefaultPath = %q, want v7.sqlite", DefaultPath())
+	if !strings.HasSuffix(filepath.ToSlash(DefaultPath()), "session-catalog/v8.sqlite") && DefaultPath() != "" {
+		t.Fatalf("DefaultPath = %q, want v8.sqlite", DefaultPath())
 	}
 }
 

--- a/internal/sessioncatalog/reconcile.go
+++ b/internal/sessioncatalog/reconcile.go
@@ -199,6 +199,7 @@ func (c *Catalog) indexSessionPath(ctx context.Context, target DirectoryTarget, 
 		order.ContentDigest = meta.ContentDigest
 		order.ListingRevision = meta.ListingRevision
 		order.ListingContentDigest = meta.ListingContentDigest
+		order.HeadID, order.HeadCount, order.LogSchema = meta.HeadID, meta.HeadCount, meta.LogSchema
 	}
 	if order.CreatedAt.IsZero() {
 		order.CreatedAt = info.ModTime()
@@ -235,8 +236,12 @@ func recordFromOrder(target DirectoryTarget, info agent.SessionOrderInfo) Sessio
 	if !info.ListingProjectionFresh() {
 		turnsState = TurnsUnknown
 	}
-	contentFingerprint := sessionContentFingerprint(info.Path)
+	heads := projectSessionHeads(info)
+	contentFingerprint := sessionContentFingerprint(info.Path) + heads.fingerprint
 	metaFingerprint := fileFingerprint(agent.BranchMetaPath(info.Path))
+	if heads.stale {
+		turnsState = TurnsUnknown
+	}
 	createdAt := unixMilli(info.CreatedAt)
 	lastActivityAt := unixMilli(info.LastActivityAt)
 	// File mtime fills a missing clock. Do not raise a known sidecar UpdatedAt:
@@ -269,6 +274,10 @@ func recordFromOrder(target DirectoryTarget, info agent.SessionOrderInfo) Sessio
 		ParentID:           info.ParentID,
 		RecoveryPreferred:  info.RecoveryPreferred,
 		RecoveryCopy:       false,
+		LogFormat:          heads.logFormat,
+		HeadCount:          heads.headCount,
+		SelectedHeadID:     heads.selected,
+		heads:              heads.heads,
 		ContentFingerprint: contentFingerprint,
 		MetaFingerprint:    metaFingerprint,
 		Health:             HealthOK,
@@ -402,7 +411,7 @@ func (c *Catalog) commitDirectoryProjection(ctx context.Context, target Director
 				_ = stmt.Close()
 				return rollback(err)
 			}
-			if _, err := stmt.ExecContext(ctx, c.sessionRowValues(record, pathKey, directoryKey, generation)...); err != nil {
+			if err := c.writeDirectoryRow(ctx, tx, stmt, record, pathKey, directoryKey, generation); err != nil {
 				_ = stmt.Close()
 				return rollback(err)
 			}

--- a/internal/sessioncatalog/recovery_copy_test.go
+++ b/internal/sessioncatalog/recovery_copy_test.go
@@ -12,15 +12,15 @@ import (
 	"reasonix/internal/provider"
 )
 
-func TestDefaultPathUsesV7CacheFile(t *testing.T) {
+func TestDefaultPathUsesV8CacheFile(t *testing.T) {
 	t.Parallel()
 	path := DefaultPath()
 	if path == "" {
 		// CacheDir unavailable in this environment; empty is still valid.
 		return
 	}
-	if !strings.HasSuffix(filepath.ToSlash(path), "session-catalog/v7.sqlite") {
-		t.Fatalf("DefaultPath = %q, want .../session-catalog/v7.sqlite", path)
+	if !strings.HasSuffix(filepath.ToSlash(path), "session-catalog/v8.sqlite") {
+		t.Fatalf("DefaultPath = %q, want .../session-catalog/v8.sqlite", path)
 	}
 	if strings.Contains(path, "v1.sqlite") {
 		t.Fatalf("DefaultPath must not reuse the 1.24.0 v1 cache: %q", path)

--- a/internal/sessioncatalog/schema.go
+++ b/internal/sessioncatalog/schema.go
@@ -212,6 +212,32 @@ CREATE INDEX IF NOT EXISTS idx_catalog_sessions_repair_due
 ON catalog_sessions(repair_state, repair_retry_at, last_activity_at DESC, path_key);
 `
 
+// migrationV12 adds the schema-2 head projection. The generation file moved
+// to v8.sqlite, and clearing the directory scans forces a rescan so every
+// existing row learns its log format.
+const migrationV12 = `
+ALTER TABLE catalog_sessions ADD COLUMN log_format INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE catalog_sessions ADD COLUMN head_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE catalog_sessions ADD COLUMN selected_head_id TEXT NOT NULL DEFAULT '';
+CREATE TABLE IF NOT EXISTS catalog_heads (
+    path_key TEXT NOT NULL,
+    head_id TEXT NOT NULL,
+    parent_head_id TEXT NOT NULL DEFAULT '',
+    kind TEXT NOT NULL DEFAULT 'main',
+    name TEXT NOT NULL DEFAULT '',
+    leaf_message_id TEXT NOT NULL DEFAULT '',
+    writer_id TEXT NOT NULL DEFAULT '',
+    last_activity_at INTEGER NOT NULL DEFAULT 0,
+    turns INTEGER NOT NULL DEFAULT 0,
+    preview TEXT NOT NULL DEFAULT '',
+    retired INTEGER NOT NULL DEFAULT 0,
+    selected INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY(path_key, head_id)
+);
+CREATE INDEX IF NOT EXISTS idx_catalog_heads_activity ON catalog_heads(path_key, retired, last_activity_at DESC);
+DELETE FROM catalog_directories;
+`
+
 func sessionMigrations() []projectiondb.Migration {
 	return []projectiondb.Migration{
 		{Version: 1, Apply: func(ctx context.Context, tx *sql.Tx) error {
@@ -256,6 +282,10 @@ func sessionMigrations() []projectiondb.Migration {
 		}},
 		{Version: 11, Apply: func(ctx context.Context, tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, migrationV11)
+			return err
+		}},
+		{Version: 12, Apply: func(ctx context.Context, tx *sql.Tx) error {
+			_, err := tx.ExecContext(ctx, migrationV12)
 			return err
 		}},
 	}

--- a/internal/sessioncatalog/session_page.go
+++ b/internal/sessioncatalog/session_page.go
@@ -21,7 +21,7 @@ const sessionSelectColumns = `path,path_key,directory,scope,workspace_root,topic
     custom_title,created_at,last_activity_at,preview,turns,turns_state,recovered,
     recovery_reason,recovery_digest,parent_id,recovery_copy,recovery_group_id,
     recovery_role,recovery_canonical,logical_topic_id,ordinary_visible,content_fingerprint,
-    meta_fingerprint,health,missing_since`
+    meta_fingerprint,health,missing_since,log_format,head_count,selected_head_id`
 
 func scanSession(scanner interface{ Scan(...any) error }) (SessionRecord, error) {
 	var record SessionRecord
@@ -32,7 +32,7 @@ func scanSession(scanner interface{ Scan(...any) error }) (SessionRecord, error)
 		&record.Recovered, &record.RecoveryReason, &record.RecoveryDigest,
 		&record.ParentID, &recoveryCopy, &record.RecoveryGroupID, &record.RecoveryRole,
 		&recoveryCanonical, &record.LogicalTopicID, &ordinaryVisible, &record.ContentFingerprint, &record.MetaFingerprint,
-		&record.Health, &record.MissingSince)
+		&record.Health, &record.MissingSince, &record.LogFormat, &record.HeadCount, &record.SelectedHeadID)
 	record.RecoveryCopy = recoveryCopy != 0
 	record.RecoveryCanonical = recoveryCanonical != 0
 	record.OrdinaryVisible = ordinaryVisible != 0

--- a/internal/sessioncatalog/types.go
+++ b/internal/sessioncatalog/types.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	SchemaVersion       = 11
+	SchemaVersion       = 12
 	repairEngineVersion = 1
 	DefaultLimit        = 50
 	MaxLimit            = 200
@@ -155,7 +155,13 @@ type SessionRecord struct {
 	LogicalTopicID string `json:"logicalTopicId,omitempty"`
 	// OrdinaryVisible is true only for the single logical representative that
 	// may appear in the ordinary project tree.
-	OrdinaryVisible    bool   `json:"ordinaryVisible,omitempty"`
+	OrdinaryVisible bool `json:"ordinaryVisible,omitempty"`
+	// LogFormat is 2 for sessions whose event log is the append-only DAG; the
+	// head fields mirror its selected head and are zero for schema 1.
+	LogFormat          int    `json:"logFormat,omitempty"`
+	HeadCount          int    `json:"headCount,omitempty"`
+	SelectedHeadID     string `json:"selectedHeadId,omitempty"`
+	heads              []HeadRecord
 	ContentFingerprint string `json:"contentFingerprint,omitempty"`
 	MetaFingerprint    string `json:"metaFingerprint,omitempty"`
 	Health             Health `json:"health"`
@@ -238,7 +244,7 @@ type SessionPage struct {
 }
 
 // DefaultPath is the disposable cache file under CacheDir ("" when unavailable).
-// v7.sqlite isolates the persistent v11 repair scheduler from v6 writers.
+// v8.sqlite isolates the v12 head projection from v11 writers.
 // Session JSONL/WAL/sidecars remain authoritative and older binaries may keep
 // using their own disposable cache without cross-writing this one.
 func DefaultPath() string {
@@ -246,5 +252,5 @@ func DefaultPath() string {
 	if cache == "" {
 		return ""
 	}
-	return filepath.Join(cache, "session-catalog", "v7.sqlite")
+	return filepath.Join(cache, "session-catalog", "v8.sqlite")
 }

--- a/internal/sessioncatalog/upsert.go
+++ b/internal/sessioncatalog/upsert.go
@@ -141,7 +141,8 @@ const sessionInsertSQL = `INSERT INTO catalog_sessions(
     recovery_role,recovery_canonical,logical_topic_id,ordinary_visible,content_fingerprint,
 	meta_fingerprint,health,missing_since,seen_generation
 	,repair_state,repair_attempts,repair_retry_at,repair_error_kind,repair_source_fingerprint,repair_engine_version
-) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+	,log_format,head_count,selected_head_id
+) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 ON CONFLICT(path_key) DO UPDATE SET `
 
 const repairScheduleUpdateSQL = `
@@ -166,7 +167,8 @@ const repairScheduleUpdateSQL = `
           OR catalog_sessions.repair_engine_version<>excluded.repair_engine_version THEN ''
         ELSE catalog_sessions.repair_error_kind END,
     repair_source_fingerprint=excluded.repair_source_fingerprint,
-    repair_engine_version=excluded.repair_engine_version`
+    repair_engine_version=excluded.repair_engine_version,
+    log_format=excluded.log_format, head_count=excluded.head_count, selected_head_id=excluded.selected_head_id`
 
 const directoryProjectionUpdateSQL = `
     path=excluded.path, directory=excluded.directory, directory_key=excluded.directory_key, scope=excluded.scope,
@@ -217,8 +219,10 @@ func (c *Catalog) upsertSessionRow(ctx context.Context, tx *sql.Tx, record Sessi
 	if mode == upsertExactSource {
 		updateSQL = exactSourceUpdateSQL
 	}
-	_, err := tx.ExecContext(ctx, sessionInsertSQL+updateSQL, c.sessionRowValues(record, pathKey, directoryKey, generation)...)
-	return err
+	if _, err := tx.ExecContext(ctx, sessionInsertSQL+updateSQL, c.sessionRowValues(record, pathKey, directoryKey, generation)...); err != nil {
+		return err
+	}
+	return upsertHeadRows(ctx, tx, pathKey, record.heads)
 }
 
 func (c *Catalog) sessionRowValues(record SessionRecord, pathKey, directoryKey string, generation int64) []any {
@@ -237,6 +241,7 @@ func (c *Catalog) sessionRowValues(record SessionRecord, pathKey, directoryKey s
 		record.ContentFingerprint, record.MetaFingerprint,
 		record.Health, 0, generation,
 		repairState, 0, 0, "", repairSourceFingerprint(record), repairEngineVersion,
+		max(record.LogFormat, 1), record.HeadCount, record.SelectedHeadID,
 	}
 }
 


### PR DESCRIPTION
## Summary

Sixth PR of the append-only DAG session log series (#8451 / #8452), after #9908, #9910, #9912, #9913 (merged) and alongside #9916. The session catalog now projects schema-2 heads without ever replaying a log.

- **Catalog schema v12, cache file `v8.sqlite`** (`internal/sessioncatalog/schema.go`, `types.go`): `catalog_sessions` gains `log_format`, `head_count`, `selected_head_id`; a new `catalog_heads` table holds one row per head (kind, name, parent head, leaf message, writer, activity, turns, preview, retired, selected). The migration clears the directory scans so every row learns its log format on the next reconcile; the generation file keeps v11 writers from cross-writing the projection.
- **Projection source** (`heads.go`, `reconcile.go`): `recordFromOrder` takes the selected head, head count, and log schema from the `BranchMeta` mirror the kernel writes on every save, and the per-head rows from the schema-2 head index when it still matches the log. A stale index (a writer died between append and index write) keeps the previous rows, marks the counts unknown, and lets the repair worker refresh the index. The content fingerprint of a schema-2 row binds the selected head and its leaf, so a head switch re-decodes even when file sizes collide.
- **Kernel fix**: the listing repair rewrote the event index with the schema-1 writer, which would have replaced a schema-2 head index with a schema-1 one; `refreshSessionEventIndexContext` now rewrites the index in the schema the log uses. `SessionOrderInfo` carries the head mirror.
- `Catalog.ListHeads(ctx, path)` and `HeadRecord` expose the rows for the versions UI and the topic list in the desktop PRs. Schema-2 rows never enter the recovery-lineage classification (they have no recovery copies), and legacy `-recovery-` families keep every existing rule.

## Verification

- `go test ./internal/sessioncatalog/ ./internal/agent/`; `go test ./...`; `cd desktop && go test ./...`.
- New tests: a two-head schema-2 session reconciles into one ordinary row with `logFormat` 2, both heads (main and concurrent, selected flag, turns), a fingerprint bound to the selected head, and an empty slice for unknown paths; a stale head index keeps the rows and marks counts unknown; the v11 → v12 migration keeps session rows as schema 1, clears directory scans, and creates `catalog_heads`; the listing repair leaves a current schema-2 head index behind and never a schema-1 one. Existing lineage and recovery-copy tests are unchanged apart from the cache file name and the migration ledger length.
- `gofmt`, `go vet`, `make lint` clean.

## Compatibility

| Field or format | Old-data behavior | New-reader behavior | Previous-reader behavior | Conclusion |
| --- | --- | --- | --- | --- |
| `session-catalog/v8.sqlite` | absent → rebuilt from authoritative files | native | keeps using its own `v7.sqlite` | compatible (per-generation file) |
| `catalog_sessions.log_format/head_count/selected_head_id`, `catalog_heads` | defaults (schema 1, no heads) | filled on reconcile | never opened | compatible |
| `.event-index.json` after a listing repair on a schema-2 log | previously downgraded to schema 1 | stays schema 2 | n/a (schema-2 logs are refused as a whole) | fix within the schema-2 boundary |
| `SessionOrderInfo.HeadID/HeadCount/LogSchema` | zero for schema-1 sidecars | mirrored from `BranchMeta` | n/a (in-memory) | compatible |

Cache-impact: none - catalog projection and index sidecars only; no provider-visible bytes change
Cache-guard: existing guard rationale - internal/sessioncatalog never feeds provider requests
Documentation-impact: updated - docs/SESSION_CATALOG.md and docs/SESSION_CATALOG.zh-CN.md now name the v8.sqlite cache generation and the head projection; the recovery and ownership docs are rewritten in the final PR of the series
