### PR TITLE
fix(frontend): unbreak the zoom snapshot test after the Electron app-zoom move / 修复 Electron 缩放迁移后失败的 zoom 快照测试

### DIFF
--- a/desktop/frontend/src/__tests__/desktopHostStub.ts
+++ b/desktop/frontend/src/__tests__/desktopHostStub.ts
@@ -17,6 +17,10 @@ export interface DesktopHostStubOptions {
   clipboardReadText?: string;
   /** Records native openExternal calls. */
   externalOpens?: string[];
+  /** Value returned by native app-zoom reads. */
+  appZoom?: () => number;
+  /** Records native app-zoom writes. */
+  appZoomWrites?: number[];
 }
 
 export interface DesktopHostStub {
@@ -79,8 +83,11 @@ export function installDesktopHostStub(commands: object, options: DesktopHostStu
         minimise: () => {},
         toggleMaximise: () => {},
       close: () => {},
-      getAppZoom: async () => 1,
-      setAppZoom: async () => 1,
+      getAppZoom: async () => options.appZoom?.() ?? 1,
+      setAppZoom: async (factor: number) => {
+        options.appZoomWrites?.push(factor);
+        return factor;
+      },
       resetAppZoom: async () => 1,
       },
       getPathForFile: options.getPathForFile ?? (() => ""),

--- a/desktop/frontend/src/__tests__/settings-refresh-snapshot.test.tsx
+++ b/desktop/frontend/src/__tests__/settings-refresh-snapshot.test.tsx
@@ -95,6 +95,10 @@ let setDisplayModeCalls = 0;
 let setSessionExperienceCalls = 0;
 let rejectSessionExperience = false;
 let onChangedSettings: SettingsView | undefined;
+// App zoom is Electron-owned now: the panel reads it from the native host, not
+// from a host command.
+let persistedZoom = 0.5;
+const savedZoomFactors: number[] = [];
 
 const desktopStub = installDesktopHostStub(({
   main: {
@@ -108,7 +112,10 @@ const desktopStub = installDesktopHostStub(({
         if (rejectSessionExperience) throw new Error("session experience persistence failed");
       },
     } as Partial<AppBindings> as AppBindings,
-  }}).main.App);
+  }}).main.App, {
+  appZoom: () => persistedZoom,
+  appZoomWrites: savedZoomFactors,
+});
 
 const rootEl = document.getElementById("root");
 if (!rootEl) throw new Error("missing root");
@@ -476,17 +483,10 @@ await act(async () => {
 const zoomRootEl = document.createElement("div");
 document.body.appendChild(zoomRootEl);
 const zoomRoot = createRoot(zoomRootEl);
-let persistedZoom = 0.5;
-const savedZoomFactors: number[] = [];
 desktopStub.replaceCommands(({
   main: {
     App: {
       Settings: async () => baseSettings("standard"),
-      GetDesktopZoomFactor: async () => persistedZoom,
-      SetDesktopZoomFactor: async (factor: number) => {
-        persistedZoom = factor;
-        savedZoomFactors.push(factor);
-      },
     } as Partial<AppBindings> as AppBindings,
   },
 }).main.App);


### PR DESCRIPTION
## Problem

`desktop-frontend` is red on `main-v2`:

```
FAIL src/__tests__/settings-refresh-snapshot.test.tsx
Error: timed out waiting for persisted display zoom sync
```

It fails on every branch based on `main-v2`, including PRs that touch nothing in the frontend, so the required check blocks unrelated work. The failure reproduces on a job re-run.

## Root cause

#10014 moved app zoom into the Electron shell. `SettingsPanel` now reads `host.native.getAppZoom()` when `desktopHost().kind === "electron"` and only falls back to the `App.GetDesktopZoomFactor` command otherwise:

```ts
const persisted = host.kind === "electron"
  ? await host.native.getAppZoom()
  : await app.GetDesktopZoomFactor();
```

The shared `installDesktopHostStub` always reports `kind: "electron"` and hard-coded `getAppZoom: async () => 1`, so the `0.5` this test injected through the retired command never reached the zoom slider and `waitFor` timed out after its 20 microtask flushes.

## Fix

Give the stub `appZoom` / `appZoomWrites` options, matching the existing `clipboardWrites` / `externalOpens` pattern, and drive the native path from the test: `persistedZoom` feeds `getAppZoom` and `setAppZoom` records the writes. The two legacy host-command stubs are removed because the panel no longer calls them.

No production code changes.

## Verification

- The suite passes: `106 passed, 0 failed` (before: `timed out waiting for persisted display zoom sync` at line 508).
- `pnpm test` — all discovered suites.
- `tsc --noEmit` and `tsc --noEmit -p tsconfig.test.json`.
- `eslint` on both changed files.

Documentation-impact: none - test-only change; the documented zoom behavior and the panel's production path are unchanged.
