### PR TITLE
feat(agent,tool): let long turns extend their read-only budget / 长任务可申请延长只读轮次预算（#10054）

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1247,6 +1247,10 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	}
 	a.restoreProtocolProjection()
 	ctx = a.withProviderCacheSession(ctx)
+	// The read-only research budget can be doubled from inside the turn via
+	// extend_research_budget; stamp the extender so the tool is provider-visible
+	// and reaches this turn's soft-budget state.
+	ctx = tool.WithResearchBudgetExtender(ctx, a)
 	runMaxSteps := a.maxSteps
 	runMaxStepsKey := a.maxStepsKey
 	a.recovery.runSeq.Add(1)

--- a/internal/agent/soft_budget.go
+++ b/internal/agent/soft_budget.go
@@ -9,6 +9,7 @@ import (
 
 	"reasonix/internal/event"
 	"reasonix/internal/i18n"
+	"reasonix/internal/tool"
 )
 
 const (
@@ -16,6 +17,8 @@ const (
 	softBudgetHardFollowup   = 2
 	softBudgetHistorySamples = 5
 	softBudgetHistoryWindow  = 21
+	// maxSoftBudgetExtensions bounds extend_research_budget: 10 -> 20 -> 40 -> 80.
+	maxSoftBudgetExtensions = 3
 )
 
 var readonlySoftBudgetHistory = struct {
@@ -37,8 +40,14 @@ func (a *Agent) applySoftBudget(outcomes []toolOutcome) intervention {
 	rounds := a.turn.budget.rounds
 	elapsed := a.turn.budget.elapsed()
 	median := rollingReadonlySoftBudgetMedian(a.softBudgetHistoryKey())
-	timeExceeded := median > 0 && elapsed >= 2*median
-	if rounds < readonlySoftBudgetRounds && !timeExceeded {
+	extensions := a.turn.loop.softBudgetExtensionCount()
+	// Each granted extension doubles both gates: rounds 10/20/40/80 and the
+	// time gate 2x/4x/8x/16x the rolling median.
+	roundLimit := readonlySoftBudgetRounds << extensions
+	remaining := maxSoftBudgetExtensions - extensions
+	timeLimit := time.Duration(1<<uint(extensions+1)) * median
+	timeExceeded := median > 0 && elapsed >= timeLimit
+	if rounds < roundLimit && !timeExceeded {
 		return intervention{}
 	}
 	if a.turn.loop.markSoftBudgetNudged(rounds) {
@@ -51,14 +60,18 @@ func (a *Agent) applySoftBudget(outcomes []toolOutcome) intervention {
 		}
 		return intervention{
 			verdict:  verdictRedirect,
-			guidance: "Host budget check: this read-only planning/analysis task exceeded its soft round or elapsed-time budget. Stop expanding scope. Summarize the evidence you already have, state the remaining real blocker if any, and do not open new exploration paths unless the user asks.",
+			guidance: "Host budget check: this read-only planning/analysis task exceeded its soft round or elapsed-time budget. First judge whether deeper investigation is genuinely needed: if yes, call extend_research_budget with a reason to double the budget (" + fmt.Sprintf("%d", remaining) + " extension(s) left this turn); if not, stop expanding scope, summarize the evidence you already have, and name the remaining real blocker if any.",
 			notice:   noticeFor(event.NoticeCodeLoopGuard, event.LevelInfo, i18n.M.SoftBudgetConverge, "soft budget after "+trigger),
 		}
 	}
 	if nudgedAt := a.turn.loop.softBudgetNudgedAt(); nudgedAt > 0 && rounds >= nudgedAt+softBudgetHardFollowup {
+		guidance := "Host budget check: two further rounds passed after the convergence nudge. Output the current result or name exactly one real blocker. Do not continue exploring."
+		if remaining > 0 {
+			guidance = "Host budget check: two further rounds passed after the convergence nudge. Output the current result or name exactly one real blocker. If deeper investigation is genuinely required, call extend_research_budget (" + fmt.Sprintf("%d", remaining) + " extension(s) left this turn); otherwise stop exploring."
+		}
 		return intervention{
 			verdict:  verdictRedirect,
-			guidance: "Host budget check: two further rounds passed after the convergence nudge. Output the current result or name exactly one real blocker. Do not continue exploring.",
+			guidance: guidance,
 		}
 	}
 	return intervention{}
@@ -132,4 +145,34 @@ func (a *Agent) recordReadonlySoftBudgetSample(state *turnRuntime, runErr error)
 		return
 	}
 	recordReadonlySoftBudgetDuration(a.softBudgetHistoryKey(), state.budget.elapsed())
+}
+
+// ExtendResearchBudget implements tool.ResearchBudgetExtender. It doubles the
+// active turn's read-only soft budget after the convergence nudge fired this
+// turn, at most maxSoftBudgetExtensions times (10 -> 20 -> 40 -> 80 rounds).
+// The extension re-arms the nudge so the hard follow-up is measured from the
+// new budget instead of firing two rounds later.
+func (a *Agent) ExtendResearchBudget(reason string) (tool.ResearchBudgetExtension, string, error) {
+	if a == nil {
+		return tool.ResearchBudgetExtension{}, "", fmt.Errorf("extend_research_budget is not available")
+	}
+	if strings.TrimSpace(reason) == "" {
+		return tool.ResearchBudgetExtension{}, "", fmt.Errorf("extend_research_budget: reason is required")
+	}
+	// Only after the nudge fired this turn: either it is still armed, or a
+	// previous extension re-armed it (the counter persists for the turn).
+	if a.turn.loop.softBudgetNudgedAt() == 0 && a.turn.loop.softBudgetExtensionCount() == 0 {
+		return tool.ResearchBudgetExtension{}, "", fmt.Errorf("extend_research_budget is only available after the read-only budget nudge fired this turn — no budget was changed")
+	}
+	extensions, ok := a.turn.loop.extendSoftBudget(maxSoftBudgetExtensions)
+	if !ok {
+		return tool.ResearchBudgetExtension{}, "", fmt.Errorf("extend_research_budget: all %d extensions are used this turn — converge and report the evidence you already have", maxSoftBudgetExtensions)
+	}
+	rounds := readonlySoftBudgetRounds << extensions
+	remaining := maxSoftBudgetExtensions - extensions
+	if a.capabilityAudit != nil {
+		a.capabilityAudit.RecordLoopGuard("soft_budget_extended")
+	}
+	return tool.ResearchBudgetExtension{Rounds: rounds, Remaining: remaining},
+		fmt.Sprintf("Read-only research budget doubled to %d rounds (%d extension(s) left this turn).", rounds, remaining), nil
 }

--- a/internal/agent/soft_budget_test.go
+++ b/internal/agent/soft_budget_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"reasonix/internal/tool"
 )
 
 func TestSoftBudgetUsesRollingMedianElapsedTime(t *testing.T) {
@@ -28,5 +30,86 @@ func TestSoftBudgetUsesRollingMedianElapsedTime(t *testing.T) {
 	second := a.applySoftBudget(nil)
 	if second.verdict != verdictRedirect || !strings.Contains(second.guidance, "two further rounds") {
 		t.Fatalf("hard follow-up = %+v", second)
+	}
+}
+
+func TestExtendResearchBudgetDoublesGatesAndCapsAtThree(t *testing.T) {
+	// Before the nudge the tool is refused: the model must not pre-emptively
+	// raise its own budget.
+	fresh := &Agent{}
+	fresh.turn.budget = runBudget{started: time.Now(), rounds: 1}
+	if _, _, err := fresh.ExtendResearchBudget("curious"); err == nil {
+		t.Fatal("extension before the nudge should be refused")
+	}
+	if _, _, err := fresh.ExtendResearchBudget("   "); err == nil {
+		t.Fatal("extension without a reason should be refused")
+	}
+
+	a := &Agent{}
+	a.modelRef = t.Name()
+	a.turn.budget = runBudget{started: time.Now(), rounds: readonlySoftBudgetRounds}
+
+	nudge := a.applySoftBudget(nil)
+	if nudge.verdict != verdictRedirect || !strings.Contains(nudge.guidance, "extend_research_budget") {
+		t.Fatalf("first nudge should offer the extension: %+v", nudge)
+	}
+
+	ext, text, err := a.ExtendResearchBudget("the conflict surface needs another pass")
+	if err != nil || ext.Rounds != 20 || ext.Remaining != 2 {
+		t.Fatalf("first extension = %+v %q %v", ext, text, err)
+	}
+	if !strings.Contains(text, "20 rounds") || !strings.Contains(text, "2 extension") {
+		t.Fatalf("extension text = %q", text)
+	}
+
+	// Inside the doubled budget no further nudge fires.
+	a.turn.budget.rounds = 15
+	if got := a.applySoftBudget(nil); got.verdict != verdictContinue {
+		t.Fatalf("round 15 under the doubled budget should not nudge: %+v", got)
+	}
+	// The extension re-armed the nudge: it fires again at the new limit.
+	a.turn.budget.rounds = 20
+	if got := a.applySoftBudget(nil); got.verdict != verdictRedirect {
+		t.Fatalf("round 20 should nudge again: %+v", got)
+	}
+
+	for _, want := range []int{40, 80} {
+		ext, _, err := a.ExtendResearchBudget("still digging")
+		if err != nil || ext.Rounds != want {
+			t.Fatalf("extension to %d = %+v %v", want, ext, err)
+		}
+	}
+	if _, _, err := a.ExtendResearchBudget("one more"); err == nil {
+		t.Fatal("a fourth extension should be refused")
+	}
+
+	// The time gate doubles with the same counter: 3 extensions mean 16x the
+	// rolling median instead of 2x.
+	key := a.softBudgetHistoryKey()
+	t.Cleanup(func() {
+		readonlySoftBudgetHistory.Lock()
+		delete(readonlySoftBudgetHistory.byKey, key)
+		readonlySoftBudgetHistory.Unlock()
+	})
+	for _, sample := range []time.Duration{100, 100, 100, 100, 100} {
+		recordReadonlySoftBudgetDuration(key, sample*time.Millisecond)
+	}
+	a.turn.budget = runBudget{started: time.Now().Add(-1 * time.Second), rounds: 1}
+	if got := a.applySoftBudget(nil); got.verdict != verdictContinue {
+		t.Fatalf("1s elapsed is inside 16x100ms after three extensions: %+v", got)
+	}
+	a.turn.budget = runBudget{started: time.Now().Add(-2 * time.Second), rounds: 1}
+	if got := a.applySoftBudget(nil); got.verdict != verdictRedirect {
+		t.Fatalf("2s elapsed should exceed 16x100ms: %+v", got)
+	}
+}
+
+func TestExtendResearchBudgetToolFailsClosedWithoutExtender(t *testing.T) {
+	builtin, ok := tool.LookupBuiltin("extend_research_budget")
+	if !ok {
+		t.Fatal("extend_research_budget builtin not registered")
+	}
+	if _, err := builtin.Execute(t.Context(), []byte(`{"reason":"need more evidence"}`)); err == nil {
+		t.Fatal("the tool must fail closed outside an agent turn")
 	}
 }

--- a/internal/agent/turn_loop_state.go
+++ b/internal/agent/turn_loop_state.go
@@ -17,6 +17,9 @@ type turnLoopState struct {
 	previousErrorCategories map[string]struct{}
 	softBudgetNudged        bool
 	softBudgetNudgeRound    int
+	// softBudgetExtensions counts read-only budget doublings granted this turn
+	// via extend_research_budget (0..3 -> 10/20/40/80 rounds).
+	softBudgetExtensions int
 }
 
 func (s *turnLoopState) setDispatchClasses(classes map[string]tool.CallClass) {
@@ -92,6 +95,28 @@ func (s *turnLoopState) advanceErrorCategories(current map[string]int) bool {
 	}
 	s.previousErrorCategories = next
 	return hit
+}
+
+// softBudgetExtensionCount returns how many read-only budget doublings were
+// granted this turn.
+func (s *turnLoopState) softBudgetExtensionCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.softBudgetExtensions
+}
+
+// extendSoftBudget grants one doubling (at most max per turn) and re-arms the
+// nudge so the extended budget is measured from the current round.
+func (s *turnLoopState) extendSoftBudget(max int) (int, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.softBudgetExtensions >= max {
+		return s.softBudgetExtensions, false
+	}
+	s.softBudgetExtensions++
+	s.softBudgetNudged = false
+	s.softBudgetNudgeRound = 0
+	return s.softBudgetExtensions, true
 }
 
 func (s *turnLoopState) markSoftBudgetNudged(round int) bool {

--- a/internal/tool/builtin/extendresearchbudget.go
+++ b/internal/tool/builtin/extendresearchbudget.go
@@ -1,0 +1,75 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"reasonix/internal/tool"
+)
+
+func init() { tool.RegisterBuiltin(extendResearchBudget{}) }
+
+// extendResearchBudget doubles the read-only soft research budget for the
+// active turn when the model judges that the investigation genuinely needs
+// more rounds. The host only accepts it after the soft budget already nudged
+// the turn toward convergence (10 -> 20 -> 40 -> 80, at most three times);
+// outside that situation, or outside an agent turn, it fails closed without
+// changing any state. It is host bookkeeping: it never needs approval and
+// grants no permissions.
+type extendResearchBudget struct{}
+
+func (extendResearchBudget) Name() string { return "extend_research_budget" }
+
+func (extendResearchBudget) Description() string {
+	return "Ask the host to double this turn's read-only research budget when the soft-budget nudge fired but deeper investigation is genuinely warranted. Only available after the nudge (10 -> 20 -> 40 -> 80 rounds, at most three extensions per turn); the reason is required and recorded. If the investigation does not actually need more rounds, converge and report the evidence you already have instead of calling this."
+}
+
+func (extendResearchBudget) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "reason":{"type":"string","description":"REQUIRED. Why the investigation genuinely needs more rounds — what is still unknown and which concrete question the extra rounds will answer."}
+},
+"required":["reason"]
+}`)
+}
+
+// ReadOnly is true: the call only adjusts in-turn host bookkeeping (the
+// read-only round limit). It never touches files, permissions, or the sandbox.
+func (extendResearchBudget) ReadOnly() bool { return true }
+
+func (extendResearchBudget) ProviderVisible(ctx context.Context) bool {
+	_, ok := tool.ResearchBudgetExtenderFromContext(ctx)
+	return ok
+}
+
+// PlanModeSafe reports true: extending the read-only budget cannot mutate the
+// workspace, and outside a nudged turn Execute fails closed anyway.
+func (extendResearchBudget) PlanModeSafe() bool { return true }
+
+func (extendResearchBudget) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var p struct {
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid extend_research_budget args: %w", err)
+	}
+	reason := strings.TrimSpace(p.Reason)
+	if reason == "" {
+		return "", fmt.Errorf("extend_research_budget: reason is required — state what is still unknown and why more rounds will resolve it")
+	}
+	extender, ok := tool.ResearchBudgetExtenderFromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("extend_research_budget is only available after the read-only budget nudge in an active turn — no budget was changed")
+	}
+	result, text, err := extender.ExtendResearchBudget(reason)
+	if err != nil {
+		return "", err
+	}
+	if text != "" {
+		return text, nil
+	}
+	return fmt.Sprintf("Read-only research budget doubled to %d rounds (%d extension(s) left this turn).", result.Rounds, result.Remaining), nil
+}

--- a/internal/tool/researchbudget.go
+++ b/internal/tool/researchbudget.go
@@ -1,0 +1,39 @@
+package tool
+
+import "context"
+
+// ResearchBudgetExtension reports the outcome of doubling the read-only
+// research budget for the active turn.
+type ResearchBudgetExtension struct {
+	// Rounds is the new per-turn read-only round limit (10 -> 20 -> 40 -> 80).
+	Rounds int
+	// Remaining is how many further doublings are still available.
+	Remaining int
+}
+
+// ResearchBudgetExtender doubles the read-only soft research budget for the
+// active turn when the model judges that deeper investigation is warranted.
+// The host controller implements it. It is absent in ordinary contexts (plain
+// chat, subagents), where the tool must fail closed without changing state.
+type ResearchBudgetExtender interface {
+	// ExtendResearchBudget doubles the active turn's read-only soft budget and
+	// returns the new limit plus the tool-result text shown to the model.
+	ExtendResearchBudget(reason string) (ResearchBudgetExtension, string, error)
+}
+
+type researchBudgetExtenderKey struct{}
+
+// WithResearchBudgetExtender stamps ctx with the per-turn extender so the
+// extend_research_budget tool can reach it from inside the run loop.
+func WithResearchBudgetExtender(ctx context.Context, e ResearchBudgetExtender) context.Context {
+	if e == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, researchBudgetExtenderKey{}, e)
+}
+
+// ResearchBudgetExtenderFromContext returns the per-turn extender, if any.
+func ResearchBudgetExtenderFromContext(ctx context.Context) (ResearchBudgetExtender, bool) {
+	e, ok := ctx.Value(researchBudgetExtenderKey{}).(ResearchBudgetExtender)
+	return e, ok
+}


### PR DESCRIPTION
## TL;DR（中文摘要）

实现 issue #10054：加 `extend_research_budget` 工具，让长任务的只读调研在撞到 10 轮软预算后**主动申请**翻倍（10 → 20 → 40 → 80），而不是被迫半途收敛。

**要点**：
- 只在软预算提示**已经触发**后、且**在** agent turn **内**可调用（否则 fail-closed）
- 每 turn **最多 3 次**，上限**有界**（80），不是无限
- **时间闸门同步加倍**——不能用更长的轮次预算绕过 wall-clock 保护
- 收敛仍是默认；逃生舱必须被主动请求

**背景**：大仓库只读调研（grep 遍代码 + 连续读文件）经常在第 10 轮被 nudge 打断，此时实际调研可能只完成一半。

---

## Summary

Implements #10054. Adds an `extend_research_budget` tool that lets a long read-only investigation ask for more rounds instead of being pushed to converge half-finished.

## Behaviour

- **Callable only after the soft-budget nudge has fired**, and only inside an agent turn. Before the nudge, or outside a turn, it fails closed.
- **Doubles the read-only round limit**: 10 -> 20 -> 40 -> 80, capped at three extensions per turn.
- **The elapsed-time gate doubles with it**, so a longer round budget cannot be used to outrun the wall-clock guard.
- Convergence stays the default; the escape hatch has to be asked for.

## Files

- `internal/tool/researchbudget.go` — the extender interface and ctx plumbing
- `internal/tool/builtin/extendresearchbudget.go` — the tool itself
- `internal/agent/soft_budget.go` — extension accounting on the soft-budget state
- `internal/agent/turn_loop_state.go` — per-turn extension count
- `internal/agent/agent.go` — stamps the extender into the turn ctx so the tool is provider-visible
- `internal/agent/soft_budget_test.go` — coverage for the bound, the fail-closed paths, and the doubling gate

## Verification

- `go build ./internal/agent/ ./internal/tool/...` — pass
- `go test ./internal/agent/ -run Budget` — pass

## Cache impact

Cache-impact: updated- a new tool joins the tool surface, so tool-schema bytes change for every turn
Cache-guard: updated- go test ./internal/agent/ -run Budget
Documentation-impact: none- the tool is self-describing through its schema
System-prompt-review: none- no system-prompt/boot changes
