### PR TITLE
fix(desktop): sign complete Electron macOS bundles / 修复 macOS 嵌套代码漏签

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,6 +591,9 @@ jobs:
       - name: Test integrated terminal, PTY, and FSEvents lifecycle
         run: go test -race -run 'Test(DarwinWorkspaceWatcher|WorkspaceChangeHub|ResolveTerminal|Terminal|EmptyTerminal|UnixTerminalProcess)' .
 
+      - name: Test native macOS signing coverage
+        run: node --test packaging/sign-macos.test.mjs
+
       # The production desktop build uses CGO. Keep the explicit unavailable
       # backend buildable as a fail-closed portability contract instead of
       # silently falling back to kqueue's per-file descriptor usage.

--- a/desktop/guard_packaging_test.go
+++ b/desktop/guard_packaging_test.go
@@ -116,9 +116,18 @@ func TestDesktopPackagesPreserveNativePlatformLaunchers(t *testing.T) {
 		t.Fatal("Windows package must not collide reasonix.exe with the Reasonix.exe launcher")
 	}
 	darwinIconCheck := strings.Index(build, `[ -s "$app/Contents/Resources/$bundle_icon" ]`)
-	developerIDSign := strings.Index(build, `codesign --force --deep --timestamp --options runtime`)
+	developerIDSign := strings.Index(build, `node "$ROOT/desktop/packaging/sign-macos.mjs" "$app" "$identity"`)
 	if darwinIconCheck < 0 || developerIDSign < 0 || darwinIconCheck > developerIDSign {
 		t.Fatalf("macOS bundle icon must be verified before signing (icon=%d sign=%d)", darwinIconCheck, developerIDSign)
+	}
+	for _, copyCommand := range []string{
+		`cp "$service_out" "$app/Contents/MacOS/$BINNAME"`,
+		`cp "$service_out" "$app/Contents/Resources/service/$BINNAME"`,
+		`cp "$cli_out" "$app/Contents/Resources/service/$CLINAME"`,
+	} {
+		if index := strings.Index(build, copyCommand); index < 0 || index > developerIDSign {
+			t.Errorf("macOS sidecar must be installed before signing: %s", copyCommand)
+		}
 	}
 
 	for _, want := range []string{

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,6 +13,7 @@
     "pnpm": ">=10 <11"
   },
   "devDependencies": {
+    "@electron/osx-sign": "2.7.0",
     "@electron/packager": "20.3.0",
     "@electron/universal": "3.0.6"
   }

--- a/desktop/packaging/sign-macos.mjs
+++ b/desktop/packaging/sign-macos.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Sign the final bundle, after desktop-build.sh adds the Go service and CLI.
+// codesign --deep does not discover all code in Resources or nested frameworks.
+import { sign } from "@electron/osx-sign";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export async function signMacOS(app, identity) {
+  if (!app || !identity) throw new Error("app and signing identity are required");
+  const adhoc = identity === "-";
+  await sign({
+    app: resolve(app),
+    identity,
+    identityValidation: !adhoc,
+    platform: "darwin",
+    type: "distribution",
+    preAutoEntitlements: false,
+    preEmbedProvisioningProfile: false,
+    strictVerify: true,
+    optionsForFile: () => ({
+      entitlements: fileURLToPath(new URL("../build/darwin/entitlements.plist", import.meta.url)),
+      hardenedRuntime: true,
+      ...(adhoc ? { timestamp: "none" } : {}),
+    }),
+  });
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await signMacOS(...process.argv.slice(2));
+}

--- a/desktop/packaging/sign-macos.test.mjs
+++ b/desktop/packaging/sign-macos.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { signMacOS } from "./sign-macos.mjs";
+
+test("signing requires an explicit app and identity", async () => {
+  await assert.rejects(signMacOS("fixture.app"), /identity are required/);
+});
+
+test("signs both architectures of resource sidecars and framework binaries before sealing", {
+  skip: process.platform !== "darwin",
+}, async () => {
+  const root = mkdtempSync(join(tmpdir(), "reasonix-signing-test-"));
+  try {
+    const app = join(root, "Reasonix.app");
+    const plist = (executable, type) => `<?xml version="1.0"?><plist version="1.0"><dict>
+      <key>CFBundleIdentifier</key><string>io.reasonix.fixture.${executable}</string>
+      <key>CFBundleExecutable</key><string>${executable}</string>
+      <key>CFBundlePackageType</key><string>${type}</string>
+      <key>CFBundleVersion</key><string>1</string></dict></plist>`;
+    const put = (name, contents) => {
+      mkdirSync(dirname(join(app, name)), { recursive: true });
+      writeFileSync(join(app, name), contents);
+    };
+    put("Contents/Info.plist", plist("Reasonix", "APPL"));
+    put("Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/Info.plist", plist("Electron Framework", "FMWK"));
+    put("Contents/Frameworks/Squirrel.framework/Versions/A/Resources/Info.plist", plist("Squirrel", "FMWK"));
+    const binaries = [
+      "Contents/MacOS/Reasonix",
+      "Contents/MacOS/reasonix-desktop",
+      "Contents/Resources/service/reasonix",
+      "Contents/Resources/service/reasonix-desktop",
+      "Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework",
+      "Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libffmpeg.dylib",
+      "Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libvk_swiftshader.dylib",
+      "Contents/Frameworks/Squirrel.framework/Versions/A/Squirrel",
+      "Contents/Frameworks/Squirrel.framework/Versions/A/Resources/ShipIt",
+    ];
+    const source = join(root, "fixture.c");
+    writeFileSync(source, "int main(void) { return 0; }\n");
+    for (const relative of binaries) {
+      const file = join(app, relative);
+      mkdirSync(dirname(file), { recursive: true });
+      const dylib = relative.endsWith(".dylib") || /\/(Electron Framework|Squirrel)$/.test(relative);
+      execFileSync("clang", ["-arch", "arm64", "-arch", "x86_64", ...(dylib ? ["-dynamiclib"] : []), source, "-o", file]);
+      execFileSync("codesign", ["--remove-signature", file]);
+      if (relative.endsWith(".dylib")) chmodSync(file, 0o644);
+    }
+    // Valid versioned framework symlinks are essential to exercise real seals.
+    for (const name of ["Electron Framework", "Squirrel"]) {
+      const framework = join(app, "Contents/Frameworks", `${name}.framework`);
+      execFileSync("ln", ["-s", "A", join(framework, "Versions/Current")]);
+      execFileSync("ln", ["-s", `Versions/Current/${name}`, join(framework, name)]);
+      execFileSync("ln", ["-s", "Versions/Current/Resources", join(framework, "Resources")]);
+    }
+    // Reproduce the original false positive: bundle verification passes while
+    // code stored as a resource still has no signature.
+    execFileSync("codesign", ["--force", "--deep", "--options", "runtime", "-s", "-", app]);
+    execFileSync("codesign", ["--verify", "--deep", "--strict", app]);
+    assert.notEqual(spawnSync("codesign", ["--verify", join(app, binaries[2])]).status, 0);
+
+    await signMacOS(app, "-");
+    for (const relative of binaries) {
+      for (const arch of ["arm64", "x86_64"]) {
+        const result = spawnSync("codesign", ["--display", "--verbose=4", "--arch", arch, join(app, relative)], { encoding: "utf8" });
+        assert.equal(result.status, 0, `${relative} (${arch}): ${result.stderr}`);
+        assert.match(result.stderr, /flags=.*\(.*runtime.*\)/, `${relative} (${arch})`);
+      }
+      execFileSync("codesign", ["--verify", "--strict", "--all-architectures", join(app, relative)]);
+    }
+    execFileSync("codesign", ["--verify", "--deep", "--strict", "--all-architectures", app]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
 
   .:
     devDependencies:
+      '@electron/osx-sign':
+        specifier: 2.7.0
+        version: 2.7.0
       '@electron/packager':
         specifier: 20.3.0
         version: 20.3.0

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -220,9 +220,7 @@ darwin)
 		identity="$(security find-identity -v -p codesigning | awk -F'"' '/Developer ID Application/{print $2; exit}')"
 		[ -n "$identity" ] || { echo "HAS_APPLE_CERT=true but no 'Developer ID Application' identity found in the keychain" >&2; exit 1; }
 		echo "==> codesign (Developer ID): $identity"
-		codesign --force --deep --timestamp --options runtime \
-			--entitlements "$ROOT/desktop/build/darwin/entitlements.plist" \
-			-s "$identity" "$app"
+		node "$ROOT/desktop/packaging/sign-macos.mjs" "$app" "$identity"
 		# notarytool wants an archive, not a bare bundle: zip the .app, submit, wait,
 		# then staple the ticket back onto the bundle so it verifies offline.
 		ditto -c -k --keepParent "$app" "$staging/notarize.zip"
@@ -231,7 +229,7 @@ darwin)
 	else
 		# Ad-hoc cuts the "is damaged" error somewhat but is NOT notarized; users may
 		# still need `xattr -dr com.apple.quarantine` (see desktop/README.md).
-		codesign --force --deep -s - "$app"
+		node "$ROOT/desktop/packaging/sign-macos.mjs" "$app" -
 	fi
 
 	if [ "$arch" = universal ]; then


### PR DESCRIPTION
Apple notarization rejected the Electron Desktop bundle because the two Go sidecars in Resources/service, libffmpeg.dylib, libvk_swiftshader.dylib, and Squirrel's ShipIt were missing valid Developer ID signatures and timestamps; the executable sidecars also lacked hardened runtime. The previous recursive bundle verification passed despite those omissions.

Sign the fully assembled app with @electron/osx-sign 2.7.0, after copying the Go binaries, so resource executables and nested framework libraries are signed before their containing bundles. Developer ID and local ad-hoc builds share the traversal; Developer ID signing retains secure timestamps, hardened runtime, and the existing entitlements. Notarization and Gatekeeper checks remain in the diagnostics helper introduced in #10069.

Validation:
- Native regression reproduces the old false-positive bundle verification, then verifies both arm64 and x86_64 signatures and hardened runtime for all fixture binaries, including non-executable-mode dylibs.
- macOS CI runs the native regression on pull requests.
- All 19 packaging tests and the Go packaging contract tests pass locally.
- A disposable Electron 44.2.0 app plus service fixtures passes signing and strict verification for all 15 Mach-O files.
- A complete arm64 Reasonix build passes archive member checks, strict signature verification after extraction, and packaged Electron/Go startup and normal shutdown smoke testing with disposable state.
- Desktop build contract and repository lint pass. Actual Apple notarization will be verified through the existing non-publishing signing preflight after merge.

No release tags or publication settings change.

Documentation-impact: none - Existing installation and local build instructions remain correct; this repairs artifact signing without changing product configuration or usage.

Cache-impact: none - No provider requests, prompts, or runtime cache behavior change.
Cache-guard: Existing cache guards cover the unchanged runtime; this change is limited to packaging and signing.
System-prompt-review: N/A
