### PR TITLE
fix(bench): settle the app-memory baseline before judging drift / 内存筛查先稳定基线再判定漂移

### DIFF
--- a/desktop/frontend/bench/app-memory-evidence.mjs
+++ b/desktop/frontend/bench/app-memory-evidence.mjs
@@ -65,6 +65,12 @@ export const OFFLINE_ATTRIBUTION_REASON = "heap-retainer-and-control-evidence-re
 // back to 512). Only a displaced final tail is persistent drift.
 export const TRANSIENT_EXCURSION_REASON = "transient-counter-excursion";
 
+// A single early baseline reading can sit above the resting value while layout
+// cleanup still owns listeners. Every later reading then looks displaced, which
+// the gate would misreport as persistent drift. An unsettled baseline is
+// reported as its own blocker instead of being judged as displacement.
+export const BASELINE_NOT_SETTLED_REASON = "baseline-not-settled";
+
 // Reasons the automated gate must block on. Observations (the offline
 // attribution duty, fully-recovered excursions) are recorded on every report
 // but are not screening failures.
@@ -77,11 +83,11 @@ export function screeningBlockers(reasons) {
 // kept as observations so they still get an offline explanation. When the
 // bench ends with an explicit "settled" resting-state sample, that sample is
 // the authoritative tail and every earlier checkpoint is intermediate.
-function counterDriftReason(values, phases) {
+function counterDriftReason(values, phases, baselineStable = true) {
   const baseline = values[0];
   const final = values.at(-1);
   const settledTail = phases.at(-1) === "settled";
-  if (final !== baseline) return "persistent";
+  if (baselineStable && final !== baseline) return "persistent";
   if (!settledTail) {
     const tail = values.slice(1).slice(-3);
     if (tail.some((value) => value !== final)) return "persistent";
@@ -96,12 +102,14 @@ export function attributeRetention(samples, cohorts = retainedCohorts(samples)) 
     [dom?.nodes, dom?.jsEventListeners].every(value => Number.isSafeInteger(value) && value >= 0));
   const released = samples.every((sample) => sample.lifecycle.activeOperations === 0);
   const phases = samples.map((sample) => sample.phase);
+  const baselineStable = samples[0]?.baselineStable !== false;
   const reasons = [];
   if (retained) reasons.push("persistent-render-cohort");
   if (!nativeCountersValid) reasons.push("invalid-native-counters");
+  if (!baselineStable) reasons.push(BASELINE_NOT_SETTLED_REASON);
   if (nativeCountersValid) {
-    const nodeDrift = counterDriftReason(samples.map((sample) => sample.dom.nodes), phases);
-    const listenerDrift = counterDriftReason(samples.map((sample) => sample.dom.jsEventListeners), phases);
+    const nodeDrift = counterDriftReason(samples.map((sample) => sample.dom.nodes), phases, baselineStable);
+    const listenerDrift = counterDriftReason(samples.map((sample) => sample.dom.jsEventListeners), phases, baselineStable);
     if (nodeDrift === "persistent" || listenerDrift === "persistent") reasons.push("post-gc-dom-or-listener-drift");
     else if (nodeDrift === "transient" || listenerDrift === "transient") reasons.push(TRANSIENT_EXCURSION_REASON);
   }

--- a/desktop/frontend/bench/app-memory-evidence.test.mjs
+++ b/desktop/frontend/bench/app-memory-evidence.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { attributeRetention, evidenceIntegrity, retainedCohorts, screeningBlockers, summarizeHeap, TRANSIENT_EXCURSION_REASON } from "./app-memory-evidence.mjs";
+import { attributeRetention, BASELINE_NOT_SETTLED_REASON, evidenceIntegrity, retainedCohorts, screeningBlockers, summarizeHeap, TRANSIENT_EXCURSION_REASON } from "./app-memory-evidence.mjs";
 
 const sample = (ids, roundTrips) => ({ phase: "full", roundTrips, lifecycle: {
   liveRenderTokenIds: ids, liveRenderTokens: ids.length,
@@ -102,6 +102,42 @@ test("an explicit settled tail sample is the authoritative resting state", () =>
   const stuck = blipBeforeSettled.map((sample_) => ({ ...sample_ }));
   stuck[21] = { ...stuck[21], dom: { nodes: 6049, jsEventListeners: 614 } };
   assert.deepEqual(screeningBlockers(attributeRetention(stuck).reasons), ["post-gc-dom-or-listener-drift"]);
+});
+test("an unsettled baseline is reported instead of being judged as displacement", () => {
+  // Round 5 CI data: the baseline sample itself caught the cleanup blip (616),
+  // every later reading rested at 514, and the gate misreported the series as
+  // persistent drift.
+  const samples = Array.from({ length: 21 }, (_, index) => ({
+    ...sample([1, index + 2], index * 32),
+    dom: { nodes: 6049, jsEventListeners: index === 0 ? 616 : 512 },
+  }));
+  samples[0] = { ...samples[0], baselineStable: false, baselineReadings: [{ nodes: 6049, jsEventListeners: 616 }, { nodes: 6049, jsEventListeners: 512 }] };
+  samples.push({ ...sample([1, 23], 512), phase: "settled", dom: { nodes: 6049, jsEventListeners: 512 } });
+  const result = attributeRetention(samples);
+  assert.ok(result.reasons.includes(BASELINE_NOT_SETTLED_REASON));
+  assert.deepEqual(screeningBlockers(result.reasons), [BASELINE_NOT_SETTLED_REASON]);
+});
+test("an unsettled baseline still blocks sustained growth away from a low point", () => {
+  // 616 -> 400 -> 450 -> 500 -> 550 ends below the baseline but keeps growing;
+  // skipping the displacement check must not hide it.
+  const listeners = [616, 400, 450, 500, 550];
+  const samples = listeners.map((value, index) => ({
+    ...sample([1, index + 2], index * 32),
+    dom: { nodes: 6049, jsEventListeners: value },
+  }));
+  samples[0] = { ...samples[0], baselineStable: false };
+  const result = attributeRetention(samples);
+  assert.ok(result.reasons.includes("post-gc-dom-or-listener-drift"));
+  assert.deepEqual(screeningBlockers(result.reasons), [BASELINE_NOT_SETTLED_REASON, "post-gc-dom-or-listener-drift"]);
+});
+test("a settled baseline keeps the displacement check", () => {
+  const samples = Array.from({ length: 21 }, (_, index) => ({
+    ...sample([1, index + 2], index * 32),
+    dom: { nodes: 6049, jsEventListeners: index === 0 ? 512 : 514 },
+  }));
+  samples[0] = { ...samples[0], baselineStable: true };
+  samples.push({ ...sample([1, 23], 512), phase: "settled", dom: { nodes: 6049, jsEventListeners: 514 } });
+  assert.deepEqual(screeningBlockers(attributeRetention(samples).reasons), ["post-gc-dom-or-listener-drift"]);
 });
 test("native objects are not automatically detached DOM", () => {
   const heap = { snapshot: { meta: {

--- a/desktop/frontend/bench/app-memory-shards.mjs
+++ b/desktop/frontend/bench/app-memory-shards.mjs
@@ -1,6 +1,8 @@
 import { attributeRetention, evidenceIntegrity, retainedCohorts, screeningBlockers } from "./app-memory-evidence.mjs";
 
-export const MEMORY_PROTOCOL = Object.freeze({ version: 2, shards: 3, cycles: 128, mixedCycles: 512, hydration: "async-task", pointerRest: [0, 0], viewport: { width: 1440, height: 1000 } });
+// Version 3 requires a settled, repeated baseline reading before the measured
+// cycles, so a single early reading can no longer anchor the drift verdict.
+export const MEMORY_PROTOCOL = Object.freeze({ version: 3, shards: 3, cycles: 128, mixedCycles: 512, hydration: "async-task", pointerRest: [0, 0], viewport: { width: 1440, height: 1000 } });
 export const MEMORY_FIXTURES = Object.freeze({
   full: { label: "bench:small-6t", marker: "ASYNC LAYOUT EXPANSION COMPLETE" },
   geometry: { label: "bench:geometry", marker: "Geometry contract fixture complete." },

--- a/desktop/frontend/bench/app-memory.mjs
+++ b/desktop/frontend/bench/app-memory.mjs
@@ -26,6 +26,7 @@ function integerEnv(name, fallback) {
 
 const CYCLES = integerEnv("REASONIX_APP_MEMORY_CYCLES", 128);
 const MIXED_CYCLES = integerEnv("REASONIX_APP_MEMORY_MIXED_CYCLES", 512);
+const BASELINE_ATTEMPTS = integerEnv("REASONIX_APP_MEMORY_BASELINE_ATTEMPTS", 4);
 const SHARD = process.env.REASONIX_APP_MEMORY_SHARD === undefined ? null : Number(process.env.REASONIX_APP_MEMORY_SHARD);
 if (SHARD !== null && ![1, 2, 3].includes(SHARD)) throw new Error("memory shard must be 1, 2 or 3");
 const PROCESSES = SHARD === null ? integerEnv("REASONIX_APP_MEMORY_PROCESSES", 3) : 1;
@@ -145,10 +146,27 @@ async function runProcess(index) {
       await settleFrames(page);
     }
     // Baseline and checkpoints share a post-navigation resting state. Layout
-    // controls can still own transient listeners immediately after closing.
+    // controls can still own transient listeners immediately after closing, so
+    // one early reading can sit above the resting value and make every later
+    // reading look displaced. Settle and require consecutive identical readings
+    // before accepting the baseline; an unsettled baseline is reported instead
+    // of being judged as drift.
     await selectFixture(page, fixtures.geometry);
     await selectFixture(page, fixtures.full);
-    const samples = [{ phase: "baseline", roundTrips: 0, ...await forceGc(cdp, page) }];
+    const samples = [];
+    const baselineReadings = [];
+    for (let attempt = 1; attempt <= BASELINE_ATTEMPTS; attempt++) {
+      await settleFrames(page, 12);
+      const reading = await forceGc(cdp, page);
+      baselineReadings.push({ nodes: reading.dom.nodes, jsEventListeners: reading.dom.jsEventListeners });
+      const previous = baselineReadings.at(-2);
+      const stable = previous && previous.nodes === reading.dom.nodes && previous.jsEventListeners === reading.dom.jsEventListeners;
+      if (stable || attempt === BASELINE_ATTEMPTS) {
+        samples.push({ phase: "baseline", roundTrips: 0, baselineStable: Boolean(stable), baselineReadings, ...reading });
+        process.stdout.write(`[app-memory] process=${index} phase=baseline stable=${Boolean(stable)} readings=${JSON.stringify(baselineReadings)}\n`);
+        break;
+      }
+    }
     const snapshots = [await heapSnapshot(cdp, `${index}-baseline`)];
     for (const phase of ["full", "windowed", "safety", "mixed"]) {
       const count = phase === "mixed" ? MIXED_CYCLES : CYCLES;


### PR DESCRIPTION
## Problem

The memory screen blocks on `post-gc-dom-or-listener-drift` whenever a counter's final value differs from the **first** sample. In [run 34206509595](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/34206509595) (shard 1) the artifact's `1-samples.json` shows:

- baseline sample: **616** listeners
- every later checkpoint (including the final `settled` sample): **514**
- `dom.nodes` constant at 6056, `activeOperations` 0 throughout

The series never grew, yet `counterDriftReason` compared the final reading against that noisy first sample and reported persistent drift, failing the shard.

## Root cause

The baseline was a single reading taken immediately after the fixture swap, while layout cleanup can still own listeners for a few tasks (the same blip the `settled` tail sample already settles 12 frames for). Nothing required the baseline to be a quiescent reading, so one early sample could anchor the whole verdict. The classifier also treats any displacement, including a decrease, as persistent drift.

## Fix

- **Settle the baseline.** `app-memory.mjs` now settles 12 frames and requires two consecutive identical readings before accepting the baseline, up to `REASONIX_APP_MEMORY_BASELINE_ATTEMPTS` (default 4). The accepted sample records `baselineStable` and every reading it took, so the artifact shows why.
- **Report an unsettled baseline as its own blocker** (`baseline-not-settled`) instead of judging it as displacement. Tail movement, retained cohorts, active operations, subscription drift, and the settled-tail check all still run, so sustained growth away from a low point (`616 -> 400 -> 450 -> 500 -> 550`) remains a blocker — it is not skipped.
- `MEMORY_PROTOCOL.version` bumps to 3 because the sampling protocol changed.

## Verification

- `node bench/app-memory-evidence.test.mjs` — 15 pass, including three new cases: an unsettled baseline is reported instead of being judged as displacement; an unsettled baseline still blocks sustained growth; a settled baseline keeps the displacement check.
- `node bench/app-memory-shards.test.mjs` — 19 pass.
- `node --check` on both modified bench modules; `go run ./tools/repolint` clean; `git diff --check` clean.
- The browser-driven screen itself only runs in CI; it cannot be exercised locally without a Chromium run.

## Note for stacked branches

`app-memory.yml` checks out the **pull request head** (`EXPECTED_SOURCE_SHA`), so a branch only picks up this fix after it merges `main-v2` (or rebases onto it). The tooling change alone does not change any other branch's screen until then.

Documentation-impact: none - the screening protocol is not described in `docs/`; existing docs remain correct.

Cache-impact: none - bench tooling only; no prompt, tool schema, provider request, or config bytes change.

Cache-guard: not applicable - not a cache-sensitive path; the bench unit tests above cover the changed logic.
