### PR TITLE
fix(agent): bill the turn phases that capability_phases reports / 修复 capability_phases 六个耗时桶恒为零 (#5178)

### DIFF
--- a/desktop/frontend/src/__tests__/completion-summary-presentation.test.ts
+++ b/desktop/frontend/src/__tests__/completion-summary-presentation.test.ts
@@ -46,7 +46,7 @@ const answer: Item = { kind: "assistant", id: "a0", text: "done", reasoning: "",
 const outside = partitionTurnItems([history!, answer]).flatMap(p => p.outsideItems);
 assert.deepEqual(outside.map(i => i.id), ["a0", "history"], "sidecar placement preserves a result footer");
 for (const phase of ["checking", "verifying", "working", "reviewing"]) {
-  const plain = { ...initialState, items: [user], seq: 1 };
+  const plain: State = { ...initialState, items: [user], seq: 1 };
   const next = reducer(plain, { type: "event", e: { kind: "turn_phase", phase } });
   assert.equal(next.turnPhase, phase);
   assert.equal(next.completionSummary?.checking ?? false, false, `${phase} is not verification evidence`);
@@ -58,11 +58,11 @@ for (const phase of ["checking", "verifying", "working", "reviewing"]) {
   assert.equal(active.completionSummary?.checking, true, `${phase} preserves real running checks`);
   assert.equal(active.items.find(i => i.kind === "notice")!.id, resultId);
 }
-let live = reducer({ ...initialState, items: [user] }, { type: "event", e: { kind: "tool_dispatch", tool: { id: "live", name: "bash", args: '{"command":"go test ./..."}' } } });
-live = reducer(live, { type: "event", e: { kind: "tool_progress", tool: { id: "live", name: "bash", verifying: true, output: "running" } } });
+let live = reducer({ ...initialState, items: [user] }, { type: "event", e: { kind: "tool_dispatch", tool: { id: "live", name: "bash", readOnly: false, args: '{"command":"go test ./..."}' } } });
+live = reducer(live, { type: "event", e: { kind: "tool_progress", tool: { id: "live", name: "bash", readOnly: false, verifying: true, output: "running" } } });
 assert.equal(live.completionSummary?.checking, true);
 live = reducer(live, { type: "event", e: { kind: "turn_phase", phase: "working" } });
 assert.equal(live.completionSummary?.checking, true);
-live = reducer(live, { type: "event", e: { kind: "tool_result", tool: { id: "live", name: "bash", output: "PASS" } } });
+live = reducer(live, { type: "event", e: { kind: "tool_result", tool: { id: "live", name: "bash", readOnly: false, output: "PASS" } } });
 assert.equal(live.completionSummary?.checking, false);
 console.log("turn result truth, stable identity, concurrent checks, phases and history passed");

--- a/desktop/frontend/src/__tests__/completion-summary-presentation.test.ts
+++ b/desktop/frontend/src/__tests__/completion-summary-presentation.test.ts
@@ -3,7 +3,7 @@ import { completionSummaryPresentation, normalizeCompletionSummary } from "../li
 import { mergeTurnResult, normalizeTurnChanges, turnChangeText, turnCheckState } from "../lib/turnResult";
 import { historicalResultNotice, withTurnResult, withRunningChecks } from "../lib/completionResultState";
 import { partitionTurnItems } from "../lib/transcriptRows";
-import { initialState, type State, type Item } from "../lib/useController";
+import { initialState, reducer, type State, type Item } from "../lib/useController";
 import { t } from "../lib/i18n";
 import type { TurnChanges } from "../lib/types";
 
@@ -45,4 +45,24 @@ assert.equal(history?.completionSummary?.checkpointTurn, 0);
 const answer: Item = { kind: "assistant", id: "a0", text: "done", reasoning: "", streaming: false };
 const outside = partitionTurnItems([history!, answer]).flatMap(p => p.outsideItems);
 assert.deepEqual(outside.map(i => i.id), ["a0", "history"], "sidecar placement preserves a result footer");
-console.log("turn result truth, stable identity, concurrent checks and history passed");
+for (const phase of ["checking", "verifying", "working", "reviewing"]) {
+  const plain = { ...initialState, items: [user], seq: 1 };
+  const next = reducer(plain, { type: "event", e: { kind: "turn_phase", phase } });
+  assert.equal(next.turnPhase, phase);
+  assert.equal(next.completionSummary?.checking ?? false, false, `${phase} is not verification evidence`);
+  assert.deepEqual(next.items, plain.items, `${phase} must not insert a result card`);
+
+  const checking = withRunningChecks({ ...plain, items: [user, tool("check")] });
+  const resultId = checking.items.find(i => i.kind === "notice")!.id;
+  const active = reducer(checking, { type: "event", e: { kind: "turn_phase", phase } });
+  assert.equal(active.completionSummary?.checking, true, `${phase} preserves real running checks`);
+  assert.equal(active.items.find(i => i.kind === "notice")!.id, resultId);
+}
+let live = reducer({ ...initialState, items: [user] }, { type: "event", e: { kind: "tool_dispatch", tool: { id: "live", name: "bash", args: '{"command":"go test ./..."}' } } });
+live = reducer(live, { type: "event", e: { kind: "tool_progress", tool: { id: "live", name: "bash", verifying: true, output: "running" } } });
+assert.equal(live.completionSummary?.checking, true);
+live = reducer(live, { type: "event", e: { kind: "turn_phase", phase: "working" } });
+assert.equal(live.completionSummary?.checking, true);
+live = reducer(live, { type: "event", e: { kind: "tool_result", tool: { id: "live", name: "bash", output: "PASS" } } });
+assert.equal(live.completionSummary?.checking, false);
+console.log("turn result truth, stable identity, concurrent checks, phases and history passed");

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1527,7 +1527,6 @@ function applyEvent(s: State, e: WireEvent, preserveToolPayloads = false): State
       const phase = (e.phase ?? e.text ?? "").trim();
       if (!phase) return s;
       const next = { ...s, turnPhase: phase, running: true, turnActive: true, cancellable: true };
-      if (phase === "verifying" || phase === "checking") return withTurnResult(next, { ...mergeTurnResult(s.completionSummary, undefined, e.turnId), checking: true });
       return withRunningChecks(next);
     }
     case "turn_status": {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -184,6 +184,9 @@ While a turn runs, the host publishes a content-free phase so a frontend can
 say what the turn is doing. The CLI shows it on the spinner line; the desktop
 app shows it in the composer.
 
+These phases describe execution timing, not verification evidence. Desktop
+check-result cards follow actual running verification tools, not phase names.
+
 | Phase | Emitted when | `capability_phases` bucket |
 | --- | --- | --- |
 | `working` | the turn starts, after each tool batch returns, and after the final-readiness check | `ProviderWaitMs` |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -178,6 +178,26 @@ same care as a session transcript.
 reasonix run --metrics run.json --trajectory run.trajectory.jsonl "fix the failing test"
 ```
 
+### Turn phases
+
+While a turn runs, the host publishes a content-free phase so a frontend can
+say what the turn is doing. The CLI shows it on the spinner line; the desktop
+app shows it in the composer.
+
+| Phase | Emitted when | `capability_phases` bucket |
+| --- | --- | --- |
+| `working` | the turn starts, and again after each tool batch returns | `ProviderWaitMs` |
+| `checking` | a tool batch is about to execute | `ToolExecMs` |
+| `verifying` | the final-readiness check runs before a final answer | `ToolExecMs` |
+| `reviewing` | the delivery review gate inspects a mutation | `ReviewMs` |
+
+A phase is billed to its bucket when the next phase opens, so the durations in
+`--metrics` split a turn into model wait versus tool execution without replaying
+the run. Spans under a millisecond are dropped, and a turn that ends through an
+error or a pause rather than an answer does not bill its last span, so the
+buckets read as a lower bound rather than a full partition of the turn.
+`SubagentWaitMs`, `UserWaitMs` and `CompactMs` have no emitter yet and stay zero.
+
 ### Output formats
 
 | Format | Behavior |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -186,17 +186,21 @@ app shows it in the composer.
 
 | Phase | Emitted when | `capability_phases` bucket |
 | --- | --- | --- |
-| `working` | the turn starts, and again after each tool batch returns | `ProviderWaitMs` |
+| `working` | the turn starts, after each tool batch returns, and after the final-readiness check | `ProviderWaitMs` |
 | `checking` | a tool batch is about to execute | `ToolExecMs` |
 | `verifying` | the final-readiness check runs before a final answer | `ToolExecMs` |
-| `reviewing` | the delivery review gate inspects a mutation | `ReviewMs` |
 
 A phase is billed to its bucket when the next phase opens, so the durations in
 `--metrics` split a turn into model wait versus tool execution without replaying
 the run. Spans under a millisecond are dropped, and a turn that ends through an
 error or a pause rather than an answer does not bill its last span, so the
 buckets read as a lower bound rather than a full partition of the turn.
-`SubagentWaitMs`, `UserWaitMs` and `CompactMs` have no emitter yet and stay zero.
+
+An approval prompt raised inside a tool batch bills to `ToolExecMs`: the batch
+stays open from `checking` until the next `working`, and no user-wait phase is
+emitted. `ReviewMs`, `SubagentWaitMs`, `UserWaitMs` and `CompactMs` stay zero
+because nothing opens those phases inside a turn — `reviewing` is published only
+at run exit, after the turn's phase clock has already closed.
 
 ### Output formats
 

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -155,6 +155,24 @@ JSONL 记录，便于离线回放并归因时间去向（工具执行 vs. 两次
 reasonix run --metrics run.json --trajectory run.trajectory.jsonl "修复失败的测试"
 ```
 
+### 回合阶段
+
+回合运行期间，宿主会发布一个不含内容的阶段标记，供前端显示当前回合正在做
+什么。CLI 显示在加载行上，桌面端显示在输入框区域。
+
+| 阶段 | 触发时机 | `capability_phases` 桶 |
+| --- | --- | --- |
+| `working` | 回合开始时，以及每批工具执行返回之后 | `ProviderWaitMs` |
+| `checking` | 即将执行一批工具时 | `ToolExecMs` |
+| `verifying` | 给出最终回答前运行最终就绪检查时 | `ToolExecMs` |
+| `reviewing` | 交付审查门检查一次改动时 | `ReviewMs` |
+
+某个阶段在下一个阶段开始时才计入对应的桶，因此 `--metrics` 中的耗时可以区分
+模型等待与工具执行，而无需重放整次运行。不足 1 毫秒的区间会被丢弃；以错误或
+暂停（而非给出回答）结束的回合不会计入最后一个区间，因此这些桶应视为下界，
+而不是对整个回合的完整划分。`SubagentWaitMs`、`UserWaitMs` 与 `CompactMs`
+目前没有发射点，保持为 0。
+
 ### 输出格式
 
 | 格式 | 行为 |

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -162,16 +162,19 @@ reasonix run --metrics run.json --trajectory run.trajectory.jsonl "修复失败�
 
 | 阶段 | 触发时机 | `capability_phases` 桶 |
 | --- | --- | --- |
-| `working` | 回合开始时，以及每批工具执行返回之后 | `ProviderWaitMs` |
+| `working` | 回合开始时、每批工具执行返回后，以及最终就绪检查之后 | `ProviderWaitMs` |
 | `checking` | 即将执行一批工具时 | `ToolExecMs` |
 | `verifying` | 给出最终回答前运行最终就绪检查时 | `ToolExecMs` |
-| `reviewing` | 交付审查门检查一次改动时 | `ReviewMs` |
 
 某个阶段在下一个阶段开始时才计入对应的桶，因此 `--metrics` 中的耗时可以区分
 模型等待与工具执行，而无需重放整次运行。不足 1 毫秒的区间会被丢弃；以错误或
 暂停（而非给出回答）结束的回合不会计入最后一个区间，因此这些桶应视为下界，
-而不是对整个回合的完整划分。`SubagentWaitMs`、`UserWaitMs` 与 `CompactMs`
-目前没有发射点，保持为 0。
+而不是对整个回合的完整划分。
+
+工具批次内弹出的审批提示会计入 `ToolExecMs`：该批次从 `checking` 一直开到下一次
+`working`，而当前没有用户等待阶段的发射点。`ReviewMs`、`SubagentWaitMs`、
+`UserWaitMs` 与 `CompactMs` 保持为 0，因为回合内没有任何地方开启这些阶段——
+`reviewing` 只在运行退出时发布，那时回合的相位时钟已经关闭。
 
 ### 输出格式
 

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -160,6 +160,9 @@ reasonix run --metrics run.json --trajectory run.trajectory.jsonl "修复失败�
 回合运行期间，宿主会发布一个不含内容的阶段标记，供前端显示当前回合正在做
 什么。CLI 显示在加载行上，桌面端显示在输入框区域。
 
+这些阶段描述执行计时，不代表验证证据。桌面端检查结果卡由实际运行中的验证工具
+驱动，不根据阶段名称生成。
+
 | 阶段 | 触发时机 | `capability_phases` 桶 |
 | --- | --- | --- |
 | `working` | 回合开始时、每批工具执行返回后，以及最终就绪检查之后 | `ProviderWaitMs` |

--- a/internal/agent/readiness_gate.go
+++ b/internal/agent/readiness_gate.go
@@ -1,6 +1,10 @@
 package agent
 
-import "reasonix/internal/taskcontract"
+import (
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+	"reasonix/internal/taskcontract"
+)
 
 // readinessPauseActive reports whether an unmet final-readiness requirement may
 // pause the turn and hand the user a recovery card.
@@ -13,4 +17,37 @@ func (a *Agent) readinessPauseActive(check finalReadinessCheck) bool {
 	}
 	return a.turn.constraints.PolicyFloor == taskcontract.PolicyFloorDelivery ||
 		a.closedLoopActive() || a.planContractSnapshot() != nil
+}
+
+// handleReadinessGap resolves an unmet final-readiness requirement: a resumable
+// pause carrying the structured gap, or an allowed-readiness audit when the
+// active policy ends normally and reports the gap in its summary instead.
+// stopped reports whether the caller must end the turn with err.
+func (a *Agent) handleReadinessGap(readiness finalReadinessCheck) (stopped bool, err error) {
+	if readiness.reason == "" {
+		return false, nil
+	}
+	// Standard ends with its answer/quality summary. Delivery and Goal hand
+	// the structured gap to the controller, which exposes an explicit recovery
+	// action or lets the Goal FSM decide whether to continue.
+	if !a.readinessPauseActive(readiness) {
+		event.RecordReadinessAudit(a.svc.sink, readiness.audit(evidence.ReadinessAllowed, a.turn.readinessRecovered))
+		return false, nil
+	}
+	event.RecordReadinessAudit(a.svc.sink, readiness.audit(evidence.ReadinessErrored, false))
+	a.pending.finalReadinessRecovery = true
+	a.persistFinalReadinessRecovery(readiness.missingIDs())
+	gaps := a.readinessOperationGaps()
+	reason := readiness.reason
+	if named := describeReadinessGaps(gaps); named != "" {
+		reason += "; " + named
+	}
+	return true, &FinalReadinessError{
+		Attempts:          1,
+		Reason:            reason,
+		Missing:           readiness.missingIDs(),
+		ContinuationClass: readiness.continuationClass(),
+		ProgressKey:       readiness.progressSignature(),
+		Operations:        gaps,
+	}
 }

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -397,7 +397,12 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, tex
 			StopReason: reason,
 		}
 	}
+	// The phase belongs at the caller: ReadinessResult runs the same check for
+	// the host, outside any turn. Reopening working keeps the continuation paths
+	// below, each of which starts a provider round, out of the tool bucket.
+	a.emitTurnPhase(event.TurnPhaseVerifying)
 	readiness := a.finalReadinessCheckFor()
+	a.emitTurnPhase(event.TurnPhaseWorking)
 	if state.graceRound && (readiness.reason != "" || !hasVisibleFinalAnswer(text)) {
 		a.contextManager().ObserveUsage(usage)
 		return false, a.gracePause(state)
@@ -471,6 +476,7 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, tex
 	// carries into the next turn un-folded and can overflow the model window.
 	// No-op below the trigger, so normal turns keep their warm cache.
 	a.contextManager().ObserveUsage(usage)
+	a.closeTurnPhase()
 	return false, nil // model gave a final answer
 }
 
@@ -503,7 +509,11 @@ func (a *Agent) handleToolRound(ctx context.Context, state *turnRuntime, step in
 	if a.task.ledger != nil {
 		receiptMark = a.task.ledger.Len()
 	}
+	// The phase pair around the batch is what makes the accounting mean its
+	// names: it bills this round's wait to the provider and the batch to tools.
+	a.emitTurnPhase(event.TurnPhaseChecking)
 	batch := a.executeBatch(ctx, state, calls)
+	a.emitTurnPhase(event.TurnPhaseWorking)
 	if batch.err != nil {
 		// Any completed results are already stored; a failed durability barrier
 		// prevents starting the next tool.
@@ -517,6 +527,7 @@ func (a *Agent) handleToolRound(ctx context.Context, state *turnRuntime, step in
 		// result is stored, so another acknowledgement adds no host value and can
 		// turn a valid bounded plan into a max-steps pause.
 		a.contextManager().ObserveUsage(usage)
+		a.closeTurnPhase()
 		return false, nil
 	}
 	if boundaryFinalizer {

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -414,29 +414,8 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, tex
 		a.contextManager().ObserveUsage(usage)
 		return false, a.gracePause(state)
 	}
-	if readiness.reason != "" {
-		// Standard ends with its answer/quality summary. Delivery and Goal hand
-		// the structured gap to the controller, which exposes an explicit recovery
-		// action or lets the Goal FSM decide whether to continue.
-		if a.readinessPauseActive(readiness) {
-			event.RecordReadinessAudit(a.svc.sink, readiness.audit(evidence.ReadinessErrored, false))
-			a.pending.finalReadinessRecovery = true
-			a.persistFinalReadinessRecovery(readiness.missingIDs())
-			gaps := a.readinessOperationGaps()
-			reason := readiness.reason
-			if named := describeReadinessGaps(gaps); named != "" {
-				reason += "; " + named
-			}
-			return false, &FinalReadinessError{
-				Attempts:          1,
-				Reason:            reason,
-				Missing:           readiness.missingIDs(),
-				ContinuationClass: readiness.continuationClass(),
-				ProgressKey:       readiness.progressSignature(),
-				Operations:        gaps,
-			}
-		}
-		event.RecordReadinessAudit(a.svc.sink, readiness.audit(evidence.ReadinessAllowed, a.turn.readinessRecovered))
+	if stopped, err := a.handleReadinessGap(readiness); stopped {
+		return false, err
 	}
 	if !hasVisibleFinalAnswer(text) {
 		// Harness-style termination accepts a reasoning-only clean stop. Only

--- a/internal/agent/turn_phase.go
+++ b/internal/agent/turn_phase.go
@@ -22,11 +22,28 @@ func (a *Agent) emitTurnPhase(phase event.TurnPhaseName) {
 		return
 	}
 	now := time.Now()
-	if !a.turn.phase.at.IsZero() && a.capabilityAudit != nil {
-		a.capabilityAudit.RecordPhaseMs(phaseAuditName(a.turn.phase.last), now.Sub(a.turn.phase.at).Milliseconds())
-	}
+	a.recordOpenPhase(now)
 	a.turn.phase = phaseClock{last: phase, at: now}
 	a.svc.sink.Emit(event.Event{Kind: event.TurnPhase, PhaseName: phase, Text: string(phase)})
+}
+
+// recordOpenPhase bills the phase that is ending. A span is accounted for only
+// when something closes it, so a phase nobody follows records nothing.
+func (a *Agent) recordOpenPhase(now time.Time) {
+	if a.turn.phase.at.IsZero() || a.capabilityAudit == nil {
+		return
+	}
+	a.capabilityAudit.RecordPhaseMs(phaseAuditName(a.turn.phase.last), now.Sub(a.turn.phase.at).Milliseconds())
+}
+
+// closeTurnPhase bills the open phase without opening another one, for the end
+// of a turn: beginRunTurn resets a.turn, so an unclosed tail span is lost.
+func (a *Agent) closeTurnPhase() {
+	if a == nil {
+		return
+	}
+	a.recordOpenPhase(time.Now())
+	a.turn.phase = phaseClock{}
 }
 
 func phaseAuditName(phase event.TurnPhaseName) string {

--- a/internal/agent/turn_phase_test.go
+++ b/internal/agent/turn_phase_test.go
@@ -5,7 +5,9 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
+	"reasonix/internal/capability"
 	"reasonix/internal/completion"
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
@@ -116,5 +118,70 @@ func TestExecutionPolicyAbsentOnNewTurn(t *testing.T) {
 		if m.Role == provider.RoleUser && strings.Contains(m.Content, "<execution-policy") {
 			t.Fatal("new turns must not inject execution-policy")
 		}
+	}
+}
+
+// The phase pair around a tool batch is what gives ProviderWaitMs and
+// ToolExecMs their meaning, so the order is asserted, not just the first phase.
+func TestToolRoundAlternatesProviderAndToolPhases(t *testing.T) {
+	sink := &phaseSink{}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("r1", "read_file", `{"path":"a.go"}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession("sys"), Options{}, sink)
+	if err := a.Run(context.Background(), "read a.go"); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		string(event.TurnPhaseWorking),
+		string(event.TurnPhaseChecking),
+		string(event.TurnPhaseWorking),
+		string(event.TurnPhaseVerifying),
+		string(event.TurnPhaseWorking),
+	}
+	if !slices.Equal(sink.phases, want) {
+		t.Fatalf("phases = %v, want %v", sink.phases, want)
+	}
+	assertToolPhasesClosed(t, sink.phases)
+}
+
+// assertToolPhasesClosed guards the accounting invariant: a tool-billed phase
+// left open swallows whatever runs next, and what runs next is usually a
+// provider round, so its wait would be billed as tool time.
+func assertToolPhasesClosed(t *testing.T, phases []string) {
+	t.Helper()
+	for i, phase := range phases {
+		switch phase {
+		case string(event.TurnPhaseChecking), string(event.TurnPhaseVerifying):
+			if i == len(phases)-1 {
+				t.Fatalf("phase %q at %d is never closed: %v", phase, i, phases)
+			}
+		}
+	}
+}
+
+// RecordPhaseMs drops anything under a millisecond, so the tool sleeps: the
+// assertion is that the bucket is reachable at all, which it was not before.
+func TestToolRoundBillsPhaseDurations(t *testing.T) {
+	audit := &capability.Audit{}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true, delay: 5 * time.Millisecond})
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("r1", "read_file", `{"path":"a.go"}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession("sys"), Options{CapabilityAudit: audit}, event.Discard)
+	if err := a.Run(context.Background(), "read a.go"); err != nil {
+		t.Fatal(err)
+	}
+	phases := audit.Snapshot().Phases
+	if phases.ToolExecMs <= 0 {
+		t.Fatalf("ToolExecMs = %d, want the tool span billed", phases.ToolExecMs)
+	}
+	if phases.ProviderWaitMs < 0 {
+		t.Fatalf("ProviderWaitMs = %d, want non-negative", phases.ProviderWaitMs)
 	}
 }

--- a/internal/boot/effect_turn_phase_test.go
+++ b/internal/boot/effect_turn_phase_test.go
@@ -1,0 +1,91 @@
+package boot
+
+// Effect test for turn-phase accounting: the phase buckets are only meaningful
+// if a real Build assembly bills them, so this asserts through the audit the
+// CLI actually exports, not through a hand-built Audit.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// slowPhaseProvider stalls before answering so the provider span clears
+// RecordPhaseMs's sub-millisecond floor by a wide margin.
+type slowPhaseProvider struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *slowPhaseProvider) Name() string { return "boot-phase-effect-test" }
+
+func (p *slowPhaseProvider) Stream(_ context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	p.mu.Lock()
+	p.calls++
+	p.mu.Unlock()
+	time.Sleep(10 * time.Millisecond)
+	chunks := []provider.Chunk{
+		{Type: provider.ChunkText, Text: "ok"},
+		{Type: provider.ChunkDone},
+	}
+	ch := make(chan provider.Chunk, len(chunks))
+	for _, chunk := range chunks {
+		ch <- chunk
+	}
+	close(ch)
+	return ch, nil
+}
+
+// TestEffectTurnPhaseBillsProviderWaitThroughRealBuild pins the boundary the
+// run --metrics JSON reads. Before the phase clock closed at turn end this
+// reported zero for every bucket no matter how long the provider took.
+func TestEffectTurnPhaseBillsProviderWaitThroughRealBuild(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	prov := &slowPhaseProvider{}
+	provider.Register("phase-effect", func(provider.Config) (provider.Provider, error) {
+		return prov, nil
+	})
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[environment]
+enabled = false
+
+[[providers]]
+name = "test-model"
+kind = "phase-effect"
+model = "x"
+`)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	if err := ctrl.Run(context.Background(), "reply ok"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	exec := ctrl.Executor()
+	if exec == nil {
+		t.Fatal("no executor on the built controller")
+	}
+	audit := exec.CapabilityAudit()
+	if audit == nil {
+		t.Fatal("real Build left the capability audit unwired")
+	}
+	phases := audit.Snapshot().Phases
+	if phases.ProviderWaitMs <= 0 {
+		t.Fatalf("ProviderWaitMs = %d, want the provider span billed (%+v)", phases.ProviderWaitMs, phases)
+	}
+}


### PR DESCRIPTION
**简述**：`run --metrics` 导出的 `capability_phases` 有六个耗时桶，实际运行中全部为零，其中五个永远不可能非零——`checking`/`verifying` 无人发出，`subagent`/`user`/`compact` 无人映射，且 `beginRunTurn` 会整体重置 `a.turn` 从而丢弃未结束的阶段。本 PR 补齐阶段发出与计费，使指标真实反映耗时。Refs #5178。

## Summary

`run --metrics` exports a `capability_phases` object with six duration buckets.
On any real run **all six are zero**, and five of them cannot be anything else.

`emitTurnPhase` (`internal/agent/turn_phase.go`) bills the duration of the
*previous* phase and then opens the new one, so a span is only ever accounted
for when something closes it. Today there are exactly two emitters:

- `run_loop.go` — `working`, once per turn, in `beginRunTurn`
- `capability_gate.go` — `reviewing`, only when the delivery review gate fires

From that:

- `phaseAuditName` maps `checking`/`verifying` to the `tool` bucket, but neither
  phase is emitted anywhere, so `ToolExecMs` can never be non-zero.
- Nothing maps to `subagent`/`user`/`compact`, and `RecordPhaseMs` is their only
  writer, so those three buckets are dead code.
- `beginRunTurn` resets `a.turn` wholesale, discarding the open phase. On an
  ordinary turn nothing closes the last span, so **nothing is recorded at all**.
- When the review gate does fire, `reviewing` closes `working` and credits the
  entire turn up to the gate as `provider` — a misleading number rather than
  provider wait. `reviewing` itself is never closed, so `ReviewMs` stays zero.

### This is a regression, and the culprit is identifiable

`5e03e03ea` emitted `TurnPhaseVerifying` from `appendClosedLoopReadiness` in
`internal/agent/final_readiness.go`. `314beed8f` ("replace task-mode routing
with fact-driven execution", #8930) deleted that whole function during a
refactor and took the emission with it, without replacing it. The constant in
`event.go`, the labels in three locales, the TUI branch in `chat_tui.go` and the
`phaseAuditName` mapping were all left orphaned.

## Changes

**`internal/agent/turn_phase.go`** — the billing body moves into
`recordOpenPhase(now)` so `emitTurnPhase` keeps its exact semantics, plus
`closeTurnPhase()`, which bills the open phase without opening another one. That
is the load-bearing piece: without it a turn's tail span is lost when
`beginRunTurn` resets the turn state.

**`internal/agent/run_loop.go`** — three insertions:

- `handleToolRound`: `checking` immediately before `executeBatch`, `working`
  immediately after it returns. The pair is what makes the two buckets mean
  their names — the round's wait is billed to the provider, the batch to tools.
  The second emission sits *before* the `batch.err` check on purpose, so a
  failed batch still bills its tool span.
- `handleFinalResponse`: `verifying` before `finalReadinessCheckFor()`, which
  restores the emission #8930 dropped, then `working` immediately after it. It
  goes at the caller rather than inside the function because `ReadinessResult`
  runs the same check for the host, outside any turn — emitting inside would
  publish a phase with no turn. The reopening is load-bearing: four of that
  function's paths `return true` to continue the loop, which starts a fresh
  provider round, and leaving the tool-billed `verifying` phase open across it
  would bill model wait as tool time.
- `closeTurnPhase()` on both clean endings — the text final answer in
  `handleFinalResponse`, and a successful terminal tool (`submit_plan`) in
  `handleToolRound`.

### Known limitation

A turn that ends through an error or a pause still drops its last open span.
Covering those needs a defer, and the only two places to hang one are
`runToolLoop`, which has no line budget left, and `Agent.Run`, which is
system-prompt-sensitive. The buckets are a lower bound on the turn rather than a
full partition of it, and `docs/CLI.md` says so rather than overclaiming.

Nothing is added to `runToolLoop`: it is 122 lines against repolint's 120-line
ceiling and the file's recorded `function-size: 2` is entirely its own, so a
single added line there would have to widen the baseline. `handleToolRound`
(93 -> 97) and `handleFinalResponse` (113 -> 118) both had headroom, and
`repolint` is clean with the baseline untouched.

**Out of scope, deliberately:** `SubagentWaitMs`, `UserWaitMs` and `CompactMs`
still have no emitter. Wiring them means deciding where those phases begin and
end, which is new behavior rather than this regression. Happy to follow up.

### Observable effect

The CLI spinner and the desktop composer now show `checking` while a tool batch
runs and `verifying` during the readiness check, instead of staying on
`working`. Desktop result cards are driven only by actual running verification tools;
`checking` and `verifying` phase events update execution status without creating
verification evidence. The frontend reducer preserves a real check card across
phase changes and removes its running state when the check finishes.

A regression test in `completion-summary-presentation.test.ts` covers all four
phase names, stable result identity, and the actual dispatch/progress/result
sequence of a verification tool. The test failed before the fix. Browser DOM
verification also confirmed that generic phases create no result card while
real verification retains its card until completion. Frontend build and bundle
budgets, completion UI tests, Go vet, lint, and builtin/boot tests passed locally.

## Issues

Refs #8930 — the refactor that dropped the `verifying` emission.

Refs #5178 — that P0 asks "where did those 87 seconds go, and which tool call is
the bottleneck (network round-trip vs local computation)", and notes the data
source is per-tool stats `internal/agent` already has. The provider-wait vs
tool-exec split is exactly that attribution, and one half of it was structurally
zero. This is a prerequisite, not the panel that issue asks for, so Refs rather
than Fixes.

## Verification

- New `TestToolRoundAlternatesProviderAndToolPhases` asserts the full sequence
  `[working, checking, working, verifying, working]` for a turn with one tool
  call. On the unpatched tree it reports `phases = [working]`. It also asserts
  the accounting invariant that no tool-billed phase is ever left open at the
  end of the sequence, which is what stops a provider round from being billed
  as tool time.
- New `TestToolRoundBillsPhaseDurations` runs a `fakeTool` with a 5ms `delay`
  (the field already exists) and asserts `Phases.ToolExecMs > 0`. `RecordPhaseMs`
  drops anything under a millisecond, hence the deliberate delay. On the
  unpatched tree it reports `ToolExecMs = 0`.
- New `internal/boot/effect_turn_phase_test.go` is the effect test REASONIX.md
  asks for: a scripted provider that sleeps 10ms, the real `boot.Build`
  assembly, and the audit read back through the same path the CLI uses
  (`ctrl.Executor().CapabilityAudit().Snapshot().Phases`). Asserts
  `ProviderWaitMs > 0`; on the unpatched tree it prints all six buckets at zero.
  It deliberately does not assert `ToolExecMs`, which would need a real slow
  tool, and `internal/boot` runs in the scoped Windows suites.
- `gofmt -l .` clean, `go vet ./...` clean, `go build ./...` clean.
- `go run ./tools/repolint`: clean, baseline unchanged.
- `golangci-lint run ./...` at the pinned `v2.12.2`: 0 issues. Needed
  `GOTOOLCHAIN=go1.26.6` locally, since on Go 1.27 the bundled staticcheck
  panics in `buildir` on the stdlib `internal/poll` — unrelated to this diff.
- `go test ./internal/agent/ ./internal/capability/ ./internal/cli/ ./internal/boot/`: ok.
- `go test -race -run 'TurnPhase|Phase' ./internal/agent/`: ok.
- `REASONIX_RELEASE_CACHE_GUARD=1 go test -run 'TestCacheHitPrefixStable|TestCacheHitClimbsWithoutCompaction' ./internal/agent/`: ok.
- `go test ./internal/tool/builtin/ ./internal/boot/`: ok.
- `make lint` also fails on `scripts/check-wails-pin.test.sh` here because this
  machine has no `node`; the identical failure reproduces on unmodified
  `main-v2`, so it is an environment gap, not this diff.

## Documentation impact

Documentation-impact: updated - docs/CLI.md and docs/CLI.zh-CN.md gain a "Turn
phases" section next to the metrics/trajectory docs, listing each phase, when it
is emitted and which `capability_phases` bucket it bills. Nothing documented the
turn_phase contract or these buckets before. The Chinese mirror is a best-effort
translation and welcome to correction.

## Cache impact

Cache-impact: none - the provider-visible prefix is byte-identical. This only
adds frontend-sink events and host-side timing; no prompt text, tool schema,
memory or config surface changes.
Cache-guard: REASONIX_RELEASE_CACHE_GUARD=1 go test -run 'TestCacheHitPrefixStable|TestCacheHitClimbsWithoutCompaction' ./internal/agent/
System-prompt-review: requested from @SivanCola and @esengine (CODEOWNERS), who
are auto-assigned on this PR. No system-prompt surface is touched: the only
internal/boot change is the new effect test file, and the guard fires solely
because check-cache-impact.sh does not exempt *_test.go the way
check-docs-impact.sh does. The effect test has to live in internal/boot because
REASONIX.md requires asserting through the real boot.Build assembly, and
importing boot from a lower package would break the layering rule.
