### PR TITLE
docs(session): describe the append-only session log, heads, and concurrent writers / 会话文档改写为只追加日志、head 版本与并发写者模型

### DIFF
--- a/docs/CHECKPOINTS.md
+++ b/docs/CHECKPOINTS.md
@@ -103,16 +103,26 @@ type RewindScope int // Code | Conversation | Both
 func (c *Controller) Checkpoints() []CheckpointMeta
 func (c *Controller) PrepareRewind(turn int, scope RewindScope) (RewindPlan, error)
 func (c *Controller) CommitRewind(planID string) (RewindResult, error)
+func (c *Controller) CommitRewindInPlace(planID string) (RewindResult, error)
+func (c *Controller) UndoRewind(transactionID string) (RewindResult, error)
 ```
 
 - **Code**: for every checkpoint from `turn` to the latest, take the earliest
   `FileSnap` per path and restore each file to that content (delete if `nil`) —
   i.e. undo all edits made at or after `turn`. Path-escape re-checked against the
   live workspace root.
-- **Conversation**: fork a new session at the turn boundary. The parent
-  transcript is never truncated. See [`SESSION_OWNERSHIP.md`](SESSION_OWNERSHIP.md).
+- **Conversation**: fork a `rewind` head of the same session log at the turn
+  boundary; a format-1 session forks a new session file instead. The previous
+  chain is never truncated. See [`SESSION_OWNERSHIP.md`](SESSION_OWNERSHIP.md).
 - **Both**: fork first, then restore files. A file conflict keeps the new
-  branch and reports `partial=true`.
+  head and reports `partial=true`.
+- `CommitRewind` leaves the controller where it was and returns the new head
+  (or fork path) in `Branch`; `CommitRewindInPlace` moves the controller onto
+  the rewound conversation. Desktop tabs and the terminal use the in-place
+  form, so the same tab or screen shows the rewound transcript.
+- `UndoRewind` restores the file after-images. When the controller sits on a
+  rewind head that received nothing since, it returns to the parent head and
+  retires the empty rewind head; a continued rewind head stays as a version.
 
 A `Rewound` event (or reuse of a history-replace event) lets every frontend
 re-render uniformly.
@@ -123,8 +133,9 @@ re-render uniformly.
   each user turn (time + which files it changed). `chat_tui` already tracks the
   double-Esc timing.
 - Select a turn → sub-menu: **`[code+conversation] [conversation] [code] [cancel]`**.
-- On a conversation/both restore, the selected prompt is prefilled into the
-  composer.
+- On a conversation/both restore, the terminal replays the rewound head in
+  place and prefills the selected prompt into the composer; the previous chain
+  stays listed under `/branch`.
 
 ## Desktop UX (aligned with the VS Code extension)
 
@@ -133,6 +144,10 @@ re-render uniformly.
 - It calls the same prepare/commit rewind API over the Wails binding; the controller's
   event stream pushes the restored state and React re-renders. No rewind logic in
   the frontend.
+- Conversation rewind and fork-from-here keep the current tab and switch it to
+  the new head; the previous chain remains under *View versions*. Only an
+  isolated-worktree fork opens a new tab, because it copies the session into
+  the new workspace.
 
 ## Non-goals & edge cases
 

--- a/docs/CHECKPOINTS.zh-CN.md
+++ b/docs/CHECKPOINTS.zh-CN.md
@@ -71,12 +71,21 @@ type RewindScope int // Code | Conversation | Both
 func (c *Controller) Checkpoints() []CheckpointMeta
 func (c *Controller) PrepareRewind(turn int, scope RewindScope) (RewindPlan, error)
 func (c *Controller) CommitRewind(planID string) (RewindResult, error)
+func (c *Controller) CommitRewindInPlace(planID string) (RewindResult, error)
+func (c *Controller) UndoRewind(transactionID string) (RewindResult, error)
 ```
 
 - **Code**：遍历从 `turn` 到最新的所有 checkpoint，按路径选取最早的 `FileSnap`，把文件恢复到对应内容；若为 `nil` 则删除。也就是撤销 `turn` 及之后的全部编辑。恢复前会再次按当前工作区根目录检查路径逃逸。
-- **Conversation**：在该回合边界创建新会话分支。父会话 transcript 永不截断。详见 [会话所有权](./SESSION_OWNERSHIP.zh-CN.md)。
-- **Both**：先创建新会话分支，再恢复代码；如果文件校验冲突，保留分支并返回
+- **Conversation**：在该回合边界于同一会话日志内分叉出 `rewind` head；格式 1
+  会话则仍创建新的会话文件。原有链永不截断。详见 [会话所有权](./SESSION_OWNERSHIP.zh-CN.md)。
+- **Both**：先分叉，再恢复代码；如果文件校验冲突，保留新 head 并返回
   `partial=true`。
+- `CommitRewind` 让 Controller 留在原处，并在 `Branch` 中返回新 head（或分叉
+  文件路径）；`CommitRewindInPlace` 则把 Controller 移到回溯后的对话上。桌面
+  标签页和终端都使用就地形式，同一个标签页或屏幕直接显示回溯后的 transcript。
+- `UndoRewind` 恢复文件 after-image。若 Controller 正位于一个此后没有新增内容
+  的回溯 head 上，则回到父 head 并退役这个空 head；已继续对话的回溯 head 作为
+  版本保留。
 
 统一的 `Rewound` 事件（或复用 history-replace 事件）让所有前端以相同方式重绘。
 
@@ -84,12 +93,16 @@ func (c *Controller) CommitRewind(planID string) (RewindResult, error)
 
 - 输入框为空时按两次 **`Esc`**，或执行 **`/rewind`**，打开用户回合列表，显示时间和每个回合改动的文件。`chat_tui` 已跟踪双 Esc 的时间窗口。
 - 选择一个回合后显示子菜单：**`[code+conversation] [conversation] [code] [cancel]`**。
-- 恢复 conversation 或 both 时，把所选提示回填到输入框。
+- 恢复 conversation 或 both 时，终端就地重放回溯后的 head，并把所选提示回填到
+  输入框；原有链仍列在 `/branch` 中。
 
 ## 桌面端体验（与 VS Code 扩展对齐）
 
 - Transcript 中每条用户消息悬停时显示 **rewind** 控件，并提供：恢复代码、恢复会话、同时恢复、从此处分叉。
 - 前端通过 Wails binding 调用同一个 prepare / commit rewind API；Controller 事件流推送恢复结果，React 负责重绘。前端不包含独立 rewind 逻辑。
+- 对话回溯和“从此处分叉”保留当前标签页并把它切到新 head，原有链留在“查看
+  版本”中。只有隔离 worktree 分叉才会打开新标签页，因为它要把会话复制到新的
+  工作区。
 
 ## 非目标与边界情况
 

--- a/docs/HISTORY_SEARCH_CATALOG.md
+++ b/docs/HISTORY_SEARCH_CATALOG.md
@@ -18,7 +18,11 @@ the authoritative commit and after file locks have been released. Continuous
 appends read only the new display-index range. Rewrites, missed notifications,
 external writers, or fingerprint mismatches rebuild that source in the
 background. Only one full transcript decoder runs at once, checkpoints are
-persisted per source, and one corrupt source cannot stop other histories.
+persisted per source, and one corrupt source cannot stop other histories. A
+format-2 session log is indexed through the derived transcript of its selected
+head; switching heads rewrites that transcript, which the projection treats
+like any other rewrite and rebuilds in the background. Other heads are not
+searchable until they are made current.
 
 The Agent `history` tool and Desktop history manager share the projection.
 Search never starts a synchronous directory scan. While indexing is incomplete,

--- a/docs/HISTORY_SEARCH_CATALOG.zh-CN.md
+++ b/docs/HISTORY_SEARCH_CATALOG.zh-CN.md
@@ -12,7 +12,9 @@ Catalog 的 FTS5 只保存规范化检索 token，不保存完整消息正文。
 权威会话提交成功且文件锁释放后，保存路径只发送非阻塞、按 path 合并的索引提示。
 连续 append 只读取 display index 的新增范围；rewrite、通知丢失、外部进程写入或指纹
 不一致会在后台重建单个 source。完整 transcript decoder 始终单并发，checkpoint 按
-source 持久化，单个坏会话不会阻断其他历史。
+source 持久化，单个坏会话不会阻断其他历史。格式 2 的会话日志通过其选中 head 的
+派生 transcript 建立索引；切换 head 会改写该 transcript，投影把它当作普通 rewrite
+在后台重建。其他 head 在被设为当前之前不可搜索。
 
 Agent 的 `history` 工具与 Desktop 历史管理器共享该投影。搜索不会同步扫描目录；首次
 索引未完成时立即返回已有结果和明确进度。open、running、current 等运行态只从内存

--- a/docs/RECOVERY_VALIDATION.md
+++ b/docs/RECOVERY_VALIDATION.md
@@ -4,6 +4,14 @@ Implementation date / 实施日期: 2026-09-05.
 
 ## Reference scope / 参考范围
 
+This document covers provider-protocol recovery: retries and stream
+resumption. Transcript persistence, session versions, and concurrent writers
+are described in [`SESSION_RECOVERY_AND_PARALLELISM.md`](SESSION_RECOVERY_AND_PARALLELISM.md)
+and [`SESSION_OWNERSHIP.md`](SESSION_OWNERSHIP.md).
+
+本文只覆盖 provider 协议层的恢复（重试与断流续传）。会话持久化、会话版本与
+并发写者见上述两份文档。
+
 Pi is pinned to `9841914c71a74d81abe07f751aefd271fd924e63`. The executable
 comparison uses its `packages/ai/src/utils/retry.ts` `retryAssistantCall`
 helper, with an injected zero delay. It is not an end-to-end comparison of the

--- a/docs/SESSION_OWNERSHIP.md
+++ b/docs/SESSION_OWNERSHIP.md
@@ -5,27 +5,54 @@ how rewind and workspace isolation interact.
 
 ## Session writers
 
-One session file has one cross-process writer at a time. The ticket and holder
-metadata share one session lease file (`.lease.lock`). Production controllers
-bind a generation-bound `SessionWriter`; a rebind invalidates every older
-generation. Legacy `.lease.json` metadata remains read-only compatible.
+A conversation lives in an append-only event log, `<id>.events.jsonl`
+(session format 2). Every message entry carries its own id and the id of its
+parent, so the log is a DAG: each path from a leaf back to the root is one
+version of the conversation, called a *head*. A log starts with one head,
+`main`; forks, rewinds, and concurrent writers add heads of kind `fork`,
+`rewind`, and `concurrent`. The transcript file `<id>.jsonl` is a derived cache
+of the selected head and is never the source of truth.
 
-Intentional path changes (`new`, `clear`, `fork`, `branch`, and `switch`) use a
-prepare-before-publish handoff: the frontend acquires the target lease and binds
-the unpublished Session before the controller swaps paths. Failure leaves the
-source intact for non-destructive transitions; `clear` never publishes an
-unleased replacement.
+The selected head is the last `select` marker that still points at a live
+head, otherwise the head with the newest activity. Opening a session by path
+opens that head. `.event-index.json` mirrors the heads so the session catalog
+can list them without replaying the log.
 
-Every save also takes the bounded `.jsonl.lock` compatibility flock. The
-session lease decides who may own a live transcript; the save lock keeps that
-owner serialized with supported older binaries and one-shot recovery/import
-writers that do not yet participate in the lease protocol.
+Writers append; they never rewrite or truncate the log. A save takes the
+bounded `.jsonl.lock` flock, reads whatever another writer appended since its
+own last save, and continues on its own head. The session lease
+(`.lease.lock`, with a generation-bound `SessionWriter`) no longer gates
+appending: it decides who writes the derived `.jsonl`, the indexes, and the
+turn ledger, so a second window can join the same conversation without
+waiting. A turn opens with a `turn_begin` marker and closes with `turn_end`;
+a crash between them is noticed on the next open and the incomplete tail is
+set aside with a `rewind` marker, never truncated.
 
-The event log (`.events.jsonl`) is the source of truth. Writer-bound saves CAS
-against the log tail (size + index revision/digest) and a paired in-memory
-transcript view. `.jsonl` remains a compatibility projection.
+Path changes (`new`, `clear`) still use the prepare-before-publish handoff:
+the frontend acquires the target lease and binds the unpublished Session
+before the controller swaps paths. `fork`, `branch`, `switch`, and
+conversation rewind stay on the same path and move between heads instead.
+
+Sessions saved before Reasonix 1.39.0 use format 1: a whole-file transcript
+plus a position-based event log. A 1.39.0 or newer binary upgrades such a
+session in place on its first save, once it can prove it is the only writer;
+until then the session keeps the format-1 rules below. A binary older than
+1.39.0 refuses to open a format-2 log and leaves the file untouched;
+`reasonix doctor session <id> --export-v1 PATH.jsonl` writes the current head
+back out as a format-1 session when a rollback needs it.
 
 ## Conflicts
+
+Two processes appending to one format-2 log cannot conflict; they interleave.
+When a save finds that another writer extended the chain this session was on
+and this session added nothing, it follows the disk. When both added content,
+the save forks a `concurrent` head from the last shared message and continues
+there; both sides receive a notice (`session_concurrent_writer`). Reloading
+the log afterwards opens the newest head and lists the other one under *View
+versions* (`session_head_switched`). Nothing is copied into a `-recovery-`
+file, and a save never removes a head.
+
+Format-1 sessions keep the previous rules until they are upgraded:
 
 1. Event-log tail still matches this writer → normal save (no-op / append / replace).
 2. Disk already covers the local prefix → adopt disk, no branch.
@@ -34,14 +61,32 @@ transcript view. `.jsonl` remains a compatibility projection.
    Lease rebinds keep that lane; later conflicts update the same path. There is
    no recovery-on-recovery chain.
 
+## Heads as versions
+
+Fork-from-here, `/branch`, and a conversation rewind append a `fork` marker
+and a `select` marker: the new head starts at the chosen message and becomes
+current, and the previous chain stays as another version of the same
+conversation. The desktop switches the current tab to the new head in place;
+the terminal replays the transcript. *View versions* lists the live heads with
+their kind, makes another head current (`select`), renames a head, and
+removes *covered* heads: heads whose whole chain is already part of the
+current one. Removing appends a `retire` marker; a retired head leaves the
+version list, and its bytes are reclaimed only when a single writer rotates
+the log. Heads with unique content are never removed automatically, and a head
+that was active within the last minute is reported busy instead of retired.
+
 ## Rewind
 
 - **Code**: restore file before-images. Already-restored files (current ==
   before) are skipped. External changes refuse overwrite.
-- **Conversation**: fork a new session. The parent transcript is never
-  truncated.
-- **Both**: fork first, then restore files. A file conflict keeps the new
-  branch and reports `partial=true`.
+- **Conversation**: fork a `rewind` head at the turn boundary and make it
+  current. The previous chain is never truncated. A format-1 session forks a
+  new session file instead.
+- **Both**: fork first, then restore files. A file conflict keeps the new head
+  and reports `partial=true`.
+- **Undo**: restores the file after-images. If nothing was added on the rewind
+  head since, the controller returns to the parent head and retires the empty
+  rewind head; a continued rewind head stays as a version.
 
 New checkpoints write `turns/<turn>/meta.json` plus raw `files/NNNN.before`
 payloads (schema v3). The newest 100 turn directories are retained by default;

--- a/docs/SESSION_OWNERSHIP.zh-CN.md
+++ b/docs/SESSION_OWNERSHIP.zh-CN.md
@@ -6,25 +6,44 @@ Reasonix 如何决定谁可以写会话、冲突如何落盘，以及回溯和�
 
 ## 会话写者
 
-同一会话文件同一时刻只有一个跨进程写者。票据和持有者信息共用一个 session
-lease 文件（`.lease.lock`）。生产路径上的 Controller 绑定带 generation 的
-`SessionWriter`；重新绑定会使旧 generation 立即失效。旧 `.lease.json` 仅作为
-只读兼容来源。
+一个会话保存在只追加的事件日志 `<id>.events.jsonl` 中（会话格式 2）。每条
+消息条目都带有自己的 id 和父消息 id，因此日志是一张 DAG：从任一叶子回溯到
+根的路径就是该会话的一个版本，称为 *head*。日志初始只有一个 head `main`；
+分叉、回溯和并发写入会新增 kind 为 `fork`、`rewind`、`concurrent` 的 head。
+`<id>.jsonl` 只是选中 head 的派生缓存，永远不是权威来源。
 
-主动路径切换（`new`、`clear`、`fork`、`branch`、`switch`）采用“先准备、后发布”
-的交接：前端先取得目标 lease，并给尚未发布的 Session 绑定写权限，然后 Controller
-才替换路径。非破坏性切换失败时会保留源 Controller 及其 lease；`clear` 也不会
-发布一个没有 lease 的替代 Session。
+选中 head 由最后一条仍指向存活 head 的 `select` 标记决定，否则取活动时间最新
+的 head。按路径打开会话即打开该 head。`.event-index.json` 镜像全部 head，
+会话目录据此列出版本，无需重放日志。
 
-所有保存仍会获取有界等待的 `.jsonl.lock` 兼容锁。session lease 决定谁可以
-长期拥有 transcript；save lock 则让该 owner 与仍受支持的旧版本，以及尚未
-接入 lease 协议的一次性 recovery/import 写者保持互斥。
+写者只追加，从不改写或截断日志。每次保存获取有界等待的 `.jsonl.lock` flock，
+读入其他写者自上次保存以来追加的内容，然后继续写自己的 head。session lease
+（`.lease.lock`，绑定带 generation 的 `SessionWriter`）不再限制追加：它只决定
+谁写派生的 `.jsonl`、索引和回合账本，因此第二个窗口无需等待即可加入同一会话。
+回合以 `turn_begin` 标记开始、以 `turn_end` 结束；两者之间崩溃会在下次打开时
+被识别，未完成的尾部用 `rewind` 标记搁置，绝不截断字节。
 
-事件日志（`.events.jsonl`）是权威来源。绑定写者的保存对日志尾部（size +
-index 的 revision/digest）做 CAS，并用配对的内存 transcript 视图判断
-no-op / append / replace。`.jsonl` 仍是兼容投影。
+路径切换（`new`、`clear`）仍采用“先准备、后发布”的交接：前端先取得目标
+lease 并给尚未发布的 Session 绑定写权限，Controller 才替换路径。`fork`、
+`branch`、`switch` 和对话回溯则停留在同一路径上，只在 head 之间移动。
+
+Reasonix 1.39.0 之前保存的会话使用格式 1：整文件 transcript 加基于位置的事件
+日志。1.39.0 及更新版本在首次保存时、且能证明自己是唯一写者的前提下，就地把
+它升级为格式 2；在此之前该会话沿用下文的格式 1 规则。早于 1.39.0 的版本会拒绝
+打开格式 2 日志，且一字节不改；需要回滚时，
+`reasonix doctor session <id> --export-v1 PATH.jsonl` 会把当前 head 导出为
+格式 1 会话。
 
 ## 冲突
+
+两个进程向同一格式 2 日志追加不会冲突，只会交错。若保存时发现另一写者延长了
+本会话所在的链而本地没有新增，就直接跟随磁盘；若双方都有新增，保存会从最后
+一条共同消息分叉出 `concurrent` head 继续写入，双方各收到一次提示
+（`session_concurrent_writer`）。之后重新加载会打开最新的 head，并在“查看
+版本”里列出另一个（`session_head_switched`）。不会再复制出 `-recovery-`
+文件，保存也绝不删除任何 head。
+
+格式 1 会话在升级前沿用原规则：
 
 1. 事件日志尾部仍匹配当前写者 → 正常保存。
 2. 磁盘已经覆盖本地前缀 → 采用磁盘版本，不建分支。
@@ -32,11 +51,25 @@ no-op / append / replace。`.jsonl` 仍是兼容投影。
    Session 首次 writer generation 决定的稳定 recovery 文件。lease 重绑不会
    改变该 lane；后续冲突更新同一路径，不再嵌套。
 
+## head 即版本
+
+从消息分叉、`/branch` 和对话回溯都会追加一条 `fork` 标记和一条 `select`
+标记：新 head 从所选消息开始并成为当前版本，原有链作为同一会话的另一个版本
+保留。桌面端就地把当前标签页切到新 head；终端重放 transcript。“查看版本”
+列出存活 head 及其类型，可以把另一个 head 设为当前（`select`）、给 head
+改名，以及清理*已覆盖*的 head——即整条链已经包含在当前链中的 head。清理只
+追加一条 `retire` 标记：退役 head 从版本列表消失，其字节只在单写者轮转日志
+时回收。含独有内容的 head 永远不会被自动清理；最近一分钟内仍有活动的 head
+会被报告为“正在使用”而不是退役。
+
 ## 回溯
 
 - **代码**：恢复 before-image。当前已等于 before 的文件跳过；外部修改拒绝覆盖。
-- **对话**：创建新会话分支。父会话 transcript 永不截断。
-- **两者**：先分叉，再恢复文件。文件冲突时保留新分支并返回 `partial=true`。
+- **对话**：在回合边界分叉出 `rewind` head 并设为当前。原有链永不截断。格式 1
+  会话则仍创建新的会话文件。
+- **两者**：先分叉，再恢复文件。文件冲突时保留新 head 并返回 `partial=true`。
+- **撤销**：恢复文件 after-image。若回溯 head 之后没有新增内容，Controller
+  回到父 head 并退役这个空的回溯 head；已经继续对话的回溯 head 作为版本保留。
 
 新 checkpoint 写入 `turns/<turn>/meta.json` 和原始字节
 `files/NNNN.before`（schema v3）。默认保留最近 100 个回合目录；新 checkpoint

--- a/docs/SESSION_RECOVERY_AND_PARALLELISM.md
+++ b/docs/SESSION_RECOVERY_AND_PARALLELISM.md
@@ -8,7 +8,23 @@ needs an independent workspace.
 
 ## Session versions
 
-Each physical JSONL transcript has a version identity in its branch metadata:
+A format-2 session log holds every version of one conversation as a head of
+its append-only DAG (see [`SESSION_OWNERSHIP.md`](SESSION_OWNERSHIP.md)).
+Heads have kinds:
+
+- `main` is the line the log started with.
+- `fork` and `rewind` come from user actions: fork-from-here, `/branch`, and
+  conversation rewind.
+- `concurrent` is created by a save that found another writer on the same
+  chain.
+
+One head is *selected*; opening the session opens it. Heads are listed,
+switched, renamed, and retired inside the log. Nothing creates a second
+session file, and a head that was retired keeps its bytes until a single writer
+rotates the log.
+
+Format-1 transcripts (saved before Reasonix 1.39.0 and not yet upgraded) keep
+their version identity in branch metadata:
 
 - `normal` is an ordinary conversation transcript.
 - `recovery` preserves local content after a transcript save conflict, file-lock
@@ -16,26 +32,63 @@ Each physical JSONL transcript has a version identity in its branch metadata:
 - `subagent` is reserved for a session-backed child run.
 
 Older sidecars remain readable. A sidecar with `Recovered=true` is interpreted as
-a recovery version when the explicit version field is absent.
-
-Recovery metadata records the parent conversation/version and the base and disk
-revisions observed at the conflict. Recovery copies stay in the same logical
-conversation lineage and are not treated as ordinary conversations or
-subagents.
+a recovery version when the explicit version field is absent. Recovery metadata
+records the parent conversation/version and the base and disk revisions
+observed at the conflict; recovery copies stay in the same logical conversation
+lineage and are not treated as ordinary conversations or subagents.
 
 ## Recovery lifecycle
 
-An append-compatible snapshot is adopted from disk without creating another
-version. A divergent snapshot is preserved as a recovery version using the
-existing CAS and digest checks. A failed lease handoff marks that recovery
-version as `pending`; the desktop client can retry activation after the writer
-is released.
+A format-2 save never conflicts. Another writer's appends are followed when
+this session added nothing; when both added content the save forks a
+`concurrent` head, and both sides receive a notice. The versions dialog shows
+both heads and the user picks. There is no `pending` state and no lease
+handoff to retry: the lease decides only who writes the derived transcript,
+the indexes, and the turn ledger.
 
-Recovery lineage reconciliation is idempotent. Covered copies may be moved to
-recoverable session trash, while divergent content remains available for an
-explicit version choice.
+For a format-1 session an append-compatible snapshot is adopted from disk
+without creating another version. A divergent snapshot is preserved as a
+recovery version using the existing CAS and digest checks. A failed lease
+handoff marks that recovery version as `pending`; the desktop client can retry
+activation after the writer is released. Recovery lineage reconciliation is
+idempotent. Covered copies may be moved to recoverable session trash, while
+divergent content remains available for an explicit version choice.
 
-The desktop bridge exposes `GetSessionVersionState`,
-`SetActiveSessionVersion`, `RetrySessionRecovery`, and
-`ReconcileRecoveryVersions`. Worktree status and merge preparation use the
-same backend inspection and identity checks as the existing merge flow.
+The desktop bridge exposes `GetRecoveryLineage` and `GetSessionVersionState`,
+which list a format-2 log's heads (state `heads`; every member shares the log's
+path and carries `headId`, `headKind`, `headName`, and `selected`);
+`ChooseRecoveryBranch` and `SetActiveSessionVersion`, which take `headId` and
+make a head current (an open tab switches in place, a closed session gets a
+`select` marker); `CleanRecoveryLineage`, which retires covered heads and
+reports heads active within the last minute as busy; `RenameSessionHead`;
+and the format-1 `RetrySessionRecovery` and `ReconcileRecoveryVersions`. A
+family whose format-1 root was upgraded after recovery copies had been made
+shows the log's heads and the copies together. Worktree status and merge
+preparation use the same backend inspection and identity checks as the
+existing merge flow.
+
+## Legacy recovery copies
+
+`-recovery-` files made before the upgrade are not imported into the log. They
+remain format-1 sessions of the same lineage: listed under *View versions*,
+selectable, and covered copies are still moved to recoverable trash by the
+existing sweep and by `reasonix sessions cleanup`. A format-2 log never forms
+a recovery group, so cleanup reports zero candidates for it, and
+`reasonix sessions diagnose` counts session logs, heads, covered heads, and
+retired heads next to the recovery-copy numbers.
+
+## Compatibility
+
+| Field or format | Old-data behavior | New-reader behavior | Previous-reader behavior | Conclusion |
+| --- | --- | --- | --- | --- |
+| `.events.jsonl` format 1 | unchanged | replayed; message ids derived deterministically | unchanged | compatible |
+| `.events.jsonl` format 2 | n/a | native | refused; file left untouched | explicit boundary (>= 1.39.0) |
+| `.jsonl` transcript | unchanged format | derived from the selected head | readable, not authoritative | compatible |
+| `.jsonl.meta` head fields | absent → treated as format 1 | used | ignored | compatible |
+| `.event-index.json` schema 2 | schema-1 index rejected → replay | native | rejected → slow path | compatible |
+| `-recovery-<hex>.jsonl` | format-1 lineage | not imported; listed as before | unchanged | compatible |
+| session catalog `v8.sqlite` | v7 file isolated | native | separate generation files | compatible |
+
+Format 2 opens in Reasonix 1.39.0 and newer. Mixed installations should
+upgrade the older side before sharing a session directory; the older binary
+reports the newer format and does not modify the file.

--- a/docs/SESSION_RECOVERY_AND_PARALLELISM.zh-CN.md
+++ b/docs/SESSION_RECOVERY_AND_PARALLELISM.zh-CN.md
@@ -7,28 +7,72 @@ worktree 隔离。
 
 ## 会话版本
 
-每个物理 JSONL 会话文件都在 branch metadata 中带有版本身份：
+格式 2 的会话日志把同一会话的所有版本保存为其只追加 DAG 的 head
+（见 [会话所有权](./SESSION_OWNERSHIP.zh-CN.md)）。head 分为几类：
+
+- `main`：日志起始的那条线；
+- `fork`、`rewind`：来自用户操作——从消息分叉、`/branch` 和对话回溯；
+- `concurrent`：保存时发现另一写者位于同一条链上而分出的 head。
+
+其中一个 head 是*选中*的，打开会话即打开它。head 在日志内部列出、切换、
+改名和退役，不会产生第二个会话文件；退役 head 的字节保留到单写者轮转日志
+时才回收。
+
+格式 1 的会话（1.39.0 之前保存且尚未升级）仍在 branch metadata 中带有
+版本身份：
 
 - `normal`：普通会话记录；
 - `recovery`：保存冲突、文件锁超时或外部删除后保留的恢复记录；
 - `subagent`：仅用于持久化的子代理会话。
 
 旧 sidecar 仍然可读。缺少显式版本字段但带有 `Recovered=true` 的记录会被
-解释为 recovery 版本。
-
-恢复元数据记录父会话、父版本以及冲突时观察到的 base/disk revision。恢复
-副本留在同一条逻辑会话谱系中，不会被当作普通会话或子代理。
+解释为 recovery 版本。恢复元数据记录父会话、父版本以及冲突时观察到的
+base/disk revision；恢复副本留在同一条逻辑会话谱系中，不会被当作普通会话
+或子代理。
 
 ## 恢复生命周期
 
-如果磁盘内容只是可采用的已保存前缀，系统直接采用磁盘版本，不创建新版本。
-如果两边有独立新增内容，系统通过现有 CAS 和 digest 校验保留 recovery
-版本。租约移交失败时，恢复版本会标记为 `pending`；占用者释放后，桌面端
-可以重试激活。
+格式 2 的保存不会冲突。本地没有新增时直接跟随另一写者的追加；双方都有新增
+时，保存分叉出 `concurrent` head，双方各收到一次提示。版本对话框同时列出两个
+head，由用户选择。不再有 `pending` 状态，也没有需要重试的租约移交：lease 只
+决定谁写派生 transcript、索引和回合账本。
 
-恢复谱系收敛操作是幂等的。已被完整覆盖的副本可以移动到可恢复的会话回收站，
-存在独立内容的分歧版本继续保留，等待用户明确选择。
+格式 1 会话中，如果磁盘内容只是可采用的已保存前缀，系统直接采用磁盘版本，
+不创建新版本；如果两边有独立新增内容，系统通过现有 CAS 和 digest 校验保留
+recovery 版本。租约移交失败时，恢复版本会标记为 `pending`，占用者释放后桌面端
+可以重试激活。恢复谱系收敛操作是幂等的：已被完整覆盖的副本可以移动到可恢复的
+会话回收站，存在独立内容的分歧版本继续保留，等待用户明确选择。
 
-桌面桥接层提供 `GetSessionVersionState`、`SetActiveSessionVersion`、
-`RetrySessionRecovery` 和 `ReconcileRecoveryVersions`。worktree 状态查询和
-合并准备复用现有后端检查及身份校验。
+桌面桥接层提供：`GetRecoveryLineage` 与 `GetSessionVersionState`，列出格式 2
+日志的 head（状态为 `heads`；所有成员共享日志路径，并带有 `headId`、
+`headKind`、`headName`、`selected`）；`ChooseRecoveryBranch` 与
+`SetActiveSessionVersion` 接受 `headId`，把某个 head 设为当前（已打开的标签页
+就地切换，未打开的会话写入 `select` 标记）；`CleanRecoveryLineage` 退役已覆盖
+的 head，并把最近一分钟内仍有活动的 head 报告为“正在使用”；
+`RenameSessionHead` 给 head 命名；以及面向格式 1 的 `RetrySessionRecovery`
+和 `ReconcileRecoveryVersions`。若某个格式 1 根会话在已有恢复副本之后才被
+升级，日志的 head 与这些副本会一起列出。worktree 状态查询和合并准备复用现有
+后端检查及身份校验。
+
+## 遗留恢复副本
+
+升级前产生的 `-recovery-` 文件不会导入日志。它们仍是同一谱系中的格式 1
+会话：在“查看版本”中列出、可以选择，已覆盖的副本继续由现有清扫和
+`reasonix sessions cleanup` 移入可恢复回收站。格式 2 日志不会形成恢复分组，
+因此 cleanup 对它的候选数恒为零；`reasonix sessions diagnose` 会在恢复副本
+数字旁边给出会话日志数、head 数、已覆盖 head 数和已退役 head 数。
+
+## 兼容性
+
+| 字段或格式 | 旧数据行为 | 新读者行为 | 旧读者行为 | 结论 |
+| --- | --- | --- | --- | --- |
+| `.events.jsonl` 格式 1 | 不变 | 重放；消息 id 确定性派生 | 不变 | 兼容 |
+| `.events.jsonl` 格式 2 | 无 | 原生 | 拒绝打开，文件不改 | 明确边界（≥ 1.39.0） |
+| `.jsonl` transcript | 格式不变 | 由选中 head 派生 | 可读但不权威 | 兼容 |
+| `.jsonl.meta` head 字段 | 缺省 → 视为格式 1 | 使用 | 忽略 | 兼容 |
+| `.event-index.json` schema 2 | 拒绝 schema 1 索引 → 重放 | 原生 | 拒绝 → 慢路径 | 兼容 |
+| `-recovery-<hex>.jsonl` | 格式 1 谱系 | 不导入，照常列出 | 不变 | 兼容 |
+| 会话目录 `v8.sqlite` | v7 文件隔离 | 原生 | 各用各的代际文件 | 兼容 |
+
+格式 2 需要 Reasonix 1.39.0 及更新版本打开。混用新旧版本时应先升级旧的一方
+再共享会话目录；旧版本会报告遇到了更新的格式，且不会修改文件。


### PR DESCRIPTION
## Summary

Final PR of the append-only DAG session log series (#8451 / #8452), after #9908, #9910, #9912, #9913, #9916, #9917, #9919 and alongside #9921, #9922, #9924. Documentation only: the session docs now describe the format-2 log, heads as versions, concurrent writers, in-place fork/rewind, cleanup, and the compatibility boundary, in English and Simplified Chinese.

- `docs/SESSION_OWNERSHIP.md` (+ zh-CN): *Session writers* explains the append-only log, heads, the selected head, the derived `.jsonl`, the lease's reduced role, turn markers, and the format-1 -> format-2 upgrade with the `doctor session --export-v1` rollback; *Conflicts* describes concurrent writers on a format-2 log and keeps the format-1 rules for sessions not yet upgraded; new *Heads as versions* covers fork/`/branch`/rewind heads, *View versions*, select, rename, and covered-head cleanup; *Rewind* now names the `rewind` head and the undo rule.
- `docs/SESSION_RECOVERY_AND_PARALLELISM.md` (+ zh-CN): *Session versions* and *Recovery lifecycle* rewritten around heads with the format-1 behavior retained; new *Legacy recovery copies* and *Compatibility* sections, including the support window (format 2 opens in >= 1.39.0; older binaries refuse and do not modify the file).
- `docs/CHECKPOINTS.md` (+ zh-CN): controller API lists `CommitRewindInPlace` and `UndoRewind`; conversation rewind forks a `rewind` head; CLI and desktop UX bullets describe the in-place switch.
- `docs/HISTORY_SEARCH_CATALOG.md` (+ zh-CN): a format-2 log is indexed through the selected head's derived transcript; a head switch counts as a rewrite.
- `docs/RECOVERY_VALIDATION.md`: scope sentence pointing transcript recovery readers to the two session docs.

Left out on purpose: `release-notes/releases.json` (the v1.39.0 entry belongs to the release PR that cuts the version), `docs/SESSION_REFERENCE_ARCHITECTURE.md` (its API excerpt is about the `@` session reference and does not change), and the doctor session bundle (still a schema-1 manifest; a follow-up adds heads to it).

## Verification

- `scripts/verify-embedded-docs.sh`; `scripts/check-docs-impact.sh` with this body.
- Every behavioral statement was checked against the merged or open code: head selection and listing (`internal/agent/session_head.go`), concurrent forks (`internal/agent/save_dag_plan.go`), in-place fork/rewind and undo (`internal/control/branch_ops.go`, `rewind_head.go`, `desktop/session_heads.go`), covered-head cleanup and the busy window (`desktop/session_heads.go`), CLI rewind (`internal/cli/rewind.go`), `sessions diagnose` counts (`internal/cli/sessions_catalog.go`), and the export flag (`internal/cli/doctor.go`).

## Compatibility

Documentation only; no persisted format, wire payload, or provider-visible byte changes.

Documentation-impact: updated - SESSION_OWNERSHIP, SESSION_RECOVERY_AND_PARALLELISM, CHECKPOINTS, HISTORY_SEARCH_CATALOG (en + zh-CN) and RECOVERY_VALIDATION describe the format-2 session log, heads as versions, concurrent writers, in-place fork/rewind, cleanup, and the >= 1.39.0 boundary
