### PR TITLE
chore(ci): streamline Electron desktop checks / 精简 Electron 桌面 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,14 +418,14 @@ jobs:
       - name: Verify frontend artifact layout
         run: test -f frontend/dist/index.html
       - name: Install browser runtimes
-        run: PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend exec playwright install --with-deps chromium webkit
+        run: PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend exec playwright install --with-deps chromium
       - name: Test desktop browser contracts
         run: |
           pnpm --dir frontend test:motion-browser
           PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend test:app-browser
-          PLAYWRIGHT_BROWSERS_PATH=.pw-browsers REASONIX_SETTINGS_BROWSERS=chromium,webkit pnpm --dir frontend test:settings-browser
+          PLAYWRIGHT_BROWSERS_PATH=.pw-browsers REASONIX_SETTINGS_BROWSERS=chromium pnpm --dir frontend test:settings-browser
           xvfb-run -a env REASONIX_TRANSCRIPT_NATIVE_THUMB=1 pnpm --dir frontend test:transcript-browser
-          PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend test:transcript-reader-browser
+          REASONIX_TRANSCRIPT_READER_BROWSERS=chromium PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend test:transcript-reader-browser
 
   desktop-prepare:
     needs: changes
@@ -830,7 +830,7 @@ jobs:
 
   govulncheck:
     needs: changes
-    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code != 'false')
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     continue-on-error: true # informational — stdlib vulns need a Go patch release
     steps:
@@ -849,7 +849,7 @@ jobs:
 
   coverage:
     needs: changes
-    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code != 'false')
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/desktop/frontend/bench/transcript-reader-transaction.mjs
+++ b/desktop/frontend/bench/transcript-reader-transaction.mjs
@@ -10,6 +10,8 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = !process.env.PLAYWRIGHT_BROWSERS_PATH || 
   ? path.join(frontendDir, ".pw-browsers")
   : process.env.PLAYWRIGHT_BROWSERS_PATH;
 const { chromium, webkit } = await import("playwright");
+const browsers = (process.env.REASONIX_TRANSCRIPT_READER_BROWSERS ?? "chromium,webkit")
+  .split(",").map((name) => name.trim()).filter(Boolean);
 const port = Number(process.env.REASONIX_TRANSCRIPT_READER_PORT ?? 4621);
 const iterations = Number(process.env.REASONIX_TRANSCRIPT_READER_ITERATIONS ?? 6);
 const url = `http://127.0.0.1:${port}/?mock=bench&bench=1`;
@@ -479,8 +481,8 @@ async function runBrowser(browserType, label) {
 const preview = await startPreviewServer(frontendDir, port);
 try {
   await waitForServer();
-  await runBrowser(chromium, "Chromium");
-  await runBrowser(webkit, "WebKit");
+  if (browsers.includes("chromium")) await runBrowser(chromium, "Chromium");
+  if (browsers.includes("webkit")) await runBrowser(webkit, "WebKit");
   process.stdout.write("transcript reader transaction browser replay passed\n");
 } finally {
   await preview.close();


### PR DESCRIPTION
## Problem
After the Wails-to-Electron migration, PR CI still installed and exercised WebKit, while vulnerability scanning and coverage were non-blocking checks running on every pull request.

## Changes
- Run desktop browser contracts with Chromium only.
- Run `govulncheck` and Go coverage on `main-v2` pushes instead of pull requests.
- Make transcript reader browser selection explicit so Chromium-only CI does not launch an uninstalled WebKit runtime.
- Preserve the existing desktop job structure and required check names.

## Verification
- `node --test scripts/ci-workflow.test.mjs desktop/frontend/bench/app-memory-paths.test.mjs`
- `git diff --check`

Documentation-impact: none - this changes CI execution and test harness selection; existing user and developer documentation remains correct.

This is a follow-up cleanup for the Electron migration; it does not remove renderer memory screening or platform-specific Electron packaging tests.
