### PR TITLE
fix(desktop): seal the macOS app after its service / 修正 macOS 主程序签名顺序

### DIFF
--- a/desktop/packaging/sign-macos.mjs
+++ b/desktop/packaging/sign-macos.mjs
@@ -2,14 +2,16 @@
 // Sign the final bundle, after desktop-build.sh adds the Go service and CLI.
 // codesign --deep does not discover all code in Resources or nested frameworks.
 import { sign } from "@electron/osx-sign";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { PRODUCT } from "./lib.mjs";
 
 export async function signMacOS(app, identity) {
   if (!app || !identity) throw new Error("app and signing identity are required");
   const adhoc = identity === "-";
+  const bundle = resolve(app);
   await sign({
-    app: resolve(app),
+    app: bundle,
     identity,
     identityValidation: !adhoc,
     platform: "darwin",
@@ -17,6 +19,9 @@ export async function signMacOS(app, identity) {
     preAutoEntitlements: false,
     preEmbedProvisioningProfile: false,
     strictVerify: true,
+    // Signing the main executable also seals its app. Defer it to osx-sign's
+    // final app signing call, after the adjacent Go service has been signed.
+    ignore: [(file) => file === join(bundle, "Contents", "MacOS", PRODUCT.executable)],
     optionsForFile: () => ({
       entitlements: fileURLToPath(new URL("../build/darwin/entitlements.plist", import.meta.url)),
       hardenedRuntime: true,

--- a/desktop/packaging/sign-macos.test.mjs
+++ b/desktop/packaging/sign-macos.test.mjs
@@ -62,6 +62,12 @@ test("signs both architectures of resource sidecars and framework binaries befor
     execFileSync("codesign", ["--verify", "--deep", "--strict", app]);
     assert.notEqual(spawnSync("codesign", ["--verify", join(app, binaries[2])]).status, 0);
 
+    // The control above signs MacOS siblings. Start the new signer from fully
+    // unsigned code so it must order those siblings before the main app seal.
+    for (const relative of binaries) {
+      execFileSync("codesign", ["--remove-signature", join(app, relative)]);
+    }
+
     await signMacOS(app, "-");
     for (const relative of binaries) {
       for (const arch of ["arm64", "x86_64"]) {


### PR DESCRIPTION
The real Developer ID check exposed a signing-order failure before notarization: signing Contents/MacOS/Reasonix seals the app while its adjacent Go service is still unsigned. osx-sign gives both files the same signing rank, so the main executable can be processed first.

Defer the root main executable to osx-sign's final app signing call. Every other discovered code object, including the adjacent service, is signed before the outer bundle is sealed. The main executable remains signed and verified through that final bundle operation.

The native universal regression now clears every Mach-O signature after reproducing the old deep-signing behavior. This fails with the exact CI error before the fix and passes afterwards; previously the control experiment left the adjacent service signed and masked the ordering problem. All 19 packaging tests and repository lint pass.

Refs #10072, #10073.

Post-merge verification: [the non-publishing Apple check](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/34496245334) passed on commit 645c156. Apple accepted both the universal app and DMG with statusCode 0 and no issues. Both artifacts passed stapling, ticket validation, and Gatekeeper assessment as Notarized Developer ID; the final zip also passed member verification. No release was published.

Documentation-impact: none - This corrects packaging order without changing product usage or configuration.
Cache-impact: none - No runtime or provider-visible behavior changes.
Cache-guard: Existing runtime cache guards remain applicable.
System-prompt-review: N/A
