### PR TITLE
fix(desktop): route stub native zoom through the command table / 桌面测试桩的原生缩放改走命令表

### DIFF
--- a/desktop/frontend/src/__tests__/desktopHostStub.ts
+++ b/desktop/frontend/src/__tests__/desktopHostStub.ts
@@ -79,8 +79,18 @@ export function installDesktopHostStub(commands: object, options: DesktopHostStu
         minimise: () => {},
         toggleMaximise: () => {},
       close: () => {},
-      getAppZoom: async () => 1,
-      setAppZoom: async () => 1,
+      // The Electron shell owns zoom natively; tests drive it through the
+      // same command table the bridge path uses, so tables without zoom
+      // commands keep the neutral default.
+      getAppZoom: async () => {
+        const fn = ref.current.GetDesktopZoomFactor as (() => Promise<number>) | undefined;
+        return typeof fn === "function" ? await fn() : 1;
+      },
+      setAppZoom: async (factor: number) => {
+        const fn = ref.current.SetDesktopZoomFactor as ((factor: number) => Promise<number>) | undefined;
+        if (typeof fn === "function") await fn(factor);
+        return factor;
+      },
       resetAppZoom: async () => 1,
       },
       getPathForFile: options.getPathForFile ?? (() => ""),


### PR DESCRIPTION
## Problem

Since 0683e05ce the settings panel persists display zoom through the
Electron-owned native path (`host.native.getAppZoom` /
`setAppZoom`), but the desktop host stub hardcoded `getAppZoom` to 1
and ignored the command table. `settings-refresh-snapshot` still
drives zoom via `GetDesktopZoomFactor`/`SetDesktopZoomFactor` in the
table, so its persisted-zoom wait (`50%`) times out **deterministically**
on any tree containing 0683e05ce.

This is the failure that has been blocking the desktop-frontend check
on #10016 (the go group bump is unrelated and passes this test locally
106/106 on a pre-0683e05ce base). main-v2 currently fails this test on
every desktop-affecting PR.

## Root cause

The stub's native zoom functions were fixed closures that bypassed the
command table the tests mutate, unlike every other stubbed surface
(the stub's own contract: "mutating the table between calls is observed
immediately").

## Fix

`getAppZoom`/`setAppZoom` now route through
`GetDesktopZoomFactor`/`SetDesktopZoomFactor` when the live command
table defines them; tables without zoom commands keep the neutral
default of 1. Only `settings-refresh-snapshot` references the zoom
commands, so the blast radius is that single file.

## Verification

- `settings-refresh-snapshot`: 106/106 pass on a tree containing
  0683e05ce (failed deterministically before the fix).
- Other stub consumers unchanged: theme-pack 305/305,
  session-takeover-ui 8/8.
- Frontend typecheck clean.

Documentation-impact: none - test stub behavior only; no user-visible
or documented surface changes.