### PR TITLE
fix(release): restore runtime and atomic update CI gates / 修复运行时及原子更新发布门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,13 @@ jobs:
         timeout-minutes: 3
         run: go test -timeout=2m -run '^TestBashSharesSessionTempAcrossCalls$' ./internal/tool/builtin
 
+      # Serve is outside the general Windows PR smoke list. Keep its public
+      # runtime path identity contract covered before a mainline push.
+      - name: test (Windows runtime status)
+        if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name == 'pull_request'
+        timeout-minutes: 5
+        run: go test -timeout=2m -run '^TestRuntimeStateHTTP' ./internal/serve
+
       # Shell execution contract: PowerShell identity, Chinese workspace paths,
       # UTF-8 output, and ExitCode retention must gate PRs on native Windows.
       # Keep this focused (not full ./internal/tool) so the smoke budget holds.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,12 +168,12 @@ jobs:
         timeout-minutes: 3
         run: go test -timeout=2m -run '^TestBashSharesSessionTempAcrossCalls$' ./internal/tool/builtin
 
-      # Serve is outside the general Windows PR smoke list. Keep its public
-      # runtime path identity contract covered before a mainline push.
-      - name: test (Windows runtime status)
+      # Serve and taskmonitor are outside the general Windows PR smoke list.
+      # Cover runtime identities and snapshot publication before mainline push.
+      - name: test (Windows runtime status and task snapshots)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name == 'pull_request'
         timeout-minutes: 5
-        run: go test -timeout=2m -run '^TestRuntimeStateHTTP' ./internal/serve
+        run: go test -timeout=2m -run '^TestRuntimeStateHTTP|^TestFileStoreSaveTaskWaitsForTransientSnapshotReader$' ./internal/serve ./internal/taskmonitor
 
       # Shell execution contract: PowerShell identity, Chinese workspace paths,
       # UTF-8 output, and ExitCode retention must gate PRs on native Windows.

--- a/internal/repair/read_regular.go
+++ b/internal/repair/read_regular.go
@@ -1,0 +1,26 @@
+package repair
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+)
+
+// Read through a regular-file handle that permits atomic replacement on
+// Windows. Pending-update readers run before acquiring the mutation lock;
+// their handles must not prevent another owner from archiving the marker.
+func readRepairRegularFile(path string) ([]byte, error) {
+	file, err := openRepairRegularRead(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", filepath.Base(path))
+	}
+	return io.ReadAll(file)
+}

--- a/internal/repair/read_regular_test.go
+++ b/internal/repair/read_regular_test.go
@@ -1,0 +1,38 @@
+package repair
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestPendingUpdateReadHandlePreservesSnapshotAcrossArchive(t *testing.T) {
+	fixture := prepareSupersededUpdateFixture(t, "v1.19.1", "v1.20.0")
+	// Hold the same regular-file handle used by pending transaction readers
+	// throughout a real archival. On Windows this requires delete sharing;
+	// readers keep their old file identity while the path is atomically moved.
+	reader, err := openRepairRegularRead(PendingUpdatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	archived, err := ArchiveSupersededPendingFileUpdate(fixture.running, fixture.root)
+	if err != nil || !archived {
+		t.Fatalf("archive with active reader: archived=%v err=%v", archived, err)
+	}
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot UpdateTransaction
+	if err := json.Unmarshal(body, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if UpdateTransactionID(&snapshot) != UpdateTransactionID(fixture.transaction) {
+		t.Fatal("reader lost the original transaction snapshot after archival")
+	}
+	if _, err := readPendingUpdateUnchecked(); !os.IsNotExist(err) {
+		t.Fatalf("new reader observed an archived pending marker: %v", err)
+	}
+}

--- a/internal/repair/update.go
+++ b/internal/repair/update.go
@@ -1100,7 +1100,7 @@ func readInstalledFileUpdateState(tx *UpdateTransaction) (*installedFileUpdateSt
 	if !repairNodeInsideResolvedRoot(filepath.Join(config.MemoryUserDir(), "repair"), path) {
 		return nil, fmt.Errorf("installed release-unit state resolves outside the repair directory")
 	}
-	b, err := os.ReadFile(path)
+	b, err := readRepairRegularFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -1881,7 +1881,7 @@ func quarantinePendingUpdate(reason string) (string, error) {
 }
 
 func pendingUpdateMarkerDigest(path string) (string, error) {
-	body, err := os.ReadFile(path)
+	body, err := readRepairRegularFile(path)
 	if err != nil {
 		return "", err
 	}
@@ -1956,7 +1956,7 @@ func readPendingUpdateUnchecked() (*UpdateTransaction, error) {
 	if path == "" {
 		return nil, os.ErrNotExist
 	}
-	b, err := os.ReadFile(path)
+	b, err := readRepairRegularFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/serve/runtime_state.go
+++ b/internal/serve/runtime_state.go
@@ -130,12 +130,13 @@ func (s *sessionTagSink) RuntimeStateChanged(snapshot event.RuntimeStateSnapshot
 
 // A per-session status query must resolve its own controller, not the foreground.
 func (s *Server) ownedRuntimeStatusView(path string) (map[string]any, bool) {
+	path = agent.CanonicalSessionPath(path)
 	s.bindMu.Lock()
 	defer s.bindMu.Unlock()
 	ctrl := s.ctl()
-	if ctrl == nil || agent.CanonicalSessionPath(ctrl.SessionPath()) != agent.CanonicalSessionPath(path) {
+	if ctrl == nil || agent.CanonicalSessionPath(ctrl.SessionPath()) != path {
 		s.detachedMu.Lock()
-		detached := s.detached[agent.CanonicalSessionPath(path)]
+		detached := s.detached[path]
 		ctrl = nil
 		if detached != nil {
 			ctrl = detached.ctrl

--- a/internal/serve/runtime_state_test.go
+++ b/internal/serve/runtime_state_test.go
@@ -165,6 +165,26 @@ func TestRuntimeStateHTTPStatusUsesRequestedDetachedController(t *testing.T) {
 	}
 }
 
+func TestOwnedRuntimeStatusCanonicalizesResponsePath(t *testing.T) {
+	dir := t.TempDir()
+	foreground := runtimeStateServeController(t, dir, "foreground", nil)
+	detached := runtimeStateServeController(t, dir, "detached", nil)
+	server := New(foreground, nil, config.ServeConfig{})
+	path := agent.CanonicalSessionPath(detached.SessionPath())
+	server.detached[path] = &detachedSession{path: path, ctrl: detached}
+	// A noncanonical spelling must not escape through the status response,
+	// even when lookup correctly resolves it to the detached owner.
+	raw := filepath.Dir(path) + string(filepath.Separator) + "." + string(filepath.Separator) + filepath.Base(path)
+	status, ok := server.ownedRuntimeStatusView(raw)
+	if !ok || status["sessionPath"] != path {
+		t.Fatalf("owned status did not preserve canonical identity: ok=%v path=%v want=%q", ok, status["sessionPath"], path)
+	}
+	state := status["runtimeState"].(event.RuntimeStateSnapshot)
+	if state.RuntimeEpoch != detached.RuntimeStateSnapshot().RuntimeEpoch {
+		t.Fatal("canonical response borrowed the foreground runtime")
+	}
+}
+
 func readRuntimeSSEFrame(t *testing.T, reader *bufio.Reader) eventwire.Event {
 	t.Helper()
 	for {

--- a/internal/serve/runtime_state_test.go
+++ b/internal/serve/runtime_state_test.go
@@ -154,7 +154,10 @@ func TestRuntimeStateHTTPStatusUsesRequestedDetachedController(t *testing.T) {
 		RuntimeState event.RuntimeStateSnapshot `json:"runtimeState"`
 	}
 	runtimeStateHTTPGet(t, httpServer.URL+"/status?runtime=1&session="+url.QueryEscape(detachedPath), &status)
-	if status.SessionPath != detachedPath || !status.Running || status.RuntimeState.Phase != "executing" || status.RuntimeState.RuntimeEpoch != detached.RuntimeStateSnapshot().RuntimeEpoch {
+	if status.SessionPath != detachedPath {
+		t.Fatalf("detached status path = %q, want canonical identity %q", status.SessionPath, detachedPath)
+	}
+	if !status.Running || status.RuntimeState.Phase != "executing" || status.RuntimeState.RuntimeEpoch != detached.RuntimeStateSnapshot().RuntimeEpoch {
 		t.Fatalf("detached status was borrowed from foreground: %+v", status)
 	}
 	if foreground.RuntimeStateSnapshot().Running {

--- a/internal/taskmonitor/jsonstore.go
+++ b/internal/taskmonitor/jsonstore.go
@@ -419,7 +419,9 @@ func (s *FileStore) SaveTask(ctx context.Context, projectDir string, snap TaskSn
 		os.Remove(tmpName)
 		return fmt.Errorf("save task: %w", err)
 	}
-	if err := os.Rename(tmpName, target); err != nil {
+	// Keep the CAS lock across bounded retries for Windows readers or filter
+	// drivers. Publication must remain an atomic rename, never a copy fallback.
+	if err := fileutil.ClaimRename(tmpName, target); err != nil {
 		os.Remove(tmpName)
 		return fmt.Errorf("save task: %w", err)
 	}

--- a/internal/taskmonitor/jsonstore_windows_test.go
+++ b/internal/taskmonitor/jsonstore_windows_test.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package taskmonitor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFileStoreSaveTaskWaitsForTransientSnapshotReader(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileStore(".reasonix/tasks")
+	ctx := context.Background()
+	now := time.Now()
+	snapshot := TaskSnapshot{SchemaVersion: 1, TaskID: "t1", SessionID: "s1", State: TaskStateRunning, Version: 1, CreatedAt: now, UpdatedAt: now}
+	if err := store.SaveTask(ctx, dir, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, ".reasonix", "tasks", "t1", "snapshot.json")
+	reader, err := os.Open(path) // ordinary Windows readers omit delete sharing
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	snapshot.Version = 2
+	done := make(chan error, 1)
+	go func() { done <- store.SaveTask(ctx, dir, snapshot) }()
+	// Hold a real OS read handle across the first publication attempts. The
+	// operation must survive this bounded sharing violation, not fail the task
+	// control command or fall back to truncating the visible snapshot.
+	select {
+	case err := <-done:
+		t.Fatalf("save completed while the snapshot reader excluded replacement: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("snapshot publication did not resume after the reader closed")
+	}
+	got, err := store.GetTask(ctx, dir, "t1")
+	if err != nil || got == nil || got.Version != 2 {
+		t.Fatalf("published snapshot = %+v, err=%v", got, err)
+	}
+}

--- a/internal/workspacelease/lease_test.go
+++ b/internal/workspacelease/lease_test.go
@@ -479,14 +479,17 @@ func TestSameRepoDifferentFilesRunInParallel(t *testing.T) {
 	}
 	first.BeginRun()
 	second.BeginRun()
-	if err := first.AcquireWriteForPath(context.Background(), filepath.Join(repo, "a.go")); err != nil {
+	t.Cleanup(first.EndRun)
+	t.Cleanup(second.EndRun)
+	firstPath, secondPath := increasingPathSlots(t, first)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := first.AcquireWriteForPath(ctx, firstPath); err != nil {
 		t.Fatal(err)
 	}
-	if err := second.AcquireWriteForPath(context.Background(), filepath.Join(repo, "b.go")); err != nil {
+	if err := second.AcquireWriteForPath(ctx, secondPath); err != nil {
 		t.Fatal(err)
 	}
-	first.EndRun()
-	second.EndRun()
 }
 
 func TestSameFilePathWritesStillSerialize(t *testing.T) {


### PR DESCRIPTION
## Summary

Windows per-session status queries returned a display path while the runtime catalog used a canonical identity, causing a detached session to appear inconsistent. Canonicalize the owned status path before both lookup and response construction.

Concurrent legacy-update recovery could fail with a sharing violation while another process or goroutine read the pending marker outside the mutation lock. Read pending transactions, marker digests and installed update state through the existing regular-file handle with delete sharing. Readers retain their original snapshot while archival or replacement proceeds; the transaction identity checks and no-overwrite mutations remain intact.

Task control could also fail to save its next snapshot when a brief Windows reader prevented replacement. Use the existing bounded atomic-rename retry boundary while retaining the per-task compare-and-swap lock; do not fall back to copying or truncating the visible snapshot.

This addresses the Windows failures observed in mainline CI runs 34268828451 and 34249145414. The independent CLI inbox teardown failure from run 34255926157 is covered by the controller shutdown changes in #9973.

Mainline Ubuntu run 34275486851 also exposed a fixture deadlock: the parallel-file test assumed two filenames always map to different hash-lock stripes. Select distinct stripes with the existing fixture helper, bound acquisition, and clean up both owners. Production collision serialization remains unchanged.

## Verification

- The corrected parallel-file fixture passed 1,000 race repetitions and the full workspacelease race suite.

- Windows detached-status regression: 10 failures before the canonical-path fix, then 100 passing repetitions.
- Windows concurrent legacy recovery and held-reader snapshot archival: 100 passing repetitions each.
- Full `internal/repair` and `internal/serve` race suites passed; the held-reader test also passed 10 race repetitions.
- A real Windows task snapshot reader reproduced the immediate access-denied failure before the fix. The corrected publication passed 50 repetitions and the full taskmonitor race suite.
- The full Windows Desktop Go suite passed with these fixes integrated alongside #9973, including signing and update-helper packages. The Windows 11 ARM64 host ran windows/amd64 Go test binaries; the separate model-settings UI qualification used a windows/arm64 Wails binary.
- Go lint, repository lint and diff checks passed. No frontend changes.
- Add bounded Serve HTTP runtime-state and task snapshot publication tests to Windows PR CI; the general smoke package list previously omitted these packages and only caught the path regression after merge.

Documentation-impact: none - internal path identity and file-handle corrections preserve the documented runtime and update contracts without changing configuration or persisted schemas.
Cache-impact: none - no provider, prompt, tool schema or serialization changes.
