### PR TITLE
fix(agent): stop defensive switch snapshots paying for deferred derived files and a recomputed schema-2 digest / 防御性切换快照不再为待补派生文件与重算的 schema-2 摘要买单

### DIFF
--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -319,16 +319,20 @@ func (s *Session) saveLocked(path string, mode sessionSaveMode) error {
 	// stalest capture written last would then read the newer transcript it
 	// lost the race to as a bogus stale-prefix conflict.
 	msgs, version, rewriteVersion := s.snapshotWithVersion()
-	digest, contentBytes, err := digestAndSizeSessionMessages(msgs)
-	if err != nil {
-		return err
-	}
 	probe, err := probeLogForSave(path)
 	if err != nil {
 		return err
 	}
 	if route := s.dagSaveRoute(path, probe); route != dagRouteSchemaOne {
+		digest, err := s.snapshotDigest(path, msgs, version)
+		if err != nil {
+			return err
+		}
 		return s.saveDAGLocked(path, mode, route, msgs, version, rewriteVersion, digest)
+	}
+	digest, contentBytes, err := digestAndSizeSessionMessages(msgs)
+	if err != nil {
+		return err
 	}
 	repairLog := false
 	deferProjection := mode.defersProjection()
@@ -1051,6 +1055,25 @@ func messageForSessionIdentity(m provider.Message) provider.Message {
 	m.CreatedAt = 0
 	m.ID = ""
 	return m
+}
+
+// snapshotDigest returns the transcript digest a schema-2 save needs. When the
+// persistence baseline already describes exactly this version — the same proof
+// the snapshot no-op relies on — the stored digest is that value by
+// construction, because it was written for this version and only a version or
+// rewrite bump invalidates it. A schema-2 save only records this digest and
+// publishes it into derived files; it never uses it to decide what to append
+// (planDAGWrite diffs the transcript itself). Recomputing it instead costs a
+// json.Marshal + sha256 pass over every message, which on a large session
+// dominates a defensive switch/close snapshot.
+func (s *Session) snapshotDigest(path string, msgs []provider.Message, version uint64) ([sha256.Size]byte, error) {
+	if s.snapshotUpToDate(path) {
+		if state := s.persistState(path); state.ok && state.version == version {
+			return state.digest, nil
+		}
+	}
+	digest, _, err := digestAndSizeSessionMessages(msgs)
+	return digest, err
 }
 
 // digestAndSizeSessionMessages also reports the encoded transcript size, which

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -302,7 +302,16 @@ func (s *Session) saveLocked(path string, mode sessionSaveMode) error {
 		// runs under the save locks, not before them, so a saver that waited
 		// on a concurrent writer still re-evaluates against the state it must
 		// persist when it finally enters the critical section.
-		return nil
+		//
+		// An up-to-date transcript does not imply up-to-date derived files: a
+		// tool checkpoint commits the transcript but defers the listing and
+		// display indexes. Republish them here instead of paying for the full
+		// save above just to rebuild a derived index. A log whose derived files
+		// need more than that (schema 2 also derives its head index and meta
+		// mirror) declines and falls through unchanged.
+		if s.flushDeferredDerivedFiles(path) {
+			return nil
+		}
 	}
 	// Capture the snapshot only while holding the save locks. Concurrent
 	// in-process savers (turn-end snapshot, periodic autosave, shutdown
@@ -823,13 +832,22 @@ func (s *Session) ownsPersistedState(path string, existingDigest [sha256.Size]by
 // damage is waiting to be persisted. Every one of these flags fails open —
 // when any is unset or stale the caller falls through to the full save path,
 // which re-derives the truth from disk.
+//
+// persisted.projectionPending is deliberately not part of this decision. It
+// reports derived files (listing sidecar, display cache) that a tool
+// checkpoint or an unlocked shutdown append left to a later save; the
+// transcript bytes themselves are already committed, and this baseline
+// describes exactly those bytes. Letting it veto the no-op would push a
+// defensive switch/close snapshot on a large session through the serialize +
+// digest + probe path this fast path exists to avoid (#6607) merely to
+// republish a derived index. The caller republishes those derived files
+// directly instead — see flushDeferredDerivedFiles.
 func (s *Session) snapshotUpToDate(path string) bool {
 	key := canonicalSessionSavePath(path)
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.persisted.ok &&
 		s.persisted.saveVerified &&
-		!s.persisted.projectionPending &&
 		s.persisted.path == key &&
 		s.persisted.version == s.version &&
 		s.persisted.revisionKnown &&

--- a/internal/agent/save_dag_digest_test.go
+++ b/internal/agent/save_dag_digest_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// TestSnapshotDigestReusesPersistedBaselineForSchemaTwo pins the schema-2 half
+// of the defensive-snapshot cost. Once a checkpoint has committed the
+// transcript, learning its digest again is a json.Marshal + sha256 pass over
+// every message, which on a large session dominates a switch/close snapshot.
+// A schema-2 save only records that digest and publishes it into derived files
+// — it never uses it to decide what to append — so the baseline value stands in
+// while the transcript is unchanged, and must not once it moves.
+func TestSnapshotDigestReusesPersistedBaselineForSchemaTwo(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("system")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "task"})
+	bindSessionWriter(t, s, path)
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatal(err)
+	}
+	probe, err := probeLogForSave(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if route := s.dagSaveRoute(path, probe); route == dagRouteSchemaOne {
+		t.Fatalf("route = %v, want a schema-2 log for this test", route)
+	}
+
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "done"})
+	if err := s.SaveToolCheckpoint(path, false); err != nil {
+		t.Fatal(err)
+	}
+	state := s.persistState(path)
+	if !state.ok || !state.projectionPending {
+		t.Fatalf("checkpoint state = %+v, want derived files left pending", state)
+	}
+
+	msgs, version, _ := s.snapshotWithVersion()
+	reused, err := s.snapshotDigest(path, msgs, version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reused != state.digest {
+		t.Fatal("snapshotDigest recomputed instead of reusing the persisted baseline")
+	}
+	// The shortcut must agree with what a full pass would produce, otherwise it
+	// would publish a digest that does not describe the committed transcript.
+	want, _, err := digestAndSizeSessionMessages(msgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want != state.digest || reused != want {
+		t.Fatal("reused digest disagrees with a full digest of the committed transcript")
+	}
+
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "more"})
+	msgs, version, _ = s.snapshotWithVersion()
+	moved, err := s.snapshotDigest(path, msgs, version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moved == state.digest {
+		t.Fatal("snapshotDigest kept a digest that no longer describes the transcript")
+	}
+}

--- a/internal/agent/save_tool_checkpoint.go
+++ b/internal/agent/save_tool_checkpoint.go
@@ -57,6 +57,46 @@ func (s *Session) refreshPendingCheckpointProjection(path string, msgs []provide
 	}
 }
 
+// flushDeferredDerivedFiles republishes the derived files a tool checkpoint or
+// an unlocked shutdown append deliberately deferred, using the digest and
+// revision that save already committed. It runs on the snapshot no-op path,
+// where the transcript is provably current against disk, so all that is left is
+// rebuilding the listing sidecar and the display cache from the in-memory view —
+// no serialize or digest pass of its own. Gating the no-op on projectionPending
+// instead would push every defensive switch/close snapshot on a large session
+// through that full path just to republish a derived index.
+//
+// It reports whether the no-op may stand. A schema-2 (DAG) log also derives its
+// head index and meta mirror from the DAG save context, so that case declines
+// and lets the full path publish what it owns. A failed derived write declines
+// too: projectionPending stays set so a later save retries, matching the full
+// save path, because a derived file must never invalidate the transcript
+// receipt.
+func (s *Session) flushDeferredDerivedFiles(path string) bool {
+	state := s.persistState(path)
+	if !state.ok || !state.projectionPending {
+		return true
+	}
+	probe, err := probeLogForSave(path)
+	if err != nil || s.dagSaveRoute(path, probe) != dagRouteSchemaOne {
+		return false
+	}
+	msgs, version, rewriteVersion := s.snapshotWithVersion()
+	if version != state.version {
+		// The transcript moved between the no-op decision and here: the
+		// ordinary save path owns this generation and will republish.
+		return false
+	}
+	if err := refreshSessionDisplayIndex(path, msgs, state.digest, state.revision, -1); err != nil {
+		slog.Warn("session: keeping save after display index write failure", "path", path, "err", err)
+		return false
+	}
+	// Publishes the listing sidecar and clears projectionPending against the
+	// digest this baseline already describes.
+	s.markPersistedWithListing(path, state.digest, version, state.revision, rewriteVersion, msgs)
+	return true
+}
+
 func (mode sessionSaveMode) eventReason() string {
 	switch mode {
 	case sessionSaveSnapshot, sessionSaveToolCheckpoint:

--- a/internal/agent/save_tool_checkpoint_test.go
+++ b/internal/agent/save_tool_checkpoint_test.go
@@ -54,8 +54,15 @@ func TestToolCheckpointDefersOnlyDerivedProjection(t *testing.T) {
 	if !bytes.Equal(before, after) || len(observer.events) != 0 {
 		t.Fatal("tool checkpoint refreshed the display projection")
 	}
-	if s.snapshotUpToDate(path) {
-		t.Fatal("deferred projection bypasses normal save")
+	// The deferred projection must not veto the snapshot no-op: the transcript
+	// itself is committed, and only its derived files are behind. Gating the
+	// no-op on it would send every defensive switch/close snapshot on a large
+	// session through the serialize + digest + probe path it exists to avoid.
+	if !s.snapshotUpToDate(path) {
+		t.Fatal("deferred projection vetoed the transcript no-op")
+	}
+	if !s.DerivedFilesPending(path) {
+		t.Fatal("deferred projection is not reported as pending")
 	}
 	if err := s.SaveSnapshot(path); err != nil {
 		t.Fatal(err)
@@ -66,6 +73,9 @@ func TestToolCheckpointDefersOnlyDerivedProjection(t *testing.T) {
 	}
 	if bytes.Equal(before, after) || len(observer.events) != 1 || !s.snapshotUpToDate(path) {
 		t.Fatal("normal save did not publish deferred projection")
+	}
+	if s.DerivedFilesPending(path) {
+		t.Fatal("deferred projection stayed pending after the no-op republished it")
 	}
 	if observer.events[0].Rewrite {
 		t.Fatal("append checkpoint falsely invalidated history as a rewrite")


### PR DESCRIPTION
**TL;DR**: 修复切换会话加载慢的上游回归：待补派生文件（projectionPending）不再否决快照 fast-path，防御性切换快照不再重算 schema-2 摘要——切换回到快路径（#10056）。

Fixes #10056.

## What

Defensive switch/close snapshots on a large session stop paying for work they provably do not need, on both log routes.

**1. The snapshot no-op stops being vetoed by derived-files state** (`8537defea`)

- `save.go` — `snapshotUpToDate` no longer requires `!s.persisted.projectionPending`; the no-op path calls the new `flushDeferredDerivedFiles` and returns only when that has published everything the log defers.
- `save_tool_checkpoint.go` — new `flushDeferredDerivedFiles`, republishing the deferred listing sidecar and display cache from the digest/revision the checkpoint already committed.
- `save_tool_checkpoint_test.go` — `TestToolCheckpointDefersOnlyDerivedProjection` now asserts the deferred state does **not** veto the no-op, that `DerivedFilesPending` still reports it, and that the no-op clears it.

**2. The schema-2 path stops recomputing a digest it already knows** (`e9bbf6930`)

- `save.go` — `saveLocked` probes the route before computing the digest, and on the schema-2 path calls the new `snapshotDigest`, which returns the baseline digest whenever that baseline describes this exact version.
- `save_dag_digest_test.go` — pins the reuse, proves it agrees with a full pass, and proves a transcript change retires it.

## Why

`persisted.projectionPending` is set by `markCheckpointPersisted`'s deferred branch, i.e. by `SaveToolCheckpoint` — which runs throughout tool execution. It reports derived files (listing sidecar, display cache, head index) that the checkpoint deliberately left to a later save; the transcript bytes it is paired with are already committed by the same call, and the baseline records their path, version, revision and digest. Its own contract says exactly that (`DerivedFilesPending`: "left its derived files … to a later locked save, as an unlocked shutdown append or a tool checkpoint does"), so it does not describe transcript staleness and does not belong in the no-op decision.

Letting it veto the no-op pushed every defensive switch/close snapshot through the work the no-op was added to skip (#6607: "Desktop switch/close/prune paths snapshot defensively on every navigation, and on large sessions that per-save cost is the user-visible seconds of UI freeze"). Measured on the reporting machine with a turn streaming:

```
[bridge] nav SetActiveTab done ms=765        (782ms in a second capture)
```

Its session is a **28 MB schema-2 event log** (`{"schema_version":2,…,"upgraded_from_schema":1}`), which is why part 2 matters: `saveLocked` computed `digestAndSizeSessionMessages` — a `json.Marshal` + SHA-256 pass over every message — **before it even asked whether the log is schema 1 or 2**. On a schema-2 save that digest is only ever recorded (`markCheckpointPersisted`) and published (`republishDAGDerivedIfPending` → `publishDAGDerived`); `planDAGWrite` diffs the transcript itself to decide what to append, so the digest is not an input to that decision.

## Behaviour

| Case | Before | After |
|---|---|---|
| No deferred derived files, any route | no-op | no-op (unchanged) |
| Deferred derived files, schema-1 log | full serialize + digest + probe | no-op + derived republish |
| Deferred derived files, schema-2 (DAG) log | full path, digest recomputed | full path, **digest reused** |
| Derived republish fails | full path next time | flag stays set, full path next time |
| Transcript changed (version/rewrite bump) | digest recomputed | digest recomputed (shortcut retired) |

Schema 2 still needs its DAG save context for the head index and meta mirror, so `flushDeferredDerivedFiles` declines there and the log keeps its normal path; what part 2 removes is the digest pass inside it. The remaining schema-2 work (`dagStateForSave`'s incremental replay, `planDAGWrite`'s diff) is untouched and is a separate optimisation.

## Verification

```
go build ./internal/agent/ ./internal/control/
go vet ./internal/agent/
go test ./internal/agent/ -count=1        # ok 178.8s
go test ./internal/agent/ -run 'TestToolCheckpoint|TestAppendForShutdownWithoutLockKeepsTailOnFreshHead' -count=1  # ok
go test ./internal/agent/ -run 'TestSnapshotDigestReusesPersistedBaselineForSchemaTwo' -count=1  # ok
```

`TestAppendForShutdownWithoutLockKeepsTailOnFreshHead` covers the decline path: it drives a schema-2 log through an unlocked shutdown append and asserts the next locked save refreshes the head index and meta mirror. `TestSnapshotDigestReusesPersistedBaselineForSchemaTwo` asserts the schema-2 route, that the reused digest equals a full `digestAndSizeSessionMessages` of the committed transcript, and that adding a message retires the shortcut.

Unrelated note for maintainers: `TestGoalTurnRunsPastTheOldRoundCeiling` in `internal/control` is flaky on this machine **on a clean `upstream/main-v2` checkout** (3/3 failures at `2330104af`, ~5.5s each), so it is not a signal for this change.

- **Cache-impact**: None. No prompt, provider request, tool schema, or cache-key path is touched; only which local save path a defensive snapshot takes, and whether a local digest is recomputed.
- **Cache-guard**: The no-op keeps the same transcript-baseline conditions (`ok`, `saveVerified`, `path`, `version`, `revisionKnown`, `rewriteVersion`, `!normalizedDirty`, `!eventLogDamaged`); `snapshotDigest` additionally requires `state.version == version` and falls back to a full digest whenever the baseline is absent or stale. Covered by the tests above plus the full `internal/agent` and `internal/control` suites.
- **Documentation-impact**: Doc comments in `save.go` and `save_tool_checkpoint.go` explain why derived-files state is not part of the no-op decision, who republishes it, and why a schema-2 save may reuse the committed digest. No user-facing docs.
- **System-prompt-review**: No system prompt, tool description, or model-visible contract is modified.

