### PR TITLE
fix(control): join inbox scans during shutdown / 关闭控制器时等待收件箱扫描结束

### DIFF
--- a/internal/bot/model_settings_test.go
+++ b/internal/bot/model_settings_test.go
@@ -5,15 +5,33 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	"reasonix/internal/config"
 	"reasonix/internal/control"
+	"reasonix/internal/history"
 	"reasonix/internal/provider"
+	"reasonix/internal/stats"
 )
 
 func TestBotNewRunAppliesModelSettingsAndKeepsSessionOnFailure(t *testing.T) {
+	closeCatalogs := func() {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := history.CloseSharedCatalog(ctx); err != nil {
+			t.Fatalf("close shared history catalog: %v", err)
+		}
+		if err := stats.CloseUsageCatalogs(ctx); err != nil {
+			t.Fatalf("close usage catalogs: %v", err)
+		}
+	}
+	closeCatalogs()
 	t.Setenv("REASONIX_HOME", t.TempDir())
 	root := t.TempDir()
+	// These projections belong to the process, not an individual controller.
+	// Release SQLite handles before the isolated home is removed on Windows.
+	t.Cleanup(closeCatalogs)
 	cfg := config.Default()
 	cfg.Providers = []config.ProviderEntry{{Name: "snapshot", Kind: "openai", BaseURL: "http://127.0.0.1:1/v1", Model: "m", APIKeyEnv: "BOT_SNAPSHOT_TEST_KEY"}}
 	cfg.DefaultModel = "snapshot/m"

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -5091,11 +5091,13 @@ func (c *Controller) close(fireSessionEnd bool, jobsMode closeJobsMode) {
 		} else {
 			c.promptOwner.Clear()
 		}
-		// Join sidecar creation without waiting for the dispatcher itself: a
-		// model refresh may close this controller from inside that dispatcher.
+		// Join sidecar creation and queue scans without waiting for the
+		// dispatcher itself: host admission may retire its own controller.
+		c.inbox.scanMu.Lock()
 		c.inbox.mu.Lock()
 		c.inbox.closed = true
 		c.inbox.mu.Unlock()
+		c.inbox.scanMu.Unlock()
 		if fireSessionEnd && started {
 			c.hooks.SessionEnd(context.Background(), "other")
 			c.extensionSessionEvent(extension.PointSessionEnd, dispatch.PhaseEnd, c.SessionPath())

--- a/internal/control/inbox.go
+++ b/internal/control/inbox.go
@@ -74,9 +74,12 @@ type inboxState struct {
 	// admissionMu serializes competing admission state machines. Snapshot
 	// recovery and completion never hold it across Store I/O.
 	admissionMu sync.Mutex
-	mu          sync.Mutex
-	store       *sessioninbox.Store
-	closed      bool // seals new sidecar opens when controller teardown starts
+	// scanMu joins autonomous sidecar reads at shutdown without waiting for a
+	// dispatcher that may itself retire this controller during host admission.
+	scanMu sync.Mutex
+	mu     sync.Mutex
+	store  *sessioninbox.Store
+	closed bool // seals new sidecar opens when controller teardown starts
 	// activeItemIDs includes the running follow-up and every accepted steer.
 	// TurnDone durable-acks the set so multi-steer rounds leave no orphans.
 	activeItemIDs map[string]struct{}

--- a/internal/control/inbox_dispatch.go
+++ b/internal/control/inbox_dispatch.go
@@ -108,19 +108,14 @@ func (c *Controller) dispatchInboxOnce() inboxDispatchResult {
 	if c.SessionPath() == "" {
 		return inboxDispatchIdle
 	}
-	st, err := c.ensureInbox()
+	meta, ok, err := c.nextInboxDispatchItem()
 	if err != nil {
 		slog.Warn("controller: open inbox for dispatch", "err", err)
 		return inboxDispatchRetry
 	}
-	meta, ok := st.NextQueued()
 	c.inbox.mu.Lock()
-	afterScan := c.inbox.afterDispatchScan
 	beforeSubmit := c.inbox.beforeDispatchSubmit
 	c.inbox.mu.Unlock()
-	if afterScan != nil {
-		afterScan(ok)
-	}
 	if !ok {
 		return inboxDispatchIdle
 	}
@@ -143,6 +138,29 @@ func (c *Controller) dispatchInboxOnce() inboxDispatchResult {
 	}
 	// A competing turn or rotation owns the next kick when its gate releases.
 	return inboxDispatchIdle
+}
+
+func (c *Controller) nextInboxDispatchItem() (sessioninbox.InboxItemMeta, bool, error) {
+	c.inbox.scanMu.Lock()
+	defer c.inbox.scanMu.Unlock()
+	c.inbox.mu.Lock()
+	closed := c.inbox.closed
+	afterScan := c.inbox.afterDispatchScan
+	c.inbox.mu.Unlock()
+	if closed {
+		return sessioninbox.InboxItemMeta{}, false, nil
+	}
+	st, err := c.ensureInbox()
+	if err != nil {
+		return sessioninbox.InboxItemMeta{}, false, err
+	}
+	// NextQueued refreshes disk state and may create its transaction-lock
+	// directory. Keep that access inside the same shutdown boundary as Open.
+	meta, ok := st.NextQueued()
+	if afterScan != nil {
+		afterScan(ok)
+	}
+	return meta, ok, nil
 }
 
 func (c *Controller) scheduleInboxDispatchRetry() {

--- a/internal/control/inbox_dispatch_shutdown_test.go
+++ b/internal/control/inbox_dispatch_shutdown_test.go
@@ -1,0 +1,89 @@
+package control
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/sessioninbox"
+)
+
+func TestControllerShutdownJoinsInboxScanBeforeReturning(t *testing.T) {
+	for _, mode := range []string{"close", "replacement"} {
+		t.Run(mode, func(t *testing.T) {
+			c := New(Options{SessionPath: filepath.Join(t.TempDir(), "session.jsonl")})
+			scanReached := make(chan struct{})
+			releaseScan := make(chan struct{})
+			var releaseOnce sync.Once
+			defer func() {
+				releaseOnce.Do(func() { close(releaseScan) })
+				c.Close()
+				c.autosaveWG.Wait()
+			}()
+			c.SetBeforeInboxDispatch(func(*Controller) (func(), error) { return nil, nil })
+			c.inbox.afterDispatchScan = func(bool) {
+				close(scanReached)
+				<-releaseScan
+			}
+			c.NotifyInboxRuntimeReady()
+			select {
+			case <-scanReached:
+			case <-time.After(inboxDispatchTestTimeout):
+				t.Fatal("dispatcher did not reach the controlled scan boundary")
+			}
+			closed := make(chan struct{})
+			go func() {
+				if mode == "replacement" {
+					c.ReleaseResources()
+				} else {
+					c.Close()
+				}
+				close(closed)
+			}()
+			// The channel fixes the interleaving; this observation window asserts
+			// that shutdown cannot finish until the scan is released.
+			select {
+			case <-closed:
+				t.Fatal("shutdown returned while the inbox scan still owned its sidecar access")
+			case <-time.After(100 * time.Millisecond):
+			}
+			releaseOnce.Do(func() { close(releaseScan) })
+			select {
+			case <-closed:
+			case <-time.After(inboxDispatchTestTimeout):
+				t.Fatal("shutdown did not finish after the scan was released")
+			}
+			c.autosaveWG.Wait()
+		})
+	}
+}
+
+func TestInboxDispatchHostAdmissionCanRetireItsController(t *testing.T) {
+	c := New(Options{SessionPath: filepath.Join(t.TempDir(), "session.jsonl")})
+	defer func() {
+		c.Close()
+		c.autosaveWG.Wait()
+	}()
+	if err := c.SetInboxPaused(true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.EnqueueInbox(InboxRequest{Intent: sessioninbox.IntentFollowup, Submit: "queued"}); err != nil {
+		t.Fatal(err)
+	}
+	retired := make(chan struct{})
+	c.SetBeforeInboxDispatch(func(current *Controller) (func(), error) {
+		current.ReleaseResources()
+		close(retired)
+		return nil, ErrInboxRuntimeUnpublished
+	})
+	if err := c.SetInboxPaused(false); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-retired:
+	case <-time.After(inboxDispatchTestTimeout):
+		t.Fatal("host admission could not retire its dispatching controller")
+	}
+	c.autosaveWG.Wait()
+}


### PR DESCRIPTION
## Summary

Controller shutdown could finish while an autonomous inbox scan still refreshed its sidecar on disk. During model-runtime replacement this could recreate the transaction-lock directory after cleanup had started, causing the stale foreground recovery test to fail on macOS.

Join sidecar opening and queue scans at the controller shutdown boundary. The scan gate is released before host admission, preserving the ability for model refresh to retire its own dispatching controller without a self-wait deadlock. Add regressions for both shutdown modes and host-triggered retirement.

Also close the process-wide history and usage catalogs before removing the bot model-settings test's isolated home. The prior full Windows candidate CI exposed open SQLite handles in this fixture; an individual controller does not own those process-wide resources.

## Verification

- New controlled scan/shutdown regression fails against the previous implementation for both Close and ReleaseResources.
- Focused shutdown and retirement tests: `go test -race ./internal/control -run 'TestControllerShutdownJoinsInboxScanBeforeReturning|TestInboxDispatchHostAdmissionCanRetireItsController' -count=20` passed.
- Original stale foreground recovery scenario: 1,000 race-enabled repetitions passed after reproducing the old failure.
- Full root and Desktop Go suites passed separately.
- Full control, serve, and sessioninbox race suites passed.
- Root golangci-lint, repository lint, and diff whitespace checks passed.
- Bot fixture cleanup: the original failure reproduced on native Windows ARM64; the corrected full bot suite passed 20 native repetitions and 10 race-enabled repetitions, with focused lint passing.
- Native Windows 11 ARM64: the three shutdown/stale-recovery regressions passed 20 repetitions and the production Wails build passed. The new Desktop and Serve restored existing SSH/local histories, completed a request, saved a disposable credential, rebuilt the remote runtime before its next request, and used the saved credential for both remote and local requests. Native window shutdown completed successfully.

## Documentation impact

Documentation-impact: none - restores the existing controller shutdown contract without changing configuration, persisted data, or public APIs.

## Cache impact

Cache-impact: none - no provider-visible prompt, schema, ordering, or serialization changes.
Cache-guard: N/A - this change only joins autonomous inbox disk scans during shutdown.
System-prompt-review: N/A
