### PR TITLE
test: clear the post-1.38.3 Windows and coverage regressions / 清除 1.38.3 之后新引入测试的 Windows 与 coverage 红灯

### DIFF
--- a/internal/boot/effect_read_file_test.go
+++ b/internal/boot/effect_read_file_test.go
@@ -108,6 +108,12 @@ system_prompt = "BASE"
 [environment]
 enabled = false
 
+# This case proves the read-evidence gate releases a later commit, so git must
+# really run. An enforced sandbox fails closed wherever the host lacks a backend
+# (coverage runners), which is the sandbox's own contract, not this one.
+[sandbox]
+bash = "off"
+
 [[providers]]
 name = "test-model"
 kind = "boot-read-then-mutate"

--- a/internal/config/opencode_go_upgrade_test.go
+++ b/internal/config/opencode_go_upgrade_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -146,7 +147,9 @@ func TestOpenCodeGoV10MigrationPreservesAccountsHistorySearchAndRawFields(t *tes
 	}
 	for _, suffix := range []string{".opencode-go-v10.backup", ".opencode-go-v10.json"} {
 		info, err := os.Stat(path + suffix)
-		if err != nil || info.Mode().Perm() != 0600 {
+		// Windows carries no POSIX permission bits, so only the Unix legs can
+		// prove the sidecar is private.
+		if err != nil || (runtime.GOOS != "windows" && info.Mode().Perm() != 0o600) {
 			t.Fatalf("private sidecar: %v %v", info, err)
 		}
 	}

--- a/internal/control/chat_run_budget_test.go
+++ b/internal/control/chat_run_budget_test.go
@@ -133,13 +133,15 @@ func TestExplicitMaxStepsOwnsTheOrdinaryTurn(t *testing.T) {
 	}
 }
 
-// This is a round-ceiling regression, not a disk-throughput benchmark. Keep a
-// five-second no-progress watchdog while bounding the entire 121-round run.
+// This is a round-ceiling regression, not a disk-throughput benchmark. The
+// five-second no-progress watchdog is the detector; the total bound only stops
+// a wedged run, so it carries headroom for the slowest leg — Windows CI drives
+// all 121 rounds through a real session writer and has measured ~45s.
 func waitForChatBudgetProgress(t *testing.T, done <-chan event.Event, progress <-chan struct{}) {
 	t.Helper()
 	idle := time.NewTimer(5 * time.Second)
 	defer idle.Stop()
-	total := time.NewTimer(30 * time.Second)
+	total := time.NewTimer(90 * time.Second)
 	defer total.Stop()
 	for {
 		select {

--- a/internal/serve/browser_broker_test.go
+++ b/internal/serve/browser_broker_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/boot"
 	"reasonix/internal/browser"
 	"reasonix/internal/config"
@@ -100,8 +101,8 @@ func TestBrowserBrokerSessionScopeTravelsOverHTTP(t *testing.T) {
 	if len(tabs) != 1 || tabs[0].ID != "t1" {
 		t.Fatalf("tabs = %+v", tabs)
 	}
-	if len(exec.sessions) != 1 || exec.sessions[0] != "/remote/sessions/a.jsonl" {
-		t.Fatalf("host saw sessions %v, want the tag path", exec.sessions)
+	if want := agent.CanonicalSessionPath("/remote/sessions/a.jsonl"); len(exec.sessions) != 1 || exec.sessions[0] != want {
+		t.Fatalf("host saw sessions %v, want the tag path %q", exec.sessions, want)
 	}
 }
 
@@ -258,7 +259,7 @@ func TestBuildTaggedScopesBrokerToSession(t *testing.T) {
 	if _, err := gotOpts.BrowserExecutor.Tabs(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if len(hostExec.sessions) == 0 || hostExec.sessions[len(hostExec.sessions)-1] != "/remote/sessions/b.jsonl" {
-		t.Fatalf("host saw sessions %v, want the built controller's tag path", hostExec.sessions)
+	if want := agent.CanonicalSessionPath("/remote/sessions/b.jsonl"); len(hostExec.sessions) == 0 || hostExec.sessions[len(hostExec.sessions)-1] != want {
+		t.Fatalf("host saw sessions %v, want the built controller's tag path %q", hostExec.sessions, want)
 	}
 }

--- a/internal/serve/session_delete_path_test.go
+++ b/internal/serve/session_delete_path_test.go
@@ -33,7 +33,10 @@ func TestDeleteSessionValidatesLocalBasenameBeforeCleanup(t *testing.T) {
 	}
 	invalid := []string{"", " ", ".", "..", "../escape", `..\escape`, "/absolute", `\absolute`, "nested/session", `nested\session`}
 	if runtime.GOOS == "windows" {
-		invalid = append(invalid, "C:escape", "C:", "CON", "NUL", "AUX", "COM1", "LPT1", "CON.txt")
+		// Device names with an extension are absent: Windows 11 stopped
+		// reserving them, and filepath.IsLocal defers to the host's
+		// RtlIsDosDeviceName_U, so their answer varies by Windows build.
+		invalid = append(invalid, "C:escape", "C:", "CON", "NUL", "AUX", "COM1", "LPT1")
 	}
 	for _, name := range invalid {
 		t.Run("reject "+name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

`main-v2` has been red since v1.38.3 — run 34292849844 on the v1.38.3 candidate
`fa018e4` was the last successful `ci.yml`. Every completed run after it failed,
so the branch has had no green candidate for roughly a day and a half. Because
`release-stable.sh` refuses to create any tag unless the exact candidate's push
CI completed successfully, v1.38.4 cannot be published until this is green.

Five checks fail. The whole streak is test-side; no production behavior is
involved.

## Root causes

1. **`coverage`** — `internal/boot/TestEffectTruncatedReadDoesNotBlockCommitOrFinalThroughRealBuild`
   (added by #10038) drives a real `git commit` through the built stack. The
   `coverage` job runs the full suite but never installs bubblewrap or enables
   unprivileged user namespaces the way the `test` job does, so the bash sandbox
   fails closed and the commit never lands. This is the first failure of the
   streak and the only one that reproduces on every run.
2. **`internal/config/opencode_go_upgrade_test.go`** asserted `Mode().Perm() == 0600`
   on the migration sidecars. Windows carries no POSIX permission bits, so the
   assertion cannot hold there.
3. **`internal/serve/browser_broker_test.go`** compared the session scope the host
   received against a hardcoded `/remote/sessions/*.jsonl`. The product derives
   that identity through `filepath`, so Windows legitimately produces
   `d:\remote\sessions\*.jsonl`.
4. **`internal/serve/session_delete_path_test.go`** expected `CON.txt` to be
   rejected as a reserved device name. Windows 11 stopped reserving device names
   that carry an extension, and `filepath.IsLocal` defers to the host's
   `RtlIsDosDeviceName_U`, so accepting it is correct — the test's assumption was
   older than the runner.
5. **`internal/control/chat_run_budget_test.go`** bounded the entire 121-round turn
   at 30s. Windows CI measured 30.5s, 36.9s and 44.6s driving those rounds through
   a real session writer; the same test passes comfortably on the Unix legs.

## Fix

Test-only. No production code changed.

- Pin `[sandbox] bash = "off"` in the effect test's own config — the escape hatch
  the product documents in its own remediation text — so its read-evidence
  contract stops depending on the host's sandbox backend.
- Guard the permission assertion with `runtime.GOOS != "windows"`, matching the
  existing idiom in `crashreport/cli_test.go`, `fileutil/atomicwrite_test.go` and
  `config/edit_test.go`.
- Expect `agent.CanonicalSessionPath(...)`, matching `serve/multisession_test.go`.
- Drop the `CON.txt` case and record why, keeping the bare device names that are
  reserved on every Windows version.
- Keep the 5s no-progress watchdog as the actual regression detector and give the
  wedged-run bound headroom for the slowest leg, rather than weakening the
  round-count assertion or adding a per-platform branch.

## Verification

- `go test ./internal/serve/ ./internal/config/ ./internal/control/ ./internal/boot/ -count=1` — all pass.
- `go vet ./...` — clean.
- `make lint` — golangci-lint at the CI pin reports 0 issues; repolint clean at the
  existing baseline (1215 findings, unchanged).
- `GOOS=windows go vet ./internal/control/ ./internal/serve/ ./internal/config/ ./internal/boot/` — clean.
- The `coverage` failure was reproduced from the CI log and traced to the sandbox
  refusal; the boot package passes locally both before and after.

Cache-impact: none - test-only diff; no provider-visible prompt, tool or memory bytes change
Cache-guard: existing guards unchanged and unaffected; the diff touches no serialization, prompt assembly or tool registration path
System-prompt-review: @SivanCola reviewed the internal/boot test-only change; no prompt bytes, standing instructions or memory files are affected
Documentation-impact: none - test-only change; no user-visible behavior or docs surface moves
