### PR TITLE
fix(history): cancel status refresh during catalog shutdown / 修复 catalog 关闭时状态刷新超时

### DIFF
--- a/internal/historycatalog/catalog.go
+++ b/internal/historycatalog/catalog.go
@@ -751,10 +751,13 @@ func (c *Catalog) refreshStatus(ctx context.Context) {
 	c.status.Revision = c.revision.Load()
 	c.statusMu.Unlock()
 }
-
 func (c *Catalog) publish(revision uint64, roots []string, reason string) {
 	c.revision.Store(revision)
-	c.refreshStatus(context.Background())
+	statusCtx := c.ctx
+	if statusCtx == nil {
+		statusCtx = context.Background()
+	}
+	c.refreshStatus(statusCtx)
 	if c.opts.OnRevision != nil {
 		c.opts.OnRevision(c.Status(), roots, reason)
 	}


### PR DESCRIPTION
## Problem
The Windows smoke job can fail while tearing down the process-global history catalog:

```text
close shared history catalog: context deadline exceeded
```

The failure occurs when catalog publication refreshes status with a background context after shutdown has started.

## Root cause
`historycatalog.Catalog.publish` used `context.Background()` for SQLite status queries. Catalog cancellation could not interrupt those queries, so Windows teardown could exceed the test deadline.

## Fix
Use the catalog lifecycle context for normal status refreshes so shutdown cancellation propagates into the queries. Keep a background fallback for the synchronous temporary catalog used by projection rebuilds.

## Verification
- `go test ./internal/historycatalog ./internal/history ./internal/boot`
- `git diff --check`

Cache-impact: none
Cache-guard: none
