### PR TITLE
test(release): confirm interrupted writes before continuation / 修正发布实测中的写入恢复流程

### DIFF
--- a/internal/agent/live_official_write_resume_test.go
+++ b/internal/agent/live_official_write_resume_test.go
@@ -90,6 +90,7 @@ func runLiveWriteAfterEffectResume(t *testing.T, p provider.Provider, label stri
 	resume.SetSessionPath(state)
 	next, done := context.WithTimeout(context.Background(), 90*time.Second)
 	defer done()
+	confirmLiveWriteRecovery(t, next, resume)
 	if err := resume.Run(next, "Continue from the interrupted operation. Use the verified write postconditions. Do not rewrite satisfied content; just report whether the target is satisfied."); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/live_tool_recovery_confirm_test.go
+++ b/internal/agent/live_tool_recovery_confirm_test.go
@@ -1,0 +1,32 @@
+//go:build live
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// File postconditions establish current state, not a historical tool outcome.
+// Model the host's explicit inspection and user confirmation before Continue.
+func confirmLiveWriteRecovery(t *testing.T, ctx context.Context, a *Agent) {
+	t.Helper()
+	pending := a.PendingToolRecovery()
+	if len(pending) != 1 || pending[0].ReadOnly {
+		t.Fatalf("expected one unresolved write, got %d recovery records", len(pending))
+	}
+	id := pending[0].Identity.AttemptID
+	proof, err := a.InspectToolRecovery(ctx, id)
+	if err != nil || proof.InspectionState != "postcondition_satisfied" {
+		t.Fatalf("write inspection: state=%s err=%v", proof.InspectionState, err)
+	}
+	if err := a.ResolveToolRecovery(id, proof.InspectionID, "confirm"); err != nil {
+		t.Fatal(err)
+	}
+	call, err := a.recoveryCall(id)
+	if err != nil || call.Recovery == nil || call.Recovery.State != provider.ToolRunUserConfirmed || len(a.PendingToolRecovery()) != 0 {
+		t.Fatal("explicit confirmation did not resolve the exact write attempt")
+	}
+}

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -497,7 +497,26 @@
           ]
         }
       ],
-      "risks": [],
+      "risks": [
+        {
+          "targets": [
+            "desktop",
+            "cli"
+          ],
+          "title": {
+            "en": "OpenCode Go Responses search limitation",
+            "zh": "OpenCode Go Responses 搜索限制"
+          },
+          "body": {
+            "en": "Release checks could not obtain completed native search evidence from the OpenCode Go DeepSeek Responses route. Use the verified OpenCode Go Anthropic search route for web search. Ordinary model calls, tool replay, and image input passed; the Responses search path is not claimed as verified for this release.",
+            "zh": "发布实测未能从 OpenCode Go DeepSeek Responses 路径取得已完成的原生搜索证据。联网搜索请使用已验证的 OpenCode Go Anthropic 路径。普通模型调用、工具回放和图片输入已通过；本版本不将 Responses 搜索标记为已验证。"
+          },
+          "refs": [
+            10015,
+            10081
+          ]
+        }
+      ],
       "contributors": [
         "SivanCola",
         "XTLine",

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -477,7 +477,26 @@
           }
         ]
       },
-      "upgrade": [],
+      "upgrade": [
+        {
+          "level": "warning",
+          "targets": [
+            "desktop",
+            "cli"
+          ],
+          "title": {
+            "en": "Resolve interrupted tools before downgrading",
+            "zh": "降级前先完成中断工具恢复"
+          },
+          "body": {
+            "en": "Inspect and confirm unresolved tool effects before downgrading the owning runtime. Older executables do not enforce the new recovery guarantees; new recovery metadata remains additive and safe retry is disabled by default.",
+            "zh": "降级运行时前，请先检查并确认未决的工具执行结果。旧版程序不会执行新增的恢复保护；恢复元数据以增量方式保存，安全重试默认关闭。"
+          },
+          "refs": [
+            10039
+          ]
+        }
+      ],
       "risks": [],
       "contributors": [
         "SivanCola",


### PR DESCRIPTION
## Problem

Stable qualification exposed an outdated opt-in live write/resume test: it expected automatic continuation after an interrupted external effect, while the durable tool recovery contract introduced in #10039 requires inspection and explicit confirmation. The runtime correctly returned `recovery_required`.

## Changes

Update the live fixture to inspect the exact attempt, require a satisfied file postcondition, confirm it through the existing host API, and require `user_confirmed` with no pending effect before continuing. The original assertion still requires exactly one disk write after resume. Production behavior is unchanged.

Add the existing documented downgrade boundary to the reviewed v1.38.5 bilingual catalog: resolve pending effects before using an older runtime, which does not enforce the new recovery guarantees. This catalog change becomes the final reviewed Notes candidate for v1.38.5 after merge.

Document the accepted OpenCode Go Responses search limitation. Ordinary model routes, tool replay, image input, and Anthropic native search passed. Responses search returned no completed native search evidence in repeated release probes, including a diagnostic using the production search budget. A direct gateway request also ended incomplete with only reasoning output. No speculative runtime or budget change is included; Anthropic search is the verified alternative.

## Verification

- Reproduced the previous live test failure at e9589ba4916e1dff0bf5a78401ae49e9d089aecd.
- Updated real DeepSeek write/resume scenario passed with one write and one confirmation.
- Real continuity, reasoning recovery, read/edit/error/pause-resume scenarios, and image recognition passed in disposable fixtures with credential scans.
- Focused deterministic recovery tests, release catalog validation/tests, and repolint passed.
- Existing recovery-action tests cover storage failure rollback, stale/duplicate confirmation, and preservation of uncertainty.

Documentation-impact: none - TOOL_RECOVERY already documents this behavior; the release catalog now surfaces its downgrade guidance.
Cache-impact: none - only opt-in live test orchestration and release prose change; production prompt and tool bytes are unchanged.
Cache-guard: existing cache guard passed; two established tool-loop cases report the guard's non-fatal 89% warning.
System-prompt-review: N/A
