### PR TITLE
fix(electron): restrict external URL protocols / 限制 Electron 外部链接协议

### DIFF
--- a/desktop/electron/src/main/hostCalls.test.ts
+++ b/desktop/electron/src/main/hostCalls.test.ts
@@ -45,7 +45,7 @@ test("every documented host/* method is dispatched with parsed params", async ()
   assert.deepEqual(await dispatchHostCall(table, "host/shell.openExternal", { url: "https://e" }), {});
   assert.deepEqual(await dispatchHostCall(table, "host/app.quit", undefined), {});
   assert.deepEqual(calls, [
-    'show("tray")', "setPosition(10.4,0)", "tray(打开,退出,Reasonix)", "remoteOpen(h1)", 'relaunch(["--x"])', "open(https://e)", "approve()",
+    'show("tray")', "setPosition(10.4,0)", "tray(打开,退出,Reasonix)", "remoteOpen(h1)", 'relaunch(["--x"])', "open(https://e/)", "approve()",
   ]);
   for (const method of ["host/window.hide", "host/window.maximise", "host/window.center", "host/devtools.toggle", "host/tray.destroy", "host/app.hide"]) {
     assert.deepEqual(await dispatchHostCall(table, method, {}), {});
@@ -56,6 +56,16 @@ test("update relaunch preserves the stable launcher path", async () => {
   const { table, calls } = deps();
   await dispatchHostCall(table, "host/app.relaunch", { args: ["--after-update"], execPath: "/opt/reasonix/reasonix-launcher" });
   assert.deepEqual(calls, ['relaunch(["--after-update"],"/opt/reasonix/reasonix-launcher")']);
+});
+
+test("host external links reject non-user-facing protocols", async () => {
+  const { table, calls } = deps();
+  for (const url of ["file:///tmp/probe", "javascript:alert(1)", "data:text/plain,probe", "not a url"]) {
+    await assert.rejects(dispatchHostCall(table, "host/shell.openExternal", { url }), /refusing to open/);
+  }
+  assert.deepEqual(calls, []);
+  await dispatchHostCall(table, "host/shell.openExternal", { url: "mailto:test@example.com" });
+  assert.deepEqual(calls, ["open(mailto:test@example.com)"]);
 });
 
 test("browser host calls merge into the table when the surface is wired", async () => {

--- a/desktop/electron/src/main/hostCalls.ts
+++ b/desktop/electron/src/main/hostCalls.ts
@@ -74,6 +74,18 @@ export interface HostCallDeps {
 }
 
 const remoteInput = (params: Params) => ({ hostKey: str(params, "hostKey"), url: str(params, "url"), title: str(params, "title") });
+const EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+
+function externalURL(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("refusing to open an invalid external URL");
+  }
+  if (!EXTERNAL_PROTOCOLS.has(url.protocol)) throw new Error(`refusing to open external URL with protocol ${url.protocol}`);
+  return url.href;
+}
 
 export function buildHostCallTable(deps: HostCallDeps): HostCallTable {
   const done = (run: () => void): HostCall => (params) => {
@@ -110,7 +122,7 @@ export function buildHostCallTable(deps: HostCallDeps): HostCallTable {
     "host/dialog.saveFile": (params) => deps.dialogs.saveFile(params),
     "host/dialog.message": (params) => deps.dialogs.message(params),
     "host/shell.openExternal": async (params) => {
-      await deps.openExternal(str(params, "url"));
+      await deps.openExternal(externalURL(str(params, "url")));
       return {};
     },
     "host/app.quit": done(() => deps.lifecycle.approve()),

--- a/docs/DESKTOP_HOST_PROTOCOL.md
+++ b/docs/DESKTOP_HOST_PROTOCOL.md
@@ -190,6 +190,10 @@ phase.
 | `host/remoteWindow.navigate` | `{"hostKey","url","title"}` | `{}` |
 | `host/remoteWindow.focus` `close` | `{"hostKey"}` | `{}` |
 | `host/tray.ensure` | `{"openTitle","openTooltip","quitTitle","quitTooltip","tooltip"}` | `{"ready":bool,"reason":string}` |
+
+`host/shell.openExternal` accepts only `http:`, `https:`, and `mailto:` URLs.
+Other schemes, including `file:`, `javascript:`, and `data:`, are rejected at
+the Electron host boundary before the system opener is invoked.
 | `host/tray.destroy` | `{}` | `{}` |
 | `host/browser.grant` `revoke` | `{"grantId","tabId","sessionId"}` / `{"grantId"}` | `{}` |
 | `host/browser.tabs.list` | `{"grantId"}` | `{"tabs":[{"id","url","title","loading","temporary"}]}` |

--- a/docs/DESKTOP_HOST_PROTOCOL.zh-CN.md
+++ b/docs/DESKTOP_HOST_PROTOCOL.zh-CN.md
@@ -159,6 +159,10 @@ Wails 实现在最后阶段删除。
 | `host/remoteWindow.navigate` | `{"hostKey","url","title"}` | `{}` |
 | `host/remoteWindow.focus` `close` | `{"hostKey"}` | `{}` |
 | `host/tray.ensure` | `{"openTitle","openTooltip","quitTitle","quitTooltip","tooltip"}` | `{"ready":bool,"reason":string}` |
+
+`host/shell.openExternal` 只接受 `http:`、`https:` 和 `mailto:` URL。
+包括 `file:`、`javascript:`、`data:` 在内的其他协议会在 Electron 宿主边界
+被拒绝，不会交给系统打开器执行。
 | `host/tray.destroy` | `{}` | `{}` |
 | `host/browser.grant` `revoke` | `{"grantId","tabId","sessionId"}` / `{"grantId"}` | `{}` |
 | `host/browser.tabs.list` | `{"grantId"}` | `{"tabs":[{"id","url","title","loading","temporary"}]}` |


### PR DESCRIPTION
## Problem

The Go-to-Electron `host/shell.openExternal` boundary accepted any parseable URL and passed it to the system opener.

## Fix

- Allow only `http:`, `https:`, and `mailto:` protocols.
- Reject `file:`, `javascript:`, `data:`, and malformed URLs before dispatch.
- Add host-call regression coverage.

## Verification

- Electron host-call tests: 8/8
- TypeScript main and preload typechecks: passed
- Desktop focused host tests: passed

Follow-up to #9988.

Documentation-impact: updated - documented the Electron host external URL protocol allowlist in the follow-up PR.
