### PR TITLE
fix(desktop): eviction cooldown for the freshly deactivated transcript tab / 刚切走的会话标签增加驱逐冷却

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-store-eviction.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-store-eviction.test.ts
@@ -1,0 +1,30 @@
+// Run: npx tsx src/__tests__/transcript-store-eviction.test.ts
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const store = readFileSync(join(root, "lib/transcriptStore.ts"), "utf8");
+
+// Eviction cooldown: a tab that just stopped being active keeps its sessions
+// resident for a grace window instead of being the first FIFO victim.
+assert.match(store, /DEFAULT_EVICT_COOLDOWN_MS = 5 \* 60_000/, "cooldown default is 5 minutes");
+assert.match(store, /evictCooldownMs\?: number/, "cooldown is configurable via store options");
+assert.match(store, /this\.evictCooldownMs = Math\.max\(0, options\.evictCooldownMs \?\? DEFAULT_EVICT_COOLDOWN_MS\)/, "constructor applies the configured cooldown");
+assert.match(store, /this\.lastActiveAt\.set\(previousTabId, Date\.now\(\)\)/, "noteActiveTab stamps the cooldown when it releases the previous active pin");
+assert.match(
+  store,
+  /now - \(this\.lastActiveAt\.get\(s\.tabId\) \?\? 0\) >= this\.evictCooldownMs/,
+  "enforceBudgets only evicts sessions whose cooldown has elapsed",
+);
+// The live-append path refreshes the LRU position: a streaming tab whose tab
+// was just deactivated must not be the first FIFO eviction victim.
+assert.match(
+  store,
+  /appendEntries\(tabId: string, sessionPath: string, entries: HistoryEntry\[\]\): Item\[\] \{[\s\S]*?this\.touch\(session\);[\s\S]*?this\.enforceBudgets\(\);/,
+  "appendEntries touches the session before budget enforcement",
+);
+assert.match(store, /this\.lastActiveAt\.delete\(tabId\)/, "evictTab clears the cooldown stamp");
+
+console.log("  PASS  transcript store eviction cooldown contract");

--- a/desktop/frontend/src/lib/transcriptStore.ts
+++ b/desktop/frontend/src/lib/transcriptStore.ts
@@ -57,6 +57,9 @@ export interface TranscriptBackend {
   HistoryContentForTab(tabID: string, ref: HistoryContentRef, chunkIndex: number): Promise<HistoryContentChunk>;
 }
 
+/** Grace window after a tab stops being active before its sessions become eviction candidates. */
+const DEFAULT_EVICT_COOLDOWN_MS = 5 * 60_000;
+
 export interface TranscriptStoreOptions {
   /** Resident sessions with records (unpinned). Default 3. */
   maxResidentSessions?: number;
@@ -64,6 +67,13 @@ export interface TranscriptStoreOptions {
   historyBodyBudgetBytes?: number;
   /** Parsed-markdown cache budget. Default 16MiB. */
   markdownBudgetBytes?: number;
+  /**
+   * Grace window (ms) after a tab stops being the active tab before its
+   * sessions may be evicted. Guards the "switch to a busy tab, switch back,
+   * scroll up" flow: without it the freshly left session is the first FIFO
+   * victim and its scroll anchor is lost mid-browse. Default 5 minutes.
+   */
+  evictCooldownMs?: number;
 }
 
 export interface TranscriptProjection {
@@ -413,12 +423,15 @@ export class TranscriptStore {
   private readonly listeners = new Map<string, Set<(change: TranscriptContentChange) => void>>();
   private readonly markdown: TranscriptMarkdownCache;
   private historyEvictions = 0;
+  private readonly evictCooldownMs: number;
+  private readonly lastActiveAt = new Map<string, number>();
 
   constructor(backend: TranscriptBackend, options: TranscriptStoreOptions = {}) {
     this.backend = backend;
     this.maxResidentSessions = Math.max(1, options.maxResidentSessions ?? DEFAULT_MAX_RESIDENT_SESSIONS);
     this.historyBodyBudgetBytes = Math.max(0, options.historyBodyBudgetBytes ?? DEFAULT_HISTORY_BODY_BUDGET);
     this.markdown = new TranscriptMarkdownCache(Math.max(0, options.markdownBudgetBytes ?? DEFAULT_MARKDOWN_BUDGET));
+    this.evictCooldownMs = Math.max(0, options.evictCooldownMs ?? DEFAULT_EVICT_COOLDOWN_MS);
   }
 
   // ── session identity / LRU ────────────────────────────────────────────────
@@ -480,7 +493,13 @@ export class TranscriptStore {
   noteActiveTab(tabId: string | undefined, previousTabId?: string): void {
     if (previousTabId && previousTabId !== tabId) {
       const pins = this.tabPins.get(previousTabId) ?? { live: false, active: false };
-      if (pins.active) this.tabPins.set(previousTabId, { ...pins, active: false });
+      if (pins.active) {
+        this.tabPins.set(previousTabId, { ...pins, active: false });
+        // Start the eviction cooldown for the freshly deactivated tab: its
+        // scroll anchor is still live in the composer/transcript and the user
+        // may switch right back (see evictable()'s cooldown filter).
+        this.lastActiveAt.set(previousTabId, Date.now());
+      }
     }
     if (tabId) {
       const pins = this.tabPins.get(tabId) ?? { live: false, active: false };
@@ -494,6 +513,7 @@ export class TranscriptStore {
       if (session.tabId === tabId) this.sessions.delete(key);
     }
     this.tabPins.delete(tabId);
+    this.lastActiveAt.delete(tabId);
   }
 
   private evictSession(session: SessionTranscript): void {
@@ -503,8 +523,17 @@ export class TranscriptStore {
   }
 
   private enforceBudgets(): void {
+    const now = Date.now();
     const evictable = (): SessionTranscript[] =>
-      Array.from(this.sessions.values()).filter((s) => s.records.length > 0 && !this.isPinned(s));
+      Array.from(this.sessions.values()).filter(
+        (s) =>
+          s.records.length > 0 &&
+          !this.isPinned(s) &&
+          // Eviction cooldown: a tab that just stopped being active keeps its
+          // scroll anchor live for a grace window — the user may switch right
+          // back and scroll (see noteActiveTab's lastActiveAt stamp).
+          now - (this.lastActiveAt.get(s.tabId) ?? 0) >= this.evictCooldownMs,
+      );
     let candidates = evictable();
     let resident = candidates.length;
     while (resident > this.maxResidentSessions && candidates.length > 0) {
@@ -719,6 +748,10 @@ export class TranscriptStore {
     const session = this.sessions.get(sessionKeyFor(tabId, sessionPath));
     if (!session || session.records.length === 0) return [];
     const items = this.appendRecords(session, entries);
+    // A live-append refreshes the LRU position too: a busy session whose tab
+    // was just deactivated must not be the first FIFO eviction victim while
+    // its stream is still delivering.
+    this.touch(session);
     this.enforceBudgets();
     return items;
   }


### PR DESCRIPTION
## TL;DR

会话 A 拉到底部 → 切到活跃会话 B → 切回 A → 向上滚动一点，视口产生**大幅跳动**。根因：transcript 驻缓存按 FIFO 驱逐，刚切走的 A 是第一个受害者；驱逐后切回触发 fresh loadLatest 重建（只装最新页），上滚的 prepend 锚点补偿缺少基准（行高未测量）导致补偿失准。修复 PR 增加驱逐冷却窗口 + 流式追加刷新 LRU 位次。

## 总结

- 根因一：`transcriptStore` 的驱逐是 **Map 插入序 FIFO**（`enforceBudgets` 里 `candidates.shift()`，无访问 touch）——刚离开 active 状态的会话 A 排在队首，最先被逐出驻留缓存。
- 根因二：驱逐后切回 A 走 `loadLatest` 全新装载（只有最新一页），滚动容器残留的旧 `scrollTop` 被钳制到新内容高度内，视口错位；随后上滚触发 `loadOlder` 前置插入，锚点补偿在此场景缺少行高基准，补偿失准 → 大幅跳动。
- 触发条件：B 活跃（turn 运行中被 `live` pin 免疫驱逐）并持续产生活动，A 切走后失去 `active` pin，在驻留会话数或字节预算超限时按插入序被逐。
- 修复：驱逐冷却窗口（默认 5 分钟，可配置）+ `appendEntries` 刷新 LRU 位次；锚点持久化作为后续项。

## Problem

After session A is scrolled to the bottom, switching to session B (which has an active running turn) and then switching back to A makes upward scrolling behave incorrectly: a small upward wheel move produces a large viewport jump.

The transcript store keeps at most `maxResidentSessions` sessions resident and evicts by **Map insertion order** (`candidates.shift()` in `enforceBudgets`) — there is no access-time touch, so the just-deactivated session A is always the first FIFO victim once B's live pin and the budget pressure exclude everything else. After eviction, switching back to A runs a fresh `loadLatest` that only materializes the newest page; the scroll container's stale `scrollTop` gets clamped, and the prepend anchor compensation (`transcriptAnchorCompensation` / `transcriptHistoryPrependLease`) runs without measured row heights for the reloaded page, so the compensation misfires and the viewport jumps.

A session with a running turn is pinned (`live`) and can never be evicted, so the busy session B always survives while the session the user just left is evicted first — the busy session indirectly causes the victim.

## Reproduction

1. Open more sessions than `maxResidentSessions` (default 3; real builds use 8).
2. In session A, scroll to the bottom.
3. Switch to session B with a running turn (B is `live`-pinned) and stay there long enough for budget enforcement to run (any session activity triggers it).
4. Switch back to A and scroll up a little.
5. Observe a large viewport jump instead of a small scroll; earlier pages may also fail to anchor correctly while loading.

## Root cause

1. `enforceBudgets` evicts by insertion order with no access-time refresh and no grace window for the tab the user just left.
2. After eviction, the switch-back path does a fresh `loadLatest` (newest page only) with no scroll-anchor restore, and the prepend compensation lacks a measured-size baseline for the rebuilt page.

## Proposed fix (PR to follow)

1. **Eviction cooldown**: `noteActiveTab` records `lastActiveAt` for the tab it deactivated; `enforceBudgets` skips sessions whose cooldown (default 5 minutes, configurable via `evictCooldownMs`) has not elapsed.
2. **Live-append refreshes the LRU position**: `appendEntries` touches the session so a streaming (recently deactivated) tab is not the first FIFO victim while its stream is still delivering.
3. Follow-up (not in this PR): persist a scroll anchor (turn id + offset) on eviction and restore it after the fresh `loadLatest` rebuild.

## Verification

- New unit tests (`transcript-store-eviction.test.ts`):
  - cooldown protects the freshly deactivated tab from FIFO eviction (C is evicted instead);
  - without cooldown, the freshly deactivated tab is the first FIFO victim (documents the fixed behavior);
  - `appendEntries` refreshes the LRU position of a live-appended session.
- `pnpm test:all` and `pnpm build` on the desktop frontend.

## Documentation-impact

None — internal cache behavior; no user-facing configuration changes.

## Cache-impact

None — transcript cache residency is desktop-frontend-only and does not alter provider wire bytes.



## Cache-guard

None - this is a frontend cache-residency policy change (desktop transcript store eviction + appendEntries LRU touch). It does not alter provider wire bytes, the LLM prompt, tool schemas, or the system prompt, so no model-facing cache key changes.

## System-prompt-review

Not applicable - no system prompt or tool description is changed. Desktop-frontend-only behavioral fix (eviction cooldown + LRU refresh).