### PR TITLE
ci(desktop): verify macOS signing before tagging / 增加发布前公证验证入口

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -804,6 +804,7 @@ jobs:
             .github/workflows/release-npm.yml \
             .github/workflows/release-desktop.yml \
             .github/workflows/apple-notary-log.yml \
+            .github/workflows/macos-signing-check.yml \
             .github/workflows/release-verify-issues.yml \
             .github/workflows/docs-impact.yml \
             .github/workflows/ci.yml

--- a/.github/workflows/macos-signing-check.yml
+++ b/.github/workflows/macos-signing-check.yml
@@ -1,0 +1,80 @@
+name: Verify macOS signing
+
+# Validate the current protected commit before creating a release tag. This
+# workflow only builds, notarizes, and retains diagnostics; it cannot publish.
+on: workflow_dispatch
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    if: github.repository == 'esengine/DeepSeek-Reasonix' && github.ref == 'refs/heads/main-v2' && github.ref_protected
+    runs-on: macos-14
+    environment: release
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: desktop/go.mod
+          cache: true
+          cache-dependency-path: desktop/go.sum
+      - uses: pnpm/action-setup@v6.1.0
+        with:
+          version: 10
+          run_install: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: desktop/pnpm-lock.yaml
+      - name: Install create-dmg
+        run: brew install create-dmg
+      - name: Build and notarize the universal app and DMG
+        env:
+          APPLE_CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/notary.p8
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_NOTARIZATION_LOG_DIR: ${{ runner.temp }}/apple-notarization
+          HAS_APPLE_CERT: "true"
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${APPLE_CERT_P12:?Apple certificate is required}"
+          : "${APPLE_CERT_PASSWORD:?Apple certificate password is required}"
+          : "${APPLE_API_KEY_P8:?Apple notarization key is required}"
+          : "${APPLE_API_KEY_ID:?Apple key ID is required}"
+          : "${APPLE_API_ISSUER_ID:?Apple issuer is required}"
+          umask 077
+          KEYCHAIN="$RUNNER_TEMP/signing-check.keychain-db"
+          KEYCHAIN_PASS="$(uuidgen)"
+          trap 'security delete-keychain "$KEYCHAIN" >/dev/null 2>&1 || true; rm -f "$RUNNER_TEMP/cert.p12" "$APPLE_API_KEY_PATH"' EXIT
+          security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          printf '%s' "$APPLE_CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN" >/dev/null
+          existing_keychains=()
+          while IFS= read -r keychain; do
+            [ -n "$keychain" ] && existing_keychains+=("$keychain")
+          done < <(security list-keychains -d user | sed -E 's/^[[:space:]]*"//; s/"[[:space:]]*$//')
+          security list-keychains -d user -s "$KEYCHAIN" "${existing_keychains[@]}"
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$APPLE_API_KEY_PATH"
+          scripts/desktop-build.sh darwin/universal v0.0.0-signing-check stable
+          node desktop/packaging/verify.mjs dist/Reasonix-darwin-arm64.zip
+      - name: Upload Apple notarization diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: apple-signing-check-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/apple-notarization/*.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -22,6 +22,24 @@ function shellStep(body, name) {
 const ci = workflow("ci");
 const release = workflow("release-desktop");
 
+test("macOS signing diagnostics require protected main and cannot publish", () => {
+  const source = workflow("macos-signing-check");
+  const verify = job(source, "verify");
+  const github = { repository: "esengine/DeepSeek-Reasonix", ref: "refs/heads/main-v2", ref_protected: true };
+  assert.equal(condition(verify, { github }), true);
+  for (const changed of [{ repository: "fork/Reasonix" }, { ref: "refs/tags/v1.0.0" }, { ref_protected: false }]) {
+    assert.equal(condition(verify, { github: { ...github, ...changed } }), false);
+  }
+  assert.match(verify, /environment: release/);
+  assert.match(verify, /ref: \$\{\{ github.sha \}\}/);
+  assert.match(source, /permissions:\n  contents: read\n/);
+  assert.doesNotMatch(source, /: write|secrets\.(R2_|SIGNPATH_|MINISIGN_|NPM_)/);
+  assert.match(verify, /HAS_APPLE_CERT: "true"/);
+  assert.match(verify, /scripts\/desktop-build.sh darwin\/universal v0.0.0-signing-check stable/);
+  assert.match(verify, /path: \$\{\{ runner.temp \}\}\/apple-notarization\/\*\.json/);
+  assert.match(verify, /if: always\(\)/);
+});
+
 test("required desktop aggregate rejects every failed, cancelled or unexpectedly skipped child", () => {
   const script = shellStep(job(ci, "desktop"), "Verify desktop validation jobs");
   const success = { CHANGES_RESULT: "success", SHOULD_RUN: "true", PREPARE_RESULT: "success", GO_RESULT: "success", FRONTEND_RESULT: "success", BROWSER_RESULT: "success" };


### PR DESCRIPTION
The signing fix in #10072 needs real Apple validation before a new release tag is created. The existing manual Desktop entry point only accepts Stable tags, so rerunning the failed tag would still execute its old signing code.

Add a manual macOS signing check restricted to protected main-v2 and the existing release environment. It builds the universal app and DMG with the production packaging script, requires all Apple credentials, notarizes and checks both artifacts, then uploads only notarization JSON diagnostics. The run has read-only repository permissions and no publisher, release tag operation, or R2/npm credentials. Temporary signing credentials are cleaned up when the build step exits.

Validation: workflow guard regression, actionlint, repository lint, and diff checks pass. After merge this entry point will validate the repaired signing path without publishing a version.

CI: all required checks pass. The first Windows job exceeded the existing five-second deadline in TestCloseCancelsCatalogWorkerContext. Session catalog code is unchanged; rerunning only that job passed, with the original failure retained in attempt 1. The Desktop checks also passed.

Documentation-impact: none - This adds an operator diagnostic workflow; product usage and embedded documentation are unchanged.
Cache-impact: none - No provider-visible requests or runtime behavior change.
Cache-guard: Existing runtime cache guards remain applicable.
System-prompt-review: N/A
