### PR TITLE
fix(cli): preserve UTF-8 when copying from WSL

### DIFF
--- a/internal/cli/clipboard_wsl.go
+++ b/internal/cli/clipboard_wsl.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/atotto/clipboard"
 
@@ -42,10 +44,15 @@ func isWSLFor(goos string, getenv func(string) string) bool {
 }
 
 func writeWSLClipboardText(text string) error {
-	cmd := newWSLClipboardCommand(text)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := newWSLClipboardCommand(ctx, text)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("write WSL clipboard: %w", ctx.Err())
+		}
 		if detail := strings.TrimSpace(stderr.String()); detail != "" {
 			return fmt.Errorf("write WSL clipboard: %w: %s", err, detail)
 		}
@@ -54,7 +61,7 @@ func writeWSLClipboardText(text string) error {
 	return nil
 }
 
-func newWSLClipboardCommand(text string) *exec.Cmd {
+func newWSLClipboardCommand(ctx context.Context, text string) *exec.Cmd {
 	args := []string{
 		"powershell.exe",
 		"-NoProfile",
@@ -71,7 +78,10 @@ func newWSLClipboardCommand(text string) *exec.Cmd {
 	case clipboardCommandAvailable("xsel"):
 		args = []string{"xsel", "--input", "--clipboard"}
 	}
-	cmd := proc.Command(args[0], args[1:]...)
+	cmd := proc.CommandContext(ctx, args[0], args[1:]...)
+	proc.SetCancelKillsTree(cmd)
+	// Bound pipe draining too, if an interop child inherits an output handle.
+	cmd.WaitDelay = time.Second
 	cmd.Stdin = strings.NewReader(text)
 	return cmd
 }

--- a/internal/cli/clipboard_wsl.go
+++ b/internal/cli/clipboard_wsl.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/atotto/clipboard"
+
+	"reasonix/internal/proc"
+)
+
+// wslClipboardWriteScript reads stdin as UTF-8 and lets Windows PowerShell
+// perform the UTF-16 clipboard write. Passing text through clip.exe instead
+// makes the Windows program decode the raw UTF-8 bytes using the active OEM
+// code page (CP936 on Chinese systems), producing mojibake such as 中文 -> 涓枃.
+const wslClipboardWriteScript = `$stdin = [Console]::OpenStandardInput()
+$reader = [IO.StreamReader]::new($stdin, [Text.UTF8Encoding]::new($false))
+Set-Clipboard -Value $reader.ReadToEnd()`
+
+// writeClipboardText uses the normal platform clipboard outside WSL. WSL is a
+// Linux process, so atotto/clipboard's Windows-interop fallback would otherwise
+// send UTF-8 bytes to clip.exe without first converting them to Unicode.
+func writeClipboardText(text string) error {
+	if isWSL() {
+		return writeWSLClipboardText(text)
+	}
+	return clipboard.WriteAll(text)
+}
+
+func isWSL() bool {
+	return isWSLFor(runtime.GOOS, os.Getenv)
+}
+
+func isWSLFor(goos string, getenv func(string) string) bool {
+	if goos != "linux" {
+		return false
+	}
+	return getenv("WSL_DISTRO_NAME") != "" || getenv("WSL_INTEROP") != ""
+}
+
+func writeWSLClipboardText(text string) error {
+	cmd := newWSLClipboardCommand(text)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if detail := strings.TrimSpace(stderr.String()); detail != "" {
+			return fmt.Errorf("write WSL clipboard: %w: %s", err, detail)
+		}
+		return fmt.Errorf("write WSL clipboard: %w", err)
+	}
+	return nil
+}
+
+func newWSLClipboardCommand(text string) *exec.Cmd {
+	cmd := proc.Command(
+		"powershell.exe",
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		wslClipboardWriteScript,
+	)
+	cmd.Stdin = strings.NewReader(text)
+	return cmd
+}

--- a/internal/cli/clipboard_wsl.go
+++ b/internal/cli/clipboard_wsl.go
@@ -21,8 +21,8 @@ $reader = [IO.StreamReader]::new($stdin, [Text.UTF8Encoding]::new($false))
 Set-Clipboard -Value $reader.ReadToEnd()`
 
 // writeClipboardText uses the normal platform clipboard outside WSL. WSL is a
-// Linux process, so atotto/clipboard's Windows-interop fallback would otherwise
-// send UTF-8 bytes to clip.exe without first converting them to Unicode.
+// Linux process: preserve its clipboard utilities, but replace the clip.exe
+// fallback that would otherwise decode UTF-8 using a Windows code page.
 func writeClipboardText(text string) error {
 	if isWSL() {
 		return writeWSLClipboardText(text)
@@ -55,13 +55,28 @@ func writeWSLClipboardText(text string) error {
 }
 
 func newWSLClipboardCommand(text string) *exec.Cmd {
-	cmd := proc.Command(
+	args := []string{
 		"powershell.exe",
 		"-NoProfile",
 		"-NonInteractive",
 		"-Command",
 		wslClipboardWriteScript,
-	)
+	}
+	// Keep native Linux clipboard support when Windows interop is unavailable.
+	switch {
+	case os.Getenv("WAYLAND_DISPLAY") != "" && clipboardCommandAvailable("wl-copy"):
+		args = []string{"wl-copy"}
+	case clipboardCommandAvailable("xclip"):
+		args = []string{"xclip", "-in", "-selection", "clipboard"}
+	case clipboardCommandAvailable("xsel"):
+		args = []string{"xsel", "--input", "--clipboard"}
+	}
+	cmd := proc.Command(args[0], args[1:]...)
 	cmd.Stdin = strings.NewReader(text)
 	return cmd
+}
+
+func clipboardCommandAvailable(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
 }

--- a/internal/cli/clipboard_wsl_process_test.go
+++ b/internal/cli/clipboard_wsl_process_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestWSLClipboardPreservesLinuxBackends(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		wayland  string
+		programs []string
+		want     string
+		args     string
+	}{
+		{"wayland", "wayland-0", []string{"wl-copy", "xclip", "xsel"}, "wl-copy", ""},
+		{"xclip", "", []string{"xclip", "xsel"}, "xclip", "-in -selection clipboard"},
+		{"prefer Linux to Windows", "", []string{"xclip", "powershell.exe"}, "xclip", "-in -selection clipboard"},
+		{"xsel", "", []string{"xsel"}, "xsel", "--input --clipboard"},
+		{"missing wayland utility", "wayland-0", []string{"xclip"}, "xclip", "-in -selection clipboard"},
+		{"no wayland session", "", []string{"wl-copy", "xclip"}, "xclip", "-in -selection clipboard"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := setupWSLClipboardProcessTest(t)
+			t.Setenv("WAYLAND_DISPLAY", tc.wayland)
+			for _, name := range tc.programs {
+				installWSLClipboardFixture(t, dir, name, "printf '%s' '"+name+"' > \"$CLIPBOARD_TEST_BACKEND\"\nprintf '%s' \"$*\" > \"$CLIPBOARD_TEST_ARGS\"\n/bin/cat > \"$CLIPBOARD_TEST_TEXT\"\n")
+			}
+			text := "中文\n你好 🚀\r\n'\"; $(not-a-command)\n"
+			if err := writeWSLClipboardText(text); err != nil {
+				t.Fatalf("copy with a working Linux backend but no PowerShell: %v", err)
+			}
+			assertWSLClipboardFile(t, "CLIPBOARD_TEST_TEXT", text)
+			assertWSLClipboardFile(t, "CLIPBOARD_TEST_BACKEND", tc.want)
+			assertWSLClipboardFile(t, "CLIPBOARD_TEST_ARGS", tc.args)
+		})
+	}
+}
+
+func TestWSLClipboardBridgeProcess(t *testing.T) {
+	for _, fail := range []bool{false, true} {
+		t.Run(map[bool]string{false: "success", true: "failure"}[fail], func(t *testing.T) {
+			dir := setupWSLClipboardProcessTest(t)
+			script := "/bin/cat > \"$CLIPBOARD_TEST_TEXT\"\n"
+			installWSLClipboardFixture(t, dir, "clip.exe", "exit 99\n")
+			if fail {
+				script += "echo clipboard-unavailable >&2\nexit 7\n"
+			}
+			installWSLClipboardFixture(t, dir, "powershell.exe", script)
+			text := "中文\n你好 🚀\r\n'\"; $(not-a-command)\n"
+			err := writeWSLClipboardText(text)
+			if fail {
+				if err == nil || !strings.Contains(err.Error(), "clipboard-unavailable") {
+					t.Fatalf("expected command failure with stderr, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			assertWSLClipboardFile(t, "CLIPBOARD_TEST_TEXT", text)
+		})
+	}
+}
+
+func setupWSLClipboardProcessTest(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("WSL command execution uses POSIX executable fixtures")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	t.Setenv("WAYLAND_DISPLAY", "")
+	for _, key := range []string{"CLIPBOARD_TEST_TEXT", "CLIPBOARD_TEST_BACKEND", "CLIPBOARD_TEST_ARGS"} {
+		t.Setenv(key, filepath.Join(dir, key))
+	}
+	return dir
+}
+
+func installWSLClipboardFixture(t *testing.T, dir, name, script string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n"+script), 0700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertWSLClipboardFile(t *testing.T, key, want string) {
+	t.Helper()
+	got, err := os.ReadFile(os.Getenv(key))
+	if err != nil || string(got) != want {
+		t.Fatalf("%s = %q, %v; want %q", key, got, err, want)
+	}
+}

--- a/internal/cli/clipboard_wsl_process_test.go
+++ b/internal/cli/clipboard_wsl_process_test.go
@@ -1,11 +1,14 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestWSLClipboardPreservesLinuxBackends(t *testing.T) {
@@ -62,6 +65,32 @@ func TestWSLClipboardBridgeProcess(t *testing.T) {
 			assertWSLClipboardFile(t, "CLIPBOARD_TEST_TEXT", text)
 		})
 	}
+}
+
+func TestWSLClipboardCommandCancellation(t *testing.T) {
+	dir := setupWSLClipboardProcessTest(t)
+	installWSLClipboardFixture(t, dir, "powershell.exe", "echo ready >&2\nexec /bin/sleep 60\n")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := newWSLClipboardCommand(ctx, "中文")
+	// Cancel only after the child is running, without relying on startup timing.
+	cmd.Stderr = clipboardCancelWriter{cancel: cancel}
+	if err := cmd.Run(); err == nil {
+		t.Fatal("a canceled clipboard command succeeded")
+	}
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("command did not respond to cancellation: %v", ctx.Err())
+	}
+	if cmd.ProcessState == nil {
+		t.Fatal("canceled clipboard child was not reaped")
+	}
+}
+
+type clipboardCancelWriter struct{ cancel context.CancelFunc }
+
+func (w clipboardCancelWriter) Write(p []byte) (int, error) {
+	w.cancel()
+	return len(p), nil
 }
 
 func setupWSLClipboardProcessTest(t *testing.T) string {

--- a/internal/cli/clipboard_wsl_test.go
+++ b/internal/cli/clipboard_wsl_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestWSLClipboardCommandPreservesUTF8Text(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("WAYLAND_DISPLAY", "")
 	for _, text := range []string{"中文测试", "hello", "你好 🚀"} {
 		t.Run(text, func(t *testing.T) {
 			cmd := newWSLClipboardCommand(text)

--- a/internal/cli/clipboard_wsl_test.go
+++ b/internal/cli/clipboard_wsl_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"io"
 	"strings"
 	"testing"
@@ -11,7 +12,7 @@ func TestWSLClipboardCommandPreservesUTF8Text(t *testing.T) {
 	t.Setenv("WAYLAND_DISPLAY", "")
 	for _, text := range []string{"中文测试", "hello", "你好 🚀"} {
 		t.Run(text, func(t *testing.T) {
-			cmd := newWSLClipboardCommand(text)
+			cmd := newWSLClipboardCommand(context.Background(), text)
 			if got := cmd.Args[0]; got != "powershell.exe" {
 				t.Fatalf("command = %q, want powershell.exe", got)
 			}

--- a/internal/cli/clipboard_wsl_test.go
+++ b/internal/cli/clipboard_wsl_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestWSLClipboardCommandPreservesUTF8Text(t *testing.T) {
+	for _, text := range []string{"中文测试", "hello", "你好 🚀"} {
+		t.Run(text, func(t *testing.T) {
+			cmd := newWSLClipboardCommand(text)
+			if got := cmd.Args[0]; got != "powershell.exe" {
+				t.Fatalf("command = %q, want powershell.exe", got)
+			}
+			script := cmd.Args[len(cmd.Args)-1]
+			if !strings.Contains(script, "[Text.UTF8Encoding]::new($false)") {
+				t.Fatalf("PowerShell script does not explicitly decode UTF-8: %q", script)
+			}
+			if !strings.Contains(script, "Set-Clipboard") {
+				t.Fatalf("PowerShell script does not use Set-Clipboard: %q", script)
+			}
+			got, err := io.ReadAll(cmd.Stdin)
+			if err != nil {
+				t.Fatalf("read command stdin: %v", err)
+			}
+			if string(got) != text {
+				t.Fatalf("clipboard bridge stdin = %q, want %q", got, text)
+			}
+		})
+	}
+}
+
+func TestIsWSLFor(t *testing.T) {
+	tests := []struct {
+		name   string
+		goos   string
+		values map[string]string
+		want   bool
+	}{
+		{name: "windows ignores WSL variables", goos: "windows", values: map[string]string{"WSL_DISTRO_NAME": "Ubuntu"}, want: false},
+		{name: "linux without WSL", goos: "linux", values: map[string]string{}, want: false},
+		{name: "WSL distro", goos: "linux", values: map[string]string{"WSL_DISTRO_NAME": "Ubuntu"}, want: true},
+		{name: "WSL interop", goos: "linux", values: map[string]string{"WSL_INTEROP": "/run/WSL/8_interop"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getenv := func(key string) string { return tt.values[key] }
+			if got := isWSLFor(tt.goos, getenv); got != tt.want {
+				t.Fatalf("isWSLFor(%q) = %v, want %v", tt.goos, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -9,7 +9,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/x/ansi"
 
 	"reasonix/internal/provider"
@@ -324,7 +323,7 @@ type clipboardCopyMsg struct {
 	seq        int
 }
 
-var writeNativeClipboardText = clipboard.WriteAll
+var writeNativeClipboardText = writeClipboardText
 
 func remoteClipboardSession() bool {
 	return os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_CLIENT") != "" || os.Getenv("SSH_TTY") != ""


### PR DESCRIPTION
## Summary

Fixes Windows Chinese/WSL2 mouse-selection copy producing garbled text such as `中文` -> `涓枃`.

WSL keeps its native Wayland/X11 clipboard utilities. When none is available, Reasonix explicitly decodes UTF-8 in Windows PowerShell and uses `Set-Clipboard`, instead of passing raw UTF-8 to `clip.exe`.

Fixes #9765

## Root cause and behavior

Reasonix runs as a Linux process in WSL. The existing clipboard library falls back to `clip.exe` when no Linux clipboard utility is available; Windows can interpret its raw UTF-8 input using a legacy code page. Shift-drag bypasses this path because Windows Terminal handles the selection itself.

- Prefer `wl-copy` in a Wayland session, followed by `xclip` and `xsel`. These backends remain usable when Windows PATH imports or Windows interoperability are disabled.
- Use the UTF-8 PowerShell bridge only when native Linux clipboard tools are unavailable. Copy text is passed through stdin, not interpolated into script source. Never use raw `clip.exe` in this WSL path.
- Bound WSL clipboard commands with a five-second deadline, process-tree cancellation, and a one-second pipe-drain wait. Errors still reach the existing OSC 52 fallback and its unverified-copy notice.
- Keep the existing clipboard behavior outside WSL, including native Windows, macOS, regular Linux and SSH handling.

## Verification

- `go test ./internal/cli -count=1`
- `go test -race ./internal/cli -run 'TestWSLClipboard|TestIsWSLFor|TestCopyToClipboard|TestClipboardCopyFallbackDoesNotClaimNativeSuccess' -count=1 -v`
- `go vet ./...`
- `go run ./tools/repolint`
- `golangci-lint run --timeout=5m ./...` — 0 issues
- `git diff --check`

Regression tests reproduce the native-backend omission before the fix and cover backend priority, missing PowerShell, exclusion of raw `clip.exe`, exact stdin bytes for Chinese/emoji/multiline text, command failure propagation, and cancellation after child startup. Process tests use isolated POSIX executable fixtures and run on Linux/macOS; they do not constitute a native WSL2/Windows clipboard round trip. Native WSL2 clipboard and latency verification remains an external validation item.

## Impact

Documentation-impact: none - corrects the existing clipboard workflow without adding user configuration.
Cache-impact: none - local clipboard writes do not change provider-visible prompts, tools, memory, or serialization.
Cache-guard: N/A - no cache-sensitive files changed.
System-prompt-review: N/A
