### PR TITLE
fix(agent,ci): make two race-suite tests deterministic and bound the test job / 让两个 race 测试确定化并为 test job 加上限

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
   test:
     needs: changes
     if: always()
+    # Backstop against a wedged step holding the workflow's concurrency group:
+    # the Windows full-suite step has outlived its own timeout and kept the job
+    # alive. Normal full-suite wall time is 8-12 minutes per platform.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -783,7 +783,10 @@ jobs:
             -HealthySeconds 5
 
       - name: test (Windows desktop and update helper)
-        timeout-minutes: 15
+        # Normal wall time is 6-7 minutes; a loaded runner has exceeded 15 with
+        # every package still passing. Keep the budget above that load spike so
+        # the job-level timeout, not this step, ends a real hang.
+        timeout-minutes: 25
         run: go test ./...
 
       - name: test (vendored systray identity)

--- a/desktop/terminal_process_windows_test.go
+++ b/desktop/terminal_process_windows_test.go
@@ -11,6 +11,11 @@ import (
 	"time"
 )
 
+// A loaded Windows runner can take far longer than the shell's own work to echo
+// a marker or reap a ConPTY child. Keep the outer responsiveness bound generous;
+// the test still fails if the process never responds.
+const conptySmokeWait = 30 * time.Second
+
 func TestWindowsTerminalProcessConPTYSmoke(t *testing.T) {
 	available, reason := terminalPlatformAvailable()
 	if !available {
@@ -65,7 +70,7 @@ func TestWindowsTerminalProcessConPTYSmoke(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-	case <-time.After(10 * time.Second):
+	case <-time.After(conptySmokeWait):
 		t.Fatal("timed out waiting for ConPTY output")
 	}
 
@@ -82,7 +87,7 @@ func TestWindowsTerminalProcessConPTYSmoke(t *testing.T) {
 		if err != nil {
 			t.Fatalf("wait for ConPTY exit: %v", err)
 		}
-	case <-time.After(10 * time.Second):
+	case <-time.After(conptySmokeWait):
 		t.Fatal("timed out waiting for ConPTY process exit")
 	}
 }

--- a/internal/agent/parallel_cancel_test.go
+++ b/internal/agent/parallel_cancel_test.go
@@ -30,6 +30,22 @@ func (s stubbornTool) Execute(context.Context, json.RawMessage) (string, error) 
 	return "late", nil
 }
 
+// fastTool reports when it has entered execution, so the test cancels only
+// after both tools of the batch are running.
+type fastTool struct {
+	once    *sync.Once
+	started chan struct{}
+}
+
+func (fastTool) Name() string            { return "fast" }
+func (fastTool) Description() string     { return "always succeeds" }
+func (fastTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (fastTool) ReadOnly() bool          { return true }
+func (f fastTool) Execute(context.Context, json.RawMessage) (string, error) {
+	f.once.Do(func() { close(f.started) })
+	return "ok", nil
+}
+
 // A read-only parallel segment must not keep the whole turn wedged behind one
 // tool that ignores cancellation: after the grace the batch reports that call
 // as an unknown effect while the calls that did finish keep their results.
@@ -40,9 +56,10 @@ func TestParallelBatchAbandonsToolThatIgnoresCancellation(t *testing.T) {
 
 	stub := stubbornTool{once: &sync.Once{}, started: make(chan struct{}), release: make(chan struct{})}
 	t.Cleanup(func() { close(stub.release) })
+	fast := fastTool{once: &sync.Once{}, started: make(chan struct{})}
 	reg := tool.NewRegistry()
 	reg.Add(stub)
-	reg.Add(okTool{name: "fast"})
+	reg.Add(fast)
 	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
 		{toolCallChunk("stubborn-1", "stubborn", `{}`), toolCallChunk("fast-1", "fast", `{}`)},
 		{{Type: provider.ChunkText, Text: "done"}},
@@ -58,6 +75,11 @@ func TestParallelBatchAbandonsToolThatIgnoresCancellation(t *testing.T) {
 	case <-stub.started:
 	case <-time.After(5 * time.Second):
 		t.Fatal("stubborn tool never started")
+	}
+	select {
+	case <-fast.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fast tool never started")
 	}
 	cancel()
 	select {

--- a/internal/agent/testutil/mock_provider.go
+++ b/internal/agent/testutil/mock_provider.go
@@ -114,6 +114,12 @@ func (p *MockProvider) Stream(ctx context.Context, req provider.Request) (<-chan
 	go func() {
 		defer close(ch)
 		for _, c := range chunks {
+			// Check before every send so an already-observed cancellation is
+			// never masked by a select that also has a ready receiver.
+			if err := ctx.Err(); err != nil {
+				ch <- provider.Chunk{Type: provider.ChunkError, Err: err}
+				return
+			}
 			select {
 			case <-ctx.Done():
 				ch <- provider.Chunk{Type: provider.ChunkError, Err: ctx.Err()}

--- a/internal/agent/testutil/mock_provider_test.go
+++ b/internal/agent/testutil/mock_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"reasonix/internal/provider"
 )
@@ -42,14 +43,39 @@ func TestMockProviderStreamStopsOnContextCancellation(t *testing.T) {
 		t.Fatalf("first chunk text = %q, want first", got)
 	}
 	cancel()
-	chunk, ok := <-ch
-	if !ok {
-		t.Fatal("stream closed without returning cancellation error")
+
+	// Cancellation can race a send that is already committed: at most one
+	// data chunk may arrive after the cancel. The stream must then deliver a
+	// cancellation error and close.
+	inFlight := 0
+	for {
+		var chunk provider.Chunk
+		var ok bool
+		select {
+		case chunk, ok = <-ch:
+		case <-time.After(5 * time.Second):
+			t.Fatal("stream did not terminate after cancellation")
+		}
+		if !ok {
+			t.Fatal("stream closed without returning cancellation error")
+		}
+		if chunk.Type == provider.ChunkError {
+			if !errors.Is(chunk.Err, context.Canceled) {
+				t.Fatalf("cancellation error = %v, want context.Canceled", chunk.Err)
+			}
+			break
+		}
+		inFlight++
+		if inFlight > 1 {
+			t.Fatalf("stream kept sending data after cancellation (%d chunks)", inFlight)
+		}
 	}
-	if chunk.Type != provider.ChunkError || !errors.Is(chunk.Err, context.Canceled) {
-		t.Fatalf("chunk after cancellation = %#v, want context.Canceled error", chunk)
-	}
-	if _, ok := <-ch; ok {
-		t.Fatal("stream stayed open after cancellation error")
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("stream stayed open after cancellation error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream did not close after the cancellation error")
 	}
 }


### PR DESCRIPTION
**TL;DR**: two different timing-sensitive tests failed on consecutive attempts of the release candidate's `race` job, and a Windows step later wedged past its own timeout and held the CI concurrency group. This makes both tests deterministic and bounds the `test` job.

## Problem

The v1.38.2 candidate (`daf18272f`) could not pass the required `race` check:

- **attempt 1** failed `TestMockProviderStreamStopsOnContextCancellation` (`internal/agent/testutil`):
  `chunk after cancellation = provider.Chunk{Type:4, ToolCall:...}, want context.Canceled error`
- **attempt 2** failed `TestParallelBatchAbandonsToolThatIgnoresCancellation` (`internal/agent`):
  `parallel_cancel_test.go:75: fast result = "cancelled: context cancelled before execution", want the finished tool's own output`

Both pass locally (`-race -count=50` each), so they only fire under CI runner load. Separately, the `test (windows-latest)` step `test (full)` ran 46 minutes against its own 20-minute timeout, kept the job alive, and held the `main-v2` concurrency group until a force-cancel; the job has no job-level timeout.

## Root cause

- The mock send loop used a single `select` with a cancellation case and a send case. When cancellation and a ready receiver arrive together, Go may commit the send, so a data chunk is delivered instead of the cancellation error.
- The parallel-cancel test cancelled as soon as the stubborn tool started, but the fast tool's goroutine might not be scheduled yet; the batch then correctly records it as cancelled before execution.
- The `test` job relied on a step timeout that cannot kill an orphaned Windows process tree.

## Fix

- `MockProvider.Stream` checks `ctx.Err()` before every send, so an observed cancellation is never masked by a ready receiver.
- `TestMockProviderStreamStopsOnContextCancellation` now allows at most one in-flight chunk concurrent with the cancel, then requires a `context.Canceled` error and a closed channel, each bounded by five seconds.
- The parallel-cancel test waits until **both** the stubborn and fast tools have entered execution before cancelling. The original assertions (stubborn abandoned with the marker, fast keeps its own output) are unchanged; no sleeps and no loosened expectations.
- `test` job gains `timeout-minutes: 45` as a queue-occupancy backstop. Existing step and Go package timeouts are untouched.

## Follow-up bounds (second commit)

The first CI run of this PR failed `desktop-windows` on a pre-existing ConPTY bound, so the same "budget, not behavior" class is fixed here too:

- `test (Windows desktop and update helper)`: `timeout-minutes` 15 → 25. The suite normally takes 6-7 minutes and has exceeded 15 with every package still reporting `ok`; the job's 45-minute backstop still ends a real hang.
- `TestWindowsTerminalProcessConPTYSmoke`: both outer waits (marker echo and process exit) move from 10s to a shared 30s bound. Assertions are unchanged — the process must still echo the marker and exit.

## Verification

- `go test -race -run TestMockProviderStreamStopsOnContextCancellation -count=50 ./internal/agent/testutil/`
- `go test -race -run TestParallelBatchAbandonsToolThatIgnoresCancellation -count=50 ./internal/agent/`
- `go test -race ./internal/agent/...`
- `go vet ./internal/agent/...`; `go run ./tools/repolint` clean
- `node scripts/ci-workflow.test.mjs`; `bash scripts/release-workflows.test.sh`
- **Not verified**: the Windows hang's root cause. Its job logs remain unavailable (`BlobNotFound`), so `timeout-minutes` bounds the job but does not fix the hang.

Documentation-impact: none - test-only and CI-workflow changes; no user-visible behavior or documentation is affected.

Cache-impact: none - no prompt, tool schema, provider serialization, or config bytes change; the touched files are a test mock and a test.

Cache-guard: not applicable - `go test -race ./internal/agent/...` covers the touched packages.
