### PR TITLE
fix(agent): stop coupling truncated reads to writes and finals / 截断读取不再冻结写操作与终答

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ branch.
 
 ### Changed
 
+- **Read pagination is advisory:** Truncated / windowed `read_file` results no
+  longer freeze undeclared tools (`git commit`) or refuse a final answer.
+  Path-scoped write evidence and host Stop (budget/policy stall) remain.
+  `read_file` reports a `PARTIAL view` trailer with a bounded look-ahead total;
+  the 32 KiB recovery marker no longer instructs the model to freeze writes.
+
 - **Fact-driven execution:** Ordinary requests always enter the executor.
   There is no automatic simple / light / full task mode and no per-turn
   `TaskPolicy` classification. The planner runs only for an explicit Plan,

--- a/docs/AGENT_CORE_SIMPLIFICATION.md
+++ b/docs/AGENT_CORE_SIMPLIFICATION.md
@@ -23,8 +23,10 @@ build request
   guardian, and typed-report flows keep their own constraints.
 - Compaction defaults to a single summary; chunked/tree-reduce recovery is
   explicit only (manual `/compact` and marked recovery workflows).
-- Final readiness, tool safety, cancellation, budgets, and incomplete-read
-  stay as hard boundaries.
+- Final readiness, tool safety, cancellation, and budgets stay as hard
+  boundaries. `read_file` pagination / unpaid coverage is a notice; unpaid
+  pages do not freeze undeclared tools or refuse a final answer. Path-scoped
+  write evidence and host Stop (budget/policy stall) remain.
 - Old configs and old session state stay readable for one release; the new
   runtime never executes the old fallbacks.
 
@@ -74,7 +76,7 @@ New consolidated suite: `internal/agent/agent_contract_test.go`.
 | zero content retries via unified `EMPTY_RESPONSE` path | `TestRunRetriesZeroContentWithTheSameFrozenRequest` |
 | exhausted retries return an explicit protocol error | `TestRunStopsAfterExhaustedZeroContentRetriesWithoutCommittingEmptyMessages` |
 | strict-provider missing reasoning: one frozen-request retry | `TestRunSilentlyRecoversMissingToolCallReasoning` and the replay suites in `loop_e2e_test.go`/`retry_e2e_test.go` (#9776 repair) |
-| incomplete-read gate | `incomplete_read_test.go` |
+| read_file pagination notice (no write/final freeze) | `internal/boot/effect_read_file_test.go`, `incomplete_read_test.go`, `read_pipeline_regression_test.go` |
 | final readiness | `final_readiness_test.go` |
 | cancellation | `cancel_test.go` |
 | task/token/cost budgets | `run_budget_test.go` |

--- a/docs/AGENT_CORE_SIMPLIFICATION.zh-CN.md
+++ b/docs/AGENT_CORE_SIMPLIFICATION.zh-CN.md
@@ -21,7 +21,9 @@
   typed report 等显式流程保留自己的约束。
 - compaction 默认单次摘要;chunked/tree-reduce 高级恢复仅限显式场景
   (手动 `/compact` 与明确标记的 recovery workflow)。
-- final readiness、工具安全、取消、预算和 incomplete-read 继续作为硬边界。
+- final readiness、工具安全、取消和预算继续作为硬边界。`read_file` 分页/未付清
+  覆盖只是提示：未付清页不会冻结未声明目标的工具，也不会拒绝最终回答。路径级
+  写证据与主机 Stop（预算/策略停机）仍然保留。
 - 旧配置/旧状态保留一版读取兼容;新运行时不再执行旧 fallback。
 
 ## 指标基线
@@ -69,7 +71,7 @@
 | 完全零内容走统一 `EMPTY_RESPONSE` retry | `TestRunRetriesZeroContentWithTheSameFrozenRequest` |
 | retry 耗尽返回明确协议错误 | `TestRunStopsAfterExhaustedZeroContentRetriesWithoutCommittingEmptyMessages` |
 | strict provider 缺失 reasoning 只做一次冻结请求重试 | `TestRunSilentlyRecoversMissingToolCallReasoning` 及 `loop_e2e_test.go`/`retry_e2e_test.go` 的 replay 套件(#9776 修复) |
-| incomplete-read 门 | `incomplete_read_test.go` |
+| read_file 分页提示（不冻写/收尾） | `internal/boot/effect_read_file_test.go`、`incomplete_read_test.go`、`read_pipeline_regression_test.go` |
 | final readiness | `final_readiness_test.go` |
 | 取消 | `cancel_test.go` |
 | task/token/cost 预算 | `run_budget_test.go` |

--- a/docs/TOOL_CONTRACT.md
+++ b/docs/TOOL_CONTRACT.md
@@ -117,7 +117,16 @@ SHA-256, and `complete`, followed by the raw page. The reader is bound to the
 current Agent session and is not inherited from a parent when a capability
 frontend is cloned. A restricted child that already has `use_capability` may
 read only its own results; an allowed-tools profile without the proxy is not
-widened.
+widened. Paging is optional: a truncated or windowed result is not unpaid host
+debt, and undeclared tools such as `git commit` or a final answer may follow
+immediately. Path-scoped write evidence still requires a fresh read of the
+file being edited.
+
+`read_file` itself pages at a fixed 2000-line default (and an 8 MiB local
+safety cap). When more lines remain, the tool appends a `PARTIAL view` trailer
+naming the visible range, the file's total line count (a `N+` lower bound once
+the bounded look-ahead is exhausted), and the next `offset`. A partial window
+is sufficient when it covers the work.
 
 `ask`, `docs`, `explore`, `fleet`, `forget`, `history`, `install_skill`, `install_source`,
 `list_sessions`, `lsp_definition`, `lsp_diagnostics`, `lsp_hover`,

--- a/docs/TOOL_CONTRACT.zh-CN.md
+++ b/docs/TOOL_CONTRACT.zh-CN.md
@@ -87,7 +87,13 @@ call ID 时必须用它消除歧义。`offset` 默认 0，`limit` 默认 16KiB�
 `result_ref`、实际 offset、`next_offset`、`total_bytes`、完整 SHA-256 与 `complete`，随后是
 原文页。reader 只绑定当前 Agent session，clone capability frontend 时不会继承父 reader。
 已经拥有 `use_capability` 的受限子 Agent 只能读取自己的结果；allowed-tools 配置若完全没有
-该代理，不会为了回读而扩大工具面。
+该代理，不会为了回读而扩大工具面。分页是可选的：截断或窗口读取不是主机侧债务，
+`git commit` 等未声明目标的工具或最终回答可以紧接着进行。路径级写证据仍要求先读
+被编辑的文件。
+
+`read_file` 本身按固定默认 2000 行分页（另有 8 MiB 本地安全上限）。还有后续行时，工具
+会追加 `PARTIAL view` 尾注，写明可见范围、文件总行数（超出有界预读后显示为 `N+` 下界）
+和下一次 `offset`。可见窗口够用时不必读完全文。
 
 `ask`, `docs`, `explore`, `fleet`, `forget`, `history`, `install_skill`, `install_source`,
 `list_sessions`, `lsp_definition`, `lsp_diagnostics`, `lsp_hover`,

--- a/internal/agent/incomplete_read.go
+++ b/internal/agent/incomplete_read.go
@@ -603,14 +603,12 @@ func (s *incompleteReadState) gate(plan *toolCallPlan) (string, bool) {
 	}
 
 	input := parseIncompleteReadGateInput(plan)
-	hasStrategy := false
 	for _, key := range s.order {
 		entry := s.entries[key]
 		if entry == nil {
 			continue
 		}
-		message, matched, strategy := matchIncompleteReadGateEntry(plan, input, key, entry)
-		hasStrategy = hasStrategy || strategy
+		message, matched, _ := matchIncompleteReadGateEntry(plan, input, key, entry)
 		if matched {
 			if message != "" {
 				s.roundViolation = true
@@ -618,38 +616,19 @@ func (s *incompleteReadState) gate(plan *toolCallPlan) (string, bool) {
 			return message, message != ""
 		}
 	}
-	if hasStrategy {
-		s.roundViolation = true
-		return "blocked: an oversized read_file is in restricted search/read mode. Only grep on the target file, read_file with explicit offset and limit, exact session:tool_result recovery, or session:read_strategy_receipt is allowed.", true
-	}
-	if plan.effects.StateMutation || plan.evidenceName == "complete_step" || plan.evidenceName == "submit_plan" {
-		s.roundViolation = true
-		return "blocked: read_file has unread content retained by the host. Complete the exact continuation requested in the latest host message before modifying state or finishing.", true
-	}
+	// Truncation is advisory. Exact continuation mismatches above still warn,
+	// but unpaid read pages do not freeze mutations or finals.
 	return "", false
 }
 
 func (s *incompleteReadState) blockFinal() (instruction string, pause *IncompleteReadError) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.failure != nil {
 		copy := *s.failure
-		s.mu.Unlock()
 		return "", &copy
 	}
-	entry := s.firstLocked()
-	if entry == nil {
-		s.mu.Unlock()
-		return "", nil
-	}
-	s.consecutiveViolations++
-	violations := s.consecutiveViolations
-	if violations >= 2 {
-		err := s.pauseForEntryLocked(entry, "the model attempted to finish in two consecutive rounds without satisfying the required read strategy")
-		s.mu.Unlock()
-		return "", err
-	}
-	s.mu.Unlock()
-	return s.nextInstruction(), nil
+	return "", nil
 }
 
 func (s *incompleteReadState) pauseForEntryLocked(entry *incompleteRead, reason string) *IncompleteReadError {

--- a/internal/agent/incomplete_read_gate.go
+++ b/internal/agent/incomplete_read_gate.go
@@ -95,14 +95,14 @@ func (s *incompleteReadState) nextInstruction() string {
 	switch entry.phase {
 	case incompleteReadAutoResultPage, incompleteReadStrategyResultPage:
 		args, _ := json.Marshal(map[string]any{"tool_call_id": entry.toolCallID, "result_ref": entry.resultRef, "offset": entry.nextByteOffset, "limit": toolResultPageMaxBytes})
-		return fmt.Sprintf("The host has an INCOMPLETE read_file result. Before any state change or final answer, call use_capability with action=\"call\", capability_id=\"session:tool_result\", arguments=%s. Continue from each returned next_offset until complete=true.", args)
+		return fmt.Sprintf("The host retained a partial read_file result. If you need more of it, call use_capability with action=\"call\", capability_id=\"session:tool_result\", arguments=%s and continue from each returned next_offset until complete=true. Independent work may continue when the visible prefix is enough.", args)
 	case incompleteReadAutoSourcePage, incompleteReadStrategySourcePage:
 		args, _ := json.Marshal(map[string]any{"path": entry.path, "offset": entry.nextSourceOffset, "limit": entry.nextSourceLimit})
-		return fmt.Sprintf("The read_file window has more source lines. Before any state change or final answer, call read_file with exactly %s.", args)
+		return fmt.Sprintf("The read_file window has more source lines. If you need them, call read_file with exactly %s. Independent work may continue when the visible window is enough.", args)
 	case incompleteReadStrategy:
 		readExample, _ := json.Marshal(map[string]any{"path": entry.path, "offset": 0, "limit": 200})
 		receiptExample, _ := json.Marshal(map[string]any{"read_id": entry.readID, "search_tool_call_ids": []string{"<grep tool call id>"}, "read_tool_call_ids": []string{"<read_file tool call id>"}, "conclusion": "<why these searches and exact windows are sufficient for the task>"})
-		return fmt.Sprintf("The complete file cannot fit the dynamic context budget. RESTRICTED READ STRATEGY read_id=%q path=%q. Do not modify state or answer yet. Search only this exact file with grep, then read relevant windows with explicit offset and limit (example %s). After at least one complete search and one complete exact window, call use_capability with action=\"call\", capability_id=\"session:read_strategy_receipt\", arguments=%s.", entry.readID, entry.path, readExample, receiptExample)
+		return fmt.Sprintf("The complete file cannot fit the dynamic context budget. Suggested READ STRATEGY read_id=%q path=%q: search only this exact file with grep, then read relevant windows with explicit offset and limit (example %s). After at least one complete search and one complete exact window, you may call use_capability with action=\"call\", capability_id=\"session:read_strategy_receipt\", arguments=%s. Independent work may continue when the visible evidence is enough.", entry.readID, entry.path, readExample, receiptExample)
 	default:
 		return ""
 	}

--- a/internal/agent/incomplete_read_parse.go
+++ b/internal/agent/incomplete_read_parse.go
@@ -65,33 +65,11 @@ func parseReadFileArgs(args json.RawMessage) (readFileArgs, bool) {
 }
 
 func parseReadFileTrailer(output string) readFileTrailer {
-	const safetyPrefix = "\n[read_file local safety page; next_offset="
-	if start := strings.LastIndex(output, safetyPrefix); start >= 0 && strings.HasSuffix(output, "]\n") {
-		fields := strings.TrimSuffix(output[start+len(safetyPrefix):], "]\n")
-		parts := strings.Fields(fields)
-		if len(parts) == 2 {
-			next, nextErr := strconv.Atoi(parts[0])
-			endText := strings.TrimPrefix(parts[1], "requested_end=")
-			end, endErr := strconv.Atoi(endText)
-			if nextErr == nil && endErr == nil && next >= 0 && end >= next {
-				return readFileTrailer{nextOffset: next, requestedEnd: end, hasMore: true, localSafety: true}
-			}
-		}
+	t := tool.ParseReadTrailer(output)
+	return readFileTrailer{
+		nextOffset: t.NextOffset, requestedEnd: t.RequestedEnd,
+		hasMore: t.HasMore, localSafety: t.LocalSafety,
 	}
-	const prefix = "\n[more lines below; pass offset="
-	start := strings.LastIndex(output, prefix)
-	if start < 0 || !strings.HasSuffix(output, "]\n") {
-		return readFileTrailer{}
-	}
-	value := output[start+len(prefix):]
-	if end := strings.IndexAny(value, " ]\r\n"); end >= 0 {
-		value = value[:end]
-	}
-	n, err := strconv.Atoi(value)
-	if err != nil || n < 0 {
-		return readFileTrailer{}
-	}
-	return readFileTrailer{nextOffset: n, hasMore: true}
 }
 
 func readFileRecoveryOffset(output string) (int, bool) {

--- a/internal/agent/incomplete_read_runtime.go
+++ b/internal/agent/incomplete_read_runtime.go
@@ -130,7 +130,7 @@ func readStrategyPreview(raw, readID string, totalTokens, limitTokens int) strin
 	if newline := strings.LastIndexByte(head, '\n'); newline >= 0 {
 		head = head[:newline+1]
 	}
-	return fmt.Sprintf("%s\n[INCOMPLETE READ: read_id=%s; complete content does not fit the dynamic context budget (estimated_tokens=%d budget_tokens=%d). This prefix is not whole-file evidence. Follow the restricted grep/read strategy from the next host message.]\n", head, readID, totalTokens, limitTokens)
+	return fmt.Sprintf("%s\n[PARTIAL READ: read_id=%s; complete content does not fit the dynamic context budget (estimated_tokens=%d budget_tokens=%d). This prefix is not whole-file evidence. Prefer grep plus narrow read_file windows; independent work may continue when the visible prefix is enough.]\n", head, readID, totalTokens, limitTokens)
 }
 
 // finalizeIncompleteReadOutcome is called by executeBatch.finalize in provider

--- a/internal/agent/incomplete_read_test.go
+++ b/internal/agent/incomplete_read_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -233,85 +232,44 @@ func TestReadFileTruncationUsesContiguousUTF8PrefixAndExactRecovery(t *testing.T
 	}
 }
 
-func TestIncompleteReadBlocksFinalUntilRecoveryAndDefersObservation(t *testing.T) {
+func TestIncompleteReadAllowsFinalWithoutForcedRecovery(t *testing.T) {
 	path := makeIncompleteReadFixture(t, "rules-crlf.txt", 430, 96, 362, incompleteReadKeyRule)
 	read := incompleteReadBuiltin(t)
 	readArgs := fmt.Sprintf(`{"path":%q}`, path)
-	full := expectedReadOutput(t, read, readArgs)
-	bounded, _ := truncateToolOutputFor(full, "read_file", "read-1")
-	offset, ok := readFileRecoveryOffset(bounded)
-	if !ok {
-		t.Fatal("missing fixture recovery offset")
-	}
 
 	inner := &scriptedProvider{name: "incomplete-read", turns: [][]provider.Chunk{
 		{toolCallChunk("read-1", "read_file", readArgs), {Type: provider.ChunkDone}},
-		textTurn("I can answer from the prefix."),
-		{toolCallChunk("recover-1", "use_capability", recoveryCapabilityArgs(t, "read-1", toolResultRef("read-1", full), offset)), {Type: provider.ChunkDone}},
-		textTurn("The full file, including line 362, has now been read."),
+		textTurn("I can answer from the visible prefix."),
 	}}
-	var agent *Agent
-	prov := &inspectingProvider{inner: inner, before: func(round int, req provider.Request) {
-		if round == 1 && len(agent.task.ledger.TextObservations()) != 0 {
-			t.Errorf("truncated read was credited before recovery: %+v", agent.task.ledger.TextObservations())
-		}
-		if round == 1 && requestHasText(req, incompleteReadKeyRule) {
-			t.Error("line 362 leaked into the prefix-only provider request")
-		}
-		if round == 3 && !requestHasText(req, incompleteReadKeyRule) {
-			t.Error("final request did not receive line 362 from the recovered suffix")
-		}
-	}}
-	sink := &incompleteReadEventSink{}
-	agent = newLegacyIncompleteReadTestAgentWithOptions(
-		prov, read, NewSession("sys"), sink, Options{ContextWindow: 64_000},
+	agent := newLegacyIncompleteReadTestAgentWithOptions(
+		inner, read, NewSession("sys"), event.Discard, Options{ContextWindow: 64_000},
 	)
-	if err := agent.Run(context.Background(), "Read the complete rules file before answering."); err != nil {
+	if err := agent.Run(context.Background(), "Skim the rules file and answer."); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if inner.call != 4 {
-		t.Fatalf("provider rounds=%d, want read + blocked final + recovery + accepted final", inner.call)
-	}
-	observations := agent.task.ledger.TextObservations()
-	observedLines := 0
-	if len(observations) > 0 {
-		observedLines = len(observations[0].LineHashes)
-	}
-	if len(observations) != 1 || len(observations[0].LineHashes) != 430 {
-		t.Fatalf("completed observation windows=%d lines=%d, want one 430-line window", len(observations), observedLines)
-	}
-	for _, code := range []string{
-		event.NoticeCodeIncompleteReadDetected,
-		event.NoticeCodeReadContinuationRequired,
-		event.NoticeCodeReadCompleted,
-	} {
-		if !sink.hasCode(code) {
-			t.Errorf("missing audit notice %q", code)
-		}
+	if inner.call != 2 {
+		t.Fatalf("provider rounds=%d, want read + accepted final", inner.call)
 	}
 }
 
-func TestIncompleteReadSecondIgnoredFinalPausesRecoverably(t *testing.T) {
+func TestIncompleteReadDoesNotPauseOnPrematureFinal(t *testing.T) {
 	path := makeIncompleteReadFixture(t, "ignored.txt", 430, 96, 362, incompleteReadKeyRule)
 	read := incompleteReadBuiltin(t)
 	readArgs := fmt.Sprintf(`{"path":%q}`, path)
 	prov := &scriptedProvider{name: "ignore-continuation", turns: [][]provider.Chunk{
 		{toolCallChunk("read-ignore", "read_file", readArgs), {Type: provider.ChunkDone}},
 		textTurn("first premature answer"),
-		textTurn("second premature answer"),
 	}}
 	agent := newLegacyIncompleteReadTestAgentWithOptions(prov, read, NewSession("sys"), event.Discard, Options{ContextWindow: 256_000})
-	err := agent.Run(context.Background(), "Read it fully.")
-	var pause *IncompleteReadError
-	if !errors.As(err, &pause) || PauseClass(err) != "incomplete_read" {
-		t.Fatalf("Run error=%T %v pause_class=%q, want IncompleteReadError", err, err, PauseClass(err))
+	if err := agent.Run(context.Background(), "Read it fully."); err != nil {
+		t.Fatalf("Run error=%v, want clean final", err)
 	}
-	if prov.call != 3 || len(agent.task.ledger.TextObservations()) != 0 {
-		t.Fatalf("rounds=%d observations=%d, want explicit pause with no read evidence", prov.call, len(agent.task.ledger.TextObservations()))
+	if prov.call != 2 {
+		t.Fatalf("rounds=%d, want read + final", prov.call)
 	}
 }
 
-func TestIncompleteReadBlocksSameBatchMutationBeforeExecution(t *testing.T) {
+func TestIncompleteReadAllowsSameBatchMutation(t *testing.T) {
 	path := makeIncompleteReadFixture(t, "read-before-write.txt", 430, 96, 362, incompleteReadKeyRule)
 	read := incompleteReadBuiltin(t)
 	readArgs := fmt.Sprintf(`{"path":%q}`, path)
@@ -322,19 +280,17 @@ func TestIncompleteReadBlocksSameBatchMutationBeforeExecution(t *testing.T) {
 			toolCallChunk("mutate", writer.Name(), `{}`),
 			{Type: provider.ChunkDone},
 		},
-		textTurn("finish without recovery"),
+		textTurn("done"),
 	}}
 	agent := newLegacyIncompleteReadTestAgent(prov, read, NewSession("sys"), event.Discard, writer)
-	err := agent.Run(context.Background(), "Read the rules and then update state.")
-	var pause *IncompleteReadError
-	if !errors.As(err, &pause) {
-		t.Fatalf("Run error=%T %v, want IncompleteReadError", err, err)
+	if err := agent.Run(context.Background(), "Read the rules and then update state."); err != nil {
+		t.Fatalf("Run: %v", err)
 	}
-	if writer.count() != 0 {
-		t.Fatalf("mutation executed %d times before recovery", writer.count())
+	if writer.count() != 1 {
+		t.Fatalf("mutation executed %d times, want 1", writer.count())
 	}
-	if got := toolResultByID(agent.Session(), "mutate"); !strings.Contains(got, "unread content") {
-		t.Fatalf("mutation result=%q, want host incomplete-read block", got)
+	if got := toolResultByID(agent.Session(), "mutate"); strings.Contains(got, "unread content") {
+		t.Fatalf("mutation result=%q, must not be blocked by incomplete-read", got)
 	}
 }
 
@@ -520,7 +476,7 @@ func TestIncompleteReadContextLimitEntersSearchReadReceiptStrategy(t *testing.T)
 		t.Fatalf("observations=%+v, want only the explicit 30-line strategy window", observations)
 	}
 	result := toolResultByID(agent.Session(), "read-context-soft")
-	if !strings.Contains(result, "INCOMPLETE READ") || strings.Contains(result, incompleteReadKeyRule) {
+	if !strings.Contains(result, "PARTIAL READ") || strings.Contains(result, incompleteReadKeyRule) {
 		t.Fatalf("provider-visible strategy result is ambiguous or leaks an unseen tail: %.500q", result)
 	}
 	for _, code := range []string{event.NoticeCodeReadStrategyRequired, event.NoticeCodeReadStrategyProgress, event.NoticeCodeReadStrategyResolved} {
@@ -536,20 +492,17 @@ func TestIncompleteReadUnknownContextEntersStrategyWithoutImmediatePause(t *test
 	readArgs := fmt.Sprintf(`{"path":%q}`, path)
 	prov := &scriptedProvider{name: "unknown-context", turns: [][]provider.Chunk{
 		{toolCallChunk("read-unknown", "read_file", readArgs), {Type: provider.ChunkDone}},
-		textTurn("first premature answer"),
-		textTurn("second premature answer"),
+		textTurn("answer from the visible prefix"),
 	}}
 	sink := &incompleteReadEventSink{}
 	agent := newLegacyIncompleteReadTestAgentWithOptions(prov, read, NewSession("sys"), sink, Options{})
-	err := agent.Run(context.Background(), "Read the complete file.")
-	var pause *IncompleteReadError
-	if !errors.As(err, &pause) {
-		t.Fatalf("Run error=%T %v, want pause only after two ignored strategy rounds", err, err)
+	if err := agent.Run(context.Background(), "Read the complete file."); err != nil {
+		t.Fatalf("Run: %v", err)
 	}
-	if prov.call != 3 || !sink.hasCode(event.NoticeCodeReadStrategyRequired) {
-		t.Fatalf("rounds=%d strategy_notice=%v, want strategy plus two ignored finals", prov.call, sink.hasCode(event.NoticeCodeReadStrategyRequired))
+	if prov.call != 2 || !sink.hasCode(event.NoticeCodeReadStrategyRequired) {
+		t.Fatalf("rounds=%d strategy_notice=%v, want strategy marker then accepted final", prov.call, sink.hasCode(event.NoticeCodeReadStrategyRequired))
 	}
-	if got := toolResultByID(agent.Session(), "read-unknown"); !strings.Contains(got, "INCOMPLETE READ") {
+	if got := toolResultByID(agent.Session(), "read-unknown"); !strings.Contains(got, "PARTIAL READ") {
 		t.Fatalf("unknown-context result=%q, want explicit strategy marker", got)
 	}
 }
@@ -589,14 +542,14 @@ func TestReadStrategyReceiptUnlocksOnlyAfterBatchBoundary(t *testing.T) {
 	if err := agent.Run(context.Background(), "Search and read the key rule, then mutate only after the receipt boundary."); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if writer.count() != 0 {
-		t.Fatalf("same-batch writer executed %d times", writer.count())
+	if writer.count() != 1 {
+		t.Fatalf("same-batch writer executed %d times, want 1 (unpaid strategy pages do not freeze mutations)", writer.count())
 	}
-	if got := toolResultByID(agent.Session(), "write-same-batch"); !strings.Contains(got, "restricted search/read mode") {
-		t.Fatalf("same-batch write result=%q, want strategy gate", got)
+	if got := toolResultByID(agent.Session(), "write-same-batch"); strings.Contains(got, "restricted search/read mode") || strings.Contains(got, "unread content") {
+		t.Fatalf("same-batch write result=%q, must not be blocked by strategy gate", got)
 	}
 	if prov.call != 5 {
-		t.Fatalf("provider rounds=%d, want final only after receipt batch boundary", prov.call)
+		t.Fatalf("provider rounds=%d, want final after the receipt/write batch", prov.call)
 	}
 }
 
@@ -604,18 +557,22 @@ func TestReadStrategyViolationsCountOncePerModelRound(t *testing.T) {
 	state := incompleteReadState{}
 	state.addEntryLocked(&incompleteRead{
 		key: "ir-round", readID: "ir-round", path: "rules.txt", requestPath: "rules.txt",
-		phase: incompleteReadStrategy, searches: map[string]incompleteReadSearch{}, reads: map[string]incompleteReadWindow{},
+		phase: incompleteReadAutoResultPage, toolCallID: "read-1", resultRef: "tr-correct", nextByteOffset: 32000,
 	})
+	wrong := &toolCallPlan{
+		evidenceName: "session_tool_result",
+		evidenceArgs: json.RawMessage(`{"tool_call_id":"read-1","result_ref":"tr-wrong","offset":0,"limit":24576}`),
+	}
 	for range 3 {
-		if _, blocked := state.gate(&toolCallPlan{evidenceName: "ls"}); !blocked {
-			t.Fatal("strategy did not block unrelated read-only tool")
+		if _, blocked := state.gate(wrong); !blocked {
+			t.Fatal("wrong continuation did not block")
 		}
 	}
 	if round := state.finishToolRound(); round.pause != nil || state.consecutiveViolations != 1 {
 		t.Fatalf("first violating round pause=%v consecutive=%d, want one violation", round.pause, state.consecutiveViolations)
 	}
-	if _, blocked := state.gate(&toolCallPlan{evidenceName: "glob"}); !blocked {
-		t.Fatal("strategy did not block second unrelated tool")
+	if _, blocked := state.gate(wrong); !blocked {
+		t.Fatal("wrong continuation did not block second round")
 	}
 	if round := state.finishToolRound(); round.pause == nil {
 		t.Fatal("second consecutive violating model round did not pause")
@@ -781,8 +738,8 @@ func TestIncompleteReadRequiresExactContinuationMetadata(t *testing.T) {
 	for _, finalizer := range []string{"complete_step", "submit_plan"} {
 		finalizerState := incompleteReadState{}
 		finalizerState.addEntryLocked(&incompleteRead{key: "pending", phase: incompleteReadAutoResultPage})
-		if msg, blocked := finalizerState.gate(&toolCallPlan{evidenceName: finalizer}); !blocked || !strings.Contains(msg, "unread content") {
-			t.Errorf("%s blocked=%v msg=%q", finalizer, blocked, msg)
+		if msg, blocked := finalizerState.gate(&toolCallPlan{evidenceName: finalizer}); blocked {
+			t.Errorf("%s must not be frozen by unpaid pages: blocked=%v msg=%q", finalizer, blocked, msg)
 		}
 	}
 

--- a/internal/agent/read_pipeline.go
+++ b/internal/agent/read_pipeline.go
@@ -99,24 +99,27 @@ func (a *Agent) gateReadOperation(_ context.Context, plan *toolCallPlan) (string
 
 // readContinuation owns the execution decision. Status rendering is only a
 // projection of this state; the legacy machine is used solely in rollback mode.
+//
+// A NeedsMore coverage gap is advisory: tool rounds may get a continuation
+// hint, but a final answer is not refused. Only an already-attached host Stop
+// (budget / policy stall) pauses the run.
 func (a *Agent) readContinuation(final bool) (string, error) {
-	var paused []string
-	for _, ob := range a.turn.readShadow.coord.Snapshot() {
-		if ob.State.Terminal() {
-			continue
-		}
-		if ob.Stop != nil {
-			paused = append(paused, fmt.Sprintf("%s: %s; %s", ob.Scope.CanonicalPath, ob.Stop.Detail, ob.Stop.Recovery))
-			continue
-		}
-		if final {
-			// A final answer that supplies no required content is also a stalled
-			// attempt, so ignoring the instruction cannot create an infinite loop.
-			tr, _ := a.turn.readShadow.coord.Observe(tool.ReadResultEnvelope{ReadID: ob.Key, Source: tool.ReadResultSource{CanonicalPath: ob.Scope.CanonicalPath, Snapshot: ob.Version}, Intent: ob.Requirement.Intent}, 0)
-			a.emitReadStatus(tr, tool.ReadResultEnvelope{Intent: ob.Requirement.Intent})
-			if tr.Stop != nil {
-				return "", &IncompleteReadError{Reason: tr.Stop.Detail}
+	if final {
+		var paused []string
+		for _, ob := range a.turn.readShadow.coord.Snapshot() {
+			if ob.State.Terminal() || ob.Stop == nil {
+				continue
 			}
+			paused = append(paused, fmt.Sprintf("%s: %s; %s", ob.Scope.CanonicalPath, ob.Stop.Detail, ob.Stop.Recovery))
+		}
+		if len(paused) > 0 {
+			return "", &IncompleteReadError{Reason: strings.Join(paused, "; ")}
+		}
+		return "", nil
+	}
+	for _, ob := range a.turn.readShadow.coord.Snapshot() {
+		if ob.State.Terminal() || ob.Stop != nil {
+			continue
 		}
 		a.reads.tasks.mu.Lock()
 		task := a.reads.tasks.byID[ob.Key]
@@ -124,7 +127,6 @@ func (a *Agent) readContinuation(final bool) (string, error) {
 		if !task.issued || task.snapshot == "" {
 			tr, _ := a.turn.readShadow.coord.Narrow(ob.Key, readcoord.Block{Code: "no_cursor", Detail: "no verifiable next page is available", Recovery: "inspect a narrower range and report that the full review remains incomplete"})
 			a.emitReadStatus(tr, tool.ReadResultEnvelope{Intent: ob.Requirement.Intent})
-			paused = append(paused, ob.Scope.CanonicalPath+": no verifiable next page")
 			continue
 		}
 		path := task.argumentPath
@@ -137,10 +139,7 @@ func (a *Agent) readContinuation(final bool) (string, error) {
 			prefix = "The last two pages added no content. Change strategy: use the host's exact next window instead of repeating the previous page. Call read_file "
 			delete(a.turn.readShadow.pivots, ob.Key)
 		}
-		return prefix + string(args) + ". Independent work may continue. Do not claim a complete review until this requirement is satisfied.", nil
-	}
-	if final && len(paused) > 0 {
-		return "", &IncompleteReadError{Reason: strings.Join(paused, "; ")}
+		return prefix + string(args) + ". Independent work may continue. A partial window is enough when it covers the work; do not claim a complete review until the requirement is satisfied.", nil
 	}
 	return "", nil
 }
@@ -201,13 +200,7 @@ func (a *Agent) outstandingReadEvidence(ctx context.Context, boundary uint64) []
 			s.mu.Unlock()
 		}
 	}
-	paths := s.snapshot()
-	if a.readPipelineActive() {
-		for _, ob := range a.turn.readShadow.coord.Snapshot() {
-			if !ob.State.Terminal() {
-				paths = append(paths, ob.Scope.CanonicalPath)
-			}
-		}
-	}
-	return paths
+	// Only writers already blocked for missing path evidence count here; open
+	// readcoord obligations must not freeze undeclared tools like git commit.
+	return s.snapshot()
 }

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -9,7 +9,6 @@ import (
 
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
-	"reasonix/internal/i18n"
 	"reasonix/internal/provider"
 	"reasonix/internal/runtimepolicy"
 	"reasonix/internal/tool"
@@ -367,21 +366,10 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, tex
 			return true, nil
 		}
 	}
-	// A partial read is a host-owned protocol state, not advisory prose. Refuse
-	// a candidate final before every ordinary readiness/validator path so a
-	// model cannot silently answer from the visible prefix alone.
-	if instruction, pause := a.legacyReadFinal(state); pause != nil {
+	// Legacy rollback only pauses on a hard read failure, never on unpaid pages.
+	if _, pause := a.legacyReadFinal(state); pause != nil {
 		a.contextManager().ObserveUsage(usage)
 		return false, pause
-	} else if instruction != "" {
-		a.sess.conversation.Add(HostGeneratedUserMessage(a.withTurnPreferences(instruction)))
-		a.emitIncompleteReadNotice(
-			event.NoticeCodeReadContinuationRequired,
-			i18n.M.IncompleteReadFinishBlocked,
-			"final answer blocked pending read continuation",
-		)
-		a.contextManager().ObserveUsage(usage)
-		return true, nil
 	}
 	// Recovery finalization produced a summary. Keep it in the session,
 	// but still pause so Goal auto-continue cannot open another Run with

--- a/internal/agent/tool_result_capability.go
+++ b/internal/agent/tool_result_capability.go
@@ -107,8 +107,8 @@ func toolOutputRecoveryMarkerAt(toolName, toolCallID, resultRef string, original
 		Offset     int    `json:"offset"`
 	}{ToolCallID: exampleID, ResultRef: resultRef, Offset: recoverOffset})
 	return fmt.Sprintf(
-		"\n\n…[truncated tool=%s call_id=%s result_ref=%s original_bytes=%d kept_bytes=%d next_offset=%d — full original retained locally; recover with use_capability(action=\"call\", capability_id=\"session:tool_result\", arguments=%s). INCOMPLETE READ: only a contiguous prefix is visible; do not answer, modify state, or finish until recovery reaches complete=true. If use_capability is unavailable, re-run the original tool with narrower arguments]…\n\n",
-		namePart, idPart, resultRef, originalBytes, keptBytes, recoverOffset, args,
+		"\n\n…[truncated tool=%s call_id=%s result_ref=%s original_bytes=%d kept_bytes=%d next_offset=%d — full original retained locally; recover with use_capability(action=\"call\", capability_id=\"session:tool_result\", arguments=%s). Only the first %d bytes are shown; page the rest with session:tool_result if the visible part is not enough, or re-read a narrower window. If use_capability is unavailable, re-run the original tool with narrower arguments]…\n\n",
+		namePart, idPart, resultRef, originalBytes, keptBytes, recoverOffset, args, keptBytes,
 	)
 }
 

--- a/internal/boot/effect_read_file_test.go
+++ b/internal/boot/effect_read_file_test.go
@@ -1,0 +1,175 @@
+package boot
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// readThenMutateProvider reads a large file, then runs git commit, then lists
+// capabilities and finishes. Truncated/windowed reads must not freeze commits
+// or finals through the real Build stack.
+type readThenMutateProvider struct {
+	mu    sync.Mutex
+	reqs  []provider.Request
+	round int
+}
+
+func (p *readThenMutateProvider) Name() string { return "boot-read-then-mutate" }
+
+func (p *readThenMutateProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.mu.Lock()
+	p.reqs = append(p.reqs, req)
+	p.round++
+	round := p.round
+	p.mu.Unlock()
+	switch round {
+	case 1:
+		return streamChunks(
+			provider.Chunk{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{
+				ID: "read-1", Name: "read_file", Arguments: `{"path":"big.txt"}`,
+			}},
+			provider.Chunk{Type: provider.ChunkDone},
+		), nil
+	case 2:
+		return streamChunks(
+			provider.Chunk{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{
+				ID: "commit-1", Name: "bash", Arguments: `{"command":"git commit -m test-commit"}`,
+			}},
+			provider.Chunk{Type: provider.ChunkDone},
+		), nil
+	case 3:
+		return streamChunks(
+			provider.Chunk{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{
+				ID: "list-1", Name: "use_capability", Arguments: `{"action":"list"}`,
+			}},
+			provider.Chunk{Type: provider.ChunkDone},
+		), nil
+	default:
+		return streamChunks(
+			provider.Chunk{Type: provider.ChunkText, Text: "committed after the partial read"},
+			provider.Chunk{Type: provider.ChunkDone},
+		), nil
+	}
+}
+
+func (p *readThenMutateProvider) requests() []provider.Request {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]provider.Request, len(p.reqs))
+	copy(out, p.reqs)
+	return out
+}
+
+func TestEffectTruncatedReadDoesNotBlockCommitOrFinalThroughRealBuild(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	writeFile(t, dir, "tracked.txt", "tracked\n")
+	cmd := exec.Command("git", "add", "tracked.txt")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v\n%s", err, out)
+	}
+
+	var body strings.Builder
+	for i := 1; i <= 4500; i++ {
+		fmt.Fprintf(&body, "line-%04d-content-for-pagination-test\n", i)
+	}
+	writeFile(t, dir, "big.txt", body.String())
+
+	rec := &readThenMutateProvider{}
+	provider.Register("boot-read-then-mutate", func(provider.Config) (provider.Provider, error) {
+		return rec, nil
+	})
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[environment]
+enabled = false
+
+[[providers]]
+name = "test-model"
+kind = "boot-read-then-mutate"
+model = "x"
+`)
+
+	ctrl, err := Build(context.Background(), Options{
+		Sink:            event.Discard,
+		PermissionAllow: []string{"Bash(git *)"},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	ctrl.SetToolApprovalMode("yolo")
+
+	if err := ctrl.Run(context.Background(), "read big.txt then commit"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	reqs := rec.requests()
+	if len(reqs) < 4 {
+		t.Fatalf("provider rounds=%d, want at least read + commit + list + final", len(reqs))
+	}
+
+	readResult := lastToolContentByID(reqs, "read-1")
+	if readResult == "" {
+		t.Fatal("read_file result never reached a later provider request")
+	}
+	if strings.Contains(readResult, "do not answer, modify state") || strings.Contains(readResult, "INCOMPLETE READ") {
+		t.Fatalf("read_file result still forces completion:\n%.400s", readResult)
+	}
+	if !strings.Contains(readResult, "PARTIAL view") && !strings.Contains(readResult, "next_offset=") {
+		t.Fatalf("read_file result missing pagination hint:\n%.400s", readResult)
+	}
+
+	commitResult := lastToolContentByID(reqs, "commit-1")
+	if commitResult == "" {
+		t.Fatal("git commit result never reached a later provider request")
+	}
+	if strings.Contains(commitResult, "unread content retained") ||
+		strings.Contains(commitResult, "restricted search/read mode") ||
+		strings.Contains(commitResult, "cannot declare which files it changes") {
+		t.Fatalf("git commit was blocked by leftover read gate:\n%.400s", commitResult)
+	}
+
+	listResult := lastToolContentByID(reqs, "list-1")
+	if listResult == "" {
+		t.Fatal("use_capability list result never reached a later provider request")
+	}
+	if !strings.Contains(listResult, "session:tool_result") {
+		t.Fatalf("capability list dropped session:tool_result:\n%.400s", listResult)
+	}
+}
+
+func lastToolContentByID(reqs []provider.Request, callID string) string {
+	var found string
+	for _, req := range reqs {
+		for _, msg := range req.Messages {
+			if msg.Role == provider.RoleTool && msg.ToolCallID == callID {
+				found = msg.Content
+			}
+		}
+	}
+	return found
+}

--- a/internal/tool/builtin/builtin_test.go
+++ b/internal/tool/builtin/builtin_test.go
@@ -193,7 +193,7 @@ func TestReadFileOffsetLimit(t *testing.T) {
 		}
 	}
 	// Trailer announces what's left so the model can paginate.
-	if !strings.Contains(out, "more line") || !strings.Contains(out, "offset=15") {
+	if !strings.Contains(out, "PARTIAL view") || !strings.Contains(out, "offset=15") {
 		t.Errorf("pagination hint missing:\n%s", out)
 	}
 }

--- a/internal/tool/builtin/readfile.go
+++ b/internal/tool/builtin/readfile.go
@@ -27,6 +27,7 @@ const (
 	readFileDetectSample      = 256 * 1024 // bytes sampled for encoding detection before streaming
 	readFileMaxLineBytes      = 1024 * 1024
 	readFileMaxFormattedBytes = 8 << 20
+	readFileCountBudget       = 32 * 1024 // bytes scanned past the window to size the trailer total
 )
 
 func init() { tool.RegisterBuiltin(readFile{}) }
@@ -399,8 +400,8 @@ func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 	var collected []string
 	textBytes := 0
 	lineNo := 0
-	hasMore := false
 	safetyPaged := false
+	capped := false
 	requestedEnd := offset + limit
 	for scanner.Scan() {
 		lineNo++
@@ -415,7 +416,6 @@ func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 			bodyBytes := textBytes + len(line) + count*(width+len("→")+1)
 			trailer := readFileSafetyTrailer(nextOffset, requestedEnd)
 			if bodyBytes+len(trailer) > readFileMaxFormattedBytes {
-				hasMore = true
 				safetyPaged = true
 				break
 			}
@@ -423,16 +423,22 @@ func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 			textBytes += len(line)
 			continue
 		}
-		// A line past the requested window exists — stop here rather than reading
-		// the rest of the file just to count the remainder.
-		hasMore = true
+		// Size the trailer total from a bounded look-ahead: a 3-line window on
+		// a multi-GB file must not drain the file. Past the budget the total
+		// is reported as a lower bound.
+		counted := 0
+		for scanner.Scan() {
+			lineNo++
+			counted += len(scanner.Bytes()) + 1
+			if counted >= readFileCountBudget {
+				capped = true
+				break
+			}
+		}
 		break
 	}
-	if err := scanner.Err(); err != nil {
-		if strings.Contains(err.Error(), "token too long") {
-			return "", fmt.Errorf("scan: source line exceeds the 1 MiB local safety limit: %w", err)
-		}
-		return "", fmt.Errorf("scan: %w", err)
+	if err := scanReadFileError(scanner.Err()); err != nil {
+		return "", err
 	}
 
 	if lineNo == 0 {
@@ -451,12 +457,30 @@ func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 	}
 	if safetyPaged {
 		b.WriteString(readFileSafetyTrailer(offset+len(collected), requestedEnd))
-	} else if hasMore {
-		fmt.Fprintf(&b, "\n[more lines below; pass offset=%d to continue]\n", offset+len(collected))
+	} else if maxShown < lineNo || capped {
+		fmt.Fprintf(&b, "\n[PARTIAL view: showing lines %d-%d of %s. The file continues; pass offset=%d to read on, or grep for the section you need. A partial read is fine when the visible range is sufficient.]\n",
+			offset+1, maxShown, formatReadFileTotal(lineNo, capped), offset+len(collected))
 	}
 	return b.String(), nil
 }
 
+func scanReadFileError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "token too long") {
+		return fmt.Errorf("scan: source line exceeds the 1 MiB local safety limit: %w", err)
+	}
+	return fmt.Errorf("scan: %w", err)
+}
+
+func formatReadFileTotal(lineNo int, capped bool) string {
+	if capped {
+		return fmt.Sprintf("%d+", lineNo)
+	}
+	return strconv.Itoa(lineNo)
+}
+
 func readFileSafetyTrailer(nextOffset, requestedEnd int) string {
-	return fmt.Sprintf("\n[read_file local safety page; next_offset=%d requested_end=%d]\n", nextOffset, requestedEnd)
+	return fmt.Sprintf("\n[read_file local safety page; next_offset=%d requested_end=%d; output capped at 8 MiB for this call]\n", nextOffset, requestedEnd)
 }

--- a/internal/tool/builtin/readfile_safety_test.go
+++ b/internal/tool/builtin/readfile_safety_test.go
@@ -42,17 +42,21 @@ func TestReadFileLocalSafetyPagesExplicitWindowWithoutGaps(t *testing.T) {
 	if start < 0 {
 		t.Fatal("first page did not include the local safety trailer")
 	}
-	fields := strings.Fields(strings.TrimSuffix(first[start+len(prefix):], "]\n"))
-	if len(fields) != 2 || !strings.HasPrefix(fields[1], "requested_end=") {
+	rest := strings.TrimSuffix(first[start+len(prefix):], "]\n")
+	fields := strings.Fields(rest)
+	if len(fields) < 2 || !strings.HasPrefix(fields[1], "requested_end=") {
 		t.Fatalf("safety trailer fields=%q", fields)
 	}
 	next, err := strconv.Atoi(fields[0])
 	if err != nil || next <= 0 || next >= totalLines {
 		t.Fatalf("next_offset=%d err=%v", next, err)
 	}
-	requestedEnd, err := strconv.Atoi(strings.TrimPrefix(fields[1], "requested_end="))
+	requestedEnd, err := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(fields[1], "requested_end="), ";"))
 	if err != nil || requestedEnd != totalLines {
 		t.Fatalf("requested_end=%d err=%v", requestedEnd, err)
+	}
+	if !strings.Contains(rest, "output capped at 8 MiB") {
+		t.Fatalf("safety trailer missing 8 MiB notice: %q", rest)
 	}
 	second, err := (readFile{}).scan(strings.NewReader(source.String()), next, requestedEnd-next)
 	if err != nil {

--- a/internal/tool/builtin/readfile_window_test.go
+++ b/internal/tool/builtin/readfile_window_test.go
@@ -20,9 +20,9 @@ func (c *countingReader) Read(p []byte) (int, error) {
 }
 
 // TestScanWindowedReadDoesNotConsumeWholeFile guards the regression where scan()
-// drained the entire file (a second `for scanner.Scan()` loop) just to count the
-// remaining lines for the pagination trailer. A small windowed read of a large
-// file must read only a small prefix, not all of it.
+// drained the entire file just to count the remaining lines for the pagination
+// trailer. A small windowed read of a large file reads only a bounded prefix and
+// reports the total as a lower bound.
 func TestScanWindowedReadDoesNotConsumeWholeFile(t *testing.T) {
 	var buf bytes.Buffer
 	for i := 1; i <= 100_000; i++ {
@@ -45,11 +45,32 @@ func TestScanWindowedReadDoesNotConsumeWholeFile(t *testing.T) {
 	if strings.Contains(out, "line 4") {
 		t.Fatalf("window leaked line 4:\n%s", out)
 	}
-	if !strings.Contains(out, "more lines below") {
-		t.Fatalf("pagination trailer missing:\n%s", out)
+	if !strings.Contains(out, "PARTIAL view: showing lines 1-3 of ") || !strings.Contains(out, "+. The file continues") {
+		t.Fatalf("pagination trailer must report a lower-bound total:\n%s", out)
+	}
+	if strings.Contains(out, "of 100000.") {
+		t.Fatalf("total must not be exact when the look-ahead budget is exceeded:\n%s", out)
+	}
+	if !strings.Contains(out, "pass offset=3") {
+		t.Fatalf("continuation offset missing:\n%s", out)
 	}
 	if cr.n > 100*1024 {
 		t.Fatalf("read %d of %d bytes for a 3-line window; should read only a small prefix", cr.n, total)
 	}
-	t.Logf("read %d of %d bytes (%.1f%%) for a 3-line window", cr.n, total, 100*float64(cr.n)/float64(total))
+}
+
+// TestScanWindowedReadReportsExactTotalForSmallFiles pins the exact total when
+// the remainder fits inside the look-ahead budget.
+func TestScanWindowedReadReportsExactTotalForSmallFiles(t *testing.T) {
+	var buf bytes.Buffer
+	for i := 1; i <= 50; i++ {
+		fmt.Fprintf(&buf, "line %d\n", i)
+	}
+	out, err := readFile{}.scan(bytes.NewReader(buf.Bytes()), 10, 5)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !strings.Contains(out, "PARTIAL view: showing lines 11-15 of 50.") {
+		t.Fatalf("exact total missing:\n%s", out)
+	}
 }

--- a/internal/tool/builtin/tool_extra_test.go
+++ b/internal/tool/builtin/tool_extra_test.go
@@ -51,7 +51,7 @@ func TestReadFileLargeFile(t *testing.T) {
 	}
 	// Pagination hint points at the next page; it no longer reads the whole file
 	// to compute an exact remaining count.
-	if !strings.Contains(out, "more line") || !strings.Contains(out, "offset=3") {
+	if !strings.Contains(out, "PARTIAL view") || !strings.Contains(out, "offset=3") {
 		t.Errorf("pagination hint missing: %s", out)
 	}
 }

--- a/internal/tool/readresult.go
+++ b/internal/tool/readresult.go
@@ -185,28 +185,46 @@ func ParseReadTrailer(output string) ReadTrailer {
 	if start := strings.LastIndex(output, safetyPrefix); start >= 0 && strings.HasSuffix(output, "]\n") {
 		fields := strings.TrimSuffix(output[start+len(safetyPrefix):], "]\n")
 		parts := strings.Fields(fields)
-		if len(parts) == 2 {
+		if len(parts) >= 2 {
 			next, nextErr := strconv.Atoi(parts[0])
-			end, endErr := strconv.Atoi(strings.TrimPrefix(parts[1], "requested_end="))
+			end, endErr := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(parts[1], "requested_end="), ";"))
 			if nextErr == nil && endErr == nil && next >= 0 && end >= next {
 				return ReadTrailer{NextOffset: next, RequestedEnd: end, HasMore: true, LocalSafety: true}
 			}
 		}
 	}
-	const prefix = "\n[more lines below; pass offset="
-	start := strings.LastIndex(output, prefix)
+	if n, ok := readTrailerOffset(output, "\n[PARTIAL view:", "pass offset="); ok {
+		return ReadTrailer{NextOffset: n, HasMore: true}
+	}
+	if n, ok := readTrailerOffset(output, "\n[more lines below; pass offset=", ""); ok {
+		return ReadTrailer{NextOffset: n, HasMore: true}
+	}
+	return ReadTrailer{}
+}
+
+func readTrailerOffset(output, marker, field string) (int, bool) {
+	start := strings.LastIndex(output, marker)
 	if start < 0 || !strings.HasSuffix(output, "]\n") {
-		return ReadTrailer{}
+		return 0, false
 	}
-	value := output[start+len(prefix):]
-	if end := strings.IndexAny(value, " ]\r\n"); end >= 0 {
-		value = value[:end]
+	segment := output[start:]
+	if field != "" {
+		idx := strings.Index(segment, field)
+		if idx < 0 {
+			return 0, false
+		}
+		segment = segment[idx+len(field):]
+	} else {
+		segment = segment[len(marker):]
 	}
-	n, err := strconv.Atoi(value)
+	if end := strings.IndexAny(segment, " ]\r\n"); end >= 0 {
+		segment = segment[:end]
+	}
+	n, err := strconv.Atoi(segment)
 	if err != nil || n < 0 {
-		return ReadTrailer{}
+		return 0, false
 	}
-	return ReadTrailer{NextOffset: n, HasMore: true}
+	return n, true
 }
 
 // WindowDigest binds one delivered window to its content. Two reads that

--- a/internal/tool/readresult_test.go
+++ b/internal/tool/readresult_test.go
@@ -176,7 +176,11 @@ func TestParseReadTrailerRecognizesBothPagingForms(t *testing.T) {
 	if !more.HasMore || more.NextOffset != 7 || more.LocalSafety {
 		t.Fatalf("more-lines trailer = %+v", more)
 	}
-	safety := ParseReadTrailer("   1→a\n\n[read_file local safety page; next_offset=9 requested_end=20]\n")
+	partial := ParseReadTrailer("   1→a\n\n[PARTIAL view: showing lines 1-3 of 50. The file continues; pass offset=3 to read on, or grep for the section you need. A partial read is fine when the visible range is sufficient.]\n")
+	if !partial.HasMore || partial.NextOffset != 3 || partial.LocalSafety {
+		t.Fatalf("partial-view trailer = %+v", partial)
+	}
+	safety := ParseReadTrailer("   1→a\n\n[read_file local safety page; next_offset=9 requested_end=20; output capped at 8 MiB for this call]\n")
 	if !safety.HasMore || !safety.LocalSafety || safety.NextOffset != 9 || safety.RequestedEnd != 20 {
 		t.Fatalf("safety trailer = %+v", safety)
 	}


### PR DESCRIPTION
## Summary

- Unpaid / truncated `read_file` coverage no longer freezes undeclared tools such as `git commit`, and no longer refuses a final answer on either the default read pipeline or the legacy rollback path.
- Path-scoped write evidence and host Stop (budget / policy stall) stay. `read_file` reports a `PARTIAL view` trailer; recovery markers are advisory. `Description()` / `Schema()` bytes are unchanged.

## Issues

Refs the dead-end where truncated standing-instruction reads blocked `git commit` / finals against progress guard.

## Verification

- `gofmt -w .`
- `go vet ./internal/agent/ ./internal/tool/ ./internal/tool/builtin/ ./internal/boot/`
- `make lint`
- `go test ./internal/tool/ ./internal/tool/builtin/ ./internal/agent/ ./internal/boot/`

## Documentation impact

Documentation-impact: updated - AGENT_CORE_SIMPLIFICATION (+zh-CN), TOOL_CONTRACT (+zh-CN), and CHANGELOG now describe advisory pagination and retained evidence/Stop boundaries.

## Cache impact

Cache-impact: none - read_file Description/Schema and use_capability provider-visible schema are byte-unchanged; only tool-result trailers/markers and host gate behavior changed.
Cache-guard: TestEffectTruncatedReadDoesNotBlockCommitOrFinalThroughRealBuild; TestParseReadTrailerRecognizesBothPagingForms; go test ./internal/tool/builtin/ ./internal/agent/ ./internal/boot/
System-prompt-review: self-reviewed - only added a boot effect test under internal/boot/; Compose system-prompt prefix bytes are unchanged.
