### PR TITLE
fix(release): preserve Apple notarization diagnostics / 保留 Apple 公证拒绝日志与校验结果

### DIFF
--- a/.github/workflows/apple-notary-log.yml
+++ b/.github/workflows/apple-notary-log.yml
@@ -1,0 +1,57 @@
+name: Diagnose Apple notarization
+run-name: Diagnose Apple notarization ${{ inputs.submission_id }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      submission_id:
+        description: "Existing Apple notarization submission UUID (read only)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  fetch-log:
+    if: github.repository == 'esengine/DeepSeek-Reasonix' && github.ref == 'refs/heads/main-v2' && github.ref_protected
+    runs-on: macos-latest
+    environment: release
+    timeout-minutes: 10
+    steps:
+      - name: Retrieve existing submission information and log
+        env:
+          SUBMISSION_ID: ${{ inputs.submission_id }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$SUBMISSION_ID" =~ ^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$ ]] || {
+            echo "::error::submission_id must be a UUID"
+            exit 1
+          }
+          : "${APPLE_API_KEY_P8:?Apple API key is not configured}"
+          : "${APPLE_API_KEY_ID:?Apple API key ID is not configured}"
+          : "${APPLE_API_ISSUER_ID:?Apple API issuer is not configured}"
+          umask 077
+          key_path="$(mktemp "$RUNNER_TEMP/apple-notary-key.XXXXXX")"
+          trap 'rm -f "$key_path"' EXIT
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$key_path"
+          diagnostics="$RUNNER_TEMP/apple-notarization"
+          mkdir -p "$diagnostics"
+          auth=(--key "$key_path" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER_ID")
+          xcrun notarytool info "$SUBMISSION_ID" "${auth[@]}" --output-format json > "$diagnostics/submission.json" || {
+            echo "::warning::Could not retrieve submission information; attempting the log directly"
+          }
+          xcrun notarytool log "$SUBMISSION_ID" "${auth[@]}" "$diagnostics/notary-log.json"
+
+      - name: Upload Apple notarization diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: apple-notary-log-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/apple-notarization/*.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,10 +800,11 @@ jobs:
             .github/workflows/release.yml \
             .github/workflows/release-npm.yml \
             .github/workflows/release-desktop.yml \
+            .github/workflows/apple-notary-log.yml \
             .github/workflows/release-verify-issues.yml \
             .github/workflows/docs-impact.yml \
             .github/workflows/ci.yml
-          node --test scripts/desktop-release-artifacts.test.mjs scripts/ci-workflow.test.mjs
+          node --test scripts/desktop-release-artifacts.test.mjs scripts/ci-workflow.test.mjs scripts/notarize-desktop.test.mjs
           bash scripts/release-workflows.test.sh
           node scripts/check-single-release-public-contract.mjs
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -406,7 +406,17 @@ jobs:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/notary.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_NOTARIZATION_LOG_DIR: ${{ runner.temp }}/apple-notarization
         run: scripts/desktop-build.sh "${{ matrix.platform }}" "${{ needs.resolve.outputs.version }}" "${{ needs.resolve.outputs.channel }}"
+
+      - name: Upload Apple notarization diagnostics
+        if: ${{ always() && runner.os == 'macOS' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: apple-notarization-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}
+          path: ${{ runner.temp }}/apple-notarization/*.json
+          if-no-files-found: ignore
+          retention-days: 7
 
       # Candidate code is immutable, but release validation belongs to the
       # protected workflow control plane. Reuse this sparse checkout later for

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -226,11 +226,8 @@ darwin)
 		# notarytool wants an archive, not a bare bundle: zip the .app, submit, wait,
 		# then staple the ticket back onto the bundle so it verifies offline.
 		ditto -c -k --keepParent "$app" "$staging/notarize.zip"
-		echo "==> notarytool submit (app)"
-		xcrun notarytool submit "$staging/notarize.zip" \
-			--key "$APPLE_API_KEY_PATH" --key-id "$APPLE_API_KEY_ID" \
-			--issuer "$APPLE_API_ISSUER_ID" --wait
-		xcrun stapler staple "$app"
+		notary_diagnostics="${APPLE_NOTARIZATION_LOG_DIR:-$ROOT/desktop/build/notarization}"
+		node "$ROOT/scripts/notarize-desktop.mjs" "$staging/notarize.zip" "$app" app "$notary_diagnostics"
 	else
 		# Ad-hoc cuts the "is damaged" error somewhat but is NOT notarized; users may
 		# still need `xattr -dr com.apple.quarantine` (see desktop/README.md).
@@ -269,11 +266,7 @@ darwin)
 		# disk image itself too — the stapled .app inside isn't enough for the image.
 		if [ "${HAS_APPLE_CERT:-}" = "true" ]; then
 			codesign --force --timestamp -s "$identity" "$dmg"
-			echo "==> notarytool submit (dmg)"
-			xcrun notarytool submit "$dmg" \
-				--key "$APPLE_API_KEY_PATH" --key-id "$APPLE_API_KEY_ID" \
-				--issuer "$APPLE_API_ISSUER_ID" --wait
-			xcrun stapler staple "$dmg"
+			node "$ROOT/scripts/notarize-desktop.mjs" "$dmg" "$dmg" dmg "$notary_diagnostics"
 		fi
 		rm -rf "$dmgsrc"
 	fi

--- a/scripts/notarize-desktop.mjs
+++ b/scripts/notarize-desktop.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Verify, notarize and staple an already-signed app or disk image.
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export function notarizeDesktop({ archive, target, kind, diagnosticsDir, env = process.env,
+  run = (command, args) => spawnSync(command, args, {
+    encoding: "utf8", stdio: ["ignore", "pipe", "inherit"], maxBuffer: 16 * 1024 * 1024,
+  }), warn = console.warn }) {
+  if (!["app", "dmg"].includes(kind)) throw new Error("Expected notarization kind app or dmg");
+  for (const name of ["APPLE_API_KEY_PATH", "APPLE_API_KEY_ID", "APPLE_API_ISSUER_ID"]) {
+    if (!env[name]) throw new Error(`Missing ${name}`);
+  }
+  mkdirSync(diagnosticsDir, { recursive: true });
+  for (const suffix of ["submission", "notary-log"]) {
+    rmSync(join(diagnosticsDir, `${kind}-${suffix}.json`), { force: true });
+  }
+  const auth = ["--key", env.APPLE_API_KEY_PATH, "--key-id", env.APPLE_API_KEY_ID,
+    "--issuer", env.APPLE_API_ISSUER_ID];
+  const checked = (command, args) => {
+    const result = run(command, args);
+    if (result.stdout) process.stdout.write(result.stdout);
+    if (result.status !== 0 || result.error) throw new Error(`${command} ${args[0]} failed`);
+    return result;
+  };
+  checked("codesign", ["--verify", ...(kind === "app" ? ["--deep"] : []), "--strict", "--verbose=4", target]);
+  console.log(`==> notarytool submit (${kind})`);
+  const submission = run("xcrun", ["notarytool", "submit", archive, ...auth, "--wait", "--output-format", "json"]);
+  let response;
+  try { response = JSON.parse(submission.stdout); } catch { /* Fail closed below. */ }
+  const id = typeof response?.id === "string" && /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(response.id)
+    ? response.id : null;
+  const status = typeof response?.status === "string" ? response.status : null;
+  // Do not archive command arguments, credentials or machine-local upload paths.
+  writeFileSync(join(diagnosticsDir, `${kind}-submission.json`), JSON.stringify({
+    id, status, exitCode: submission.status, signal: submission.signal ?? null,
+  }, null, 2) + "\n");
+  console.log(`==> notarization (${kind}): ${status ?? "unknown"}; submission: ${id ?? "unavailable"}`);
+  if (id) {
+    const log = run("xcrun", ["notarytool", "log", id, ...auth]);
+    if (log.status === 0 && !log.error) {
+      try {
+        const report = JSON.parse(log.stdout);
+        writeFileSync(join(diagnosticsDir, `${kind}-notary-log.json`), JSON.stringify(report, null, 2) + "\n");
+      } catch {
+        warn(`Could not decode notarization log for ${id}; retrieve it with notarytool log.`);
+      }
+    } else {
+      warn(`Could not fetch notarization log for ${id}; retrieve it with notarytool log.`);
+    }
+  }
+  // notarytool can exit successfully after Apple rejects the submission.
+  if (submission.status !== 0 || submission.error || !id || status !== "Accepted") {
+    throw new Error(`Notarization ${status ?? "unknown"} (${id ?? "no submission ID"}); see ${kind}-submission.json and the notary log`);
+  }
+  checked("xcrun", ["stapler", "staple", target]);
+  checked("xcrun", ["stapler", "validate", target]);
+  // Gatekeeper requires notarization; it is not a pre-submission signature test.
+  checked("spctl", ["--assess", "--verbose=4", "--type", kind === "app" ? "exec" : "open",
+    ...(kind === "dmg" ? ["--context", "context:primary-signature"] : []), target]);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const [archive, target, kind, diagnosticsDir] = process.argv.slice(2);
+  if (!archive || !target || !kind || !diagnosticsDir) {
+    console.error("usage: notarize-desktop.mjs <archive> <target> <app|dmg> <diagnostics-directory>");
+    process.exitCode = 2;
+  } else {
+    try { notarizeDesktop({ archive, target, kind, diagnosticsDir }); }
+    catch (error) { console.error(error.message); process.exitCode = 1; }
+  }
+}

--- a/scripts/notarize-desktop.test.mjs
+++ b/scripts/notarize-desktop.test.mjs
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { notarizeDesktop } from "./notarize-desktop.mjs";
+
+const id = "00000000-0000-4000-8000-000000000001";
+const env = { APPLE_API_KEY_PATH: "private/key.p8", APPLE_API_KEY_ID: "key-id", APPLE_API_ISSUER_ID: "issuer" };
+const ok = (value = {}) => ({ status: 0, stdout: JSON.stringify(value) });
+
+function fixture(t, { kind = "app", status = "Accepted", submit, log, fail } = {}) {
+  const diagnosticsDir = mkdtempSync(join(tmpdir(), "reasonix-notary-test-"));
+  t.after(() => rmSync(diagnosticsDir, { recursive: true, force: true }));
+  const calls = [], warnings = [];
+  const execute = () => notarizeDesktop({
+    archive: kind === "app" ? "upload.zip" : "Reasonix.dmg",
+    target: kind === "app" ? "Reasonix.app" : "Reasonix.dmg",
+    kind, diagnosticsDir, env, warn: (message) => warnings.push(message),
+    run: (command, args) => {
+      calls.push([command, ...args]);
+      if (fail?.(command, args)) return { status: 65, stdout: "" };
+      if (args[0] === "notarytool" && args[1] === "submit") return submit ?? ok({ id, status, path: "private/upload.zip" });
+      if (args[0] === "notarytool" && args[1] === "log") return log ?? ok({ jobId: id, status, issues: [] });
+      return { status: 0, stdout: "" };
+    },
+  });
+  const report = (name) => JSON.parse(readFileSync(join(diagnosticsDir, `${kind}-${name}.json`), "utf8"));
+  return { execute, calls, warnings, report, diagnosticsDir };
+}
+
+for (const kind of ["app", "dmg"]) {
+  test(`${kind}: verify before submit, then log, staple, validate and assess`, (t) => {
+    const f = fixture(t, { kind });
+    f.execute();
+    assert.deepEqual(f.calls.map((call) => call.slice(0, 3)), [
+      ["codesign", "--verify", kind === "app" ? "--deep" : "--strict"],
+      ["xcrun", "notarytool", "submit"], ["xcrun", "notarytool", "log"],
+      ["xcrun", "stapler", "staple"], ["xcrun", "stapler", "validate"],
+      ["spctl", "--assess", "--verbose=4"],
+    ]);
+    assert.ok(f.calls[0].includes("--strict"));
+    assert.deepEqual(f.calls[1].slice(-3), ["--wait", "--output-format", "json"]);
+    assert.equal(f.calls[2][3], id);
+    assert.deepEqual(f.calls.at(-1), kind === "app"
+      ? ["spctl", "--assess", "--verbose=4", "--type", "exec", "Reasonix.app"]
+      : ["spctl", "--assess", "--verbose=4", "--type", "open", "--context", "context:primary-signature", "Reasonix.dmg"]);
+    assert.deepEqual(f.report("submission"), { id, status: "Accepted", exitCode: 0, signal: null });
+    assert.equal(f.report("notary-log").jobId, id);
+    for (const name of readdirSync(f.diagnosticsDir)) {
+      const text = readFileSync(join(f.diagnosticsDir, name), "utf8");
+      assert.doesNotMatch(text, /private\/|key-id|issuer/);
+    }
+  });
+}
+
+for (const status of ["Invalid", "Rejected", "In Progress", undefined]) {
+  test(`zero exit with ${status} must fetch log and stop before stapling`, (t) => {
+    const f = fixture(t, { submit: ok({ id, status }) });
+    assert.throws(f.execute, /Notarization/);
+    assert.equal(f.report("submission").status, status ?? null);
+    assert.equal(f.report("notary-log").jobId, id);
+    assert.equal(f.calls.length, 3);
+  });
+}
+
+test("Apple rejection details are preserved in the log artifact", (t) => {
+  const issues = [{ severity: "error", path: "Reasonix.app/Contents/MacOS/Reasonix", message: "The signature is invalid." }];
+  const f = fixture(t, { status: "Invalid", log: ok({ jobId: id, issues }) });
+  assert.throws(f.execute, /Invalid/);
+  assert.deepEqual(f.report("notary-log").issues, issues);
+});
+
+test("a repeated local build cannot retain an older submission's log", (t) => {
+  const f = fixture(t, { status: "Invalid", log: { status: 1, stdout: "" } });
+  writeFileSync(join(f.diagnosticsDir, "app-notary-log.json"), JSON.stringify({ status: "Accepted" }));
+  writeFileSync(join(f.diagnosticsDir, "dmg-notary-log.json"), JSON.stringify({ status: "Accepted" }));
+  assert.throws(f.execute, /Invalid/);
+  assert.deepEqual(readdirSync(f.diagnosticsDir).sort(), ["app-submission.json", "dmg-notary-log.json"]);
+});
+
+test("nonzero submit still fetches log and cannot pass with Accepted", (t) => {
+  const f = fixture(t, { submit: { status: 1, stdout: JSON.stringify({ id, status: "Accepted" }) } });
+  assert.throws(f.execute, /Notarization/);
+  assert.equal(f.report("submission").exitCode, 1);
+  assert.equal(f.calls.length, 3);
+});
+
+for (const submit of [
+  { status: 1, stdout: "not JSON" }, ok({ status: "Accepted" }),
+  ok({ id: "--unexpected-option", status: "Accepted" }),
+  { status: null, signal: "SIGTERM", stdout: "" },
+  { status: null, error: new Error("spawn failed"), stdout: "" },
+]) {
+  test(`unusable submit response fails without fetching an unknown ID: ${JSON.stringify(submit)}`, (t) => {
+    const f = fixture(t, { submit });
+    assert.throws(f.execute, /no submission ID/);
+    assert.equal(f.report("submission").id, null);
+    assert.equal(f.calls.length, 2);
+  });
+}
+
+for (const status of ["Accepted", "Invalid"]) {
+  for (const log of [{ status: 1, stdout: "" }, { status: 0, stdout: "not JSON" }]) {
+    test(`unavailable log does not replace the ${status} verdict (${log.status})`, (t) => {
+      const f = fixture(t, { status, log });
+      if (status === "Accepted") f.execute();
+      else assert.throws(f.execute, /Invalid/);
+      assert.equal(f.warnings.length, 1);
+      assert.match(f.warnings[0], new RegExp(id));
+      assert.deepEqual(readdirSync(f.diagnosticsDir), ["app-submission.json"]);
+    });
+  }
+}
+
+for (const stage of ["codesign", "staple", "validate", "spctl"]) {
+  test(`${stage} failure stops the pipeline`, (t) => {
+    const f = fixture(t, { fail: (command, args) => command === stage || args[1] === stage });
+    assert.throws(f.execute, /failed/);
+    assert.equal(f.calls.length, { codesign: 1, staple: 4, validate: 5, spctl: 6 }[stage]);
+  });
+}
+
+test("both release artifacts use the shared notarization gate and diagnostics survive failure", () => {
+  const build = readFileSync(new URL("./desktop-build.sh", import.meta.url), "utf8");
+  const workflow = readFileSync(new URL("../.github/workflows/release-desktop.yml", import.meta.url), "utf8");
+  assert.match(build, /notarize-desktop\.mjs" "\$staging\/notarize\.zip" "\$app" app "\$notary_diagnostics"/);
+  assert.match(build, /notarize-desktop\.mjs" "\$dmg" "\$dmg" dmg "\$notary_diagnostics"/);
+  assert.doesNotMatch(build, /xcrun (notarytool|stapler)/);
+  const upload = workflow.split("- name: Upload Apple notarization diagnostics")[1]?.split("\n      #")[0];
+  assert.ok(upload);
+  assert.match(upload, /always\(\) && runner.os == 'macOS'/);
+  assert.match(upload, /uses: actions\/upload-artifact@v7/);
+  assert.match(upload, /path: \$\{\{ runner.temp \}\}\/apple-notarization\/\*\.json/);
+  assert.match(workflow, /APPLE_NOTARIZATION_LOG_DIR: \$\{\{ runner.temp \}\}\/apple-notarization/);
+});
+
+test("historical log workflow only reads Apple submissions from the protected release environment", () => {
+  const workflow = readFileSync(new URL("../.github/workflows/apple-notary-log.yml", import.meta.url), "utf8");
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /github\.ref == 'refs\/heads\/main-v2' && github\.ref_protected/);
+  assert.match(workflow, /environment: release/);
+  assert.match(workflow, /contents: read/);
+  assert.match(workflow, /SUBMISSION_ID: \$\{\{ inputs.submission_id \}\}/);
+  assert.match(workflow, /\[\[ "\$SUBMISSION_ID" =~ \^\[0-9a-fA-F\]/);
+  assert.match(workflow, /trap 'rm -f "\$key_path"' EXIT/);
+  assert.match(workflow, /umask 077/);
+  assert.match(workflow, /xcrun notarytool log "\$SUBMISSION_ID"/);
+  assert.match(workflow, /if: always\(\)/);
+  assert.match(workflow, /path: \$\{\{ runner.temp \}\}\/apple-notarization\/\*\.json/);
+  assert.doesNotMatch(workflow, /notarytool submit|codesign|stapler|actions\/checkout|contents: write|pull_request_target/);
+});
+
+for (const scenario of ["success", "log-failure", "invalid-id"]) {
+  test(`historical workflow shell: ${scenario}, with credential cleanup`, (t) => {
+    const root = mkdtempSync(join(tmpdir(), "reasonix-notary-workflow-"));
+    t.after(() => rmSync(root, { recursive: true, force: true }));
+    const xcrun = join(root, "xcrun");
+    writeFileSync(xcrun, `#!${process.execPath}
+import fs from 'node:fs';
+const args = process.argv.slice(2);
+if (args[0] !== 'notarytool' || !['info', 'log'].includes(args[1])) process.exit(99);
+const key = args[args.indexOf('--key') + 1];
+if (fs.readFileSync(key, 'utf8') !== 'fixture-key') process.exit(98);
+if ((fs.statSync(key).mode & 0o777) !== 0o600) process.exit(97);
+fs.appendFileSync(process.env.RUNNER_TEMP + '/calls', args[1] + '\\n');
+if (args[1] === 'info') console.log(JSON.stringify({id: args[2], status: 'Invalid'}));
+else if (process.env.FAIL_LOG === 'true') process.exit(1);
+else fs.writeFileSync(args.at(-1), JSON.stringify({jobId: args[2], status: 'Invalid'}));
+`);
+    chmodSync(xcrun, 0o755);
+    const workflow = readFileSync(new URL("../.github/workflows/apple-notary-log.yml", import.meta.url), "utf8");
+    const script = workflow.split("        run: |\n")[1].split("\n      - name:")[0]
+      .split("\n").map((line) => line.replace(/^          /, "")).join("\n");
+    const result = spawnSync("bash", ["-c", script], { encoding: "utf8", env: {
+      ...process.env, PATH: `${root}:${process.env.PATH}`, RUNNER_TEMP: root,
+      SUBMISSION_ID: scenario === "invalid-id" ? "$(touch should-not-exist)" : id,
+      APPLE_API_KEY_P8: Buffer.from("fixture-key").toString("base64"),
+      APPLE_API_KEY_ID: "fixture-id", APPLE_API_ISSUER_ID: "fixture-issuer",
+      FAIL_LOG: String(scenario === "log-failure"),
+    } });
+    assert.equal(result.status, scenario === "success" ? 0 : 1, result.stderr);
+    assert.ok(!readdirSync(root).some((name) => name.startsWith("apple-notary-key.")));
+    assert.doesNotMatch(result.stdout + result.stderr, /fixture-key/);
+    if (scenario === "invalid-id") assert.deepEqual(readdirSync(root), ["xcrun"]);
+    else assert.equal(readFileSync(join(root, "calls"), "utf8"), "info\nlog\n");
+    if (scenario === "success") {
+      assert.equal(JSON.parse(readFileSync(join(root, "apple-notarization/notary-log.json"))).status, "Invalid");
+    }
+  });
+}


### PR DESCRIPTION
## Summary

When Apple rejects notarization, `notarytool submit --wait` can still exit zero. The desktop release then attempts to staple a nonexistent ticket and reports error 65 without preserving Apple's rejection details.

- Share an explicit Accepted-status gate between the signed app and disk image. Verify signatures before submission, preserve the submission ID and Apple log, and validate the stapled ticket and Gatekeeper assessment after acceptance.
- Upload JSON diagnostics even when packaging fails. Preserve the existing signing commands and entitlements.
- Add a protected, manually dispatched diagnostic workflow that reads an existing Apple submission using the existing release environment secrets. It performs no checkout, build, signing, submission, or release publication, and deletes its temporary key on exit.

The diagnostic workflow can retrieve historical rejection logs after this PR merges. The packaging helper is used by candidates containing this change; merging it does not change the build script at an existing immutable release tag. This change does not establish or repair Apple's underlying reason for rejecting the existing Electron bundle.

## Issues

Investigated from [the failed stable release run](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/34481890005). The separate Windows failure was traced to a stale SignPath service configuration that omitted the Electron app tree; it is outside this code change.

## Verification

- 27 notarization tests pass, including zero-exit rejection, malformed responses, log retrieval failures, stale diagnostic cleanup, stage ordering, and execution of the diagnostic workflow shell against disposable tool fixtures with credential cleanup.
- Release workflow contracts and desktop build contract pass.
- actionlint, repolint, shell syntax, and diff whitespace checks pass.
- Real Apple log retrieval and notarization remain external verification items; local tests do not contact Apple or use signing credentials.

## Documentation impact

Documentation-impact: none - This changes release diagnostics and verification only; installed CLI and Desktop behavior and embedded documentation remain unchanged.

## Cache impact

Cache-impact: none - No provider-visible prompts, tools, memory, or request serialization changed.
Cache-guard: N/A - Changes are confined to release workflows and notarization tooling.
System-prompt-review: N/A
