### PR TITLE
fix(desktop): 对齐设置页工作区布局

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ branch.
 
 ### Fixed
 
+- **Desktop settings workspace:** navigation and content panes now have a shared
+  outer gutter, matched rounded boundaries, and a visible return-to-workspace
+  control; the compact layout remains a continuous single-column surface.
 - **Relay image input:** ID-only or invalid model metadata now stays unknown.
   Both Desktop model editors expose per-model Auto / On / Off overrides, with
   official protocol limits retained. A separate V2 discovery cache rejects stale

--- a/desktop/frontend/src/__tests__/settings-responsive-layout.test.ts
+++ b/desktop/frontend/src/__tests__/settings-responsive-layout.test.ts
@@ -50,6 +50,13 @@ eq(declaration(caption, "background"), "var(--bg-soft)", "caption controls blend
 eq(declaration(caption, "border"), "0", "workspace borders do not leak into the settings caption");
 const settingsCenter = ruleBlock(panelStyles, ".settings-center");
 eq(declaration(settingsCenter, "grid-template-columns"), "clamp(220px, 20.5vw, 304px) minmax(0, 1fr)", "settings navigation remains readable without consuming the content pane");
+const desktopSettingsCenter = ruleBlock(panelStyles, ".settings-screen .settings-center");
+eq(declaration(desktopSettingsCenter, "gap"), "8px", "desktop settings panes have a visible gutter");
+eq(declaration(desktopSettingsCenter, "padding"), "0 8px 8px", "desktop settings panes keep an outer gutter");
+const settingsSidebar = ruleBlock(panelStyles, ".settings-screen__sidebar");
+eq(declaration(settingsSidebar, "border-radius"), "16px", "desktop navigation matches the content pane corners");
+const settingsBack = ruleBlock(panelStyles, ".settings-screen .management-screen__back");
+eq(declaration(settingsBack, "background"), "var(--bg-elev)", "return-to-workspace control has a visible background");
 
 const generalPage = ruleBlock(panelStyles, ".settings-page--general");
 eq(declaration(generalPage, "container"), "settings-general / inline-size", "general settings respond to their available content width");
@@ -109,6 +116,8 @@ const compactNav = ruleBlock(compactPanel, ".settings-center__nav,\n  :root[data
 eq(declaration(compactNav, "width"), "100%", "minimum-width navigation spans the settings panel");
 eq(declaration(compactNav, "overflow-x"), "auto", "minimum-width navigation scrolls horizontally");
 eq(declaration(compactNav, "overflow-y"), "hidden", "minimum-width navigation does not create a second vertical scroller");
+const compactSettingsCenter = ruleBlock(compactPanel, ".settings-screen .settings-center");
+eq(declaration(compactSettingsCenter, "gap"), "0", "minimum-width settings return to one continuous surface");
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/SettingsPanel.css
+++ b/desktop/frontend/src/components/SettingsPanel.css
@@ -11,14 +11,18 @@
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
-  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--bg);
 }
 
 .settings-screen .settings-center__nav { flex: 1; min-height: 0; border-right: 0; }
-.settings-screen .settings-center__content { margin: 0 8px 8px 0; border: 1px solid var(--border); border-radius: 16px; background: var(--bg); }
+.settings-screen .management-screen__back { margin: 8px; border: 1px solid var(--border); border-radius: 12px; background: var(--bg-elev); }
+.settings-screen .settings-center__content { margin: 0; border: 1px solid var(--border); border-radius: 16px; background: var(--bg); }
 .settings-center {
   grid-template-columns: clamp(220px, 20.5vw, 304px) minmax(0, 1fr);
 }
+.settings-screen .settings-center { gap: 8px; padding: 0 8px 8px; }
 
 .settings-center__nav {
   display: flex;
@@ -515,6 +519,9 @@
   }
 
   .management-screen__back { margin: 0 10px; padding: 8px; }
+  .settings-screen .settings-center { gap: 0; padding: 0; }
+  .settings-screen__sidebar { border: 0; border-radius: 0; background: var(--bg-soft); }
+  .settings-screen .management-screen__back { margin: 0 10px; border: 0; border-radius: 8px; background: transparent; }
   .settings-screen .settings-center__content { margin: 0; border-radius: 0; border-inline: 0; border-bottom: 0; }
 
   .settings-center,


### PR DESCRIPTION
## Summary

- give the desktop settings navigation and content panes a shared outer gutter and matching rounded boundaries
- give the return-to-workspace control a persistent surface
- preserve the compact single-column layout

Closes #9968

Documentation-impact: none - this is a visual-only desktop layout adjustment; existing user documentation remains correct.

## Verification

- `pnpm run check:css`
- `pnpm run test:typecheck`
- `pnpm run test:settings-responsive`
- `tsx src/__tests__/startup-settings-contract.test.ts`
- `pnpm run build`
- Edge preview at 1440px and 600px
