### PR TITLE
fix(sidecar): release Windows handles once / 修复 Windows 扩展句柄重复释放

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         env:
           REASONIX_RELEASE_CACHE_GUARD: "1"
           WINDOWS_SANDBOX_WAIT_MS: "20000"
-        run: go test -p 4 -timeout=8m ./internal/agent/... ./internal/appidentity/... ./internal/boot/... ./internal/checkpoint/... ./internal/cli/... ./internal/desktoplauncher/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sessioncatalog/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
+        run: go test -p 4 -timeout=8m ./internal/agent/... ./internal/appidentity/... ./internal/boot/... ./internal/checkpoint/... ./internal/cli/... ./internal/desktoplauncher/... ./internal/extension/sidecar/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sessioncatalog/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
 
       # The general Windows PR smoke list intentionally omits internal/tool.
       # Keep the session-temp portability contract covered without widening the

--- a/internal/extension/sidecar/process.go
+++ b/internal/extension/sidecar/process.go
@@ -237,8 +237,8 @@ func (p *process) wait() {
 	})
 }
 
-// finishJob releases the Windows Job Object once the process is known to be
-// gone (a no-op off Windows and after KillTracked already released it).
+// finishJob and kill share ownership of the Windows Job Object. Its numeric
+// handle may be reused immediately after either path closes it.
 func (p *process) finishJob() {
 	p.jobOnce.Do(func() { proc.FinishTracked(p.job) })
 }
@@ -248,8 +248,11 @@ func (p *process) kill() {
 	if p.cmd == nil || p.cmd.Process == nil {
 		return
 	}
-	proc.KillTracked(p.cmd, p.job)
-	p.finishJob()
+	if p.job != 0 {
+		p.jobOnce.Do(func() { proc.KillTracked(p.cmd, p.job) })
+		return
+	}
+	proc.KillTracked(p.cmd, 0)
 }
 
 // close stops the sidecar with the bounded sequence: close stdin, grant a

--- a/internal/extension/sidecar/process_windows_test.go
+++ b/internal/extension/sidecar/process_windows_test.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package sidecar
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"golang.org/x/sys/windows"
+
+	"reasonix/internal/proc"
+)
+
+func TestReleasedJobHandleIsNeverClosedAgain(t *testing.T) {
+	for _, first := range []string{"kill", "finish"} {
+		t.Run(first, func(t *testing.T) {
+			cmd := proc.Command("cmd", "/c", "exit", "0")
+			if err := cmd.Run(); err != nil {
+				t.Fatal(err)
+			}
+			job, err := windows.CreateJobObject(nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			p := &process{cmd: cmd, job: uintptr(job)}
+			if first == "kill" {
+				p.kill()
+			} else {
+				p.finishJob()
+			}
+			if err := windows.SetHandleInformation(job, 0, 0); !errors.Is(err, windows.ERROR_INVALID_HANDLE) {
+				t.Fatalf("completed cleanup did not invalidate the Job Object: %v", err)
+			}
+			event, err := windows.CreateEvent(nil, 0, 0, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer windows.CloseHandle(event)
+			// Model Windows reusing the stale handle for an unrelated object;
+			// choosing its value explicitly avoids depending on allocator timing.
+			p.job = uintptr(event)
+			var calls sync.WaitGroup
+			for range 8 {
+				calls.Go(p.kill)
+				calls.Go(p.finishJob)
+			}
+			calls.Wait()
+			if err := windows.SetEvent(event); err != nil {
+				t.Fatalf("cleanup closed an unrelated reused handle: %v", err)
+			}
+		})
+	}
+}

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -3,7 +3,7 @@
   "releases": [
     {
       "version": "1.38.5",
-      "date": "2026-09-10",
+      "date": "2026-09-11",
       "channel": "stable",
       "targetingVersion": 1,
       "title": {
@@ -345,6 +345,17 @@
           }
         ],
         "fixed": [
+          {
+            "targets": ["desktop", "cli"],
+            "title": {
+              "en": "Windows extension shutdown stability",
+              "zh": "Windows 扩展关闭稳定性"
+            },
+            "body": {
+              "en": "Forced extension shutdown and normal process cleanup now release the Windows process-tracking handle exactly once, preventing later cleanup from closing an unrelated reused handle.",
+              "zh": "强制关闭扩展与正常进程回收现在只释放一次 Windows 进程跟踪句柄，避免后续清理误关已被其他对象复用的句柄。"
+            }
+          },
           {
             "targets": [
               "desktop"

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -354,7 +354,8 @@
             "body": {
               "en": "Forced extension shutdown and normal process cleanup now release the Windows process-tracking handle exactly once, preventing later cleanup from closing an unrelated reused handle.",
               "zh": "强制关闭扩展与正常进程回收现在只释放一次 Windows 进程跟踪句柄，避免后续清理误关已被其他对象复用的句柄。"
-            }
+            },
+            "refs": [10082]
           },
           {
             "targets": [


### PR DESCRIPTION
Windows extension shutdown could close a process-tracking Job Object twice: `process.kill` called `KillTracked`, which already closes the handle, then called `finishJob`. A concurrent normal wait could also release the same handle. Windows can reuse the numeric handle immediately, allowing later cleanup to close an unrelated runtime handle.

Make forced termination and normal completion share the existing `jobOnce` owner for nonzero Job Object handles. Keep the zero-handle process-tree fallback unchanged. Include the sidecar suite in the Windows PR smoke gate so the regression runs before merge, and update the reviewed v1.38.5 notes with the shutdown fix.

Validation:
- A native Windows regression models handle reuse and concurrent cleanup. Both cleanup orders fail on the previous candidate and pass 30 consecutive iterations after the fix.
- The complete sidecar suite passes on native Windows ARM64.
- `go test -race ./internal/extension/sidecar ./internal/proc ./internal/plugin` passes.
- Release catalog validation/tests, formatting and repolint pass.
- Audited the other `KillTracked`/`FinishTracked` owners: stdio transport uses mutually exclusive paths under `closeOnce`; tracked commands transfer the handle under a mutex.

Release qualification caught this in main push CI 34501595179 at candidate 5f1d8e9331c1a16468a38793922eaffde5aa6a00: `runtime.preemptM: duplicatehandle failed; errno=6` in the Windows sidecar suite. The handle bug is confirmed independently by the regression; the precise recycled object at the original crash is not observable from that log. No v1.38.5 tags or artifacts have been published. The merged fix and reviewed notes will become the replacement candidate and require full exact-SHA push CI.

Compatibility: no persisted format, protocol or configuration changes.
Cache-impact: none; prompt, tool and provider-visible bytes are unchanged.
Cache-guard: release qualification already passed; repeat the guard on the replacement candidate.
