### PR TITLE
test(desktop): move test-only helpers out of the shipped binary / 把仅测试使用的 helper 移出生产代码

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5376,10 +5376,6 @@ func historyCheckpointTurns(msgs []provider.Message, resolveUserContent func(str
 	return out
 }
 
-func historyMessages(msgs []provider.Message, resolveUserContent func(string) string) []HistoryMessage {
-	return historyMessagesWithPlannerDisplays(msgs, resolveUserContent, nil, nil)
-}
-
 func historyMessagesWithPlannerDisplays(msgs []provider.Message, resolveUserContent func(string) string, plannerTurns []plannerDisplayTurn, checkpointTurns map[int]int) []HistoryMessage {
 	replayedTodoArgs := historyTodoArgsWithCompleteSteps(msgs)
 	toolResults := historyToolResultsByID(msgs)
@@ -7873,13 +7869,6 @@ func (a *App) invalidateSkillRootsCache() {
 	a.skillRootsMu.Unlock()
 }
 
-func skillRootsView() []SkillRootView {
-	cwd, _ := os.Getwd()
-	cfg, _ := config.Load()
-	userCfg := config.LoadForEdit(config.UserConfigPath())
-	return skillRootsViewFrom(cwd, cfg, userCfg)
-}
-
 func skillRootsViewFrom(workspaceRoot string, cfg, userCfg *config.Config) []SkillRootView {
 	workspaceRoot = normalizeWorkspaceRoot(workspaceRoot)
 	var custom []string
@@ -8996,18 +8985,6 @@ func mcpConnected(ctrl control.SessionAPI, name string) bool {
 	}
 	for _, s := range ctrl.Host().Servers() {
 		if s.Name == name {
-			return true
-		}
-	}
-	return false
-}
-
-func mcpFailed(ctrl control.SessionAPI, name string) bool {
-	if ctrl == nil || ctrl.Host() == nil {
-		return false
-	}
-	for _, f := range ctrl.Host().Failures() {
-		if f.Name == name {
 			return true
 		}
 	}
@@ -10625,12 +10602,6 @@ func numberedExportPath(path string, partIndex, partCount int) string {
 	ext := filepath.Ext(path)
 	stem := strings.TrimSuffix(path, ext)
 	return fmt.Sprintf("%s-%d-of-%d%s", stem, partIndex+1, partCount, ext)
-}
-
-func saveExclusiveExportFiles(targets []string, payloads [][]byte) error {
-	return saveExclusiveExportPayloads(targets, len(payloads), func(index int) ([]byte, error) {
-		return payloads[index], nil
-	})
 }
 
 func saveExclusiveExportPayloads(targets []string, payloadCount int, payloadAt func(int) ([]byte, error)) error {

--- a/desktop/delivery_worktree.go
+++ b/desktop/delivery_worktree.go
@@ -586,19 +586,6 @@ func (a *App) worktreeRuntimeReferenced(worktreeRoot string) bool {
 	return a.runtimeReferencesCanonicalLocked(key)
 }
 
-func pathWithinWorktree(path, worktreeRoot string) bool {
-	pathKey := canonicalRuntimeRoot(path)
-	rootKey := canonicalRuntimeRoot(worktreeRoot)
-	if pathKey == "" || rootKey == "" {
-		return false
-	}
-	if pathKey == rootKey {
-		return true
-	}
-	rel, err := filepath.Rel(rootKey, pathKey)
-	return err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
 func canonicalRuntimeRoot(root string) string {
 	canonical, _ := canonicalRuntimeRootErr(root)
 	return canonical

--- a/desktop/heartbeat_store.go
+++ b/desktop/heartbeat_store.go
@@ -16,15 +16,6 @@ import (
 	"reasonix/internal/fileutil"
 )
 
-// loadTasks reads tasks from disk.
-func (e *HeartbeatEngine) loadTasks() []HeartbeatTask {
-	snapshot, err := e.readConfigSnapshot()
-	if err != nil {
-		return nil
-	}
-	return snapshot.cfg.Tasks
-}
-
 func (e *HeartbeatEngine) readConfigSnapshot() (heartbeatConfigSnapshot, error) {
 	path := e.configPath()
 	b, err := readFileUTF8(path)
@@ -102,11 +93,6 @@ func (e *HeartbeatEngine) adoptExternalEditsLocked() {
 	e.recordConfigSnapshotLocked(snapshot)
 	e.tasks = snapshot.cfg.Tasks
 	e.prunePendingTopicsLocked(e.tasks)
-}
-
-// saveTasks writes tasks to disk atomically.
-func (e *HeartbeatEngine) saveTasks(tasks []HeartbeatTask) error {
-	return e.writeTasks(tasks, heartbeatConfigSnapshot{}, false)
 }
 
 func (e *HeartbeatEngine) writeTasks(tasks []HeartbeatTask, expected heartbeatConfigSnapshot, compare bool) error {

--- a/desktop/scroll_diagnostics_export.go
+++ b/desktop/scroll_diagnostics_export.go
@@ -301,11 +301,6 @@ func oneOf(value string, candidates ...string) bool {
 	return slices.Contains(candidates, value)
 }
 
-func buildScrollDiagnosticsZip(payload string) ([]byte, error) {
-	data, _, err := buildScrollDiagnosticsArchive(payload)
-	return data, err
-}
-
 func buildScrollDiagnosticsArchive(payload string) ([]byte, string, error) {
 	decoded, err := decodeScrollDiagnosticsPayload(payload)
 	if err != nil {

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -109,41 +109,6 @@ func saveSessionTitles(dir string, m map[string]string) error {
 	return fileutil.AtomicWriteFile(sessionTitlesPath(dir), b, 0o600)
 }
 
-// setSessionTitle sets (or, with an empty title, clears) a session's custom name.
-func setSessionTitle(dir, sessionPath, title string) error {
-	sessionPath, _, err := validateSessionPath(dir, sessionPath)
-	if err != nil {
-		return err
-	}
-	key := filepath.Base(sessionPath)
-	return updateSessionTitles(dir, func(m map[string]string) bool {
-		title = strings.TrimSpace(title)
-		if title == "" {
-			if _, ok := m[key]; !ok {
-				return false
-			}
-			delete(m, key)
-			return true
-		}
-		if m[key] == title {
-			return false
-		}
-		m[key] = title
-		return true
-	})
-}
-
-// deleteSessionFile moves a session's .jsonl and file sidecars into the local
-// trash. Title/display sidecars stay in place so trash previews and restores can
-// preserve the user's labels.
-func deleteSessionFile(dir, sessionPath string) error {
-	sessionPath, key, err := validateSessionPath(dir, sessionPath)
-	if err != nil {
-		return err
-	}
-	return trashSessionArtifacts(dir, sessionPath, key)
-}
-
 type trashedSessionMeta struct {
 	Key       string `json:"key"`
 	DeletedAt int64  `json:"deletedAt"`

--- a/desktop/testhelpers_test.go
+++ b/desktop/testhelpers_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+	"reasonix/internal/provider"
+)
+
+// Test-only helpers for the desktop suite. They exercise production state
+// through the same package internals, so they live here instead of in the
+// shipped binary.
+
+// setSessionTitle sets (or, with an empty title, clears) a session's custom name.
+func setSessionTitle(dir, sessionPath, title string) error {
+	sessionPath, _, err := validateSessionPath(dir, sessionPath)
+	if err != nil {
+		return err
+	}
+	key := filepath.Base(sessionPath)
+	return updateSessionTitles(dir, func(m map[string]string) bool {
+		title = strings.TrimSpace(title)
+		if title == "" {
+			if _, ok := m[key]; !ok {
+				return false
+			}
+			delete(m, key)
+			return true
+		}
+		if m[key] == title {
+			return false
+		}
+		m[key] = title
+		return true
+	})
+}
+
+// deleteSessionFile moves a session's .jsonl and file sidecars into the local
+// trash. Title/display sidecars stay in place so trash previews and restores can
+// preserve the user's labels.
+func deleteSessionFile(dir, sessionPath string) error {
+	sessionPath, key, err := validateSessionPath(dir, sessionPath)
+	if err != nil {
+		return err
+	}
+	return trashSessionArtifacts(dir, sessionPath, key)
+}
+
+// loadTasks reads tasks from disk.
+func (e *HeartbeatEngine) loadTasks() []HeartbeatTask {
+	snapshot, err := e.readConfigSnapshot()
+	if err != nil {
+		return nil
+	}
+	return snapshot.cfg.Tasks
+}
+
+// saveTasks writes tasks to disk atomically.
+func (e *HeartbeatEngine) saveTasks(tasks []HeartbeatTask) error {
+	return e.writeTasks(tasks, heartbeatConfigSnapshot{}, false)
+}
+
+func historyMessages(msgs []provider.Message, resolveUserContent func(string) string) []HistoryMessage {
+	return historyMessagesWithPlannerDisplays(msgs, resolveUserContent, nil, nil)
+}
+
+func skillRootsView() []SkillRootView {
+	cwd, _ := os.Getwd()
+	cfg, _ := config.Load()
+	userCfg := config.LoadForEdit(config.UserConfigPath())
+	return skillRootsViewFrom(cwd, cfg, userCfg)
+}
+
+func mcpFailed(ctrl control.SessionAPI, name string) bool {
+	if ctrl == nil || ctrl.Host() == nil {
+		return false
+	}
+	for _, f := range ctrl.Host().Failures() {
+		if f.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func saveExclusiveExportFiles(targets []string, payloads [][]byte) error {
+	return saveExclusiveExportPayloads(targets, len(payloads), func(index int) ([]byte, error) {
+		return payloads[index], nil
+	})
+}
+
+func pathWithinWorktree(path, worktreeRoot string) bool {
+	pathKey := canonicalRuntimeRoot(path)
+	rootKey := canonicalRuntimeRoot(worktreeRoot)
+	if pathKey == "" || rootKey == "" {
+		return false
+	}
+	if pathKey == rootKey {
+		return true
+	}
+	rel, err := filepath.Rel(rootKey, pathKey)
+	return err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func buildScrollDiagnosticsZip(payload string) ([]byte, error) {
+	data, _, err := buildScrollDiagnosticsArchive(payload)
+	return data, err
+}


### PR DESCRIPTION
## Problem

Five production files in the desktop module carry helpers that only the test suite calls, so they compile into the app binary and read as production API:

- `sessions.go`: `setSessionTitle`, `deleteSessionFile`
- `heartbeat_store.go`: `HeartbeatEngine.loadTasks`, `.saveTasks`
- `app.go`: `historyMessages`, `skillRootsView`, `mcpFailed`, `saveExclusiveExportFiles`
- `delivery_worktree.go`: `pathWithinWorktree`
- `scroll_diagnostics_export.go`: `buildScrollDiagnosticsZip`

## Fix

Move all ten into a new `desktop/testhelpers_test.go`. No call site changes: the tests keep the same names, and no production path referenced any of them.

They did not go into the existing test files because `sessions_test.go` (1586 lines) and `app_test.go` already sit above repolint's 800-line ceiling — growing them would create a new `test-file-size` violation rather than remove one.

## Verification

- `go build ./...` and `go vet ./...` clean in the desktop module.
- `go test ./...` in the desktop module.
- `go run ./tools/repolint`: no finding for any touched file or the new one.
- Focused: `TestSession*`, `TestHeartbeat*`, `TestHistory*`, `TestSkill*`, `TestMCP*`, `TestExport*`, `TestDeliveryWorktree*`, `TestScrollDiagnostics*`.

## Not moved

`icon_repair_darwin.go`'s `writeMacAlias`, `resolveMacAlias` and `macURLReferencesReasonixBundle` stay in their `darwin && cgo` production file: they call cgo, and Go does not allow `import "C"` in a `_test.go` file.

Documentation-impact: none - no user-visible behavior changes; the helpers are test scaffolding that never ran in production.
