### PR TITLE
chore(desktop): drop host commands superseded by their tab-scoped variants / 删除已被 tab 级变体取代的 host command

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1094,12 +1094,6 @@ func (a *App) submitUserTurnToTabWithSink(tabID, input string, forwarder event.S
 	return started
 }
 
-// RunShell executes a shell command directly (bypassing the model) and streams
-// output as events on eventChannel.
-func (a *App) RunShell(command string) error {
-	return a.RunShellForTab("", command)
-}
-
 func (a *App) RunShellForTab(tabID, command string) error {
 	admission, ctrl, err := a.beginTabTurn(tabID, true)
 	if err != nil {
@@ -1771,10 +1765,6 @@ func normalizeCollaborationMode(mode string) string {
 	default:
 		return "normal"
 	}
-}
-
-func (a *App) SetCollaborationMode(mode string) {
-	a.SetCollaborationModeForTab("", mode)
 }
 
 // SetComposerProfileForTab applies the controller-facing profile axes under one
@@ -6224,11 +6214,6 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-// ContextUsage returns the latest context-window gauge numbers.
-func (a *App) ContextUsage() ContextInfo {
-	return a.ContextUsageForTab("")
-}
-
 func (a *App) ContextUsageForTab(tabID string) ContextInfo {
 	a.mu.RLock()
 	tab := a.tabByIDLocked(tabID)
@@ -6683,10 +6668,6 @@ func syncTabGoalToController(ctrl control.SessionAPI, goal string) {
 		return
 	}
 	ctrl.SetGoal(goal)
-}
-
-func (a *App) ClearGoal() error {
-	return a.SetGoal("")
 }
 
 func (a *App) ClearGoalForTab(tabID string) error {
@@ -10326,12 +10307,6 @@ func (a *App) ReadFileForTab(tabID, rel string) FilePreview {
 	return out
 }
 
-// OpenWorkspacePath opens a workspace or authorized external-ref file/folder in
-// the OS default app.
-func (a *App) OpenWorkspacePath(rel string) error {
-	return a.OpenWorkspacePathForTab("", rel)
-}
-
 // OpenWorkspacePathForTab opens a path resolved against the requested tab.
 func (a *App) OpenWorkspacePathForTab(tabID, rel string) error {
 	path, ok, err := a.workspaceOrExternalPathForTab(tabID, rel)
@@ -10339,12 +10314,6 @@ func (a *App) OpenWorkspacePathForTab(tabID, rel string) error {
 		return os.ErrInvalid
 	}
 	return openWorkspacePath(path)
-}
-
-// RevealWorkspacePath shows a workspace or authorized external-ref file in the
-// native file manager.
-func (a *App) RevealWorkspacePath(rel string) error {
-	return a.RevealWorkspacePathForTab("", rel)
 }
 
 // RevealWorkspacePathForTab reveals a path resolved against the requested tab.
@@ -11486,10 +11455,6 @@ func (a *App) GetTask(taskID string) (*taskmonitor.TaskSnapshot, error) {
 	return a.taskStore().GetTask(a.ctx, a.projectDir(), taskID)
 }
 
-func (a *App) ListTaskEvents(taskID string, afterSequence int) ([]taskmonitor.TaskEvent, error) {
-	return a.taskStore().ListEvents(a.ctx, a.projectDir(), taskID, afterSequence)
-}
-
 func (a *App) ListTaskEventsForTab(tabID, taskID string, afterSequence int) ([]taskmonitor.TaskEvent, error) {
 	target, err := a.taskMonitorTargetForTab(tabID)
 	if err != nil {
@@ -11536,20 +11501,12 @@ func (a *App) CancelTaskForTab(tabID, taskID string, expectedVersion uint64, rea
 	)
 }
 
-func (a *App) RequeueTask(taskID string, expectedVersion uint64, idemKey string) (taskmonitor.ControlResult, error) {
-	return a.taskControl().RequeueTask(a.ctx, a.projectDir(), taskID, expectedVersion, idemKey)
-}
-
 func (a *App) RequeueTaskForTab(tabID, taskID string, expectedVersion uint64, idemKey string) (taskmonitor.ControlResult, error) {
 	target, err := a.taskMonitorTargetForTab(tabID)
 	if err != nil {
 		return taskmonitor.ControlResult{}, err
 	}
 	return a.taskControl().RequeueTask(a.ctx, target.projectDir, taskID, expectedVersion, idemKey)
-}
-
-func (a *App) OpenTaskSession(taskID string) (taskmonitor.ControlResult, error) {
-	return a.taskControl().OpenTaskSession(a.ctx, a.projectDir(), taskID)
 }
 
 func (a *App) OpenTaskSessionForTab(tabID, taskID string) (taskmonitor.ControlResult, error) {

--- a/desktop/external_opener.go
+++ b/desktop/external_opener.go
@@ -208,12 +208,6 @@ func (a *App) SetPreferredExternalOpener(id string) error {
 	})
 }
 
-// OpenWorkspaceInExternalOpener opens the active workspace using either the
-// requested installed app or the persisted/fallback selection when id is empty.
-func (a *App) OpenWorkspaceInExternalOpener(id string) error {
-	return a.OpenWorkspaceInExternalOpenerForTab("", id)
-}
-
 // OpenWorkspaceInExternalOpenerForTab is tab-scoped so a rapid tab switch cannot
 // send the wrong project to an external application.
 func (a *App) OpenWorkspaceInExternalOpenerForTab(tabID, id string) error {

--- a/desktop/frontend/src/generated/desktopContract.generated.json
+++ b/desktop/frontend/src/generated/desktopContract.generated.json
@@ -1899,22 +1899,6 @@
     {
       "cancellation": "before-dispatch",
       "domain": "desktop/app.go",
-      "name": "ClearGoal",
-      "owner": "App.ClearGoal",
-      "params": [],
-      "returnsError": true,
-      "scope": {
-        "inputs": [],
-        "kind": "owner-state",
-        "resolver": "App.ClearGoal"
-      },
-      "sources": [
-        "desktop/app.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
-      "domain": "desktop/app.go",
       "name": "ClearGoalForTab",
       "owner": "App.ClearGoalForTab",
       "params": [
@@ -2496,25 +2480,6 @@
       },
       "sources": [
         "desktop/tabs.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
-      "domain": "desktop/app.go",
-      "name": "ContextUsage",
-      "owner": "App.ContextUsage",
-      "params": [],
-      "result": {
-        "kind": "object",
-        "ref": "main.ContextInfo"
-      },
-      "scope": {
-        "inputs": [],
-        "kind": "owner-state",
-        "resolver": "App.ContextUsage"
-      },
-      "sources": [
-        "desktop/app.go"
       ]
     },
     {
@@ -5579,39 +5544,6 @@
     {
       "cancellation": "before-dispatch",
       "domain": "desktop/app.go",
-      "name": "ListTaskEvents",
-      "owner": "App.ListTaskEvents",
-      "params": [
-        {
-          "kind": "string"
-        },
-        {
-          "kind": "integer"
-        }
-      ],
-      "result": {
-        "elem": {
-          "kind": "object",
-          "ref": "taskmonitor.TaskEvent"
-        },
-        "kind": "array"
-      },
-      "returnsError": true,
-      "scope": {
-        "inputs": [
-          "taskID",
-          "afterSequence"
-        ],
-        "kind": "owner-inputs",
-        "resolver": "App.ListTaskEvents"
-      },
-      "sources": [
-        "desktop/app.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
-      "domain": "desktop/app.go",
       "name": "ListTaskEventsForTab",
       "owner": "App.ListTaskEventsForTab",
       "params": [
@@ -5854,39 +5786,6 @@
     {
       "cancellation": "before-dispatch",
       "domain": "desktop/mcp_apps_app.go",
-      "name": "MCPAppCallTool",
-      "owner": "App.MCPAppCallTool",
-      "params": [
-        {
-          "kind": "string"
-        },
-        {
-          "kind": "string"
-        },
-        {
-          "kind": "any"
-        }
-      ],
-      "result": {
-        "kind": "string"
-      },
-      "returnsError": true,
-      "scope": {
-        "inputs": [
-          "instanceToken",
-          "toolName",
-          "args"
-        ],
-        "kind": "owner-inputs",
-        "resolver": "App.MCPAppCallTool"
-      },
-      "sources": [
-        "desktop/mcp_apps_app.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
-      "domain": "desktop/mcp_apps_app.go",
       "name": "MCPAppCallToolForTab",
       "owner": "App.MCPAppCallToolForTab",
       "params": [
@@ -5997,27 +5896,6 @@
     {
       "cancellation": "before-dispatch",
       "domain": "desktop/mcp_apps_app.go",
-      "name": "MCPCloseAppInstance",
-      "owner": "App.MCPCloseAppInstance",
-      "params": [
-        {
-          "kind": "string"
-        }
-      ],
-      "scope": {
-        "inputs": [
-          "instanceToken"
-        ],
-        "kind": "owner-inputs",
-        "resolver": "App.MCPCloseAppInstance"
-      },
-      "sources": [
-        "desktop/mcp_apps_app.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
-      "domain": "desktop/mcp_apps_app.go",
       "name": "MCPCloseAppInstanceForTab",
       "owner": "App.MCPCloseAppInstanceForTab",
       "params": [
@@ -6096,51 +5974,6 @@
     {
       "cancellation": "before-dispatch",
       "domain": "desktop/mcp_apps_app.go",
-      "name": "MCPOpenAppInstance",
-      "owner": "App.MCPOpenAppInstance",
-      "params": [
-        {
-          "kind": "string"
-        },
-        {
-          "kind": "string"
-        },
-        {
-          "kind": "integer"
-        },
-        {
-          "kind": "string"
-        },
-        {
-          "kind": "string"
-        }
-      ],
-      "result": {
-        "elem": {
-          "kind": "object",
-          "ref": "main.MCPAppInstanceView"
-        },
-        "kind": "nullable"
-      },
-      "returnsError": true,
-      "scope": {
-        "inputs": [
-          "server",
-          "tool",
-          "generation",
-          "callID",
-          "resourceURI"
-        ],
-        "kind": "owner-inputs",
-        "resolver": "App.MCPOpenAppInstance"
-      },
-      "sources": [
-        "desktop/mcp_apps_app.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
-      "domain": "desktop/mcp_apps_app.go",
       "name": "MCPOpenAppInstanceForTab",
       "owner": "App.MCPOpenAppInstanceForTab",
       "params": [
@@ -6182,28 +6015,6 @@
         ],
         "kind": "owner-inputs",
         "resolver": "App.MCPOpenAppInstanceForTab"
-      },
-      "sources": [
-        "desktop/mcp_apps_app.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
-      "domain": "desktop/mcp_apps_app.go",
-      "name": "MCPOpenAppLink",
-      "owner": "App.MCPOpenAppLink",
-      "params": [
-        {
-          "kind": "string"
-        }
-      ],
-      "returnsError": true,
-      "scope": {
-        "inputs": [
-          "rawURL"
-        ],
-        "kind": "owner-inputs",
-        "resolver": "App.MCPOpenAppLink"
       },
       "sources": [
         "desktop/mcp_apps_app.go"
@@ -6936,32 +6747,6 @@
     },
     {
       "cancellation": "before-dispatch",
-      "domain": "desktop/app.go",
-      "name": "OpenTaskSession",
-      "owner": "App.OpenTaskSession",
-      "params": [
-        {
-          "kind": "string"
-        }
-      ],
-      "result": {
-        "kind": "object",
-        "ref": "taskmonitor.ControlResult"
-      },
-      "returnsError": true,
-      "scope": {
-        "inputs": [
-          "taskID"
-        ],
-        "kind": "owner-inputs",
-        "resolver": "App.OpenTaskSession"
-      },
-      "sources": [
-        "desktop/app.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
       "domain": "desktop/task_catalog.go",
       "name": "OpenTaskSessionByKey",
       "owner": "App.OpenTaskSessionByKey",
@@ -7074,28 +6859,6 @@
     {
       "cancellation": "before-dispatch",
       "domain": "desktop/external_opener.go",
-      "name": "OpenWorkspaceInExternalOpener",
-      "owner": "App.OpenWorkspaceInExternalOpener",
-      "params": [
-        {
-          "kind": "string"
-        }
-      ],
-      "returnsError": true,
-      "scope": {
-        "inputs": [
-          "id"
-        ],
-        "kind": "owner-inputs",
-        "resolver": "App.OpenWorkspaceInExternalOpener"
-      },
-      "sources": [
-        "desktop/external_opener.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
-      "domain": "desktop/external_opener.go",
       "name": "OpenWorkspaceInExternalOpenerForTab",
       "owner": "App.OpenWorkspaceInExternalOpenerForTab",
       "params": [
@@ -7117,28 +6880,6 @@
       },
       "sources": [
         "desktop/external_opener.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
-      "domain": "desktop/app.go",
-      "name": "OpenWorkspacePath",
-      "owner": "App.OpenWorkspacePath",
-      "params": [
-        {
-          "kind": "string"
-        }
-      ],
-      "returnsError": true,
-      "scope": {
-        "inputs": [
-          "rel"
-        ],
-        "kind": "owner-inputs",
-        "resolver": "App.OpenWorkspacePath"
-      },
-      "sources": [
-        "desktop/app.go"
       ]
     },
     {
@@ -9201,40 +8942,6 @@
     },
     {
       "cancellation": "before-dispatch",
-      "domain": "desktop/app.go",
-      "name": "RequeueTask",
-      "owner": "App.RequeueTask",
-      "params": [
-        {
-          "kind": "string"
-        },
-        {
-          "kind": "integer"
-        },
-        {
-          "kind": "string"
-        }
-      ],
-      "result": {
-        "kind": "object",
-        "ref": "taskmonitor.ControlResult"
-      },
-      "returnsError": true,
-      "scope": {
-        "inputs": [
-          "taskID",
-          "expectedVersion",
-          "idemKey"
-        ],
-        "kind": "owner-inputs",
-        "resolver": "App.RequeueTask"
-      },
-      "sources": [
-        "desktop/app.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
       "domain": "desktop/task_catalog.go",
       "name": "RequeueTaskByKey",
       "owner": "App.RequeueTaskByKey",
@@ -10176,28 +9883,6 @@
     {
       "cancellation": "before-dispatch",
       "domain": "desktop/app.go",
-      "name": "RevealWorkspacePath",
-      "owner": "App.RevealWorkspacePath",
-      "params": [
-        {
-          "kind": "string"
-        }
-      ],
-      "returnsError": true,
-      "scope": {
-        "inputs": [
-          "rel"
-        ],
-        "kind": "owner-inputs",
-        "resolver": "App.RevealWorkspacePath"
-      },
-      "sources": [
-        "desktop/app.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
-      "domain": "desktop/app.go",
       "name": "RevealWorkspacePathForTab",
       "owner": "App.RevealWorkspacePathForTab",
       "params": [
@@ -10331,28 +10016,6 @@
       },
       "sources": [
         "desktop/remote_tab.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
-      "domain": "desktop/app.go",
-      "name": "RunShell",
-      "owner": "App.RunShell",
-      "params": [
-        {
-          "kind": "string"
-        }
-      ],
-      "returnsError": true,
-      "scope": {
-        "inputs": [
-          "command"
-        ],
-        "kind": "owner-inputs",
-        "resolver": "App.RunShell"
-      },
-      "sources": [
-        "desktop/app.go"
       ]
     },
     {
@@ -11385,27 +11048,6 @@
       },
       "sources": [
         "desktop/settings_preferences.go"
-      ]
-    },
-    {
-      "cancellation": "before-dispatch",
-      "domain": "desktop/app.go",
-      "name": "SetCollaborationMode",
-      "owner": "App.SetCollaborationMode",
-      "params": [
-        {
-          "kind": "string"
-        }
-      ],
-      "scope": {
-        "inputs": [
-          "mode"
-        ],
-        "kind": "owner-inputs",
-        "resolver": "App.SetCollaborationMode"
-      },
-      "sources": [
-        "desktop/app.go"
       ]
     },
     {

--- a/desktop/frontend/src/generated/desktopContract.generated.ts
+++ b/desktop/frontend/src/generated/desktopContract.generated.ts
@@ -3,7 +3,7 @@
 
 export const DESKTOP_PROTOCOL_VERSION = 1;
 
-export const DESKTOP_CONTRACT_DIGEST = "sha256:3953b6f826df64435dff252f1eae941630d218cd80bfde13153c86ccce83fcc2";
+export const DESKTOP_CONTRACT_DIGEST = "sha256:bc35be07dc5badc1623a556dd7aa38597e6a91dc87072b0a1dad7a91f4fea7f6";
 
 export const DESKTOP_COMMANDS = [
   "AIRenameSession",
@@ -75,7 +75,6 @@ export const DESKTOP_COMMANDS = [
   "CleanRecoveryLineage",
   "CleanRemoteLegacyWorkbenchData",
   "ClearBotSecret",
-  "ClearGoal",
   "ClearGoalForTab",
   "ClearMCPServerAuthentication",
   "ClearProviderKey",
@@ -100,7 +99,6 @@ export const DESKTOP_COMMANDS = [
   "ConnectKey",
   "ConnectRemoteHost",
   "ContextPanel",
-  "ContextUsage",
   "ContextUsageForTab",
   "CopyThemePack",
   "CreateBlankProject",
@@ -216,7 +214,6 @@ export const DESKTOP_COMMANDS = [
   "ListSessionsForTab",
   "ListTabs",
   "ListTaskEventPage",
-  "ListTaskEvents",
   "ListTaskEventsForTab",
   "ListTaskPage",
   "ListTasks",
@@ -226,18 +223,14 @@ export const DESKTOP_COMMANDS = [
   "ListTrashedSessions",
   "ListWorkspaces",
   "LookupInboxFollowupForTarget",
-  "MCPAppCallTool",
   "MCPAppCallToolForTab",
   "MCPAppResourceDigest",
   "MCPAppResourceDigestForTab",
   "MCPCapabilityMatrix",
-  "MCPCloseAppInstance",
   "MCPCloseAppInstanceForTab",
   "MCPMarketplace",
   "MCPMarketplaceResolve",
-  "MCPOpenAppInstance",
   "MCPOpenAppInstanceForTab",
-  "MCPOpenAppLink",
   "MCPOpenAppLinkForTab",
   "MCPServers",
   "Memory",
@@ -267,14 +260,11 @@ export const DESKTOP_COMMANDS = [
   "OpenProjectTab",
   "OpenRemoteProjectTab",
   "OpenRemoteWorkspace",
-  "OpenTaskSession",
   "OpenTaskSessionByKey",
   "OpenTaskSessionForTab",
   "OpenTopicSession",
   "OpenUserConfigPath",
-  "OpenWorkspaceInExternalOpener",
   "OpenWorkspaceInExternalOpenerForTab",
-  "OpenWorkspacePath",
   "OpenWorkspacePathForTab",
   "PauseGoalForTab",
   "PauseRemoteTabGoal",
@@ -359,7 +349,6 @@ export const DESKTOP_COMMANDS = [
   "ReplayRemoteTabPrompts",
   "ReportCrash",
   "ReportDesktopWebViewReady",
-  "RequeueTask",
   "RequeueTaskByKey",
   "RequeueTaskForTab",
   "ResetProviderPresetAccess",
@@ -393,13 +382,11 @@ export const DESKTOP_COMMANDS = [
   "RetrySessionRecovery",
   "RevealBackgroundRuntime",
   "RevealPath",
-  "RevealWorkspacePath",
   "RevealWorkspacePathForTab",
   "RevealWorkspaceWriterForTab",
   "Rewind",
   "RewindForTab",
   "RewindRemoteTab",
-  "RunShell",
   "RunShellForTab",
   "RuntimeDoctor",
   "SaveClipboardImage",
@@ -439,7 +426,6 @@ export const DESKTOP_COMMANDS = [
   "SetBotSettings",
   "SetBypass",
   "SetCloseBehavior",
-  "SetCollaborationMode",
   "SetCollaborationModeForTab",
   "SetCompactRatio",
   "SetComposerProfileForTab",
@@ -4243,7 +4229,6 @@ export interface GeneratedDesktopCommands {
   CleanRecoveryLineage(arg0: RecoveryCleanupRequest): Promise<RecoveryCleanupResult>;
   CleanRemoteLegacyWorkbenchData(arg0: string): Promise<void>;
   ClearBotSecret(arg0: string): Promise<void>;
-  ClearGoal(): Promise<void>;
   ClearGoalForTab(arg0: string): Promise<void>;
   ClearMCPServerAuthentication(arg0: string): Promise<void>;
   ClearProviderKey(arg0: string): Promise<void>;
@@ -4268,7 +4253,6 @@ export interface GeneratedDesktopCommands {
   ConnectKey(arg0: string): Promise<string>;
   ConnectRemoteHost(arg0: string): Promise<void>;
   ContextPanel(arg0: string): Promise<ContextPanelInfo>;
-  ContextUsage(): Promise<ContextInfo>;
   ContextUsageForTab(arg0: string): Promise<ContextInfo>;
   CopyThemePack(arg0: string, arg1: string, arg2: string): Promise<ThemePackView>;
   CreateBlankProject(arg0: string, arg1: string): Promise<string>;
@@ -4384,7 +4368,6 @@ export interface GeneratedDesktopCommands {
   ListSessionsForTab(arg0: string): Promise<SessionMeta[]>;
   ListTabs(): Promise<TabMeta[]>;
   ListTaskEventPage(arg0: TaskEventPageRequest): Promise<EventPage>;
-  ListTaskEvents(arg0: string, arg1: number): Promise<TaskEvent[]>;
   ListTaskEventsForTab(arg0: string, arg1: string, arg2: number): Promise<TaskEvent[]>;
   ListTaskPage(arg0: TaskPageRequest): Promise<TaskPage>;
   ListTasks(): Promise<TaskSnapshot[]>;
@@ -4394,18 +4377,14 @@ export interface GeneratedDesktopCommands {
   ListTrashedSessions(): Promise<SessionMeta[]>;
   ListWorkspaces(): Promise<WorkspaceMeta[]>;
   LookupInboxFollowupForTarget(arg0: InboxTargetView, arg1: string): Promise<InboxReceiptView>;
-  MCPAppCallTool(arg0: string, arg1: string, arg2: unknown): Promise<string>;
   MCPAppCallToolForTab(arg0: string, arg1: string, arg2: string, arg3: unknown): Promise<string>;
   MCPAppResourceDigest(arg0: string): Promise<string>;
   MCPAppResourceDigestForTab(arg0: string, arg1: string): Promise<string>;
   MCPCapabilityMatrix(): Promise<MCPCapabilityMatrixView>;
-  MCPCloseAppInstance(arg0: string): Promise<void>;
   MCPCloseAppInstanceForTab(arg0: string, arg1: string): Promise<void>;
   MCPMarketplace(arg0: string): Promise<MCPMarketplaceView>;
   MCPMarketplaceResolve(arg0: string): Promise<MCPMarketplaceEntryView>;
-  MCPOpenAppInstance(arg0: string, arg1: string, arg2: number, arg3: string, arg4: string): Promise<MCPAppInstanceView | null>;
   MCPOpenAppInstanceForTab(arg0: string, arg1: string, arg2: string, arg3: number, arg4: string, arg5: string): Promise<MCPAppInstanceView | null>;
-  MCPOpenAppLink(arg0: string): Promise<void>;
   MCPOpenAppLinkForTab(arg0: string, arg1: string, arg2: string): Promise<void>;
   MCPServers(): Promise<ServerView[]>;
   Memory(): Promise<MemoryView>;
@@ -4435,14 +4414,11 @@ export interface GeneratedDesktopCommands {
   OpenProjectTab(arg0: string, arg1: string): Promise<TabMeta>;
   OpenRemoteProjectTab(arg0: string, arg1: string, arg2: RemoteTabOpenOptions): Promise<TabMeta>;
   OpenRemoteWorkspace(arg0: string, arg1: string): Promise<void>;
-  OpenTaskSession(arg0: string): Promise<ControlResult>;
   OpenTaskSessionByKey(arg0: TaskOpenRequest): Promise<ControlResult>;
   OpenTaskSessionForTab(arg0: string, arg1: string): Promise<ControlResult>;
   OpenTopicSession(arg0: string, arg1: string, arg2: string, arg3: string): Promise<TabMeta>;
   OpenUserConfigPath(): Promise<void>;
-  OpenWorkspaceInExternalOpener(arg0: string): Promise<void>;
   OpenWorkspaceInExternalOpenerForTab(arg0: string, arg1: string): Promise<void>;
-  OpenWorkspacePath(arg0: string): Promise<void>;
   OpenWorkspacePathForTab(arg0: string, arg1: string): Promise<void>;
   PauseGoalForTab(arg0: string): Promise<boolean>;
   PauseRemoteTabGoal(arg0: string): Promise<void>;
@@ -4527,7 +4503,6 @@ export interface GeneratedDesktopCommands {
   ReplayRemoteTabPrompts(arg0: string): Promise<unknown>;
   ReportCrash(arg0: string, arg1: string): Promise<void>;
   ReportDesktopWebViewReady(): Promise<void>;
-  RequeueTask(arg0: string, arg1: number, arg2: string): Promise<ControlResult>;
   RequeueTaskByKey(arg0: TaskActionRequest): Promise<ControlResult>;
   RequeueTaskForTab(arg0: string, arg1: string, arg2: number, arg3: string): Promise<ControlResult>;
   ResetProviderPresetAccess(arg0: string): Promise<void>;
@@ -4561,13 +4536,11 @@ export interface GeneratedDesktopCommands {
   RetrySessionRecovery(arg0: RecoveryPreferenceRequest): Promise<void>;
   RevealBackgroundRuntime(arg0: string): Promise<TabMeta>;
   RevealPath(arg0: string): Promise<void>;
-  RevealWorkspacePath(arg0: string): Promise<void>;
   RevealWorkspacePathForTab(arg0: string, arg1: string): Promise<void>;
   RevealWorkspaceWriterForTab(arg0: string): Promise<TabMeta>;
   Rewind(arg0: number, arg1: string): Promise<void>;
   RewindForTab(arg0: string, arg1: number, arg2: string): Promise<void>;
   RewindRemoteTab(arg0: string, arg1: string, arg2: string): Promise<void>;
-  RunShell(arg0: string): Promise<void>;
   RunShellForTab(arg0: string, arg1: string): Promise<void>;
   RuntimeDoctor(): Promise<RuntimeDoctorReport>;
   SaveClipboardImage(): Promise<string>;
@@ -4607,7 +4580,6 @@ export interface GeneratedDesktopCommands {
   SetBotSettings(arg0: BotSettingsView): Promise<void>;
   SetBypass(arg0: boolean): Promise<void>;
   SetCloseBehavior(arg0: string): Promise<void>;
-  SetCollaborationMode(arg0: string): Promise<void>;
   SetCollaborationModeForTab(arg0: string, arg1: string): Promise<void>;
   SetCompactRatio(arg0: number): Promise<void>;
   SetComposerProfileForTab(arg0: string, arg1: string, arg2: string, arg3: string): Promise<string[]>;

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -239,7 +239,6 @@ export interface AppBindings extends ModelSettingsBindings, SessionCatalogBindin
   SubmitInitialGoalToTabWithID(tabID: string, goal: string, display: string, input: string, invocations: InvocationRequest[], collaborationMode: string, toolApprovalMode: string, submissionID: string): Promise<string[]>;
   SubmitEditedDisplayToTab(tabID: string, display: string, input: string, original: string): Promise<void>;
   SubmitEditedDisplayToTabWithID(tabID: string, display: string, input: string, original: string, submissionID: string): Promise<void>;
-  RunShell(command: string): Promise<void>;
   RunShellForTab(tabID: string, command: string): Promise<void>;
   Steer(text: string): Promise<void>;
   SteerForTab(tabID: string, text: string): Promise<void>;
@@ -322,7 +321,6 @@ export interface AppBindings extends ModelSettingsBindings, SessionCatalogBindin
   // Returns auto-allowed prompt ids; unlisted prompts remain pending (#6432).
   SetModeForTab(tabID: string, mode: string): Promise<string[] | void>;
   SetAutoApproveTools(on: boolean): Promise<void>;
-  SetCollaborationMode(mode: string): Promise<void>;
   SetCollaborationModeForTab(tabID: string, mode: string): Promise<void>;
   SetToolApprovalMode(mode: string): Promise<void>;
   // Same drained-prompt-id contract as SetModeForTab.
@@ -334,7 +332,6 @@ export interface AppBindings extends ModelSettingsBindings, SessionCatalogBindin
   SetGoalForTab(tabID: string, goal: string): Promise<void>;
   ResumeGoalForTab(tabID: string): Promise<boolean>;
   PauseGoalForTab(tabID: string): Promise<boolean>;
-  ClearGoal(): Promise<void>;
   ClearGoalForTab(tabID: string): Promise<void>;
   Compact(): Promise<void>;
   CompactForTab(tabID: string): Promise<void>;
@@ -397,7 +394,6 @@ export interface AppBindings extends ModelSettingsBindings, SessionCatalogBindin
   PickWorkspace(): Promise<string>;
   SwitchWorkspace(path: string): Promise<string>;
   RemoveWorkspace(path: string): Promise<void>;
-  ContextUsage(): Promise<ContextInfo>;
   ContextUsageForTab(tabID: string): Promise<ContextInfo>;
   Balance(): Promise<BalanceInfo>;
   BalanceForTab(tabID: string): Promise<BalanceInfo>;
@@ -407,11 +403,8 @@ export interface AppBindings extends ModelSettingsBindings, SessionCatalogBindin
   CurrentTaskSessionID(): Promise<string>;
   ListTasksForSession(sessionID: string): Promise<TaskSnapshot[]>;
   GetTask(taskID: string): Promise<TaskSnapshot | null>;
-  ListTaskEvents(taskID: string, afterSequence: number): Promise<TaskEvent[]>;
   StopTask(taskID: string, expectedVersion: number, reason: string, idemKey: string): Promise<ControlResult>;
   CancelTask(taskID: string, expectedVersion: number, reason: string, idemKey: string): Promise<ControlResult>;
-  RequeueTask(taskID: string, expectedVersion: number, idemKey: string): Promise<ControlResult>;
-  OpenTaskSession(taskID: string): Promise<ControlResult>;
   ListTasksForTab(tabID: string): Promise<TaskSnapshot[]>;
   ListTaskEventsForTab(tabID: string, taskID: string, afterSequence: number): Promise<TaskEvent[]>;
   StopTaskForTab(tabID: string, taskID: string, expectedVersion: number, reason: string, idemKey: string): Promise<ControlResult>;
@@ -501,14 +494,11 @@ export interface AppBindings extends ModelSettingsBindings, SessionCatalogBindin
   GitCheckout(branch: string): Promise<void>;
   WorkspaceGitHistory(tabID: string, path: string): Promise<GitCommitView[]>;
   WorkspaceGitCommitDetail(tabID: string, hash: string, path: string): Promise<GitCommitDetailView>;
-  OpenWorkspacePath(rel: string): Promise<void>;
   OpenWorkspacePathForTab(tabID: string, rel: string): Promise<void>;
   ResolveWorkspacePathForTab(tabID: string, rel: string): Promise<string>;
   ExternalOpeners(): Promise<ExternalOpenersView>; ExternalOpenersForTab(tabID: string): Promise<ExternalOpenersView>;
   SetPreferredExternalOpener(id: string): Promise<void>;
-  OpenWorkspaceInExternalOpener(id: string): Promise<void>;
   OpenWorkspaceInExternalOpenerForTab(tabID: string, id: string): Promise<void>; OpenLocalPathInExternalOpener(path: string, id: string): Promise<void>; SaveLocalPathAs(path: string): Promise<string>;
-  RevealWorkspacePath(rel: string): Promise<void>;
   RevealWorkspacePathForTab(tabID: string, rel: string): Promise<void>;
   RevealPath(path: string): Promise<void>;
   OpenLocalPath(path: string): Promise<void>;
@@ -2834,23 +2824,22 @@ function makeMockApp(): AppBindings {
         async SubmitInitialGoalToTabWithID(_tabID, goal, display, input, invocations, _collaborationMode, _toolApprovalMode, submissionID) { await this.SetGoalForTab(_tabID, goal); if (invocations.length > 0) await this.SubmitInvocationsToTabWithID(_tabID, display, input, invocations, submissionID); else await this.SubmitDisplayToTabWithID(_tabID, display, input, submissionID); return []; },
         async SubmitEditedDisplayToTab(_tabID, display, input, _original) { await withMockTabScope(_tabID, () => this.SubmitDisplay(display, input)); },
         async SubmitEditedDisplayToTabWithID(_tabID, display, input, _original, submissionID) { await this.SubmitDisplayToTabWithID(_tabID, display, input, submissionID); },
-        async RunShell(command) {
-          cancelled = false;
-          emitMockTurnStarted();
-          await delay(100);
-          if (cancelled) return;
-          const id = `shell-${command.slice(0, 32)}`;
-          emit({ kind: "tool_dispatch", tool: { id, name: "bash", args: JSON.stringify({ command }), readOnly: false } });
-          await delay(200);
-          if (cancelled) return;
-          emit({ kind: "tool_progress", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false } });
-          await delay(100);
-          if (cancelled) return;
-          emit({ kind: "tool_result", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false, durationMs: 300 } });
-          emitMockTurnDone();
-        },
         async RunShellForTab(_tabID, command) {
-          await withMockTabScope(_tabID, () => this.RunShell(command));
+          await withMockTabScope(_tabID, async () => {
+            cancelled = false;
+            emitMockTurnStarted();
+            await delay(100);
+            if (cancelled) return;
+            const id = `shell-${command.slice(0, 32)}`;
+            emit({ kind: "tool_dispatch", tool: { id, name: "bash", args: JSON.stringify({ command }), readOnly: false } });
+            await delay(200);
+            if (cancelled) return;
+            emit({ kind: "tool_progress", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false } });
+            await delay(100);
+            if (cancelled) return;
+            emit({ kind: "tool_result", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false, durationMs: 300 } });
+            emitMockTurnDone();
+          });
         },
         async Steer(_text) {
           // Mock: emit a steer event as confirmation in the transcript.
@@ -3015,10 +3004,6 @@ function makeMockApp(): AppBindings {
           });
           return drainMockApprovalPreviews(nextToolApprovalMode);
         },
-        async SetCollaborationMode(mode) {
-          const active = mockTabs.find((tab) => tab.active);
-          if (active) await this.SetCollaborationModeForTab(active.id, mode);
-        },
         async SetCollaborationModeForTab(tabID, mode) {
           const next = normalizeCollaborationMode(mode);
           mockTabs = mockTabs.map((tab) => {
@@ -3106,9 +3091,6 @@ function makeMockApp(): AppBindings {
             return { ...tab, goalStatus: "blocked", goalRuntime: undefined };
           });
           return paused;
-        },
-        async ClearGoal() {
-          await this.SetGoal("");
         },
         async ClearGoalForTab(tabID) {
           await this.SetGoalForTab(tabID, "");
@@ -3353,7 +3335,7 @@ function makeMockApp(): AppBindings {
       const index = mockProjectTree.findIndex((node) => node.root === path);
       if (index >= 0) mockProjectTree.splice(index, 1);
     },
-        async ContextUsage() {
+        async ContextUsageForTab() {
           return {
             used: 42124,
             window: 128000,
@@ -3373,52 +3355,49 @@ function makeMockApp(): AppBindings {
               rateBand: "mixed",
             },
           };
-        },
-        async ContextUsageForTab() {
-          return this.ContextUsage();
-        },
-        async Balance() {
-      // Mirror the active mock provider: deepseek-flash carries a balance_url.
-      const p = settings.providers.find((x) => x.name === settings.defaultModel);
-      if (!p?.balanceUrl) return { available: false, display: "" };
-          return { available: true, display: "¥128.50" };
-        },
-        async BalanceForTab() {
-          return this.Balance();
-        },
-        async UsageStats() {
-          // Browser dev mock has no stats files; the panel does not consume
-          // provider aggregates, so keep this initial-bundle fallback lean.
-          return { from: "", to: "", tokens: 0, requests: 0, turns: 0, cacheHit: 0, cacheMiss: 0, activeDays: 0, topModel: "", daily: [], models: [] } as unknown as UsageStatsRange;
-        },
-        async Jobs() {
-          return []; // browser dev mock has no background jobs
-        },
-        async JobsForTab() {
-          return this.Jobs();
-        },
-        async CancelJob() {
-          return false;
-        },
-        async CancelJobForTab(_tabID, jobID) {
-          return this.CancelJob(jobID);
-        },
-        async CancelJobsForTab(_tabID, jobIDs) {
-          return { cancelled: [], notRunning: [...jobIDs] };
-        },
-        async ActiveWorkForTab() {
-          return { running: false, pendingPrompt: false, cancellable: false, jobs: [] };
-        },
-        async BackgroundRuntimes() {
-          return [];
-        },
-        async RevealBackgroundRuntime() {
-          throw new Error("background runtime is unavailable in browser preview");
-        },
-        async WorkspaceConflictForTab() {
-          return {
-            state: "none", ownerWork: { running: false, pendingPrompt: false, cancellable: false, jobs: [] },
-            canReveal: false, canCreateWorktree: false,
+          },
+          async Balance() {
+        // Mirror the active mock provider: deepseek-flash carries a balance_url.
+        const p = settings.providers.find((x) => x.name === settings.defaultModel);
+        if (!p?.balanceUrl) return { available: false, display: "" };
+            return { available: true, display: "¥128.50" };
+          },
+          async BalanceForTab() {
+            return this.Balance();
+          },
+          async UsageStats() {
+            // Browser dev mock has no stats files; the panel does not consume
+            // provider aggregates, so keep this initial-bundle fallback lean.
+            return { from: "", to: "", tokens: 0, requests: 0, turns: 0, cacheHit: 0, cacheMiss: 0, activeDays: 0, topModel: "", daily: [], models: [] } as unknown as UsageStatsRange;
+          },
+          async Jobs() {
+            return []; // browser dev mock has no background jobs
+          },
+          async JobsForTab() {
+            return this.Jobs();
+          },
+          async CancelJob() {
+            return false;
+          },
+          async CancelJobForTab(_tabID, jobID) {
+            return this.CancelJob(jobID);
+          },
+          async CancelJobsForTab(_tabID, jobIDs) {
+            return { cancelled: [], notRunning: [...jobIDs] };
+          },
+          async ActiveWorkForTab() {
+            return { running: false, pendingPrompt: false, cancellable: false, jobs: [] };
+          },
+          async BackgroundRuntimes() {
+            return [];
+          },
+          async RevealBackgroundRuntime() {
+            throw new Error("background runtime is unavailable in browser preview");
+          },
+          async WorkspaceConflictForTab() {
+            return {
+              state: "none", ownerWork: { running: false, pendingPrompt: false, cancellable: false, jobs: [] },
+              canReveal: false, canCreateWorktree: false,
           };
         },
         async RevealWorkspaceWriterForTab() {
@@ -4045,14 +4024,11 @@ function makeMockApp(): AppBindings {
       }
       return { files: ["mock_file_1.ts", "mock_file_2.ts"] };
     },
-    async OpenWorkspacePath(rel: string) {
-      console.info("mock OpenWorkspacePath", rel);
-    },
     async OpenLocalPath(path: string) {
       console.info("mock OpenLocalPath", path);
     },
     async OpenWorkspacePathForTab(_tabID: string, rel: string) {
-      await this.OpenWorkspacePath(rel);
+      console.info("mock OpenWorkspacePath", rel);
     },
     async ResolveWorkspacePathForTab(_tabID: string, rel: string) { return `${cwd.replace(/[\\/]+$/, "")}/${rel.replace(/^[/\\]+/, "").replace(/[\\/]+$/, "")}`; },
     async ExternalOpeners() {
@@ -4067,15 +4043,9 @@ function makeMockApp(): AppBindings {
       } as ExternalOpenersView;
     }, async ExternalOpenersForTab(_tabID: string) { return { ...(await this.ExternalOpeners()), workspaceOpenable: true }; },
     async SetPreferredExternalOpener(_id: string) {},
-    async OpenWorkspaceInExternalOpener(_id: string) {},
-    async OpenWorkspaceInExternalOpenerForTab(_tabID: string, id: string) {
-      await this.OpenWorkspaceInExternalOpener(id);
-    }, async OpenLocalPathInExternalOpener(path: string, id: string) { console.info("mock OpenLocalPathInExternalOpener", path, id); }, async SaveLocalPathAs(path: string) { console.info("mock SaveLocalPathAs", path); return path; },
-    async RevealWorkspacePath(rel: string) {
-      console.info("mock RevealWorkspacePath", rel);
-    },
+    async OpenWorkspaceInExternalOpenerForTab(_tabID: string, _id: string) {}, async OpenLocalPathInExternalOpener(path: string, id: string) { console.info("mock OpenLocalPathInExternalOpener", path, id); }, async SaveLocalPathAs(path: string) { console.info("mock SaveLocalPathAs", path); return path; },
     async RevealWorkspacePathForTab(_tabID: string, rel: string) {
-      await this.RevealWorkspacePath(rel);
+      console.info("mock RevealWorkspacePath", rel);
     },
     async RevealPath(path: string) {
       console.info("mock RevealPath", path);
@@ -4964,11 +4934,8 @@ function makeMockApp(): AppBindings {
     async CurrentTaskSessionID() { return ""; },
     async ListTasksForSession() { return []; },
     async GetTask() { return null; },
-    async ListTaskEvents() { return []; },
     async StopTask() { return { schema_version: 1, command: "stop", task_id: "", accepted: false, idempotent: false, error: { code: "mock", message: "not available in browser mock" } }; },
     async CancelTask() { return { schema_version: 1, command: "cancel", task_id: "", accepted: false, idempotent: false, error: { code: "mock", message: "not available in browser mock" } }; },
-    async RequeueTask() { return { schema_version: 1, command: "requeue", task_id: "", accepted: false, idempotent: false, error: { code: "mock", message: "not available in browser mock" } }; },
-    async OpenTaskSession() { return { schema_version: 1, command: "open_session", task_id: "", accepted: false, idempotent: false, error: { code: "mock", message: "not available in browser mock" } }; },
     async ListTasksForTab() { return []; },
     ...makeMockTaskCatalogBindings(),
     async ListTaskEventsForTab() { return []; },

--- a/desktop/host_command_owners.generated.json
+++ b/desktop/host_command_owners.generated.json
@@ -1008,18 +1008,6 @@
       ]
     }
   },
-  "ClearGoal": {
-    "domain": "desktop/app.go",
-    "owner": "App.ClearGoal",
-    "sources": [
-      "desktop/app.go"
-    ],
-    "scope": {
-      "kind": "owner-state",
-      "resolver": "App.ClearGoal",
-      "inputs": []
-    }
-  },
   "ClearGoalForTab": {
     "domain": "desktop/app.go",
     "owner": "App.ClearGoalForTab",
@@ -1358,18 +1346,6 @@
       "inputs": [
         "tabID"
       ]
-    }
-  },
-  "ContextUsage": {
-    "domain": "desktop/app.go",
-    "owner": "App.ContextUsage",
-    "sources": [
-      "desktop/app.go"
-    ],
-    "scope": {
-      "kind": "owner-state",
-      "resolver": "App.ContextUsage",
-      "inputs": []
     }
   },
   "ContextUsageForTab": {
@@ -2986,21 +2962,6 @@
       ]
     }
   },
-  "ListTaskEvents": {
-    "domain": "desktop/app.go",
-    "owner": "App.ListTaskEvents",
-    "sources": [
-      "desktop/app.go"
-    ],
-    "scope": {
-      "kind": "owner-inputs",
-      "resolver": "App.ListTaskEvents",
-      "inputs": [
-        "taskID",
-        "afterSequence"
-      ]
-    }
-  },
   "ListTaskEventsForTab": {
     "domain": "desktop/app.go",
     "owner": "App.ListTaskEventsForTab",
@@ -3122,22 +3083,6 @@
       ]
     }
   },
-  "MCPAppCallTool": {
-    "domain": "desktop/mcp_apps_app.go",
-    "owner": "App.MCPAppCallTool",
-    "sources": [
-      "desktop/mcp_apps_app.go"
-    ],
-    "scope": {
-      "kind": "owner-inputs",
-      "resolver": "App.MCPAppCallTool",
-      "inputs": [
-        "instanceToken",
-        "toolName",
-        "args"
-      ]
-    }
-  },
   "MCPAppCallToolForTab": {
     "domain": "desktop/mcp_apps_app.go",
     "owner": "App.MCPAppCallToolForTab",
@@ -3196,20 +3141,6 @@
       "inputs": []
     }
   },
-  "MCPCloseAppInstance": {
-    "domain": "desktop/mcp_apps_app.go",
-    "owner": "App.MCPCloseAppInstance",
-    "sources": [
-      "desktop/mcp_apps_app.go"
-    ],
-    "scope": {
-      "kind": "owner-inputs",
-      "resolver": "App.MCPCloseAppInstance",
-      "inputs": [
-        "instanceToken"
-      ]
-    }
-  },
   "MCPCloseAppInstanceForTab": {
     "domain": "desktop/mcp_apps_app.go",
     "owner": "App.MCPCloseAppInstanceForTab",
@@ -3253,24 +3184,6 @@
       ]
     }
   },
-  "MCPOpenAppInstance": {
-    "domain": "desktop/mcp_apps_app.go",
-    "owner": "App.MCPOpenAppInstance",
-    "sources": [
-      "desktop/mcp_apps_app.go"
-    ],
-    "scope": {
-      "kind": "owner-inputs",
-      "resolver": "App.MCPOpenAppInstance",
-      "inputs": [
-        "server",
-        "tool",
-        "generation",
-        "callID",
-        "resourceURI"
-      ]
-    }
-  },
   "MCPOpenAppInstanceForTab": {
     "domain": "desktop/mcp_apps_app.go",
     "owner": "App.MCPOpenAppInstanceForTab",
@@ -3287,20 +3200,6 @@
         "generation",
         "callID",
         "resourceURI"
-      ]
-    }
-  },
-  "MCPOpenAppLink": {
-    "domain": "desktop/mcp_apps_app.go",
-    "owner": "App.MCPOpenAppLink",
-    "sources": [
-      "desktop/mcp_apps_app.go"
-    ],
-    "scope": {
-      "kind": "owner-inputs",
-      "resolver": "App.MCPOpenAppLink",
-      "inputs": [
-        "rawURL"
       ]
     }
   },
@@ -3708,20 +3607,6 @@
       ]
     }
   },
-  "OpenTaskSession": {
-    "domain": "desktop/app.go",
-    "owner": "App.OpenTaskSession",
-    "sources": [
-      "desktop/app.go"
-    ],
-    "scope": {
-      "kind": "owner-inputs",
-      "resolver": "App.OpenTaskSession",
-      "inputs": [
-        "taskID"
-      ]
-    }
-  },
   "OpenTaskSessionByKey": {
     "domain": "desktop/task_catalog.go",
     "owner": "App.OpenTaskSessionByKey",
@@ -3780,20 +3665,6 @@
       "inputs": []
     }
   },
-  "OpenWorkspaceInExternalOpener": {
-    "domain": "desktop/external_opener.go",
-    "owner": "App.OpenWorkspaceInExternalOpener",
-    "sources": [
-      "desktop/external_opener.go"
-    ],
-    "scope": {
-      "kind": "owner-inputs",
-      "resolver": "App.OpenWorkspaceInExternalOpener",
-      "inputs": [
-        "id"
-      ]
-    }
-  },
   "OpenWorkspaceInExternalOpenerForTab": {
     "domain": "desktop/external_opener.go",
     "owner": "App.OpenWorkspaceInExternalOpenerForTab",
@@ -3806,20 +3677,6 @@
       "inputs": [
         "tabID",
         "id"
-      ]
-    }
-  },
-  "OpenWorkspacePath": {
-    "domain": "desktop/app.go",
-    "owner": "App.OpenWorkspacePath",
-    "sources": [
-      "desktop/app.go"
-    ],
-    "scope": {
-      "kind": "owner-inputs",
-      "resolver": "App.OpenWorkspacePath",
-      "inputs": [
-        "rel"
       ]
     }
   },
@@ -4996,22 +4853,6 @@
       "inputs": []
     }
   },
-  "RequeueTask": {
-    "domain": "desktop/app.go",
-    "owner": "App.RequeueTask",
-    "sources": [
-      "desktop/app.go"
-    ],
-    "scope": {
-      "kind": "owner-inputs",
-      "resolver": "App.RequeueTask",
-      "inputs": [
-        "taskID",
-        "expectedVersion",
-        "idemKey"
-      ]
-    }
-  },
   "RequeueTaskByKey": {
     "domain": "desktop/task_catalog.go",
     "owner": "App.RequeueTaskByKey",
@@ -5510,20 +5351,6 @@
       ]
     }
   },
-  "RevealWorkspacePath": {
-    "domain": "desktop/app.go",
-    "owner": "App.RevealWorkspacePath",
-    "sources": [
-      "desktop/app.go"
-    ],
-    "scope": {
-      "kind": "owner-inputs",
-      "resolver": "App.RevealWorkspacePath",
-      "inputs": [
-        "rel"
-      ]
-    }
-  },
   "RevealWorkspacePathForTab": {
     "domain": "desktop/app.go",
     "owner": "App.RevealWorkspacePathForTab",
@@ -5597,20 +5424,6 @@
         "tabID",
         "checkpointID",
         "scope"
-      ]
-    }
-  },
-  "RunShell": {
-    "domain": "desktop/app.go",
-    "owner": "App.RunShell",
-    "sources": [
-      "desktop/app.go"
-    ],
-    "scope": {
-      "kind": "owner-inputs",
-      "resolver": "App.RunShell",
-      "inputs": [
-        "command"
       ]
     }
   },
@@ -6172,20 +5985,6 @@
     "scope": {
       "kind": "owner-inputs",
       "resolver": "App.SetCloseBehavior",
-      "inputs": [
-        "mode"
-      ]
-    }
-  },
-  "SetCollaborationMode": {
-    "domain": "desktop/app.go",
-    "owner": "App.SetCollaborationMode",
-    "sources": [
-      "desktop/app.go"
-    ],
-    "scope": {
-      "kind": "owner-inputs",
-      "resolver": "App.SetCollaborationMode",
       "inputs": [
         "mode"
       ]

--- a/desktop/mcp_apps_app.go
+++ b/desktop/mcp_apps_app.go
@@ -34,17 +34,6 @@ func (a *App) mcpRuntimeForTab(tabID string) (*WorkspaceTab, control.SessionAPI,
 	return tab, ctrl, hoster.Host(), nil
 }
 
-// MCPOpenAppInstance registers a host App instance for a tool result and
-// returns the double-iframe sandbox coordinates. The resource itself loads
-// only after the frontend posts the init nonce.
-func (a *App) MCPOpenAppInstance(server, tool string, generation uint64, callID, resourceURI string) (*MCPAppInstanceView, error) {
-	tab, _ := a.activeTabAndCtrl()
-	if tab == nil {
-		return nil, fmt.Errorf("no active MCP runtime")
-	}
-	return a.MCPOpenAppInstanceForTab(tab.ID, server, tool, generation, callID, resourceURI)
-}
-
 // MCPOpenAppInstanceForTab binds the App to the tab/controller that produced
 // its tool result. The resource is read once, validated against the current
 // catalog, fingerprinted, and frozen before any iframe can load it.
@@ -121,13 +110,6 @@ func (a *App) MCPAppResourceDigestForTab(tabID, instanceToken string) (string, e
 	return a.MCPAppResourceDigest(instanceToken)
 }
 
-// MCPCloseAppInstance reclaims an instance (tab closed, component unmounted).
-func (a *App) MCPCloseAppInstance(instanceToken string) {
-	if binding, ok := a.mcpAppsSandbox.release(instanceToken); ok && binding.host != nil {
-		binding.host.ReleaseAppInstance(instanceToken)
-	}
-}
-
 func (a *App) MCPCloseAppInstanceForTab(tabID, instanceToken string) error {
 	binding, ok := a.mcpAppsSandbox.binding(instanceToken)
 	if !ok {
@@ -136,7 +118,7 @@ func (a *App) MCPCloseAppInstanceForTab(tabID, instanceToken string) error {
 	if binding.tabID != tabID {
 		return fmt.Errorf("app instance does not belong to tab")
 	}
-	a.MCPCloseAppInstance(instanceToken)
+	a.mcpCloseAppInstance(instanceToken)
 	return nil
 }
 
@@ -146,18 +128,6 @@ func validatedAppLink(rawURL string) (*url.URL, error) {
 		return nil, fmt.Errorf("MCP App links must use a credential-free http(s) URL")
 	}
 	return u, nil
-}
-
-// MCPOpenAppLink opens a ui/open-link target after per-origin confirmation.
-// The frontend asks first and shows the confirmation; this only routes to the
-// system browser.
-func (a *App) MCPOpenAppLink(rawURL string) error {
-	u, err := validatedAppLink(rawURL)
-	if err != nil {
-		return err
-	}
-	a.nativeHost().OpenExternal(a.ctx, u.String())
-	return nil
 }
 
 // MCPOpenAppLinkForTab independently validates the instance/tab binding and
@@ -171,24 +141,7 @@ func (a *App) MCPOpenAppLinkForTab(tabID, instanceToken, rawURL string) error {
 	if _, ok := binding.host.LookupAppInstance(instanceToken); !ok {
 		return fmt.Errorf("app instance expired")
 	}
-	return a.MCPOpenAppLink(rawURL)
-}
-
-// MCPAppCallTool routes an App-initiated tools/call through the controller's
-// gated channel: same server as the instance, visibility includes "app",
-// catalog generation unchanged, and the ordinary permission policy decides.
-func (a *App) MCPAppCallTool(instanceToken, toolName string, args json.RawMessage) (string, error) {
-	binding, ok := a.mcpAppsSandbox.binding(instanceToken)
-	if !ok || binding.ctrl == nil {
-		return "", fmt.Errorf("unknown app instance")
-	}
-	caller, ok := binding.ctrl.(interface {
-		MCPAppCallTool(instanceToken, toolName string, args json.RawMessage) (string, error)
-	})
-	if !ok {
-		return "", fmt.Errorf("runtime does not support app tool calls")
-	}
-	return caller.MCPAppCallTool(instanceToken, toolName, args)
+	return a.mcpOpenAppLink(rawURL)
 }
 
 func (a *App) MCPAppCallToolForTab(tabID, instanceToken, toolName string, args json.RawMessage) (string, error) {
@@ -196,5 +149,41 @@ func (a *App) MCPAppCallToolForTab(tabID, instanceToken, toolName string, args j
 	if !ok || binding.tabID != tabID {
 		return "", fmt.Errorf("app instance does not belong to tab")
 	}
-	return a.MCPAppCallTool(instanceToken, toolName, args)
+	return a.mcpAppCallTool(instanceToken, toolName, args)
+}
+
+// mcpCloseAppInstance reclaims an instance (tab closed, component unmounted).
+func (a *App) mcpCloseAppInstance(instanceToken string) {
+	if binding, ok := a.mcpAppsSandbox.release(instanceToken); ok && binding.host != nil {
+		binding.host.ReleaseAppInstance(instanceToken)
+	}
+}
+
+// mcpOpenAppLink opens a ui/open-link target after per-origin confirmation.
+// The frontend asks first and shows the confirmation; this only routes to the
+// system browser.
+func (a *App) mcpOpenAppLink(rawURL string) error {
+	u, err := validatedAppLink(rawURL)
+	if err != nil {
+		return err
+	}
+	a.nativeHost().OpenExternal(a.ctx, u.String())
+	return nil
+}
+
+// mcpAppCallTool routes an App-initiated tools/call through the controller's
+// gated channel: same server as the instance, visibility includes "app",
+// catalog generation unchanged, and the ordinary permission policy decides.
+func (a *App) mcpAppCallTool(instanceToken, toolName string, args json.RawMessage) (string, error) {
+	binding, ok := a.mcpAppsSandbox.binding(instanceToken)
+	if !ok || binding.ctrl == nil {
+		return "", fmt.Errorf("unknown app instance")
+	}
+	caller, ok := binding.ctrl.(interface {
+		mcpAppCallTool(instanceToken, toolName string, args json.RawMessage) (string, error)
+	})
+	if !ok {
+		return "", fmt.Errorf("runtime does not support app tool calls")
+	}
+	return caller.mcpAppCallTool(instanceToken, toolName, args)
 }


### PR DESCRIPTION
## Problem

Fourteen exported `App` methods exist only as host-contract surface: they have no frontend call site, no Go test and no Go caller, and each has a tab-scoped successor that the frontend actually calls. They still ship in `desktopContract.generated.*` and in the `bridge.ts` interface, so the shell advertises RPC entry points nothing uses.

## Fix

Removed from the contract and from the Go side:

`ClearGoal`, `ContextUsage`, `ListTaskEvents`, `MCPOpenAppInstance`, `OpenTaskSession`, `OpenWorkspaceInExternalOpener`, `OpenWorkspacePath`, `RequeueTask`, `RevealWorkspacePath`, `RunShell`, `SetCollaborationMode` — each superseded by a `*ForTab` variant the frontend calls (`ClearGoalForTab`, `RunShellForTab`, …).

Three of the fourteen carry logic their `*ForTab` variant still needs, so they lose only the exported surface:

- `MCPCloseAppInstance` → `mcpCloseAppInstance`
- `MCPOpenAppLink` → `mcpOpenAppLink`
- `MCPAppCallTool` → `mcpAppCallTool`

`desktopContract.generated.{ts,json}` and `host_command_owners.generated.json` are regenerated with `go run . -emit-contract frontend/src/generated` (587 → 573 commands), and the matching `bridge.ts` interface entries are dropped. The browser mock's `*ForTab` bodies inline the behaviour the removed methods delegated to, so no mock path changes behaviour.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` in the desktop module.
- `go run . -emit-contract frontend/src/generated` is idempotent — a second run leaves the three generated files byte-identical, so the contract-drift CI check passes.
- `tsc --noEmit` and `tsc --noEmit -p tsconfig.test.json`; `eslint` on `bridge.ts`.
- `pnpm test` (all discovered frontend suites).
- `go run ./tools/repolint`: no finding for any touched file.

## Scope

Only the 14 commands with a live tab-scoped successor are removed. The remaining commands with no frontend caller are untouched: 45 have no successor and need a per-feature decision, and 90 are covered by Go tests.

Documentation-impact: none - the host contract is generated from the Go surface; no `docs/*.md` names these commands and no user-visible behavior changes.
