### PR TITLE
fix(desktop): keep running composer controls usable / 修复运行中输入控件与推理强度预选

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -817,7 +817,7 @@ func (a *App) restoreOrBuildTabs() {
 				a.activeTabID = ordered[0]
 			}
 		}
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 		a.mu.Unlock()
 		for _, tab := range toBuild {
 			a.startTabControllerBuild(tab)
@@ -1277,7 +1277,7 @@ func (a *App) submitInitialGoalToLocalTab(
 	tab.toolApprovalMode = toolApprovalMode
 	tab.goal = goal
 	tab.mode = tabModeFromAxes(false, toolApprovalMode == control.ToolApprovalYolo)
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	a.mu.Unlock()
 
 	ctrl.SetPlanMode(false)
@@ -1608,7 +1608,7 @@ func (a *App) ensureTabControllerWorkspace(tab *WorkspaceTab) error {
 			tab.sink = &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
 		}
 		hostKey = takeTabSharedHostKey(tab)
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 	if hostKey != "" {
@@ -1807,7 +1807,7 @@ func (a *App) SetModeForTab(tabID, mode string) []string {
 	drained = append(drained, applyTabToolApprovalModeToController(ctrl, approvalMode)...)
 	a.mu.Lock()
 	if a.tabs[tabIDForSave] == tab {
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 	return drained
@@ -1917,7 +1917,7 @@ func (a *App) SetComposerProfileForTab(tabID, collaborationMode, toolApprovalMod
 
 	a.mu.Lock()
 	if a.tabs[tabIDForSave] == tab {
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 	if drained == nil {
@@ -1961,7 +1961,7 @@ func (a *App) SetCollaborationModeForTab(tabID, mode string) {
 	}
 	a.mu.Lock()
 	if a.tabs[tabIDForSave] == tab {
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 }
@@ -2087,7 +2087,7 @@ func (a *App) assignFreshSessionTopic(tab *WorkspaceTab) {
 	tab.TopicTitle = defaultTopicTitle
 	tab.topicTitleSource = topicTitleSourceAuto
 	if current := a.tabs[tab.ID]; current == tab {
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 	if strings.TrimSpace(scope) == "global" {
@@ -2118,7 +2118,7 @@ func (a *App) ensureTabTopicIndexedForUserTurn(tab *WorkspaceTab) {
 	tab.TopicTitle = defaultTopicTitle
 	tab.topicTitleSource = topicTitleSourceAuto
 	if current := a.tabs[tab.ID]; current == tab {
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 	if strings.TrimSpace(scope) == "global" {
@@ -2274,7 +2274,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	// was just destroyed, and finishing later would pass the generation
 	// check and overwrite this controller.
 	a.supersedeTabBuildLocked(tab)
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	a.mu.Unlock()
 	// Same contract as ClearSession's non-running path: the replacement
 	// session starts with zero spend.
@@ -3087,7 +3087,7 @@ func (a *App) removeSessionRuntimeBindings(dir, sessionPath string) ([]removedSe
 	dir, entries, activeID, version := a.saveTabsCollectLocked()
 	a.mu.Unlock()
 
-	a.saveTabsWrite(dir, entries, activeID, version)
+	_ = a.saveTabsWrite(dir, entries, activeID, version)
 
 	return removed, fallback
 }
@@ -3348,7 +3348,7 @@ func (a *App) openTransientBlankRuntime(scope, workspaceRoot string) error {
 	a.tabs[tab.ID] = tab
 	a.tabOrder = append(a.tabOrder, tab.ID)
 	a.activeTabID = tab.ID
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	a.mu.Unlock()
 
 	a.startTabControllerBuild(tab)
@@ -3957,7 +3957,7 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 		a.newSessionRuntimeLocked(tab, transition.targetKey)
 	}
 	newEpoch := a.advanceSessionRuntimeEpochLocked(tab)
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	candidate.ctrl = nil
 	candidate.sink = nil
 	committed = true
@@ -4057,7 +4057,7 @@ func (a *App) reattachDetachedSessionRuntimeForRebind(
 
 	delete(a.detachedSessions, key)
 	applyRuntimeTab(tab, detached, sessionPath, a.ctx, a)
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	attachedCtrl := tab.Ctrl
 	attachedSink := tab.sink
 	attachedEpoch := a.runtimeEpochForTabLocked(tab)
@@ -4958,7 +4958,7 @@ func (a *App) RemoveWorkspace(dir string) error {
 				a.activeTabID = ordered[0]
 			}
 		}
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 		a.mu.Unlock()
 
 		for _, tab := range closeTabs {
@@ -6761,7 +6761,7 @@ func (a *App) SetGoalForTab(tabID, goal string) error {
 	}
 	a.mu.Lock()
 	if a.tabs[tabIDForSave] == tab {
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 	return nil
@@ -6806,7 +6806,7 @@ func (a *App) ResumeGoalForTab(tabID string) bool {
 	a.mu.Lock()
 	if a.tabs[tab.ID] == tab {
 		tab.goal = strings.TrimSpace(ctrl.Goal())
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 	return true
@@ -6869,7 +6869,7 @@ func (a *App) SetToolApprovalModeForTab(tabID, mode string) []string {
 	drained := applyTabToolApprovalModeToController(ctrl, mode)
 	a.mu.Lock()
 	if a.tabs[tabIDForSave] == tab {
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 	return drained
@@ -9764,7 +9764,7 @@ func (a *App) SetModelForTab(tabID, name string) (retErr error) {
 	// Supersede any in-flight startup build: it would otherwise finish later,
 	// overwrite this controller, and release/steal the tab's session lease.
 	a.supersedeTabBuildLocked(tab)
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	a.mu.Unlock()
 	if oldCtrl != nil {
 		oldCtrl.Close()
@@ -9872,7 +9872,7 @@ func (a *App) persistTabTokenMode(tab *WorkspaceTab) {
 		return
 	}
 	a.mu.Lock()
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	a.mu.Unlock()
 	_ = a.saveTabSessionMetaForCurrentSession(tab)
 }

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3828,6 +3828,7 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 
 		a.clearDeferredRebuildVersion(tab.ID, pendingSequence)
 		a.emitReady(a.ctx, tab.ID)
+		a.notifyEffortSelectionCleared(tab, source.pendingEffort != nil)
 
 		tab.turnStartMu.Unlock()
 		a.runtimeAdmissionMu.Unlock()
@@ -3933,6 +3934,7 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	tab.adoptSessionLease(targetLease)
 	targetLease = nil
 	tab.Ctrl = candidate.ctrl
+	tab.pendingEffort = nil
 	tab.sink = candidate.sink
 	tab.SessionPath = sessionPath
 	tab.model = candidate.model
@@ -3989,6 +3991,7 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	a.clearDeferredRebuildVersion(tab.ID, pendingSequence)
 	a.notifyTabRuntimeRebuiltAtEpoch(tab, newEpoch)
 	a.emitReady(a.ctx, tab.ID)
+	a.notifyEffortSelectionCleared(tab, source.pendingEffort != nil)
 	return nil
 }
 
@@ -9242,6 +9245,8 @@ type EffortInfo struct {
 	Current   string                     `json:"current"`
 	Default   string                     `json:"default"`
 	Levels    []string                   `json:"levels"`
+	Pending   *string                    `json:"pending,omitempty"`
+	CanDefer  bool                       `json:"canDefer,omitempty"`
 }
 
 // Models flattens the configured providers into their (provider, model) pairs —
@@ -9752,6 +9757,8 @@ func (a *App) SetModelForTab(tabID, name string) (retErr error) {
 	tab.Ctrl = newCtrl
 	tab.model = name
 	tab.effort = cloneStringPtr(effortOverride)
+	clearedEffort := tab.pendingEffort != nil
+	tab.pendingEffort = nil
 	tab.Label = newCtrl.Label()
 	applyNormalizedRuntimeToTabLocked(tab, restoredRuntime)
 	// Supersede any in-flight startup build: it would otherwise finish later,
@@ -9779,6 +9786,7 @@ func (a *App) SetModelForTab(tabID, name string) (retErr error) {
 	// A model switch changes the pricing context; discard the session-local
 	// automatic wallet hint and let the next balance response rebind it.
 	tab.clearRuntimeDisplayCurrency()
+	a.notifyEffortSelectionCleared(tab, clearedEffort)
 	a.notifyTabRuntimeRebuilt(tab)
 	timing.SwapAndPersist = time.Since(stageStarted)
 	return nil
@@ -9789,7 +9797,19 @@ func (a *App) Effort() EffortInfo {
 }
 
 func (a *App) EffortForTab(tabID string) EffortInfo {
-	entry, err := a.currentProviderEntryForTab(tabID)
+	tab := a.tabByID(tabID)
+	if tab != nil {
+		a.reconcileTabWithPinnedSessionMeta(tab)
+	}
+	a.mu.RLock()
+	snap := snapshotTabRuntimeLocked(tab)
+	var pending *string
+	if tab != nil && tab.pendingEffort != nil {
+		display := displayedEffort(tab.pendingEffort.value)
+		pending = &display
+	}
+	a.mu.RUnlock()
+	entry, err := providerEntryForTabSnapshot(snap)
 	if err != nil {
 		return EffortInfo{Current: "auto", Levels: []string{}}
 	}
@@ -9801,154 +9821,11 @@ func (a *App) EffortForTab(tabID string) EffortInfo {
 	if levels == nil {
 		levels = []string{}
 	}
-	return EffortInfo{Supported: true, Current: config.EffortDisplay(entry), Default: cap.Default, Levels: levels, Options: config.ReasoningCapabilityForEntry(entry).Options}
+	return EffortInfo{Supported: true, Current: config.EffortDisplay(entry), Default: cap.Default, Levels: levels, Options: config.ReasoningCapabilityForEntry(entry).Options, Pending: pending, CanDefer: tab != nil && !snap.readOnly}
 }
 
 func (a *App) SetEffort(level string) error {
 	return a.SetEffortForTab("", level)
-}
-
-func (a *App) SetEffortForTab(tabID, level string) error {
-	tab := a.tabByID(tabID)
-	if tab == nil {
-		if strings.TrimSpace(tabID) == "" {
-			entry, err := a.currentProviderEntryForTab("")
-			if err != nil {
-				return err
-			}
-			effort, err := config.NormalizeEffort(entry, level)
-			if err != nil {
-				return err
-			}
-			return a.applyProviderEffortConfig(entry, effort)
-		}
-		return fmt.Errorf("tab %q not found", tabID)
-	}
-	// Build+swap path; serialize with the other rebuild paths (see
-	// runtimeRebuildMu). The tab==nil branch above goes through
-	// applyProviderEffortConfig → rebuildSetting, which takes the lock itself.
-	pendingSequence := a.deferredRebuildSequence(tab.ID)
-	a.runtimeRebuildMu.Lock()
-	defer a.runtimeRebuildMu.Unlock()
-	tab.turnStartMu.Lock()
-	defer tab.turnStartMu.Unlock()
-	prevPath := a.reconciledSessionPathForTab(tab)
-	if prevPath == "" {
-		prevPath = a.currentSessionPathFor(tab)
-	}
-	// Recomputing prevPath after this attach would be a dead store: it is
-	// unconditionally derived again after ensureTabControllerWorkspace below.
-	if a.controllerForTab(tab) == nil && prevPath != "" {
-		a.attachExistingSessionRuntime(tab, prevPath, a.ctx)
-	}
-	if err := rebuildControllerActiveWorkErrorFor(a.controllerForTab(tab), "effort"); err != nil {
-		return err
-	}
-	if err := a.ensureTabControllerWorkspace(tab); err != nil {
-		return err
-	}
-	prevPath = a.reconciledSessionPathForTab(tab)
-	if prevPath == "" {
-		prevPath = a.currentSessionPathFor(tab)
-	}
-	if a.controllerForTab(tab) == nil && prevPath != "" && a.attachExistingSessionRuntime(tab, prevPath, a.ctx) {
-		prevPath = a.reconciledSessionPathForTab(tab)
-		if prevPath == "" {
-			prevPath = a.currentSessionPathFor(tab)
-		}
-		if err := rebuildControllerActiveWorkErrorFor(a.controllerForTab(tab), "effort"); err != nil {
-			return err
-		}
-	}
-	snap := a.tabRuntimeSnapshot(tab)
-	runtime := snap.normalizedRuntime()
-	entry, err := a.currentProviderEntryForTab(tabID)
-	if err != nil {
-		return err
-	}
-	modelRef := entry.Name + "/" + entry.Model
-	effort, err := config.NormalizeEffort(entry, level)
-	if err != nil {
-		return err
-	}
-	var carried []provider.Message
-	oldCtrl := a.controllerForTab(tab)
-	if oldCtrl != nil {
-		if prevPath == "" {
-			prevPath = oldCtrl.SessionPath()
-		}
-		if err := a.ensureTabSessionLeaseForRebuild(tab, prevPath, "effort"); err != nil {
-			return err
-		}
-		if err := a.snapshotTabForAction(tab, "changing effort"); err != nil {
-			return err
-		}
-		prevPath = sessionPathAfterSnapshot(oldCtrl, prevPath)
-		carried = oldCtrl.History()
-	}
-	sharedHost := a.lookupSharedHost(snap.sharedHostKey)
-	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
-		Model:                    modelRef,
-		RequireKey:               false,
-		StatsSource:              "desktop",
-		TaskStore:                a.taskStore(),
-		OnConfigLoadWarnings:     a.configLoadWarningsHandler(),
-		Sink:                     snap.sink,
-		WorkspaceRoot:            snap.workspaceRoot,
-		SessionDir:               sessionDirForSnapshot(snap),
-		EffortOverride:           &effort,
-		SharedHost:               sharedHost,
-		MCPHostProfile:           plugin.HostProfileDesktopApps,
-		CleanupPendingReconciler: reconcileDesktopCleanupPending,
-		SubagentParentLive:       a.subagentParentProbeForBuild(tab),
-		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
-		PinnedContextLoader:      pinnedContextLoader(snap.workspaceRoot),
-		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
-		OnSessionTransition:      a.handleTabSessionTransition(tab),
-		BeforeInboxDispatch:      a.beforeInboxDispatch,
-		OnSessionTitleChanged:    a.onSessionTitleChanged,
-		// Keep the private temporary directory across effort switches (#7575).
-		SessionTemp: sessionTempFromController(oldCtrl),
-	})
-	if err != nil {
-		return err
-	}
-	a.bindControllerDisplayRecorder(newCtrl)
-	configureControllerRuntime(newCtrl, oldCtrl, runtime)
-	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
-	if err := a.ensureTabSessionLeaseForRebuild(tab, path, "effort"); err != nil {
-		newCtrl.Close()
-		return err
-	}
-	restoredRuntime, err := resumeControllerRuntimeWithMessages(newCtrl, carried, path, runtime)
-	if err != nil {
-		newCtrl.Close()
-		return err
-	}
-	a.mu.Lock()
-	if err := a.authorizeTabReplacementLocked(tab, newCtrl, "switching effort", "effort-switch"); err != nil {
-		a.mu.Unlock()
-		newCtrl.Close()
-		tab.releaseSessionLease()
-		return err
-	}
-	tab.Ctrl = newCtrl
-	tab.model = modelRef
-	tab.effort = &effort
-	tab.Label = newCtrl.Label()
-	applyNormalizedRuntimeToTabLocked(tab, restoredRuntime)
-	clearTabStartupError(tab)
-	tab.Ready = true
-	a.supersedeTabBuildLocked(tab)
-	a.saveTabsLocked()
-	a.mu.Unlock()
-	if oldCtrl != nil {
-		oldCtrl.Close()
-	}
-	a.clearDeferredRebuildVersion(tab.ID, pendingSequence)
-	a.persistTabSessionPath(tab, path)
-	a.notifyTabRuntimeRebuilt(tab)
-	return nil
 }
 
 // SetAgentPresetDeprecatedNotice is returned by the deprecated execution-mode
@@ -10541,20 +10418,19 @@ func (a *App) runEffortCommandForTab(tabID, input string) {
 }
 
 func (a *App) currentProviderEntryForTab(tabID string) (*config.ProviderEntry, error) {
-	if tab := a.tabByID(tabID); tab != nil {
+	return a.currentProviderEntryForRuntimeTab(a.tabByID(tabID))
+}
+
+func (a *App) currentProviderEntryForRuntimeTab(tab *WorkspaceTab) (*config.ProviderEntry, error) {
+	if tab != nil {
 		a.reconcileTabWithPinnedSessionMeta(tab)
 	}
-	a.mu.RLock()
-	ref := ""
-	workspaceRoot := ""
-	effortOverride := (*string)(nil)
-	if tab := a.tabByIDLocked(tabID); tab != nil {
-		ref = tab.model
-		workspaceRoot = tab.WorkspaceRoot
-		effortOverride = cloneStringPtr(tab.effort)
-	}
-	a.mu.RUnlock()
-	cfg, err := config.LoadForRoot(workspaceRoot)
+	return providerEntryForTabSnapshot(a.tabRuntimeSnapshot(tab))
+}
+
+func providerEntryForTabSnapshot(snap tabRuntimeSnapshot) (*config.ProviderEntry, error) {
+	ref := snap.model
+	cfg, err := config.LoadForRoot(snap.workspaceRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -10570,8 +10446,13 @@ func (a *App) currentProviderEntryForTab(tabID string) (*config.ProviderEntry, e
 	if !ok {
 		return nil, fmt.Errorf("unknown model %q", resolved)
 	}
-	if effortOverride != nil {
-		entry.Effort = *effortOverride
+	if snap.effort != nil {
+		entry.Effort = *snap.effort
+	}
+	if current, ok := snap.ctrl.(interface{ EffortSnapshot() (string, bool) }); ok {
+		if effort, available := current.EffortSnapshot(); available {
+			entry.Effort = effort
+		}
 	}
 	return entry, nil
 }

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -5894,7 +5894,7 @@ func TestSetTokenModeKeepsControllerWhenRebuildFails(t *testing.T) {
 	assertDeprecatedExecutionModeNoop(t, app, tab, old, *notices)
 }
 
-func TestSetEffortRejectsRunningTurn(t *testing.T) {
+func TestSetEffortDefersRunningTurn(t *testing.T) {
 	isolateDesktopUserDirs(t)
 
 	runner := &blockingRunner{started: make(chan struct{}), release: make(chan struct{})}
@@ -5904,8 +5904,12 @@ func TestSetEffortRejectsRunningTurn(t *testing.T) {
 	<-runner.started
 
 	err := app.SetEffort("max")
-	if err == nil || !strings.Contains(err.Error(), "finish or cancel") {
-		t.Fatalf("SetEffort while running error = %v, want finish/cancel guard", err)
+	if err != nil {
+		t.Fatalf("SetEffort while running: %v", err)
+	}
+	info := app.Effort()
+	if info.Current != "auto" || info.Pending == nil || *info.Pending != "max" || !info.CanDefer {
+		t.Fatalf("running effort = %+v, want auto with max pending", info)
 	}
 
 	close(runner.release)

--- a/desktop/deferred_rebuild.go
+++ b/desktop/deferred_rebuild.go
@@ -414,7 +414,7 @@ func (a *App) rebuildStartupTabLocked(tab *WorkspaceTab) error {
 	if tab.sink == nil {
 		tab.sink = &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
 	}
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	a.mu.Unlock()
 
 	a.buildTabControllerWithContext(tab, loadedTabSession{}, buildCtx, generation, cancel)

--- a/desktop/delivery_worktree.go
+++ b/desktop/delivery_worktree.go
@@ -343,7 +343,7 @@ func (a *App) CloseMergedWorktreeTab(request CloseMergedWorktreeTabRequest) (Clo
 	a.markTabRemovedLocked(current)
 	delete(a.tabs, current.ID)
 	a.removeTabOrderLocked(current.ID)
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	a.mu.Unlock()
 
 	if a.terminals != nil {

--- a/desktop/effort_selection.go
+++ b/desktop/effort_selection.go
@@ -8,6 +8,7 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/boot"
 	"reasonix/internal/config"
+	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
@@ -200,30 +201,7 @@ func (a *App) applySelectedEffortTurnLocked(tab *WorkspaceTab, selection *pendin
 		prevPath = sessionPathAfterSnapshot(oldCtrl, prevPath)
 		carried = oldCtrl.History()
 	}
-	sharedHost := a.lookupSharedHost(snap.sharedHostKey)
-	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
-		Model:                    modelRef,
-		RequireKey:               false,
-		StatsSource:              "desktop",
-		TaskStore:                a.taskStore(),
-		OnConfigLoadWarnings:     a.configLoadWarningsHandler(),
-		Sink:                     snap.sink,
-		WorkspaceRoot:            snap.workspaceRoot,
-		SessionDir:               sessionDirForSnapshot(snap),
-		EffortOverride:           &effort,
-		SharedHost:               sharedHost,
-		MCPHostProfile:           plugin.HostProfileDesktopApps,
-		CleanupPendingReconciler: reconcileDesktopCleanupPending,
-		SubagentParentLive:       a.subagentParentProbeForBuild(tab),
-		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
-		PinnedContextLoader:      pinnedContextLoader(snap.workspaceRoot),
-		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
-		OnSessionTransition:      a.handleTabSessionTransition(tab),
-		BeforeInboxDispatch:      a.beforeInboxDispatch,
-		OnSessionTitleChanged:    a.onSessionTitleChanged,
-		// Keep the private temporary directory across effort switches (#7575).
-		SessionTemp: sessionTempFromController(oldCtrl),
-	})
+	newCtrl, err := boot.Build(a.bootContext(), a.effortRebuildBootOptions(tab, snap, oldCtrl, modelRef, effort))
 	if err != nil {
 		return err
 	}
@@ -283,4 +261,32 @@ func (a *App) applySelectedEffortTurnLocked(tab *WorkspaceTab, selection *pendin
 	a.persistTabSessionPath(tab, path)
 	a.notifyTabRuntimeRebuilt(tab)
 	return nil
+}
+
+// effortRebuildBootOptions keeps the effort-switch build inputs in one owner so
+// applySelectedEffortTurnLocked stays within the repo function-size budget.
+func (a *App) effortRebuildBootOptions(tab *WorkspaceTab, snap tabRuntimeSnapshot, oldCtrl control.SessionAPI, modelRef, effort string) boot.Options {
+	return boot.Options{
+		Model:                    modelRef,
+		RequireKey:               false,
+		StatsSource:              "desktop",
+		TaskStore:                a.taskStore(),
+		OnConfigLoadWarnings:     a.configLoadWarningsHandler(),
+		Sink:                     snap.sink,
+		WorkspaceRoot:            snap.workspaceRoot,
+		SessionDir:               sessionDirForSnapshot(snap),
+		EffortOverride:           &effort,
+		SharedHost:               a.lookupSharedHost(snap.sharedHostKey),
+		MCPHostProfile:           plugin.HostProfileDesktopApps,
+		CleanupPendingReconciler: reconcileDesktopCleanupPending,
+		SubagentParentLive:       a.subagentParentProbeForBuild(tab),
+		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
+		PinnedContextLoader:      pinnedContextLoader(snap.workspaceRoot),
+		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+		OnSessionTransition:      a.handleTabSessionTransition(tab),
+		BeforeInboxDispatch:      a.beforeInboxDispatch,
+		OnSessionTitleChanged:    a.onSessionTitleChanged,
+		// Keep the private temporary directory across effort switches (#7575).
+		SessionTemp: sessionTempFromController(oldCtrl),
+	}
 }

--- a/desktop/effort_selection.go
+++ b/desktop/effort_selection.go
@@ -65,7 +65,7 @@ func (a *App) discardPendingTabEffort(tab *WorkspaceTab) {
 	cleared := tab != nil && tab.pendingEffort != nil
 	if cleared {
 		tab.pendingEffort = nil
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 	a.notifyEffortSelectionCleared(tab, cleared)
@@ -268,7 +268,13 @@ func (a *App) applySelectedEffortTurnLocked(tab *WorkspaceTab, selection *pendin
 	clearTabStartupError(tab)
 	tab.Ready = true
 	a.supersedeTabBuildLocked(tab)
-	a.saveTabsLocked()
+	if err := a.saveTabsLocked(); err != nil {
+		a.mu.Unlock()
+		if oldCtrl != nil {
+			oldCtrl.Close()
+		}
+		return fmt.Errorf("reasoning effort applied but could not persist tab settings: %w", err)
+	}
 	a.mu.Unlock()
 	if oldCtrl != nil {
 		oldCtrl.Close()

--- a/desktop/effort_selection.go
+++ b/desktop/effort_selection.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/boot"
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+	"reasonix/internal/plugin"
+	"reasonix/internal/provider"
+)
+
+// pendingEffortSelection is immutable after publication. Pointer identity is
+// the version fence across selection, session replacement, and runtime rebuild.
+// App.mu guards the pointer; the existing tabs-file effort field stores value.
+type pendingEffortSelection struct {
+	value string // normalized adapter ID; empty means auto
+}
+
+func displayedEffort(value string) string {
+	if value == "" {
+		return "auto"
+	}
+	return value
+}
+
+// The caller holds App.mu at the successful model replacement boundary.
+func clearPendingEffortForModelLocked(tab *WorkspaceTab, model string) bool {
+	if tab.model == model || tab.pendingEffort == nil {
+		return false
+	}
+	tab.pendingEffort = nil
+	return true
+}
+
+// persistedTabEffort stores the selected next-run value without changing the
+// running controller's profile. Old readers and startup already consume this
+// field as the initial effort override.
+func persistedTabEffort(tab *WorkspaceTab) *string {
+	if tab.pendingEffort != nil {
+		return cloneStringPtr(&tab.pendingEffort.value)
+	}
+	return cloneStringPtr(tab.effort)
+}
+
+func (a *App) notifyEffortSelectionCleared(tab *WorkspaceTab, cleared bool) {
+	if !cleared || tab == nil {
+		return
+	}
+	a.mu.RLock()
+	sink := tab.sink
+	a.mu.RUnlock()
+	if sink != nil {
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
+			Code: "effort_selection_cleared",
+			Text: "The pending reasoning effort selection was cleared because the session or model changed."})
+	}
+}
+
+func (a *App) discardPendingTabEffort(tab *WorkspaceTab) {
+	a.mu.Lock()
+	cleared := tab != nil && tab.pendingEffort != nil
+	if cleared {
+		tab.pendingEffort = nil
+		a.saveTabsLocked()
+	}
+	a.mu.Unlock()
+	a.notifyEffortSelectionCleared(tab, cleared)
+}
+
+func (a *App) SetEffortForTab(tabID, level string) error {
+	tab := a.tabByID(tabID)
+	if tab == nil {
+		if strings.TrimSpace(tabID) == "" {
+			entry, err := a.currentProviderEntryForTab("")
+			if err != nil {
+				return err
+			}
+			effort, err := config.NormalizeEffort(entry, level)
+			if err != nil {
+				return err
+			}
+			return a.applyProviderEffortConfig(entry, effort)
+		}
+		return fmt.Errorf("tab %q not found", tabID)
+	}
+	// A Wails request waiting behind a rebuild still belongs to the session
+	// and model it targeted, not a replacement that happens to reuse its tab.
+	a.mu.RLock()
+	generation, model, sessionPath := tab.SessionGeneration, tab.model, tab.SessionPath
+	a.mu.RUnlock()
+	a.runtimeRebuildMu.Lock()
+	defer a.runtimeRebuildMu.Unlock()
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
+	a.mu.RLock()
+	valid := a.tabs[tab.ID] == tab && !tab.removed && tab.SessionGeneration == generation && tab.model == model && tab.SessionPath == sessionPath
+	a.mu.RUnlock()
+	if !valid {
+		return fmt.Errorf("session or model changed before selecting reasoning effort; retry")
+	}
+	if a.tabIsReadOnly(tab) {
+		return readOnlyChannelErr()
+	}
+	entry, err := a.currentProviderEntryForRuntimeTab(tab)
+	if err != nil {
+		return err
+	}
+	effort, err := config.NormalizeEffort(entry, level)
+	if err != nil {
+		return err
+	}
+	var selection *pendingEffortSelection
+	if displayedEffort(effort) != config.EffortDisplay(entry) {
+		selection = &pendingEffortSelection{value: effort}
+	}
+	a.mu.Lock()
+	previous := tab.pendingEffort
+	tab.pendingEffort = selection
+	if err := a.saveTabsLocked(); err != nil {
+		tab.pendingEffort = previous
+		a.mu.Unlock()
+		return fmt.Errorf("could not save reasoning effort selection")
+	}
+	a.mu.Unlock()
+	if selection == nil || controllerHasActiveRuntimeWork(a.controllerForTab(tab)) {
+		return nil
+	}
+	return a.applySelectedEffortTurnLocked(tab, selection)
+}
+
+func (a *App) pendingTabEffort(tab *WorkspaceTab) *pendingEffortSelection {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if tab == nil {
+		return nil
+	}
+	return tab.pendingEffort
+}
+
+// Called outside runtime admission, like refreshTabModelSettings. Both manual
+// submissions and durable inbox dispatch re-resolve the controller afterward.
+func (a *App) applyPendingTabEffort(tab *WorkspaceTab, selection *pendingEffortSelection) error {
+	a.runtimeRebuildMu.Lock()
+	defer a.runtimeRebuildMu.Unlock()
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
+	a.mu.RLock()
+	current := a.ownsRuntimeTabLocked(tab) && tab.pendingEffort == selection
+	a.mu.RUnlock()
+	if !current {
+		return nil
+	}
+	return a.applySelectedEffortTurnLocked(tab, selection)
+}
+
+// The caller owns runtimeRebuildMu and turnStartMu. No current request may be
+// active here. Failed builds leave both the old runtime and selected value live.
+func (a *App) applySelectedEffortTurnLocked(tab *WorkspaceTab, selection *pendingEffortSelection) error {
+	pendingSequence := a.deferredRebuildSequence(tab.ID)
+	if err := rebuildControllerActiveWorkErrorFor(a.controllerForTab(tab), "effort"); err != nil {
+		return err
+	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	prevPath := a.reconciledSessionPathForTab(tab)
+	if prevPath == "" {
+		prevPath = a.currentSessionPathFor(tab)
+	}
+	if a.controllerForTab(tab) == nil && prevPath != "" && a.attachExistingSessionRuntime(tab, prevPath, a.ctx) {
+		prevPath = a.currentSessionPathFor(tab)
+	}
+	if err := rebuildControllerActiveWorkErrorFor(a.controllerForTab(tab), "effort"); err != nil {
+		return err
+	}
+	snap := a.tabRuntimeSnapshot(tab)
+	runtime := snap.normalizedRuntime()
+	entry, err := a.currentProviderEntryForRuntimeTab(tab)
+	if err != nil {
+		return err
+	}
+	modelRef := entry.Name + "/" + entry.Model
+	effort, err := config.NormalizeEffort(entry, displayedEffort(selection.value))
+	if err != nil {
+		return err
+	}
+	var carried []provider.Message
+	oldCtrl := a.controllerForTab(tab)
+	if oldCtrl != nil {
+		if prevPath == "" {
+			prevPath = oldCtrl.SessionPath()
+		}
+		if err := a.snapshotSettingsRebuildSource(tab, oldCtrl, prevPath, "effort"); err != nil {
+			return err
+		}
+		prevPath = sessionPathAfterSnapshot(oldCtrl, prevPath)
+		carried = oldCtrl.History()
+	}
+	sharedHost := a.lookupSharedHost(snap.sharedHostKey)
+	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
+		Model:                    modelRef,
+		RequireKey:               false,
+		StatsSource:              "desktop",
+		TaskStore:                a.taskStore(),
+		OnConfigLoadWarnings:     a.configLoadWarningsHandler(),
+		Sink:                     snap.sink,
+		WorkspaceRoot:            snap.workspaceRoot,
+		SessionDir:               sessionDirForSnapshot(snap),
+		EffortOverride:           &effort,
+		SharedHost:               sharedHost,
+		MCPHostProfile:           plugin.HostProfileDesktopApps,
+		CleanupPendingReconciler: reconcileDesktopCleanupPending,
+		SubagentParentLive:       a.subagentParentProbeForBuild(tab),
+		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
+		PinnedContextLoader:      pinnedContextLoader(snap.workspaceRoot),
+		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+		OnSessionTransition:      a.handleTabSessionTransition(tab),
+		BeforeInboxDispatch:      a.beforeInboxDispatch,
+		OnSessionTitleChanged:    a.onSessionTitleChanged,
+		// Keep the private temporary directory across effort switches (#7575).
+		SessionTemp: sessionTempFromController(oldCtrl),
+	})
+	if err != nil {
+		return err
+	}
+	a.bindControllerDisplayRecorder(newCtrl)
+	configureControllerRuntime(newCtrl, oldCtrl, runtime)
+	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
+	if err := a.ensureTabSessionLeaseForRebuild(tab, path, "effort"); err != nil {
+		newCtrl.Close()
+		return err
+	}
+	restoredRuntime, err := resumeControllerRuntimeWithMessages(newCtrl, carried, path, runtime)
+	if err != nil {
+		newCtrl.Close()
+		return err
+	}
+	if err := a.runRebindCandidateHook("effort_before_authority"); err != nil {
+		newCtrl.Close()
+		return err
+	}
+	a.mu.Lock()
+	if tab.pendingEffort != selection {
+		a.mu.Unlock()
+		newCtrl.Close()
+		return fmt.Errorf("reasoning effort selection changed; retry")
+	}
+	if err := a.authorizeTabReplacementLocked(tab, newCtrl, "switching effort", "effort-switch"); err != nil {
+		// Only retire a revoked lease. An ownership/identity failure must not
+		// release a lease that still belongs to the unchanged source runtime.
+		if errors.Is(err, agent.ErrSessionWriteAuthorityStale) {
+			tab.releaseSessionLease()
+		}
+		a.mu.Unlock()
+		newCtrl.Close()
+		return err
+	}
+	tab.Ctrl = newCtrl
+	tab.model = modelRef
+	tab.effort = &effort
+	tab.pendingEffort = nil
+	tab.Label = newCtrl.Label()
+	applyNormalizedRuntimeToTabLocked(tab, restoredRuntime)
+	clearTabStartupError(tab)
+	tab.Ready = true
+	a.supersedeTabBuildLocked(tab)
+	a.saveTabsLocked()
+	a.mu.Unlock()
+	if oldCtrl != nil {
+		oldCtrl.Close()
+	}
+	a.clearDeferredRebuildVersion(tab.ID, pendingSequence)
+	a.persistTabSessionPath(tab, path)
+	a.notifyTabRuntimeRebuilt(tab)
+	return nil
+}

--- a/desktop/effort_selection_test.go
+++ b/desktop/effort_selection_test.go
@@ -1,0 +1,592 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/boot"
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+const effortFinalReply = `{"choices":[{"delta":{"content":"Done."},"finish_reason":"stop"}]}`
+const effortReadReply = `{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"read-fixture","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"fixture.txt\"}"}}]},"finish_reason":"tool_calls"}]}`
+
+type selectedEffortRequest struct {
+	effort string
+	reply  chan string
+}
+
+type effortSelectionFixture struct {
+	app      *App
+	tab      *WorkspaceTab
+	ctx      context.Context
+	requests chan selectedEffortRequest
+	count    atomic.Int32
+}
+
+func newEffortSelectionFixture(t *testing.T) *effortSelectionFixture {
+	t.Helper()
+	isolateDesktopUserDirs(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	f := &effortSelectionFixture{ctx: ctx, requests: make(chan selectedEffortRequest, 8)}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Effort    string `json:"reasoning_effort"`
+			MaxTokens int    `json:"max_tokens"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Session title generation is not a foreground model request.
+		if body.MaxTokens == 512 {
+			fmt.Fprintf(w, "data: %s\n\ndata: [DONE]\n\n", effortFinalReply)
+			return
+		}
+		f.count.Add(1)
+		request := selectedEffortRequest{effort: body.Effort, reply: make(chan string, 1)}
+		select {
+		case f.requests <- request:
+		case <-ctx.Done():
+			return
+		}
+		select {
+		case response := <-request.reply:
+			fmt.Fprintf(w, "data: %s\n\ndata: [DONE]\n\n", response)
+		case <-r.Context().Done():
+		case <-ctx.Done():
+		}
+	}))
+	t.Cleanup(server.Close)
+	cfg := config.Default()
+	cfg.DefaultModel = "effort-test/m"
+	cfg.Desktop.ProviderAccess = []string{"effort-test"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name: "effort-test", Kind: "openai", BaseURL: server.URL, Model: "m", Models: []string{"m", "other"},
+		APIKeyEnv: "EFFORT_SELECTION_TEST_KEY", NoProxy: true,
+		ReasoningProtocol: config.ReasoningProtocolOpenAI, SupportedEfforts: []string{"low", "high", "max"}, Effort: "low",
+	}}
+	setDesktopTestCredential(t, "EFFORT_SELECTION_TEST_KEY", "test-only")
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatal(err)
+	}
+	f.app = NewApp()
+	f.app.ctx = ctx
+	f.app.readyHook = func() {}
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "fixture.txt"), []byte("fixture\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	f.tab = &WorkspaceTab{ID: "effort", Scope: "project", WorkspaceRoot: root, Ready: true,
+		model: cfg.DefaultModel, disabledMCP: map[string]ServerView{}}
+	f.tab.sink = &tabEventSink{tabID: f.tab.ID, app: f.app}
+	installNoopRuntimeEvents(f.app, f.tab.sink)
+	ctrl, err := boot.Build(ctx, boot.Options{Model: cfg.DefaultModel, WorkspaceRoot: root,
+		SessionDir: desktopSessionDir(root), Sink: f.tab.sink, BeforeInboxDispatch: f.app.beforeInboxDispatch,
+		OnSessionTransition: f.app.handleTabSessionTransition(f.tab)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(ctrl.SessionDir(), "effort.jsonl")
+	ctrl.AdoptHistory(append(ctrl.History(), provider.Message{Role: provider.RoleUser, Content: "Keep history."}), path)
+	f.app.mu.Lock()
+	f.tab.Ctrl = ctrl
+	f.tab.SessionPath = path
+	f.app.tabs = map[string]*WorkspaceTab{f.tab.ID: f.tab}
+	f.app.tabOrder = []string{f.tab.ID}
+	f.app.activeTabID = f.tab.ID
+	f.app.mu.Unlock()
+	if err := f.tab.ensureSessionLease(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := bindTabWriteAuthority(f.tab, ctrl); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.app.saveTabSessionMeta(f.tab, path); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if current := f.app.controllerForTab(f.tab); current != nil {
+			waitForAutosaveIdle(t, f.tab)
+			current.Close()
+		}
+		f.tab.releaseSessionLease()
+	})
+	t.Cleanup(cancel)
+	return f
+}
+
+func (f *effortSelectionFixture) request(t *testing.T, want string) selectedEffortRequest {
+	t.Helper()
+	select {
+	case request := <-f.requests:
+		if request.effort != want {
+			t.Fatalf("request effort = %q, want %q", request.effort, want)
+		}
+		return request
+	case <-f.ctx.Done():
+		t.Fatal("waiting for provider request:", f.ctx.Err())
+		return selectedEffortRequest{}
+	}
+}
+
+func (f *effortSelectionFixture) selectEffort(t *testing.T, value string) {
+	t.Helper()
+	if err := f.app.SetEffortForTab(f.tab.ID, value); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f *effortSelectionFixture) assertEffort(t *testing.T, current, pending string) {
+	t.Helper()
+	info := f.app.EffortForTab(f.tab.ID)
+	if !info.CanDefer || info.Current != current {
+		t.Fatalf("effort = %+v, want current %q and local deferral", info, current)
+	}
+	if pending == "" {
+		if info.Pending != nil {
+			t.Fatalf("unexpected pending effort %q", *info.Pending)
+		}
+	} else if info.Pending == nil || *info.Pending != pending {
+		t.Fatalf("effort = %+v, want pending %q", info, pending)
+	}
+}
+
+func TestEffortSelectionAppliesOnlyAtNextRun(t *testing.T) {
+	for _, mode := range []string{"manual", "inbox"} {
+		t.Run(mode, func(t *testing.T) {
+			f := newEffortSelectionFixture(t)
+			old := f.tab.Ctrl
+			if err := f.app.SubmitToTab(f.tab.ID, "Read fixture.txt and answer done."); err != nil {
+				t.Fatal(err)
+			}
+			first := f.request(t, "low")
+			f.selectEffort(t, "high")
+			f.selectEffort(t, "max")
+			f.assertEffort(t, "low", "max")
+			if f.app.controllerForTab(f.tab) != old {
+				t.Fatal("selection replaced a running controller")
+			}
+			if mode == "inbox" {
+				if _, err := f.app.EnqueueInboxFollowup(f.tab.ID, "Say done again.", "Say done again.", "effort-next"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			first.reply <- effortReadReply
+			// Even the subsequent request in the same task uses the old effort.
+			second := f.request(t, "low")
+			second.reply <- effortFinalReply
+			if mode == "manual" {
+				waitNotRunning(t, old)
+				f.assertEffort(t, "low", "max")
+				if f.count.Load() != 2 {
+					t.Fatal("selection started a new task on its own")
+				}
+				if err := f.app.SubmitToTab(f.tab.ID, "Say done again."); err != nil {
+					t.Fatal(err)
+				}
+			}
+			next := f.request(t, "max")
+			f.assertEffort(t, "max", "")
+			next.reply <- effortFinalReply
+			waitNotRunning(t, f.app.controllerForTab(f.tab))
+			if f.count.Load() != 3 {
+				t.Fatalf("provider called %d times, want exactly three", f.count.Load())
+			}
+			if f.app.controllerForTab(f.tab) == old {
+				t.Fatal("next task did not replace the old runtime")
+			}
+			var foundFirst bool
+			for _, message := range f.tab.Ctrl.History() {
+				foundFirst = foundFirst || strings.Contains(message.Content, "Read fixture.txt")
+			}
+			if !foundFirst {
+				t.Fatal("effort change lost earlier history")
+			}
+		})
+	}
+}
+
+func TestEffortSelectionCancellationStopAndPersistence(t *testing.T) {
+	f := newEffortSelectionFixture(t)
+	old := f.tab.Ctrl
+	if err := f.app.SubmitToTab(f.tab.ID, "Say done."); err != nil {
+		t.Fatal(err)
+	}
+	f.request(t, "low")
+	f.selectEffort(t, "max")
+	f.selectEffort(t, "low")
+	f.assertEffort(t, "low", "")
+	f.selectEffort(t, "auto")
+	f.assertEffort(t, "low", "auto")
+	f.selectEffort(t, "high")
+	saved := loadTabsFile()
+	if len(saved.Tabs) != 1 || saved.Tabs[0].Effort == nil || *saved.Tabs[0].Effort != "high" {
+		t.Fatalf("selected effort was not persisted in the existing field: %+v", saved.Tabs)
+	}
+	f.app.CancelTab(f.tab.ID)
+	waitNotRunning(t, old)
+	f.assertEffort(t, "low", "high")
+	if f.count.Load() != 1 || f.app.controllerForTab(f.tab) != old {
+		t.Fatal("stopping applied the pending selection or started another task")
+	}
+	// Simulate the previous process exiting, then exercise the normal startup
+	// builder using the persisted tab entry. No new persisted schema is needed.
+	old.Close()
+	f.tab.releaseSessionLease()
+	restored := NewApp()
+	restored.ctx = f.ctx
+	restored.readyHook = func() {}
+	entry := saved.Tabs[0]
+	tab := &WorkspaceTab{ID: entry.ID, Scope: entry.Scope, WorkspaceRoot: entry.WorkspaceRoot,
+		TopicID: entry.TopicID, SessionPath: entry.SessionPath, model: entry.Model, effort: cloneStringPtr(entry.Effort),
+		disabledMCP: map[string]ServerView{}}
+	restored.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	restored.tabOrder = []string{tab.ID}
+	restored.activeTabID = tab.ID
+	installNoopRuntimeEvents(restored, nil)
+	restored.buildTabController(tab)
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+	if tab.StartupErr != "" || tab.Ctrl == nil {
+		t.Fatalf("restored tab failed to start: %s", tab.StartupErr)
+	}
+	info := restored.EffortForTab(tab.ID)
+	if info.Current != "high" || info.Pending != nil {
+		t.Fatalf("restored selection = %+v, want applied high", info)
+	}
+}
+
+func TestEffortSelectionFailureRetainsRuntimeAndQueue(t *testing.T) {
+	f := newEffortSelectionFixture(t)
+	old := f.tab.Ctrl
+	if err := f.app.SubmitToTab(f.tab.ID, "Say done."); err != nil {
+		t.Fatal(err)
+	}
+	first := f.request(t, "low")
+	f.selectEffort(t, "max")
+	if err := f.app.SetInboxPaused(f.tab.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := f.app.EnqueueInboxFollowup(f.tab.ID, "queued", "queued", "effort-failure")
+	if err != nil {
+		t.Fatal(err)
+	}
+	first.reply <- effortFinalReply
+	waitNotRunning(t, old)
+	fail := errors.New("injected effort build failure")
+	f.app.rebindCandidateHook = func(stage string) error {
+		if stage == "effort_before_authority" {
+			return fail
+		}
+		return nil
+	}
+	if _, _, err := f.app.beginTabTurn(f.tab.ID, false); !errors.Is(err, fail) {
+		t.Fatalf("next-run failure = %v, want injected build error", err)
+	}
+	f.assertEffort(t, "low", "max")
+	snapshot, err := f.app.InboxSnapshot(f.tab.ID)
+	if err != nil || len(snapshot.Items) != 1 || snapshot.Items[0].ID != receipt.ItemID || snapshot.Items[0].State != "queued" {
+		t.Fatalf("failed application consumed queued input: %+v %v", snapshot, err)
+	}
+	if f.app.controllerForTab(f.tab) != old || f.count.Load() != 1 {
+		t.Fatal("failed application replaced or ran the old controller")
+	}
+	if err := old.Snapshot(); err != nil {
+		t.Fatal("failed candidate invalidated the old controller's write authority:", err)
+	}
+	f.app.rebindCandidateHook = nil
+	if err := f.app.SetInboxPaused(f.tab.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	next := f.request(t, "max")
+	next.reply <- effortFinalReply
+	waitNotRunning(t, f.app.controllerForTab(f.tab))
+}
+
+func TestEffortSelectionClearedByModelOrSessionChange(t *testing.T) {
+	for _, action := range []string{"model", "new", "clear"} {
+		t.Run(action, func(t *testing.T) {
+			f := newEffortSelectionFixture(t)
+			if err := f.app.SubmitToTab(f.tab.ID, "Say done."); err != nil {
+				t.Fatal(err)
+			}
+			first := f.request(t, "low")
+			f.selectEffort(t, "max")
+			first.reply <- effortFinalReply
+			waitNotRunning(t, f.tab.Ctrl)
+			var cleared atomic.Int32
+			f.tab.sink.SetBotSink(event.FuncSink(func(e event.Event) {
+				if e.Code == "effort_selection_cleared" {
+					cleared.Add(1)
+				}
+			}))
+			var err error
+			switch action {
+			case "model":
+				err = f.app.SetModelForTab(f.tab.ID, "effort-test/other")
+			case "new":
+				err = f.app.NewSessionForTab(f.tab.ID)
+			case "clear":
+				_, err = f.app.ClearSessionForTab(f.tab.ID)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			f.assertEffort(t, "low", "")
+			if cleared.Load() != 1 {
+				t.Fatalf("cleared-selection notice count = %d, want one", cleared.Load())
+			}
+		})
+	}
+}
+
+func TestEffortSelectionDoesNotSpoofCurrentWhenConfigChanges(t *testing.T) {
+	f := newEffortSelectionFixture(t)
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	cfg.Providers[0].Effort = "high"
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatal(err)
+	}
+	f.assertEffort(t, "low", "")
+}
+
+func TestEffortSelectionPersistenceFailureRollsBack(t *testing.T) {
+	f := newEffortSelectionFixture(t)
+	if err := f.app.SubmitToTab(f.tab.ID, "Wait."); err != nil {
+		t.Fatal(err)
+	}
+	request := f.request(t, "low")
+	f.selectEffort(t, "high")
+	tmp := filepath.Join(desktopConfigDir(), tabsFileName+".tmp")
+	if err := os.Mkdir(tmp, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.app.SetEffortForTab(f.tab.ID, "max"); err == nil {
+		t.Fatal("unpersisted selection was acknowledged")
+	}
+	f.assertEffort(t, "low", "high")
+	if got := loadTabsFile().Tabs[0].Effort; got == nil || *got != "high" {
+		t.Fatalf("saved target changed: %v", got)
+	}
+	if err := os.Remove(tmp); err != nil {
+		t.Fatal(err)
+	}
+	request.reply <- effortFinalReply
+	waitNotRunning(t, f.tab.Ctrl)
+}
+
+func TestEffortSelectionConcurrentRebuildLastAcceptedWins(t *testing.T) {
+	f := newEffortSelectionFixture(t)
+	entered, release := make(chan struct{}), make(chan struct{})
+	var blocked atomic.Bool
+	f.app.rebindCandidateHook = func(stage string) error {
+		if stage == "effort_before_authority" && blocked.CompareAndSwap(false, true) {
+			close(entered)
+			select {
+			case <-release:
+			case <-f.ctx.Done():
+				return f.ctx.Err()
+			}
+		}
+		return nil
+	}
+	first := make(chan error, 1)
+	go func() { first <- f.app.SetEffortForTab(f.tab.ID, "high") }()
+	select {
+	case <-entered:
+	case <-f.ctx.Done():
+		t.Fatal(f.ctx.Err())
+	}
+	last := make(chan error, 1)
+	go func() { last <- f.app.SetEffortForTab(f.tab.ID, "max") }()
+	f.assertEffort(t, "low", "high")
+	close(release)
+	if err := <-first; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-last; err != nil {
+		t.Fatal(err)
+	}
+	f.assertEffort(t, "max", "")
+	if err := f.tab.Ctrl.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEffortSelectionFinishingTurnAdmission(t *testing.T) {
+	f := newEffortSelectionFixture(t)
+	finishing, release := make(chan struct{}), make(chan struct{})
+	var blocked atomic.Bool
+	f.tab.sink.SetBotSink(event.FuncSink(func(e event.Event) {
+		if e.Kind == event.TurnDone && blocked.CompareAndSwap(false, true) {
+			close(finishing)
+			select {
+			case <-release:
+			case <-f.ctx.Done():
+			}
+		}
+	}))
+	if err := f.app.SubmitToTab(f.tab.ID, "First."); err != nil {
+		t.Fatal(err)
+	}
+	first := f.request(t, "low")
+	f.selectEffort(t, "max")
+	first.reply <- effortFinalReply
+	select {
+	case <-finishing:
+	case <-f.ctx.Done():
+		t.Fatal(f.ctx.Err())
+	}
+	submitted := make(chan error, 1)
+	go func() { submitted <- f.app.SubmitToTab(f.tab.ID, "Second.") }()
+	close(release)
+	if err := <-submitted; err != nil {
+		t.Fatal(err)
+	}
+	next := f.request(t, "max")
+	next.reply <- effortFinalReply
+	waitNotRunning(t, f.app.controllerForTab(f.tab))
+	if f.count.Load() != 2 {
+		t.Fatal("finishing boundary submitted duplicate requests")
+	}
+}
+
+func TestEffortSelectionFinalAuthorityFailureAndRecovery(t *testing.T) {
+	f := newEffortSelectionFixture(t)
+	old := f.tab.Ctrl
+	var revoked atomic.Bool
+	f.app.rebindCandidateHook = func(stage string) error {
+		if stage == "effort_before_authority" && revoked.CompareAndSwap(false, true) {
+			f.tab.sessionLeaseMu.Lock()
+			lease := f.tab.sessionLease
+			f.tab.sessionLeaseMu.Unlock()
+			lease.Release()
+		}
+		return nil
+	}
+	if err := f.app.SetEffortForTab(f.tab.ID, "max"); !errors.Is(err, agent.ErrSessionWriteAuthorityStale) {
+		t.Fatalf("expected revoked authority error, got %v", err)
+	}
+	f.assertEffort(t, "low", "max")
+	if f.app.controllerForTab(f.tab) != old || f.count.Load() != 0 {
+		t.Fatal("failed authority published or started the candidate")
+	}
+	f.selectEffort(t, "max")
+	f.assertEffort(t, "max", "")
+	if err := f.tab.Ctrl.Snapshot(); err != nil {
+		t.Fatal("retry did not restore write authority:", err)
+	}
+}
+
+func TestEffortSelectionBuildFailureRetainsSource(t *testing.T) {
+	f := newEffortSelectionFixture(t)
+	old := f.tab.Ctrl
+	configPath := filepath.Join(f.tab.WorkspaceRoot, "reasonix.toml")
+	if err := os.WriteFile(configPath, []byte("[agent]\nsystem_prompt_file = \"/outside-workspace/missing-effort-prompt.md\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.app.SetEffortForTab(f.tab.ID, "max"); err == nil {
+		t.Fatal("invalid prompt did not fail boot")
+	}
+	if f.app.controllerForTab(f.tab) != old {
+		t.Fatal("failed build replaced source")
+	}
+	f.assertEffort(t, "low", "max")
+	if err := old.Snapshot(); err != nil {
+		t.Fatal("source no longer writable:", err)
+	}
+	if err := os.Remove(configPath); err != nil {
+		t.Fatal(err)
+	}
+	f.selectEffort(t, "max")
+	f.assertEffort(t, "max", "")
+}
+
+func TestEffortSelectionIsScopedToTab(t *testing.T) {
+	f := newEffortSelectionFixture(t)
+	siblingCtrl, err := boot.Build(f.ctx, boot.Options{Model: "effort-test/m", WorkspaceRoot: t.TempDir(), Sink: event.Discard})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sibling := &WorkspaceTab{ID: "sibling", Scope: "global", Ready: true, Ctrl: siblingCtrl, model: "effort-test/m", disabledMCP: map[string]ServerView{}}
+	sibling.sink = &tabEventSink{tabID: sibling.ID, app: f.app}
+	f.app.mu.Lock()
+	f.app.tabs[sibling.ID] = sibling
+	f.app.tabOrder = append(f.app.tabOrder, sibling.ID)
+	f.app.mu.Unlock()
+	t.Cleanup(func() {
+		if ctrl := f.app.controllerForTab(sibling); ctrl != nil {
+			ctrl.Close()
+		}
+		sibling.releaseSessionLease()
+	})
+	if err := f.app.SubmitToTab(f.tab.ID, "Wait."); err != nil {
+		t.Fatal(err)
+	}
+	request := f.request(t, "low")
+	f.app.mu.Lock()
+	f.app.activeTabID = sibling.ID
+	f.app.mu.Unlock()
+	f.selectEffort(t, "max")
+	f.assertEffort(t, "low", "max")
+	if info := f.app.EffortForTab(sibling.ID); info.Current != "low" || info.Pending != nil {
+		t.Fatalf("selection leaked to active sibling: %+v", info)
+	}
+	if err := f.app.SetEffort("high"); err != nil {
+		t.Fatal("legacy active-tab setter:", err)
+	}
+	if info := f.app.Effort(); info.Current != "high" || info.Pending != nil {
+		t.Fatalf("legacy getter = %+v", info)
+	}
+	f.assertEffort(t, "low", "max")
+	request.reply <- effortFinalReply
+	waitNotRunning(t, f.app.controllerForTab(f.tab))
+}
+
+func TestEffortSelectionSessionRebindClearsSource(t *testing.T) {
+	f := newEffortSelectionFixture(t)
+	if err := f.tab.Ctrl.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(f.tab.SessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(filepath.Dir(f.tab.SessionPath), "different-session.jsonl")
+	if err := os.WriteFile(target, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.app.SubmitToTab(f.tab.ID, "Wait."); err != nil {
+		t.Fatal(err)
+	}
+	request := f.request(t, "low")
+	f.selectEffort(t, "max")
+	request.reply <- effortFinalReply
+	waitNotRunning(t, f.app.controllerForTab(f.tab))
+	if _, err := f.app.ResumeSessionForTab(f.tab.ID, target); err != nil {
+		t.Fatal(err)
+	}
+	f.assertEffort(t, "low", "")
+	if got := f.app.currentSessionPathFor(f.tab); got != target {
+		t.Fatalf("rebind path = %q", got)
+	}
+}

--- a/desktop/effort_selection_test.go
+++ b/desktop/effort_selection_test.go
@@ -394,6 +394,40 @@ func TestEffortSelectionPersistenceFailureRollsBack(t *testing.T) {
 	waitNotRunning(t, f.tab.Ctrl)
 }
 
+// A failure after the new controller is published must not leave the tab in a
+// half-applied state: the swapped controller stays live and usable, the applied
+// effort is visible immediately, and no pending selection survives.
+func TestEffortSelectionPersistenceFailureAfterPublication(t *testing.T) {
+	f := newEffortSelectionFixture(t)
+	old := f.tab.Ctrl
+	tmp := filepath.Join(desktopConfigDir(), tabsFileName+".tmp")
+	t.Cleanup(func() { _ = os.Remove(tmp) })
+	f.app.rebindCandidateHook = func(stage string) error {
+		if stage == "effort_before_authority" {
+			return os.Mkdir(tmp, 0o700)
+		}
+		return nil
+	}
+	err := f.app.SetEffortForTab(f.tab.ID, "max")
+	if err == nil || !strings.Contains(err.Error(), "could not persist tab settings") {
+		t.Fatalf("post-publication persistence error = %v, want tab settings failure", err)
+	}
+	f.app.rebindCandidateHook = nil
+	if f.app.controllerForTab(f.tab) == old {
+		t.Fatal("published controller was rolled back after the persistence failure")
+	}
+	f.assertEffort(t, "max", "")
+	if got := loadTabsFile().Tabs[0].Effort; got == nil || *got != "max" {
+		t.Fatalf("published effort was not saved: %v", got)
+	}
+	if err := f.tab.Ctrl.Snapshot(); err != nil {
+		t.Fatal("published controller is not usable:", err)
+	}
+	if err := os.Remove(tmp); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestEffortSelectionConcurrentRebuildLastAcceptedWins(t *testing.T) {
 	f := newEffortSelectionFixture(t)
 	entered, release := make(chan struct{}), make(chan struct{})

--- a/desktop/fork_tab.go
+++ b/desktop/fork_tab.go
@@ -238,7 +238,7 @@ func (a *App) openForkedSessionTabWithWorkspace(sourceTab *WorkspaceTab, newPath
 	if activateFork {
 		a.activeTabID = newTabID
 	}
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	meta := a.tabMeta(tab, activateFork)
 	a.mu.Unlock()
 

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -311,7 +311,9 @@ for (const path of localeChunks) {
   // 64606 / 65349 B, so both dialect ceilings ratchet to the next tenth.
   // Model-application copy on the read-pause base measures 64734 / 65499 B,
   // adding 128 / 150 B. Retain only the next one-decimal ceiling.
-  const budget = name.startsWith("zh-TW-") ? 64.0 * 1024 : 63.3 * 1024;
+  // The session-change notice adds 65 / 50 B over fa018e410 (64734 /
+  // 65499 B), measuring 64799 / 65549 B. Only zh-TW needs one tenth.
+  const budget = name.startsWith("zh-TW-") ? 64.1 * 1024 : 63.3 * 1024;
   assertBudget(`${name} gzip`, gzipBytes(path), budget);
 }
 
@@ -445,6 +447,9 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // measure 2488853 B. Keep the next tenth; gzip, CSS, and chunk limits unchanged.
 // Combined model-settings and read-evidence integration measures 2492541 B,
 // adding 3688 B (0.148%) over the base. Retain the next one-decimal ceiling.
-const rawInitialBudgetKiB = 2_434.2;
+// Session-scoped effort ordering, content guards, and mock parity add 1733 B
+// (0.070%) over the same-toolchain fa018e410 build (2492623 B).
+// Measured total: 2494356 B; retain the next one-decimal ceiling.
+const rawInitialBudgetKiB = 2_435.9;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -313,7 +313,9 @@ for (const path of localeChunks) {
   // adding 128 / 150 B. Retain only the next one-decimal ceiling.
   // The session-change notice adds 65 / 50 B over fa018e410 (64734 /
   // 65499 B), measuring 64799 / 65549 B. Only zh-TW needs one tenth.
-  const budget = name.startsWith("zh-TW-") ? 64.1 * 1024 : 63.3 * 1024;
+  // The pending-effort next-turn hint adds 16 / 23 B, measuring 64815 /
+  // 65572 B; zh now needs the next one-decimal ceiling for CI headroom.
+  const budget = name.startsWith("zh-TW-") ? 64.1 * 1024 : 63.4 * 1024;
   assertBudget(`${name} gzip`, gzipBytes(path), budget);
 }
 
@@ -450,6 +452,9 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // Session-scoped effort ordering, content guards, and mock parity add 1733 B
 // (0.070%) over the same-toolchain fa018e410 build (2492623 B).
 // Measured total: 2494356 B; retain the next one-decimal ceiling.
-const rawInitialBudgetKiB = 2_435.9;
+// The pending-effort next-turn hint adds 144 B (2494356 -> 2494500 B): one
+// English locale string plus its trigger-title plumbing. Retain the next
+// one-decimal ceiling.
+const rawInitialBudgetKiB = 2_436.1;
 assertBudget("initial raw JavaScript and CSS", rawInitialBytes, rawInitialBudgetKiB * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -2269,10 +2269,10 @@ console.log("\ncomposer goal toggle");
   eq(textarea.value, "existing text", "disabled command action does not insert / into existing text");
 
   await rerender({ running: true });
-  await waitFor("content menu closes when a run starts", () => !document.querySelector(".composer-content-menu"));
+  ok(Boolean(document.querySelector(".composer-content-menu")), "content menu remains available when a run starts");
+  await act(async () => { contentTrigger.click(); await flushTimers(); });
   await rerender({ running: false });
   ok(!document.querySelector(".composer-content-menu"), "content menu stays closed after the run ends");
-
   await replaceComposerDraft(rerender, 3004, "");
   await act(async () => {
     contentTrigger.click();
@@ -2286,9 +2286,9 @@ console.log("\ncomposer goal toggle");
   });
   await waitFor("recent-session picker before running", () => Boolean(document.querySelector(".slashmenu__search")));
   await rerender({ running: true });
-  await waitFor("recent-session picker closes when a run starts", () => !document.querySelector(".slashmenu__search"));
+  ok(Boolean(document.querySelector(".slashmenu__search")), "recent-session picker remains usable during a run");
   await rerender({ running: false });
-  ok(!document.querySelector(".slashmenu__search"), "recent-session picker stays closed after the run ends");
+  ok(Boolean(document.querySelector(".slashmenu__search")), "finishing a run does not discard the reference being prepared");
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/__tests__/composer-running-controls.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-running-controls.test.tsx
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { act } from "react";
+import { installDom, installBridgeApp, renderComposer } from "./composerInboxHarness";
+import type { EffortInfo } from "../lib/types";
+
+const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+async function waitFor(check: () => boolean, label: string) {
+  for (let i = 0; i < 60 && !check(); i++) await act(async () => { await flush(); });
+  assert.ok(check(), label);
+}
+async function click(selector: string) {
+  const target = document.querySelector<HTMLButtonElement>(selector);
+  assert.ok(target, selector);
+  await act(async () => { target.click(); await flush(); });
+}
+
+const dom = installDom();
+Object.defineProperty(dom.window.HTMLElement.prototype, "scrollIntoView", { configurable: true, value: () => {} });
+const emptyInbox = { revision: 1, paused: false, recovered: false, items: [], itemsCount: 0, bytes: 0, maxItems: 64, maxBytes: 65536 };
+const selected: string[] = [];
+const submitted: string[] = [];
+let releaseImage!: (path: string) => void;
+let savingImage = false;
+installBridgeApp({
+  InboxSnapshot: async () => emptyInbox,
+  ListSessions: async () => [{ path: "/sessions/reference.jsonl", title: "Reference session", current: false }],
+  PreviewSession: async () => [{ role: "user", content: "Earlier requirements" }],
+  SavePastedFile: async (name: string) => ".reasonix/attachments/" + name,
+  SavePastedImage: async () => {
+    savingImage = true;
+    return new Promise<string>(resolve => { releaseImage = resolve; });
+  },
+  AttachmentDataURL: async () => "data:image/png;base64,aGVsbG8=",
+  EnqueueInboxSteer: async (_tab: string, _display: string, submit: string) => {
+    submitted.push(submit);
+    return { itemId: "queued-" + submitted.length, disposition: "queued_followup", position: 1, paused: false };
+  },
+});
+const effort: EffortInfo = { supported: true, current: "auto", default: "high", levels: ["auto", "high", "max"], canDefer: true };
+const { root, rerender } = await renderComposer({ running: true, effort, onSetEffort: level => selected.push(level) });
+try {
+  const plus = document.querySelector<HTMLButtonElement>(".composer-content-trigger")!;
+  assert.equal(plus.disabled, false);
+  await click(".composer-content-trigger");
+  assert.ok(document.querySelector(".composer-content-menu"));
+  const taskModes = [...document.querySelectorAll<HTMLButtonElement>(".composer-intent-menu__item")];
+  assert.ok(taskModes.length >= 2 && taskModes.every(item => item.disabled), "task modes retain their own busy guard");
+
+  await click(".composer-content-menu__item");
+  const fileInput = document.querySelector<HTMLInputElement>(".composer-content-file-input")!;
+  assert.equal(fileInput.disabled, false);
+  await act(async () => {
+    Object.defineProperty(fileInput, "files", { configurable: true, value: [new File(["notes"], "notes.txt", { type: "text/plain" })] });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+    await flush();
+  });
+  await waitFor(() => document.body.textContent?.includes("notes.txt") === true, "file picker adds a file while running");
+
+  await click(".composer-content-trigger");
+  const referenceItem = document.querySelectorAll<HTMLButtonElement>(".composer-content-menu__item")[2];
+  await act(async () => { referenceItem.click(); await flush(); });
+  await waitFor(() => document.querySelector(".slashmenu__search") !== null, "history picker opens while running");
+  const reference = [...document.querySelectorAll<HTMLButtonElement>(".slashmenu button")].find(item => item.textContent?.includes("Reference session"));
+  assert.ok(reference);
+  await act(async () => {
+    reference.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    await flush();
+  });
+  assert.ok(document.querySelector(".composer-context__item--session"), "history reference is attached");
+
+  // Image save remains asynchronous: a fast Enter/button click cannot enqueue
+  // an incomplete reference. Releasing the save makes the same draft sendable.
+  const textarea = document.querySelector<HTMLTextAreaElement>("textarea")!;
+  await act(async () => {
+    const paste = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(paste, "clipboardData", { value: {
+      files: [new File(["image"], "screen.png", { type: "image/png" })],
+      items: [], types: ["Files"], getData: () => "",
+    } });
+    textarea.dispatchEvent(paste);
+    await flush();
+  });
+  await waitFor(() => savingImage, "pasted image starts saving during a run");
+  assert.equal(document.querySelector<HTMLButtonElement>(".composer__btn--send")?.disabled, true);
+  await act(async () => {
+    textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    document.querySelector<HTMLButtonElement>(".composer__btn--send")?.click();
+  });
+  assert.equal(submitted.length, 0, "unfinished attachment is never submitted");
+  await act(async () => { releaseImage(".reasonix/attachments/screen.png"); await flush(); });
+  await waitFor(() => document.querySelector<HTMLButtonElement>(".composer__btn--send")?.disabled === false, "save completion enables enqueue");
+  await click(".composer__btn--send");
+  await waitFor(() => submitted.length === 1, "running content is durably queued");
+  assert.match(submitted[0], /@\.reasonix\/attachments\/notes\.txt/);
+  assert.match(submitted[0], /@\.reasonix\/attachments\/screen\.png/);
+  assert.match(submitted[0], /Earlier requirements/);
+
+  await click(".composer-effort-control button");
+  assert.doesNotMatch(document.querySelector(".composer-access-menu")?.textContent ?? "", /Currently applied|Next turn/i, "existing menu presentation stays unchanged");
+  await click('[role="menuitemradio"][data-value="max"]');
+  assert.deepEqual(selected, ["max"]);
+  assert.match(document.querySelector(".composer-effort-control")?.textContent ?? "", /auto/i, "no optimistic selection before acknowledgement");
+  await rerender({ effort: { ...effort, pending: "max" } });
+  assert.equal(document.querySelector(".composer-effort-control")?.textContent, "max", "the existing label displays the acknowledged choice without a new badge");
+  await click(".composer-effort-control button");
+  await click('[role="menuitemradio"][data-value="auto"]');
+  assert.deepEqual(selected, ["max", "auto"], "selecting current value cancels a pending selection");
+
+  await rerender({ running: false });
+  assert.equal(document.querySelector(".composer-effort-control")?.textContent, "max", "stopping does not clear the backend selection");
+  await rerender({ effort: { ...effort, current: "max" } });
+  assert.doesNotMatch(document.querySelector(".composer-effort-control")?.textContent ?? "", /Next turn/);
+
+  await rerender({ running: true, effort, remoteSession: true, attachmentInputEnabled: false });
+  assert.equal(plus.disabled, true, "remote running content menu keeps its existing guard");
+  const remoteEffort = document.querySelector<HTMLButtonElement>(".composer-effort-control button")!;
+  assert.equal(remoteEffort.disabled, true, "remote sessions cannot defer even if an unexpected capability arrives");
+  const before = selected.length;
+  await act(async () => { remoteEffort.click(); });
+  assert.equal(selected.length, before);
+
+  await rerender({ remoteSession: false, effort: { ...effort, canDefer: undefined } });
+  assert.equal(document.querySelector<HTMLButtonElement>(".composer-effort-control button")?.disabled, true, "older backend retains its guard");
+  await rerender({ readOnly: true, attachmentInputEnabled: true });
+  assert.equal(plus.disabled, true, "read-only mode still blocks the menu");
+  assert.equal(fileInput.disabled, true, "read-only mode still blocks file selection");
+  console.log("PASS running composer: attachments, history, save barrier, enqueue, effort acknowledgement, cancel, remote and legacy guards");
+} finally {
+  await act(async () => { root.unmount(); });
+  dom.window.close();
+}

--- a/desktop/frontend/src/__tests__/composer-running-controls.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-running-controls.test.tsx
@@ -100,8 +100,10 @@ try {
   await click('[role="menuitemradio"][data-value="max"]');
   assert.deepEqual(selected, ["max"]);
   assert.match(document.querySelector(".composer-effort-control")?.textContent ?? "", /auto/i, "no optimistic selection before acknowledgement");
+  assert.equal(document.querySelector<HTMLButtonElement>(".composer-effort-control button")?.getAttribute("title"), null, "applied effort carries no next-turn hint");
   await rerender({ effort: { ...effort, pending: "max" } });
   assert.equal(document.querySelector(".composer-effort-control")?.textContent, "max", "the existing label displays the acknowledged choice without a new badge");
+  assert.equal(document.querySelector<HTMLButtonElement>(".composer-effort-control button")?.getAttribute("title"), "Selected for the next task turn", "pending effort explains it applies to the next task turn");
   await click(".composer-effort-control button");
   await click('[role="menuitemradio"][data-value="auto"]');
   assert.deepEqual(selected, ["max", "auto"], "selecting current value cancels a pending selection");
@@ -110,6 +112,7 @@ try {
   assert.equal(document.querySelector(".composer-effort-control")?.textContent, "max", "stopping does not clear the backend selection");
   await rerender({ effort: { ...effort, current: "max" } });
   assert.doesNotMatch(document.querySelector(".composer-effort-control")?.textContent ?? "", /Next turn/);
+  assert.equal(document.querySelector<HTMLButtonElement>(".composer-effort-control button")?.getAttribute("title"), null, "applied effort drops the next-turn hint");
 
   await rerender({ running: true, effort, remoteSession: true, attachmentInputEnabled: false });
   assert.equal(plus.disabled, true, "remote running content menu keeps its existing guard");

--- a/desktop/frontend/src/__tests__/effort-selection-ordering.test.ts
+++ b/desktop/frontend/src/__tests__/effort-selection-ordering.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { createControllerModelCommands } from "../lib/controllerModelCommands";
+
+const calls: Array<{ tab: string; value: string; resolve: () => void; reject: (error: Error) => void }> = [];
+const refreshes: string[] = [];
+const notices: string[] = [];
+(globalThis as unknown as { window: unknown }).window = { go: { main: { App: {
+  SetEffortForTab: (tab: string, value: string) => new Promise<void>((resolve, reject) => calls.push({ tab, value, resolve, reject })),
+} } } };
+const ref = <T>(current: T) => ({ current });
+const ports: Parameters<typeof createControllerModelCommands>[0] = {
+  statesRef: ref(new Map([["a", { sessionGen: 1, meta: { sessionPath: "session-a", sessionGeneration: 1 } }],
+    ["b", { sessionGen: 1, meta: { sessionPath: "session-b", sessionGeneration: 1 } }]])),
+  modelSwitchSeqByTab: ref(new Map()),
+  modelSwitchSuccessVersionByTab: ref(new Map()),
+  modelSwitchQueueByTab: ref(new Map()),
+  effortSwitchSeqByTab: ref(new Map()),
+  effortSwitchQueueByTab: ref(new Map()),
+  enqueueModelSwitch: async () => "applied",
+  clearBalanceForTab: () => {},
+  dispatchTo: (_tab, action) => { if (action.type === "local_notice") notices.push(action.text); },
+  refreshBalanceForTab: async () => {},
+  refreshMetaForTab: async tab => { refreshes.push(tab); },
+};
+const flush = async () => { for (let i = 0; i < 10; i++) await Promise.resolve(); };
+const commands = createControllerModelCommands(ports);
+
+const first = commands.setEffortForTab("a", "high");
+await flush();
+assert.deepEqual(calls.map(call => call.value), ["high"]);
+const skipped = commands.setEffortForTab("a", "max");
+// Recreating the command facade cannot create a second concurrent write owner.
+const latest = createControllerModelCommands(ports).setEffortForTab("a", "auto");
+const sibling = commands.setEffortForTab("b", "max");
+await flush();
+assert.deepEqual(calls.map(call => call.tab), ["a", "b"], "other tabs do not wait for this session");
+calls[1].resolve();
+await sibling;
+calls[0].resolve();
+await flush();
+assert.deepEqual(calls.map(call => call.value), ["high", "max", "auto"], "intermediate selection was superseded before dispatch");
+calls[2].resolve();
+await Promise.all([first, skipped, latest]);
+assert.deepEqual(refreshes, ["b", "a"], "only authoritative latest selections refresh the UI");
+
+// A pending selection from another session is never sent after navigation.
+const running = commands.setEffortForTab("a", "high");
+await flush();
+const obsolete = commands.setEffortForTab("a", "max");
+ports.statesRef.current = new Map([["a", { sessionGen: 2, meta: { sessionPath: "different-session", sessionGeneration: 2 } }]]);
+calls[3].resolve();
+await Promise.all([running, obsolete]);
+assert.equal(calls.length, 4);
+assert.deepEqual(refreshes, ["b", "a"]);
+
+// The backend may save a pending value before an idle rebuild fails; refresh
+// after failure too, so the pending value remains visible and can be cancelled.
+const failure = commands.setEffortForTab("a", "max");
+await flush();
+calls[4].reject(new Error("injected build failure"));
+await failure;
+assert.equal(notices.length, 1);
+assert.deepEqual(refreshes, ["b", "a", "a"]);
+assert.equal(ports.effortSwitchQueueByTab.current.size, 0);
+const beforeModel = commands.setEffortForTab("a", "high");
+await flush();
+const oldModelSelection = commands.setEffortForTab("a", "max");
+await commands.setModelForTab("a", "different-model");
+calls[5].resolve();
+await Promise.all([beforeModel, oldModelSelection]);
+assert.equal(calls.length, 6, "a queued choice cannot cross a model switch");
+console.log("PASS effort ordering: latest selection, independent tabs, session/model fences, failure reconciliation");

--- a/desktop/frontend/src/app-runtime/conversationProjection.ts
+++ b/desktop/frontend/src/app-runtime/conversationProjection.ts
@@ -60,6 +60,7 @@ export function projectConversation({ local, remote, tab, activeTabId, backgroun
       imageInputEnabled: !remoteActive && local.meta?.imageInputEnabled !== false,
       imageUnderstandingEnabled: !remoteActive && local.meta?.visionFallbackEnabled === true,
       attachmentInputEnabled: !remoteActive,
+      remoteSession: remoteActive,
       pinnedFiles: remote ? undefined : local.meta?.pinnedFiles,
       turnId: remote ? undefined : local.activeTurnId,
       effort: remote ? remote.effort : local.effort,

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -3735,6 +3735,7 @@ export function Composer({
   const effortLevels = effort?.options ? ["auto", ...effortOptions.map((option) => option.id)] : asArray(effort?.levels);
   const currentEffort = effort?.current || "auto";
   const selectedEffort = effort?.pending ?? currentEffort;
+  const effortPendingHint = effort?.pending ? t("composer.effortNextTurnHint") : undefined;
   const effortDeferredUnavailable = running && (remoteSession || effort?.canDefer !== true);
   const hasEffort = Boolean(effort?.supported && effortLevels.length > 0);
   const chooseEffortLevel = (level: string) => {
@@ -4632,7 +4633,7 @@ export function Composer({
               {hasEffort && !heroMode && <div className="composer-effort-control">
                 <ComposerChoice key={`effort-${draftKey}`} label={effortLabel(selectedEffort)}
                   ariaLabel={`${t("status.effortTitle")}: ${effortLabel(selectedEffort)}`}
-                  icon={<Brain size={16} />} showChevron
+                  icon={<Brain size={16} />} showChevron title={effortPendingHint}
                   value={selectedEffort} disabled={disabled || readOnly || effortDeferredUnavailable}
                   onPick={chooseEffortLevel}
                   options={effortLevels.map(level => ({ value: level, label: effortLabel(level) }))} />

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -561,6 +561,7 @@ export function Composer({
   imageInputEnabled = true,
   imageUnderstandingEnabled = false,
   attachmentInputEnabled = true,
+  remoteSession = false,
   tabId, turnId,
   effort,
   onSend,
@@ -646,6 +647,7 @@ export function Composer({
   imageUnderstandingEnabled?: boolean;
   /** False for remote sessions because local filesystem paths are not portable to Serve. */
   attachmentInputEnabled?: boolean;
+  remoteSession?: boolean;
   tabId?: string; turnId?: string;
   effort?: EffortInfo;
   onSend: (displayText: string, submitText?: string, tabId?: string, structured?: StructuredInvocationSubmit) => void | Promise<void>;
@@ -749,6 +751,7 @@ export function Composer({
   const finishing = runtimeState.finishing;
   if (runtimeState.known) running = runtimeState.running ?? running;
   if (runtimeState.unknown) disabled = true;
+  attachmentInputEnabled = attachmentInputEnabled && !disabled && !readOnly;
   const pendingKey = followupSessionKey(inboxSessionPath, inboxHostId, inboxWorkspace);
   const pendingKeyRef = useRef(pendingKey);
   pendingKeyRef.current = pendingKey;
@@ -1585,17 +1588,19 @@ export function Composer({
     if (menuMode && menuMode !== "pastChats") setContentMenuOpen(false);
   }, [menuMode]);
 
-  // A starting run closes the transient content surfaces. Without this the
-  // popover state survives the run (its open prop gates on !running) and the
-  // menu would pop back unprompted the moment the turn finishes.
+  // Content remains editable during a run; task-mode controls still close.
   useEffect(() => {
     if (!running) return;
-    setContentMenuOpen(false);
-    setDirectPastChats(false);
-    setShowPastChats(false);
-    setPastChatQuery("");
-    if (pastChatToken) setDismissed(true);
-  }, [pastChatToken, running]);
+    setIntentMenuOpen(false);
+    setIntentMenuClosing(false);
+    if (remoteSession) {
+      setContentMenuOpen(false);
+      setDirectPastChats(false);
+      setShowPastChats(false);
+      setPastChatQuery("");
+      if (pastChatToken) setDismissed(true);
+    }
+  }, [pastChatToken, remoteSession, running]);
 
   const resetPromptHistoryNavigation = () => {
     if (historyIndexRef.current === -1) return;
@@ -2412,6 +2417,7 @@ export function Composer({
   }, [attachmentInputEnabled]);
 
   const onPaste = (e: ClipboardEvent<HTMLTextAreaElement | HTMLDivElement>) => {
+    if (disabled || readOnly) return;
     clearNativeClipboardPasteTimer();
     const files = clipboardFiles(e.clipboardData);
     if (files.length > 0) {
@@ -3165,10 +3171,10 @@ export function Composer({
   }, []);
 
   useEffect(() => {
-    if (!pastChatToken || directPastChats || dismissed || running || disabled || readOnly) return;
+    if (!pastChatToken || directPastChats || dismissed || (running && remoteSession) || disabled || readOnly) return;
     setDirectPastChats(true);
     void openPastChats(pastChatToken.query);
-  }, [directPastChats, disabled, dismissed, openPastChats, pastChatToken, readOnly, running]);
+  }, [directPastChats, disabled, dismissed, openPastChats, pastChatToken, readOnly, remoteSession, running]);
 
   const clearDirectPastChatToken = () => {
     const current = textRef.current;
@@ -3728,9 +3734,11 @@ export function Composer({
   const effortLabel = (id: string) => id === "auto" ? t("common.auto") : effortOptions.find((option) => option.id === id)?.name || id;
   const effortLevels = effort?.options ? ["auto", ...effortOptions.map((option) => option.id)] : asArray(effort?.levels);
   const currentEffort = effort?.current || "auto";
+  const selectedEffort = effort?.pending ?? currentEffort;
+  const effortDeferredUnavailable = running && (remoteSession || effort?.canDefer !== true);
   const hasEffort = Boolean(effort?.supported && effortLevels.length > 0);
   const chooseEffortLevel = (level: string) => {
-    if (level !== currentEffort) onSetEffort(level);
+    if (!disabled && !readOnly && !effortDeferredUnavailable && level !== selectedEffort) onSetEffort(level);
   };
   // Run-strip state machine: retry > waiting-approval > waiting-ask > streaming.
   // Decision surfaces own the "waiting on user" UI; while suspendedByDecision
@@ -3941,7 +3949,7 @@ export function Composer({
         }}
       />
       {!heroMode && <AnchoredPopover
-        open={(contentMenuOpen || intentMenuOpen) && !disabled && !readOnly && !running}
+        open={((contentMenuOpen && !(running && remoteSession)) || (intentMenuOpen && !running)) && !disabled && !readOnly}
         anchorRef={contentMenuOpen ? contentMenuAnchorRef : intentMenuAnchorRef}
         onClose={() => { setContentMenuOpen(false); closeIntentMenu(); }}
         className="composer-access-menu composer-content-menu composer-intent-menu composer-menu-surface"
@@ -4548,7 +4556,7 @@ export function Composer({
                     type="button"
                     className={`composer-content-trigger${contentMenuOpen ? " composer-content-trigger--open" : ""}`}
                     onClick={() => (contentMenuOpen ? setContentMenuOpen(false) : openContentMenu())}
-                    disabled={disabled || readOnly || running}
+                    disabled={disabled || readOnly || (running && remoteSession)}
                     aria-haspopup="menu"
                     aria-expanded={contentMenuOpen}
                     aria-label={t("composer.contentMenuTitle")}
@@ -4622,10 +4630,10 @@ export function Composer({
                 useAppNavigationStore.getState().setSettingsTarget("models");
               }} /></Suspense>
               {hasEffort && !heroMode && <div className="composer-effort-control">
-                <ComposerChoice key={`effort-${tabId}`} label={effortLabel(currentEffort)}
-                  ariaLabel={`${t("status.effortTitle")}: ${effortLabel(currentEffort)}`}
+                <ComposerChoice key={`effort-${draftKey}`} label={effortLabel(selectedEffort)}
+                  ariaLabel={`${t("status.effortTitle")}: ${effortLabel(selectedEffort)}`}
                   icon={<Brain size={16} />} showChevron
-                  value={currentEffort} disabled={disabled || readOnly || running}
+                  value={selectedEffort} disabled={disabled || readOnly || effortDeferredUnavailable}
                   onPick={chooseEffortLevel}
                   options={effortLevels.map(level => ({ value: level, label: effortLabel(level) }))} />
               </div>}

--- a/desktop/frontend/src/components/ComposerChoice.tsx
+++ b/desktop/frontend/src/components/ComposerChoice.tsx
@@ -2,7 +2,7 @@ import { useRef, useState, type ReactNode } from "react";
 import { Check, ChevronDown } from "lucide-react";
 import { AnchoredPopover } from "./AnchoredPopover";
 
-export function ComposerChoice({ label, ariaLabel, icon, showChevron, value, options, disabled, onPick, tone }: {
+export function ComposerChoice({ label, ariaLabel, icon, showChevron, value, options, disabled, onPick, tone, title }: {
   label: string;
   ariaLabel?: string;
   showChevron?: boolean;
@@ -12,12 +12,13 @@ export function ComposerChoice({ label, ariaLabel, icon, showChevron, value, opt
   disabled?: boolean;
   onPick: (value: string) => void;
   tone?: string;
+  title?: string;
 }) {
   const [open, setOpen] = useState(false);
   const anchor = useRef<HTMLButtonElement>(null);
   return <>
     <button ref={anchor} type="button" className={`composer-choice ${tone || ""}`} disabled={disabled}
-      aria-label={ariaLabel || label} aria-haspopup="menu" aria-expanded={open && !disabled} onClick={() => setOpen(!open)}>
+      aria-label={ariaLabel || label} aria-haspopup="menu" aria-expanded={open && !disabled} title={title} onClick={() => setOpen(!open)}>
       {icon}<span>{label}</span>{(showChevron ?? !icon) && <ChevronDown size={12} />}
     </button>
     <AnchoredPopover open={open && !disabled} anchorRef={anchor} onClose={() => setOpen(false)} className="composer-access-menu composer-menu-surface" align="start">

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -1,4 +1,5 @@
 import { makeMockModelSettingsBindings, type ModelSettingsBindings } from "./modelSettingsBridge";
+import { MockEffortSelections } from "./mockEffortSelections";
 import { mockProviderTemplate, mockPreset, mockBundlePreset, mockKimiAPIModels, mockLongCatModels, mockTokenRhythmModels, mockTokenRhythmModelOverrides, mockMiMoV25Models, mockMiniMaxModels, mockGLMAPIModels, mockGLMCodingModels, mockGLMAnthropicModels, mockQwenAPIModels, mockQwenPlanModels, mockQwenPlanVisionModels, mockStepFunModels, mockOpenCodeGoModels, mockNovitaModels, mockGMIModels, mockVercelModels, mockOllamaCloudModels } from "./mockProviderTemplates";
 // Wails and the browser mock share this React-to-Go contract.
 // @ts-ignore generated locally; fresh checkouts use the disabled drift check below.
@@ -1455,7 +1456,7 @@ function makeMockApp(): AppBindings {
   const globalWorkspaceRoot = "~/Library/Application Support/reasonix/global-workspace";
   let cwd = freshMock ? globalWorkspaceRoot : "~/projects/joyquant-db"; // mutable so PickWorkspace is visible in dev
   let workspaces = freshMock ? [] : ["~/projects/joyquant-db", "~/projects/joyquant-sys", "~/projects/reasonix", "~/projects/blade"];
-  let mockEffort = "auto";
+  const mockEfforts = new MockEffortSelections();
   let mockDesktopZoomFactor = 1.0;
   let mockActiveThemeId = "";
   let mockBaseStyle = "graphite";
@@ -2286,6 +2287,7 @@ function makeMockApp(): AppBindings {
     mockTabs = mockTabs.map((tab) => (tab.id === tabId ? { ...tab, running } : tab));
   };
   const emitMockTurnStarted = (submissionId?: string) => {
+    mockEfforts.beginTurn(currentMockTurnTabId() ?? "");
     setMockTabRunning(currentMockTurnTabId(), true);
     emit({ kind: "turn_started", submissionId });
   };
@@ -2498,6 +2500,7 @@ function makeMockApp(): AppBindings {
     mockTabs = mockTabs.map((tab) => {
       const match = tabID ? tab.id === tabID : tab.active;
       if (!match) return tab;
+      mockEfforts.clearPending(tab.id);
       applied = true;
       return { ...tab, label };
     });
@@ -3284,9 +3287,9 @@ function makeMockApp(): AppBindings {
         async Compact() {},
         async CompactForTab() {},
         async NewSession() {},
-        async NewSessionForTab() {},
+        async NewSessionForTab(tabID) { mockEfforts.clearPending(tabID || currentMockTurnTabId() || ""); },
         async ClearSession() { return { sessionPath: "", sessionGeneration: 0 }; },
-        async ClearSessionForTab() { return { sessionPath: "", sessionGeneration: 0 }; },
+        async ClearSessionForTab(tabID) { mockEfforts.clearPending(tabID || currentMockTurnTabId() || ""); return { sessionPath: "", sessionGeneration: 0 }; },
     async Checkpoints() {
       return [
         { turn: 0, prompt: "你好呀", files: ["src/App.tsx"], fileCount: 1, turnFileCount: 1, time: Date.now() - 30_000, canCode: true, canConversation: true },
@@ -4326,16 +4329,18 @@ function makeMockApp(): AppBindings {
           setMockTabModel(tabID, name);
         },
         async Effort() {
-          return { supported: true, current: mockEffort, default: "high", levels: ["auto", "high", "max"] };
+          return this.EffortForTab(currentMockTurnTabId() ?? "");
         },
-        async EffortForTab() {
-          return this.Effort();
+        async EffortForTab(tabID) {
+          const effort = mockEfforts.get(tabID || currentMockTurnTabId() || "");
+          return { supported: true, ...effort, canDefer: true, default: "high", levels: ["auto", "high", "max"] };
         },
         async SetEffort(level: string) {
-          mockEffort = level || "auto";
+          await this.SetEffortForTab(currentMockTurnTabId() ?? "", level);
         },
-        async SetEffortForTab(_tabID, level) {
-          await this.SetEffort(level);
+        async SetEffortForTab(tabID, level) {
+          const id = tabID || currentMockTurnTabId() || "";
+          mockEfforts.select(id, level, mockTabs.find(tab => tab.id === id)?.running === true);
         },
         async ReloadRuntime(_tabID) {},
     async Memory() {

--- a/desktop/frontend/src/lib/controllerModelCommands.ts
+++ b/desktop/frontend/src/lib/controllerModelCommands.ts
@@ -1,9 +1,11 @@
 import { app } from "./bridge";
-import type { BalanceInfo } from "./types";
+import type { BalanceInfo, TabMeta } from "./types";
 
 type Ref<T> = { current: T };
 type Ports = {
-  statesRef: Ref<ReadonlyMap<string, { balance?: BalanceInfo }>>;
+  statesRef: Ref<ReadonlyMap<string, { balance?: BalanceInfo; sessionGen?: number; meta?: Pick<TabMeta, "sessionPath" | "sessionGeneration"> }>>;
+  effortSwitchSeqByTab: Ref<Map<string, number>>;
+  effortSwitchQueueByTab: Ref<Map<string, Promise<void>>>;
   modelSwitchSeqByTab: Ref<Map<string, number>>;
   modelSwitchSuccessVersionByTab: Ref<Map<string, number>>;
   modelSwitchQueueByTab: Ref<ReadonlyMap<string, { fallbackBalance?: BalanceInfo }>>;
@@ -69,14 +71,38 @@ export function createControllerModelCommands(ports: Ports) {
 
   const setEffortForTab = async (tabId: string, level: string) => {
     if (!tabId) return;
+    const { effortSwitchSeqByTab, effortSwitchQueueByTab } = ports;
+    const sequence = (effortSwitchSeqByTab.current.get(tabId) ?? 0) + 1;
+    effortSwitchSeqByTab.current.set(tabId, sequence);
+    const source = statesRef.current.get(tabId);
+    const modelSequence = modelSwitchSeqByTab.current.get(tabId);
+    const ownsTarget = () => {
+      const current = statesRef.current.get(tabId);
+      return effortSwitchSeqByTab.current.get(tabId) === sequence
+        && modelSwitchSeqByTab.current.get(tabId) === modelSequence
+        && source?.sessionGen === current?.sessionGen
+        && source?.meta?.sessionPath === current?.meta?.sessionPath
+        && source?.meta?.sessionGeneration === current?.meta?.sessionGeneration;
+    };
+    // Wails calls can finish out of order. Serialize writes per tab and skip
+    // superseded requests before dispatch; other tabs remain independent.
+    const write = (effortSwitchQueueByTab.current.get(tabId) ?? Promise.resolve())
+      .catch(() => {})
+      .then(async () => {
+        if (ownsTarget()) await app.SetEffortForTab(tabId, level);
+      });
+    effortSwitchQueueByTab.current.set(tabId, write);
     try {
-      await app.SetEffortForTab(tabId, level);
+      await write;
     } catch (err) {
       const { effortSwitchNoticeText } = await import("./controllerSwitchNotices");
-      dispatchTo(tabId, { type: "local_notice", level: "warn", text: effortSwitchNoticeText(err) });
-      return;
+      if (ownsTarget()) dispatchTo(tabId, { type: "local_notice", level: "warn", text: effortSwitchNoticeText(err) });
+    } finally {
+      if (effortSwitchQueueByTab.current.get(tabId) === write) effortSwitchQueueByTab.current.delete(tabId);
+      // A failed idle rebuild can still leave a saved pending selection. Read
+      // the authoritative current/pending pair after both success and failure.
+      if (ownsTarget()) await refreshMetaForTab(tabId);
     }
-    await refreshMetaForTab(tabId);
   };
 
 

--- a/desktop/frontend/src/lib/controllerNotices.ts
+++ b/desktop/frontend/src/lib/controllerNotices.ts
@@ -19,6 +19,7 @@ export function errorMessage(err: unknown): string {
 }
 
 const noticeCodeKeys: Record<string, DictKey> = {
+  effort_selection_cleared: "composer.effortSelectionCleared",
   final_readiness: "notice.finalReadiness",
   search_sources_not_provided: "sources.notProvided",
   empty_final: "notice.emptyFinal",

--- a/desktop/frontend/src/lib/mockEffortSelections.ts
+++ b/desktop/frontend/src/lib/mockEffortSelections.ts
@@ -1,0 +1,33 @@
+type Selection = { current: string; pending?: string };
+
+/** Mirrors the desktop's per-tab selection and task-turn application boundary. */
+export class MockEffortSelections {
+  private readonly selections = new Map<string, Selection>();
+
+  get(tabId: string): Selection {
+    return this.selections.get(tabId) ?? { current: "auto" };
+  }
+
+  select(tabId: string, level: string, running: boolean): void {
+    const effort = this.get(tabId);
+    const selected = level || "auto";
+    if (running && selected !== effort.current) effort.pending = selected;
+    else {
+      delete effort.pending;
+      effort.current = selected;
+    }
+    this.selections.set(tabId, effort);
+  }
+
+  beginTurn(tabId: string): void {
+    const effort = this.get(tabId);
+    if (effort.pending) {
+      effort.current = effort.pending;
+      delete effort.pending;
+    }
+  }
+
+  clearPending(tabId: string): void {
+    delete this.get(tabId).pending;
+  }
+}

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -1516,6 +1516,8 @@ export interface EffortInfo {
   options?: { id: string; name: string; description?: string }[];
   supported: boolean;
   current: string; // adapter-owned ID; "auto" inherits the configured default
+  pending?: string; // accepted selection for the next run; current stays truthful
+  canDefer?: boolean; // absent on older/remote runtimes: keep the running guard
   default: string;
   levels: string[];
 }

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -2505,6 +2505,8 @@ export function useController() {
   const liveListenersByTabRef = useRef(new Map<string, Set<() => void>>());
   const balanceRefreshSeqByTab = useRef(new Map<string, number>());
   const modelSwitchSeqByTab = useRef(new Map<string, number>());
+  const effortSwitchSeqByTab = useRef(new Map<string, number>());
+  const effortSwitchQueueByTab = useRef(new Map<string, Promise<void>>());
   const modelSwitchSuccessVersionByTab = useRef(new Map<string, number>());
   const modelSwitchQueueByTab = useRef(new Map<string, ModelSwitchQueueState>());
   const lastTurnActivityAtByTab = useRef(new Map<string, number>());
@@ -2656,14 +2658,9 @@ export function useController() {
   }, [dispatchTo]);
 
   const invalidateProviderStateForTab = useCallback((tabId: string): void => {
-    balanceRefreshSeqByTab.current.set(
-      tabId,
-      (balanceRefreshSeqByTab.current.get(tabId) ?? 0) + 1,
-    );
-    modelSwitchSeqByTab.current.set(
-      tabId,
-      (modelSwitchSeqByTab.current.get(tabId) ?? 0) + 1,
-    );
+    for (const sequences of [effortSwitchSeqByTab, balanceRefreshSeqByTab, modelSwitchSeqByTab]) {
+      sequences.current.set(tabId, (sequences.current.get(tabId) ?? 0) + 1);
+    }
   }, []);
 
   const refreshBalanceForTab = useCallback(async (
@@ -4485,6 +4482,7 @@ export function useController() {
 
   const { setModelForTab, setEffortForTab } = useMemo(() => createControllerModelCommands({
     statesRef, modelSwitchSeqByTab, modelSwitchSuccessVersionByTab, modelSwitchQueueByTab,
+    effortSwitchSeqByTab, effortSwitchQueueByTab,
     enqueueModelSwitch, clearBalanceForTab, dispatchTo, refreshBalanceForTab, refreshMetaForTab,
   }), [enqueueModelSwitch, clearBalanceForTab, dispatchTo, refreshBalanceForTab, refreshMetaForTab]);
   const setModel = useCallback((name: string) => activeTabId ? setModelForTab(activeTabId, name) : Promise.resolve(false), [activeTabId, setModelForTab]);

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -879,6 +879,7 @@ export const en = {
   "composer.steer": "Add guidance to current turn (Enter)",
   "composer.steerPlaceholder": "Running — type guidance, {combo} adds it to the queue",
   "composer.effortSelectionCleared": "The session or model changed, so the previous reasoning effort selection was cleared.",
+  "composer.effortNextTurnHint": "Selected for the next task turn",
   "composer.runWaitingApproval": "Waiting for your approval — {tool}",
   "composer.runWaitingAsk": "Waiting for your answer",
   "composer.runAnnounceRunning": "Reasonix is working",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -878,6 +878,7 @@ export const en = {
   "composer.queueGuidance": "Add to guidance queue ({combo})",
   "composer.steer": "Add guidance to current turn (Enter)",
   "composer.steerPlaceholder": "Running — type guidance, {combo} adds it to the queue",
+  "composer.effortSelectionCleared": "The session or model changed, so the previous reasoning effort selection was cleared.",
   "composer.runWaitingApproval": "Waiting for your approval — {tool}",
   "composer.runWaitingAsk": "Waiting for your answer",
   "composer.runAnnounceRunning": "Reasonix is working",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -676,6 +676,7 @@ export const zhTW: Record<DictKey, string> = {
   "composer.steer": "追加到目前任務（Enter）",
   "composer.steerPlaceholder": "正在執行——輸入補充指示，{combo} 加入佇列",
   "composer.effortSelectionCleared": "工作階段或模型已更換，原來的思考強度預選已撤銷。",
+  "composer.effortNextTurnHint": "已選擇，下一回合生效",
   "composer.runWaitingApproval": "等待你核准 — {tool}",
   "composer.runWaitingAsk": "等待你回答",
   "composer.runAnnounceRunning": "正在執行",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -675,6 +675,7 @@ export const zhTW: Record<DictKey, string> = {
   "composer.queueGuidance": "加入引導佇列（{combo}）",
   "composer.steer": "追加到目前任務（Enter）",
   "composer.steerPlaceholder": "正在執行——輸入補充指示，{combo} 加入佇列",
+  "composer.effortSelectionCleared": "工作階段或模型已更換，原來的思考強度預選已撤銷。",
   "composer.runWaitingApproval": "等待你核准 — {tool}",
   "composer.runWaitingAsk": "等待你回答",
   "composer.runAnnounceRunning": "正在執行",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -880,6 +880,7 @@ export const zh: Record<DictKey, string> = {
   "composer.steer": "追加到当前任务（Enter）",
   "composer.steerPlaceholder": "正在运行——输入补充指示，{combo} 加入队列",
   "composer.effortSelectionCleared": "会话或模型已更换，原来的思考强度预选已撤销。",
+  "composer.effortNextTurnHint": "已选择，下一回合生效",
   "composer.runWaitingApproval": "等待你批准 — {tool}",
   "composer.runWaitingAsk": "等待你回答",
   "composer.runAnnounceRunning": "正在运行",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -879,6 +879,7 @@ export const zh: Record<DictKey, string> = {
   "composer.queueGuidance": "加入引导队列（{combo}）",
   "composer.steer": "追加到当前任务（Enter）",
   "composer.steerPlaceholder": "正在运行——输入补充指示，{combo} 加入队列",
+  "composer.effortSelectionCleared": "会话或模型已更换，原来的思考强度预选已撤销。",
   "composer.runWaitingApproval": "等待你批准 — {tool}",
   "composer.runWaitingAsk": "等待你回答",
   "composer.runAnnounceRunning": "正在运行",

--- a/desktop/quality_floor.go
+++ b/desktop/quality_floor.go
@@ -48,7 +48,7 @@ func (a *App) SetQualityFloorForTab(tabID, floor string) error {
 	}
 	a.mu.Lock()
 	if a.tabs[tabIDForSave] == tab {
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 	return nil

--- a/desktop/remote_single_surface.go
+++ b/desktop/remote_single_surface.go
@@ -94,7 +94,7 @@ func (a *App) keepOnlyRemoteVisibleTab(tabID string) (TabMeta, error) {
 		for _, tab := range removedLocal {
 			a.removeVisibleTabRuntimeAdmissionHeld(tab)
 		}
-		a.saveTabsWrite(dir, entries, activeID, version)
+		_ = a.saveTabsWrite(dir, entries, activeID, version)
 		return meta, remoteCancels, nil
 	}()
 	if err != nil {

--- a/desktop/remote_tab_persistence.go
+++ b/desktop/remote_tab_persistence.go
@@ -55,5 +55,5 @@ func (a *App) saveTabsFromRemote() {
 	a.mu.Lock()
 	dir, entries, activeID, version := a.saveTabsCollectLocked()
 	a.mu.Unlock()
-	a.saveTabsWrite(dir, entries, activeID, version)
+	_ = a.saveTabsWrite(dir, entries, activeID, version)
 }

--- a/desktop/session_canonical_retarget.go
+++ b/desktop/session_canonical_retarget.go
@@ -172,7 +172,7 @@ func (a *App) retargetOpenTabsToContinuations() {
 			a.mu.Lock()
 			if !item.tab.hasActiveRuntimeWork() && (a.tabs[item.tab.ID] == item.tab || a.detachedSessions[sessionRuntimeKey(item.tab.currentSessionPath())] == item.tab) {
 				item.tab.SessionPath = item.next
-				a.saveTabsLocked()
+				_ = a.saveTabsLocked()
 			}
 			a.mu.Unlock()
 			continue

--- a/desktop/session_clear.go
+++ b/desktop/session_clear.go
@@ -111,7 +111,7 @@ func (a *App) clearTabGoal(tab *WorkspaceTab) {
 	a.mu.Lock()
 	tab.goal = ""
 	if current := a.tabs[tab.ID]; current == tab {
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 }

--- a/desktop/session_clear.go
+++ b/desktop/session_clear.go
@@ -79,6 +79,7 @@ func (a *App) bumpAndSnapshotSessionClear(tab *WorkspaceTab) SessionClearResult 
 	if tab == nil {
 		return SessionClearResult{}
 	}
+	a.discardPendingTabEffort(tab)
 	a.mu.Lock()
 	tab.SessionGeneration++
 	gen := tab.SessionGeneration

--- a/desktop/session_heads.go
+++ b/desktop/session_heads.go
@@ -26,6 +26,7 @@ func (a *App) tabMetaAfterHeadSwitch(tab *WorkspaceTab) TabMeta {
 	if tab == nil {
 		return TabMeta{}
 	}
+	a.discardPendingTabEffort(tab)
 	a.mu.Lock()
 	tab.SessionGeneration++
 	if tab.sink != nil {

--- a/desktop/session_lease_handoff.go
+++ b/desktop/session_lease_handoff.go
@@ -151,7 +151,7 @@ func (a *App) handleTabSessionTransition(tab *WorkspaceTab) func(control.Session
 		}
 		tab.SessionPath = canonicalTabSessionPath(info.TargetPath)
 		if a.tabs[tab.ID] == tab {
-			a.saveTabsLocked()
+			_ = a.saveTabsLocked()
 		}
 		a.mu.Unlock()
 		if oldLease != nil {

--- a/desktop/session_lease_handoff.go
+++ b/desktop/session_lease_handoff.go
@@ -158,6 +158,9 @@ func (a *App) handleTabSessionTransition(tab *WorkspaceTab) func(control.Session
 			go oldLease.Release()
 		}
 		info.OnCommit(func() {
+			if info.OriginalPath != "" && sessionRuntimeKey(info.OriginalPath) != sessionRuntimeKey(info.TargetPath) {
+				a.discardPendingTabEffort(tab)
+			}
 			tab.setPinnedFiles(pinnedState.Files)
 			a.emitRuntimeEvent(tabMetaRefreshEventChannel, TabMetaRefreshEvent{TabID: tab.ID, Meta: a.MetaForTab(tab.ID)})
 		})

--- a/desktop/session_recovery_pinned.go
+++ b/desktop/session_recovery_pinned.go
@@ -44,7 +44,7 @@ func (a *App) handleTabSessionRecovered(tab *WorkspaceTab) func(control.SessionR
 			}
 			tab.SessionPath = canonicalTabSessionPath(info.RecoveryPath)
 			if a.tabs[tab.ID] == tab {
-				a.saveTabsLocked()
+				_ = a.saveTabsLocked()
 			}
 		}
 		a.mu.Unlock()

--- a/desktop/session_takeover.go
+++ b/desktop/session_takeover.go
@@ -369,7 +369,7 @@ func (a *App) TakeoverSession(tabID, mode string) error {
 		if a.tabs[tab.ID] == tab && !tab.removed && tab.Ctrl == nil {
 			tab.restoreStartupState(previousStartup)
 			a.setSessionRuntimePhaseLocked(tab, sessionRuntimeLeaseBlocked, &sessionLeaseBusyError{})
-			a.saveTabsLocked()
+			_ = a.saveTabsLocked()
 		}
 		a.mu.Unlock()
 		return err

--- a/desktop/session_takeover_promote.go
+++ b/desktop/session_takeover_promote.go
@@ -60,7 +60,7 @@ func (a *App) markLocalTakeoverSpectator(tab *WorkspaceTab) {
 	if a.tabs[tab.ID] == tab && !tab.removed {
 		tab.ReadOnly = true
 		tab.Takeover.Spectator = true
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 		marked = true
 	}
 	a.mu.Unlock()
@@ -189,7 +189,7 @@ func (a *App) promoteLocalTakeoverSpectator(
 	}
 	a.supersedeTabBuildLocked(tab)
 	newEpoch := a.advanceSessionRuntimeEpochLocked(tab)
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	candidate.ctrl = nil
 	candidate.sink = nil
 	committed = true

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -2007,7 +2007,7 @@ func (a *App) rebuildSettingTurnLockedWithModel(setting string, tab *WorkspaceTa
 	// Supersede any in-flight startup build: it would otherwise finish later,
 	// pass its generation check, and overwrite the controller just installed.
 	a.supersedeTabBuildLocked(tab)
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	a.mu.Unlock()
 	// True subgraph rebuilds reuse the same controller pointer — never Close it.
 	if oldCtrl != nil && oldCtrl != ctrl {

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1998,6 +1998,7 @@ func (a *App) rebuildSettingTurnLockedWithModel(setting string, tab *WorkspaceTa
 	}
 	tab.Ctrl = ctrl
 	tab.modelApplication.failure = nil
+	clearedEffort := clearPendingEffortForModelLocked(tab, model)
 	tab.model = model
 	tab.Label = ctrl.Label()
 	applyNormalizedRuntimeToTabLocked(tab, restoredRuntime)
@@ -2014,6 +2015,7 @@ func (a *App) rebuildSettingTurnLockedWithModel(setting string, tab *WorkspaceTa
 	}
 	a.persistTabSessionPath(tab, path)
 	a.clearDeferredRebuildVersion(tab.ID, pendingSequence)
+	a.notifyEffortSelectionCleared(tab, clearedEffort)
 	a.notifyTabRuntimeRebuilt(tab)
 	a.emitReady(a.ctx)
 	return nil

--- a/desktop/startup_health_test.go
+++ b/desktop/startup_health_test.go
@@ -259,7 +259,7 @@ func TestShutdownPersistsRecoveryPathCommittedAfterCallback(t *testing.T) {
 			// the old path. The recovery lease must keep this write anchored to
 			// recovery instead of undoing the callback's first save.
 			a.mu.Lock()
-			a.saveTabsLocked()
+			_ = a.saveTabsLocked()
 			a.mu.Unlock()
 			// Controller.commitRecoveredSession updates its path only after the
 			// callback succeeds. Mirror that ordering exactly.

--- a/desktop/tab_profile_test.go
+++ b/desktop/tab_profile_test.go
@@ -65,6 +65,15 @@ func TestSetEffortForTabIsTabLocal(t *testing.T) {
 	}
 }
 
+func TestPersistedDesktopTabEntryKeepsPendingEffort(t *testing.T) {
+	base := "auto"
+	tab := &WorkspaceTab{effort: &base, pendingEffort: &pendingEffortSelection{value: "max"}}
+	entry := persistedDesktopTabEntry(tab)
+	if entry.Effort == nil || *entry.Effort != "max" {
+		t.Fatalf("persisted effort = %#v, want max", entry.Effort)
+	}
+}
+
 func TestEffortForTabResolvesProjectProviderConfig(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/desktop/tab_readonly.go
+++ b/desktop/tab_readonly.go
@@ -25,7 +25,7 @@ func (a *App) setTabReadOnly(tabID string, readOnly bool) {
 	if !readOnly {
 		tab.Takeover.Spectator = false
 	}
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	a.mu.Unlock()
 	if len(terminalSessions) > 0 {
 		// Existing shells can keep modifying the workspace without renderer

--- a/desktop/tab_selection.go
+++ b/desktop/tab_selection.go
@@ -94,7 +94,7 @@ func (a *App) SetActiveTab(tabID string) error {
 
 	// I/O outside the lock — disk writes can block for hundreds of ms on
 	// Windows when antivirus or the search indexer briefly locks the file.
-	a.saveTabsWrite(dir, entries, activeID, version)
+	_ = a.saveTabsWrite(dir, entries, activeID, version)
 	if active != nil {
 		active.clearRuntimeDisplayCurrency()
 	}

--- a/desktop/tab_startup_failure.go
+++ b/desktop/tab_startup_failure.go
@@ -45,7 +45,7 @@ func (a *App) markTabStartupFailureLocked(tab *WorkspaceTab, err error, policy s
 
 func (a *App) writeTabsSaveRequest(req *tabsSaveRequest) {
 	if req != nil {
-		a.saveTabsWrite(req.dir, req.entries, req.activeID, req.version)
+		_ = a.saveTabsWrite(req.dir, req.entries, req.activeID, req.version)
 	}
 }
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -825,7 +825,7 @@ func (a *App) attachExistingSessionRuntimeCore(tab *WorkspaceTab, path string, w
 		delete(a.detachedSessions, key)
 		applyRuntimeTab(tab, detached, path, wailsCtx, a)
 		if current := a.tabs[tab.ID]; current == tab {
-			a.saveTabsLocked()
+			_ = a.saveTabsLocked()
 		}
 		attachedCtrl := tab.Ctrl
 		attachedSink := tab.sink
@@ -865,7 +865,7 @@ func (a *App) attachExistingSessionRuntimeCore(tab *WorkspaceTab, path string, w
 		a.activeTabID = tab.ID
 	}
 	applyRuntimeTab(tab, source, path, wailsCtx, a)
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	attachedCtrl := tab.Ctrl
 	attachedSink := tab.sink
 	attachedEpoch := a.runtimeEpochForTabLocked(tab)
@@ -2228,7 +2228,7 @@ func (a *App) syncTabWorkspaceRootSpellings() {
 		changed = syncRuntimeWorkspaceRootSpelling(tab, projects) || changed
 	}
 	if changed {
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	a.mu.Unlock()
 	if changed {
@@ -2305,7 +2305,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 					a.activeTabID = tab.ID
 				}
 				meta := a.tabMeta(tab, tab.ID == a.activeTabID)
-				a.saveTabsLocked()
+				_ = a.saveTabsLocked()
 				a.mu.Unlock()
 				return enrichTabMeta(meta), nil
 			}
@@ -2319,7 +2319,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			}
 			sameSession := targetKey == "" || sessionRuntimeKey(tab.currentSessionPath()) == targetKey
 			meta := a.tabMeta(tab, tab.ID == a.activeTabID)
-			a.saveTabsLocked()
+			_ = a.saveTabsLocked()
 			a.mu.Unlock()
 			if sameSession || a.skipContinuationRebind(tab, sessionPath) {
 				return enrichTabMeta(meta), nil
@@ -2372,7 +2372,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 	if activate {
 		a.activeTabID = tabID
 	}
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	meta := a.tabMeta(tab, tab.ID == a.activeTabID)
 	a.mu.Unlock()
 
@@ -2571,7 +2571,7 @@ func (a *App) ensureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 		}
 		a.activeTabID = reusable.ID
 		meta := a.tabMeta(reusable, true)
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 		a.mu.Unlock()
 		return enrichTabMeta(meta), nil
 	}
@@ -2638,7 +2638,7 @@ func (a *App) ensureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 			return TabMeta{}, err
 		}
 		created.SessionPath = prePath
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 		meta := a.tabMeta(created, true)
 		a.mu.Unlock()
 
@@ -2690,7 +2690,7 @@ func (a *App) ensureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 		return TabMeta{}, err
 	}
 	created.SessionPath = prePath
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	meta := a.tabMeta(created, true)
 	a.mu.Unlock()
 
@@ -2764,7 +2764,7 @@ func (a *App) alignReusableBlankTabModel(tab *WorkspaceTab, model string) error 
 	tab.Label = model
 	tab.Ready = false
 	clearTabStartupError(tab)
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	a.mu.Unlock()
 	a.startTabControllerBuild(tab)
 	return nil
@@ -3046,7 +3046,7 @@ func (a *App) ReorderTabs(tabIDs []string) error {
 	a.tabOrder = next
 	dir, entries, activeID, version := a.saveTabsCollectLocked()
 	a.mu.Unlock()
-	a.saveTabsWrite(dir, entries, activeID, version)
+	_ = a.saveTabsWrite(dir, entries, activeID, version)
 	return nil
 }
 
@@ -3136,7 +3136,7 @@ func (a *App) closeTabRuntime(tabID string, allowDetach bool) error {
 			a.activeTabID = a.tabOrder[nextIndex]
 		}
 	}
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	// Snapshot the teardown targets while still holding the lock: the tab is
 	// no longer reachable from a.tabs after this section, but locked writers
 	// holding stale pointers (rememberTabSessionPath, applySessionBindingToTab)
@@ -3253,7 +3253,7 @@ func (a *App) keepOnlyVisibleTab(tabID string) (TabMeta, error) {
 			a.removeTabOrderLocked(id)
 		}
 		a.tabOrder = []string{tabID}
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 		meta := a.tabMeta(active, true)
 		a.mu.Unlock()
 
@@ -3721,7 +3721,7 @@ func (a *App) buildTabControllerWithContextCore(tab *WorkspaceTab, loadedSession
 	buildToolApprovalMode := tab.toolApprovalMode
 	buildGoal := tab.goal
 	buildSink := tab.sink
-	a.saveTabsLocked()
+	_ = a.saveTabsLocked()
 	a.mu.Unlock()
 	buildRuntime := (tabRuntimeSnapshot{
 		tokenMode:        buildTokenMode,
@@ -4105,7 +4105,7 @@ func (a *App) applySessionBindingToTab(tab *WorkspaceTab, binding sessionBinding
 		tab.TopicTitle = topicTitle
 	}
 	if changed && current == tab {
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	}
 	sink := tab.sink
 	a.mu.Unlock()
@@ -7729,7 +7729,7 @@ func (a *App) rememberTabSessionPath(tab *WorkspaceTab, path string) {
 	a.mu.Lock()
 	if current := a.tabs[tab.ID]; current == tab {
 		tab.SessionPath = path
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 	} else {
 		tab.SessionPath = path
 	}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -149,8 +149,9 @@ type WorkspaceTab struct {
 
 	model            string // active model ref (for meta)
 	effort           *string
-	qualityFloor     string // standard|delivery; see desktop/quality_floor.go
-	mode             string // "normal" | "plan" | "yolo" | "plan-yolo"; yolo/full access is runtime-only
+	pendingEffort    *pendingEffortSelection // next-run selection; guarded by App.mu
+	qualityFloor     string                  // standard|delivery; see desktop/quality_floor.go
+	mode             string                  // "normal" | "plan" | "yolo" | "plan-yolo"; yolo/full access is runtime-only
 	goal             string
 	toolApprovalMode string
 	disabledMCP      map[string]ServerView
@@ -612,6 +613,7 @@ func cloneDetachedRuntimeTab(tab *WorkspaceTab, key, path string) *WorkspaceTab 
 		displayState:             tab.displayBufferState(),
 		model:                    tab.model,
 		effort:                   cloneStringPtr(tab.effort),
+		pendingEffort:            tab.pendingEffort,
 		qualityFloor:             tab.qualityFloor,
 		mode:                     tab.mode,
 		goal:                     tab.goal,
@@ -663,6 +665,10 @@ func (a *App) detachRuntimeForReplacementLocked(tab *WorkspaceTab) bool {
 	if detached == nil {
 		return false
 	}
+	// This source is being replaced with another session. Retire its pending
+	// selection in both wrappers; ordinary tab detach keeps its own profile.
+	detached.pendingEffort = nil
+	tab.pendingEffort = nil
 	// Transfer lease ownership through the locked helpers: a concurrent
 	// ensureSessionLease (blank-session boot, recovery callback) must never
 	// observe a torn pointer or have its freshly acquired lease clobbered.
@@ -722,6 +728,7 @@ func applyRuntimeTab(target, source *WorkspaceTab, path string, wailsCtx context
 	target.ActivityStatus = source.ActivityStatus
 	target.model = source.model
 	target.effort = cloneStringPtr(source.effort)
+	target.pendingEffort = source.pendingEffort
 	target.qualityFloor = source.qualityFloor
 	target.mode = source.mode
 	target.goal = source.goal
@@ -4723,9 +4730,9 @@ func desktopConfigDir() string {
 	return config.ReasonixHomeDir()
 }
 
-func (a *App) saveTabsLocked() {
+func (a *App) saveTabsLocked() error {
 	dir, entries, activeID, version := a.saveTabsCollectLocked()
-	a.saveTabsWrite(dir, entries, activeID, version)
+	return a.saveTabsWrite(dir, entries, activeID, version)
 }
 
 // saveTabsCollectLocked gathers the tab-snapshot data under the caller's lock
@@ -4750,15 +4757,15 @@ func (a *App) saveTabsCollectLocked() (string, []desktopTabEntry, string, uint64
 // saveTabsWrite writes the tab-snapshot to disk. It does not require a.mu, but
 // writes must be serialized because every save uses the same destination and
 // fixed .tmp path.
-func (a *App) saveTabsWrite(dir string, entries []desktopTabEntry, activeID string, version uint64) {
+func (a *App) saveTabsWrite(dir string, entries []desktopTabEntry, activeID string, version uint64) error {
 	a.tabsSaveMu.Lock()
 	defer a.tabsSaveMu.Unlock()
 	if version < a.tabsLastWrittenVersion {
-		return
+		return nil
 	}
 
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return
+		return err
 	}
 	localIDs := make([]string, 0, len(entries))
 	for _, entry := range entries {
@@ -4771,17 +4778,18 @@ func (a *App) saveTabsWrite(dir string, entries []desktopTabEntry, activeID stri
 	f := desktopTabsFile{Tabs: entries, ActiveTab: activeID, RemoteTabs: remoteEntries, RemoteTabOrder: remoteOrder, TabOrder: tabOrder}
 	b, err := json.MarshalIndent(f, "", "  ")
 	if err != nil {
-		return
+		return err
 	}
 	path := filepath.Join(dir, tabsFileName)
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, b, 0o644); err != nil {
-		return
+		return err
 	}
 	if err := fileutil.ReplaceFile(tmp, path); err != nil {
-		return
+		return err
 	}
 	a.tabsLastWrittenVersion = version
+	return nil
 }
 
 func (a *App) orderedTabIDsLocked() []string {
@@ -7065,6 +7073,7 @@ type tabRuntimeSnapshot struct {
 	sharedHostKey                 string
 	model                         string
 	effort                        *string
+	pendingEffort                 *pendingEffortSelection
 	tokenMode, qualityFloor, mode string
 	goal, toolApprovalMode        string
 }
@@ -7098,6 +7107,7 @@ func snapshotTabRuntimeLocked(tab *WorkspaceTab) tabRuntimeSnapshot {
 		sharedHostKey:    tab.SharedHostKey,
 		model:            tab.model,
 		effort:           cloneStringPtr(tab.effort),
+		pendingEffort:    tab.pendingEffort,
 		tokenMode:        currentTabTokenMode(tab),
 		qualityFloor:     tab.qualityFloor,
 		mode:             tab.mode,

--- a/desktop/tabs_persistence_types.go
+++ b/desktop/tabs_persistence_types.go
@@ -39,7 +39,7 @@ func persistedDesktopTabEntry(tab *WorkspaceTab) desktopTabEntry {
 		ReadOnly:          tab.ReadOnly,
 		TakeoverSpectator: tab.Takeover.Spectator,
 		Model:             tab.model,
-		Effort:            cloneStringPtr(tab.effort),
+		Effort:            persistedTabEffort(tab),
 		AgentPreset:       currentTabAgentPreset(tab),
 		TokenMode:         currentTabTokenMode(tab),
 		QualityFloor:      tab.qualityFloor,

--- a/desktop/topic_archive_runtime.go
+++ b/desktop/topic_archive_runtime.go
@@ -114,7 +114,7 @@ func (a *App) removeTopicRuntimeBindingsIfUnchanged(topicID string, captured []r
 	fallback.needs = len(captured) > 0 && len(a.tabs) == 0
 	dir, entries, activeID, version := a.saveTabsCollectLocked()
 	a.mu.Unlock()
-	a.saveTabsWrite(dir, entries, activeID, version)
+	_ = a.saveTabsWrite(dir, entries, activeID, version)
 	return fallback, true
 }
 

--- a/desktop/topic_live_runtime.go
+++ b/desktop/topic_live_runtime.go
@@ -124,7 +124,7 @@ func (a *App) openTopicTabPreferLiveActivation(scope, workspaceRoot, topicID, se
 	a.mu.Lock()
 	if promoted := a.promoteDetachedRuntimeLocked(sessionPath, activate); promoted != nil {
 		meta := a.tabMeta(promoted, promoted.ID == a.activeTabID)
-		a.saveTabsLocked()
+		_ = a.saveTabsLocked()
 		a.mu.Unlock()
 		// A TurnDone missed while the runtime was detached leaves a permanent
 		// spinner; reconcile against the controller's real turn state on open.

--- a/desktop/turn_admission.go
+++ b/desktop/turn_admission.go
@@ -128,6 +128,13 @@ func (a *App) beginRuntimeTurn(tabID string, reclaim, detached bool, submissionI
 			abort()
 			return nil, nil, control.ErrTurnRunning
 		}
+		if selection := a.pendingTabEffort(tab); selection != nil {
+			abort()
+			if err := a.applyPendingTabEffort(tab, selection); err != nil {
+				return nil, nil, fmt.Errorf("apply reasoning effort before the next run: %w", err)
+			}
+			continue
+		}
 		if a.ctx != nil {
 			needed, err := modelSettingsNeedApply(ctrl)
 			if err != nil {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1779,6 +1779,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 	ctrlOpts := control.Options{
 		ModelSettingsRevision:          cfg.ModelRuntimeFingerprint(modelRef),
 		ModelSettingsCurrent:           runtimeModelSettingsReader(root, modelName, modelRef, opts.ModelSettings),
+		FrozenEffort:                   &entry.Effort,
 		FrozenImageInput:               &imageEnabled,
 		ImageCapabilityChanged:         runtimeImageCapabilityReader(root, modelName, imageSnapshot, opts.ModelSettings),
 		TaskBudget:                     taskBudgetFromConfig(cfg),

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -514,6 +514,9 @@ type Options struct {
 	ModelSettingsRevision       string
 	ModelSettingsSourceRevision string
 	ModelSettingsCurrent        func() (string, error)
+	// FrozenEffort is the configured adapter ID used to build this runtime.
+	// Nil permits legacy/custom controllers to fall back to host metadata.
+	FrozenEffort *string
 	// BeforeInboxDispatch lets the owner reserve runtime admission before a
 	// queued message becomes a new turn. The returned release runs after claim
 	// and synchronous turn admission, outside every controller lock.

--- a/internal/control/effort_snapshot_test.go
+++ b/internal/control/effort_snapshot_test.go
@@ -1,0 +1,18 @@
+package control
+
+import "testing"
+
+func TestEffortSnapshotIsImmutableAndOptional(t *testing.T) {
+	level := "high"
+	ctrl := New(Options{FrozenEffort: &level})
+	defer ctrl.Close()
+	level = "max"
+	if got, available := ctrl.EffortSnapshot(); !available || got != "high" {
+		t.Fatalf("snapshot = %q/%t, want immutable high", got, available)
+	}
+	legacy := New(Options{})
+	defer legacy.Close()
+	if _, available := legacy.EffortSnapshot(); available {
+		t.Fatal("legacy controller reported an invented effort snapshot")
+	}
+}

--- a/internal/control/model_settings.go
+++ b/internal/control/model_settings.go
@@ -4,6 +4,7 @@ package control
 // callback together for the lifetime of one controller. The callback is guarded
 // by Controller.mu; snapshot fields are immutable after construction.
 type controllerModelSettings struct {
+	effort              *string
 	revision            string
 	sourceRevision      string
 	current             func() (string, error)
@@ -11,10 +12,25 @@ type controllerModelSettings struct {
 }
 
 func newControllerModelSettings(opts Options) controllerModelSettings {
+	var effort *string
+	if opts.FrozenEffort != nil {
+		value := *opts.FrozenEffort
+		effort = &value
+	}
 	return controllerModelSettings{
+		effort:              effort,
 		revision:            opts.ModelSettingsRevision,
 		sourceRevision:      opts.ModelSettingsSourceRevision,
 		current:             opts.ModelSettingsCurrent,
 		beforeInboxDispatch: opts.BeforeInboxDispatch,
 	}
+}
+
+// EffortSnapshot reports the current runtime's selection without reading
+// mutable disk settings or a host's pending next-run selection.
+func (c *Controller) EffortSnapshot() (string, bool) {
+	if c.modelSettings.effort == nil {
+		return "", false
+	}
+	return *c.modelSettings.effort, true
 }


### PR DESCRIPTION
## Summary

Running local desktop tasks can now add attachments and file/history references through the existing composer controls. Task-mode actions retain their running guards, and remote running controls retain their existing restrictions. The composer layout, styling, buttons, and menu presentation are unchanged.

Reasoning effort selections made during a task are saved for the next task turn. The running controller keeps its original effort through tool continuations and supplementary input. Manual submissions and durable inbox dispatch apply the pending selection before admitting the next turn. Repeated selections keep the latest accepted value; selecting the current value cancels it. Stop preserves the selection without starting work. Session/model replacement clears it through the existing notice channel. While a selection is pending during a running task, the effort trigger carries a localized next-turn hint so the label is not mistaken for the currently applied effort.

The runtime owns applied versus pending state, preserves the old controller and queue on rebuild failure, and retries through session write authority. Frontend writes are serialized per tab and fenced against stale session/model completions.

## Issues

No linked issue; fixes the reported running-composer behavior.

## Verification

- Repository: `go run ./tools/repolint`, `git diff --check`.
- Desktop: `go test . -count=1` and focused `go test ./... -run 'TestEffortSelection|TestSetEffort|TestSaveTabs' -count=1`.
- Desktop race: `go test -race . -run 'TestEffortSelection|TestSetEffortDefersRunningTurn' -count=1`.
- Desktop vet: `go vet ./...`.
- Root: `go test ./internal/control -run EffortSnapshot -count=1`.
- Frontend: `pnpm build`, `pnpm test:typecheck`, and `pnpm exec tsx src/__tests__/composer-running-controls.test.tsx`.
- Regression coverage includes request effort across tool continuations, manual/inbox admission, selection ordering, stop/restart, pre- and post-publication persistence failures, session/model replacement, sibling tabs, build failure, and revoked-lease retry. `TestEffortSelectionPersistenceFailureAfterPublication` pins the controller-swapped-then-save-fails path: the published controller stays live and usable, the applied effort is visible immediately, and no pending selection survives.
- Browser interaction checks and isolated native macOS Wails QA: open the system file chooser during a run, attach a file, queue supplementary input, observe the current task still request `low`, then observe the next manual task request `max` against a synthetic local provider.

## Compatibility and capacity

Optional `pending` and `canDefer` fields extend effort metadata; older backends keep running effort controls disabled. Pending effort uses the existing persisted effort field, so startup and older readers consume the selected initial override without a schema migration. No new configuration is required.

Using the same toolchain, initial raw assets measure 2,494,500 bytes versus 2,492,623 bytes on base fa018e410 (+1,877 bytes, 0.075%). The raw ceiling moves to 2436.1 KiB. The session-change notice and the pending-effort next-turn hint add 81/73 gzip bytes to zh/zh-TW (64,815/65,572 B); zh moves from 63.3 to 63.4 KiB and zh-TW from 64.0 to 64.1 KiB. Other bundle limits and all source-size/complexity baselines are unchanged.

## Integration notes

- #9866 adds an immediate per-request effort override that conflicts with this PR's next-turn contract; rebase/order it after #9984.
- #9865 is largely subsumed because selecting the currently applied value now skips the rebuild.
- #9983/#9988 have file-level overlap and may need rebase coordination.

## Documentation impact

Documentation-impact: none - This repairs the existing composer controls and next-run setting behavior without adding commands, configuration, or a new interface; embedded usage documentation remains accurate.

## Cache impact

Cache-impact: none - No prompt, history serialization, memory prefix, or tool schema bytes change. The existing provider effort override is applied only at the next task-turn boundary.
Cache-guard: Request-capture regressions verify that every request in the current task retains its original effort and only the next manual or inbox task uses the selected effort; immutable runtime snapshot tests prevent mutable configuration from spoofing applied state.
System-prompt-review: Codex inspected the boot change: it only copies the resolved effort into immutable controller metadata; system-prompt construction, memory injection, and tool registration are unchanged.
