### PR TITLE
fix(ci): bound the Windows WebView2 selection smoke so it cannot hold the queue / 为 Windows WebView2 选择测试加上限，避免阻塞 CI 队列

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,6 +668,9 @@ jobs:
     needs: changes
     if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
     runs-on: windows-latest
+    # A hung native step must not hold the workflow's concurrency group for the
+    # six-hour default. Normal runs finish in ~25 minutes.
+    timeout-minutes: 45
     defaults:
       run:
         shell: bash

--- a/scripts/test-transcript-selection-webview2.ps1
+++ b/scripts/test-transcript-selection-webview2.ps1
@@ -6,7 +6,8 @@ param(
     [string]$PreviewFrontendRoot = "",
     [string]$Commit = "",
     [int]$Width = 1200,
-    [int]$Height = 800
+    [int]$Height = 800,
+    [int]$TimeoutSeconds = 180
 )
 
 $ErrorActionPreference = "Stop"
@@ -33,6 +34,7 @@ New-Item -ItemType Directory -Path $artifactRoot -Force | Out-Null
 $previewOut = Join-Path $artifactRoot "preview.stdout.log"
 $previewErr = Join-Path $artifactRoot "preview.stderr.log"
 $nativeLog = Join-Path $artifactRoot "native.log"
+$nativeErrorLog = Join-Path $artifactRoot "native.stderr.log"
 $resultPath = Join-Path $artifactRoot "result.json"
 $testedCommit = if ($Commit) { $Commit } elseif ($env:GITHUB_SHA) { $env:GITHUB_SHA } else { "local" }
 $url = "http://127.0.0.1:$Port/?mock=bench&bench=1"
@@ -72,25 +74,44 @@ try {
     }
 
     Push-Location $desktopRoot
+    $smoke = $null
     try {
-        $nativeErrorPreference = $ErrorActionPreference
-        $ErrorActionPreference = "Continue"
-        & go run -tags reasonix_transcript_smoke ./cmd/transcript-selection-smoke `
-            -url $url `
-            -script "transcript_selection_smoke_contract.js" `
-            -artifacts $artifactRoot `
-            -result-file $resultPath `
-            -iterations $Iterations `
-            -width $Width `
-            -height $Height `
-            -commit $testedCommit 2>&1 | Tee-Object -FilePath $nativeLog
-        $nativeExitCode = $LASTEXITCODE
-        $ErrorActionPreference = $nativeErrorPreference
-        if ($nativeExitCode -ne 0) {
-            throw "native transcript selection smoke failed with exit code $nativeExitCode"
+        # Start-Process owns the whole native tree (go -> smoke binary ->
+        # msedgewebview2) so a hung child can be killed by PID. A hung child
+        # outlives the step's own timeout on Windows and keeps the job, and
+        # the workflow's concurrency group, alive.
+        $smoke = Start-Process -FilePath "go" -NoNewWindow -PassThru `
+            -WorkingDirectory $desktopRoot `
+            -RedirectStandardOutput $nativeLog `
+            -RedirectStandardError $nativeErrorLog `
+            -ArgumentList @(
+                "run", "-tags", "reasonix_transcript_smoke", "./cmd/transcript-selection-smoke",
+                "-url", "`"$url`"",
+                "-script", "transcript_selection_smoke_contract.js",
+                "-artifacts", "`"$artifactRoot`"",
+                "-result-file", "`"$resultPath`"",
+                "-iterations", "$Iterations",
+                "-width", "$Width",
+                "-height", "$Height",
+                "-commit", "$testedCommit")
+        if (-not $smoke.WaitForExit($TimeoutSeconds * 1000)) {
+            & taskkill.exe /PID $smoke.Id /T /F 2>$null | Out-Null
+            $smoke.WaitForExit(30000) | Out-Null
+            throw "native transcript selection smoke exceeded $TimeoutSeconds seconds and was killed"
+        }
+        if ($smoke.ExitCode -ne 0) {
+            throw "native transcript selection smoke failed with exit code $($smoke.ExitCode)"
         }
     }
     finally {
+        if ($null -ne $smoke -and -not $smoke.HasExited) {
+            & taskkill.exe /PID $smoke.Id /T /F 2>$null | Out-Null
+        }
+        foreach ($logPath in @($nativeLog, $nativeErrorLog)) {
+            if (Test-Path -LiteralPath $logPath) {
+                Get-Content -LiteralPath $logPath | Write-Host
+            }
+        }
         Pop-Location
     }
 }


### PR DESCRIPTION
**TL;DR**: the `desktop-windows` job had no job-level timeout and ran the native selection smoke as a synchronous `go run`. One hung WebView2 child kept the job, and therefore the workflow's per-ref concurrency group, occupied for 45+ minutes, which stalled every later run for that PR. This bounds both the step and the job.

## Problem

Run `34201483401` (PR #9947, commit `e76226007`) hung in `desktop-windows`: the step **Test WebView2 transcript selection compositor** stayed `in_progress` from `08:00:28Z` with its own `timeout-minutes: 5` already exceeded, and the 8 following steps never started. Normal `desktop-windows` legs finish in 22-25 minutes, so this was a hang, not a long job.

`ci.yml` serializes runs per ref (`concurrency: group: ci-${{ github.ref }}`, `cancel-in-progress: true`). While the hung run held the group, later runs for the same PR could not start: the newest one sat in `pending` with zero jobs, so `lint`, `race` and the test matrix never reported. The pull request then showed `Expected - Waiting for status to be reported` for its required checks even though the code was fine.

## Root cause

The step timeout kills the `pwsh` process, but on Windows the orphaned `go` / `transcript-selection-smoke` / `msedgewebview2` process tree survives and keeps the job alive. Nothing bounds the job itself, so the runner's six-hour default is what eventually ends it, and the concurrency group stays held for that entire window.

## Fix

- Give the `desktop-windows` job an explicit `timeout-minutes: 45` backstop. Normal runs finish in about 25 minutes.
- Run the native smoke through `Start-Process` with a bounded `WaitForExit` (`-TimeoutSeconds`, default 180s; the step normally takes 15-18s) and kill the whole process tree with `taskkill /T /F` on timeout. This mirrors the existing `scripts/test-webview2-native-smoke.ps1` pattern. Captured stdout and stderr are still printed to the step log.

## Verification

- `go run ./tools/repolint`: clean.
- YAML parses; `desktop-windows` keeps its 20 steps and gains `timeout-minutes: 45`.
- `git diff --check`: clean.
- External verification item: `pwsh` is unavailable on the authoring machine, so the script's timeout path is exercised by this pull request's own `desktop-windows` run.

Cache-impact: none - CI workflow and PowerShell test script only; no provider request bytes, prompt prefix, tool schema, or config format change.

Cache-guard: not applicable - no cache-sensitive path is touched; the diff is limited to `.github/workflows/ci.yml` and `scripts/test-transcript-selection-webview2.ps1`.

Documentation-impact: none - CI-only change with no user-facing behavior; existing docs remain correct.

System-prompt-review: not applicable - no system prompt, memory prefix, output style, or skill surface is touched.
