### PR TITLE
fix(desktop): restore the 104px composer default / 恢复 104px 输入框默认高度

### DIFF
--- a/desktop/frontend/src/__tests__/composer-run-strip.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-run-strip.test.tsx
@@ -617,7 +617,7 @@ console.log("\ncomposer run strip");
   const { root, rerender } = await renderComposer({ running: true, turnStartAt: Date.now() });
 
   const handle = document.querySelector(".composer-resize-handle") as HTMLButtonElement;
-  eq((document.querySelector(".composer-card") as HTMLElement).style.getPropertyValue("--composer-height"), "140px", "fresh composer defaults to the selected 140px height");
+  eq((document.querySelector(".composer-card") as HTMLElement).style.getPropertyValue("--composer-height"), "104px", "fresh composer defaults to the selected 104px height");
   await act(async () => {
     handle.focus();
     handle.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Home", bubbles: true }));
@@ -697,7 +697,7 @@ console.log("\ncomposer run strip");
     handle.dispatchEvent(new window.MouseEvent("dblclick", { bubbles: true }));
     await flushTimers();
   });
-  eq(card.style.getPropertyValue("--composer-height"), "140px", "reset restores the 140px default after manual resizing");
+  eq(card.style.getPropertyValue("--composer-height"), "104px", "reset restores the 104px default after manual resizing");
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -107,7 +107,9 @@ export interface WorkspaceReference {
 const LONG_PASTE_MIN_CHARS = 2000;
 const LONG_PASTE_MIN_LINES = 20;
 const COMPOSER_MIN_HEIGHT = 104;
-const COMPOSER_DEFAULT_HEIGHT = 140;
+// Fresh installs open at the compact baseline; a manual resize still persists
+// and takes precedence over this default.
+const COMPOSER_DEFAULT_HEIGHT = 104;
 const COMPOSER_MAX_HEIGHT = 360;
 // Height reserved for the in-card run strip while a turn runs; applied via a
 // CSS calc so --composer-height always stays in "logical height" space.


### PR DESCRIPTION
## Problem

Since v1.38.3 (#9958), a fresh profile or a profile without a saved composer height opens the regular and welcome composers at 140px. Before that change, the natural empty-input card height was 104px. Existing users with a persisted manual height continued using their saved value, which masked the new default.

## Root cause

PR #9958 introduced `COMPOSER_DEFAULT_HEIGHT = 140` in `desktop/frontend/src/components/Composer.tsx`. A saved manual height takes precedence over that fallback, so the regression only appeared for profiles with no saved composer height.

## Fix

Restore `COMPOSER_DEFAULT_HEIGHT` to 104px, the compact card baseline used before v1.38.3. Manual resize values remain persisted and continue to take precedence. Double-click reset now returns to 104px.

## Verification

- `pnpm exec tsx src/__tests__/composer-run-strip.test.tsx` - 83 passed
- `pnpm exec tsx src/__tests__/composer-content-sizing.test.ts` - 12 passed
- `pnpm test:composer` - passed
- Browser: no saved manual value renders `--composer-height: 104px`; resize to 154px survives refresh; double-click reset returns to 104px
- `git diff --check` - passed

## Impact

No persisted-format, provider, prompt-cache, or runtime-contract changes. This only restores the fallback used when no manual composer height has been saved.

Documentation-impact: none - This restores an existing UI default and does not change documented configuration, commands, or user workflows.
