### PR TITLE
fix(ci): isolate Windows test resource ownership / 修复 Windows 测试资源争用与夹具泄漏

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,11 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - if: env.RUN_STEPS == 'true' && runner.os == 'Windows'
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
       - name: Install and verify Linux sandbox backend
         if: env.RUN_STEPS == 'true' && runner.os == 'Linux'
         run: |
@@ -137,27 +142,16 @@ jobs:
           REASONIX_RELEASE_CACHE_GUARD: "1"
         run: go test ./...
 
-      # Pull requests run a Windows smoke suite: the packages that actually
-      # carry *_windows.go code, the startup/checkpoint packages with portable
-      # filesystem contracts, plus cmd/. The full ./... sweep stays on pushes
-      # to main-v2; the Unix legs always run the full suite. Keep the job-level
-      # budget above normal 7-9 minute runner variance; each package test binary
-      # remains independently bounded by Go's per-package timeout below.
-      #
-      # That timeout is 8m, not 3m: across four consecutive runs of the same
-      # code, internal/boot measured 133s, 146s, 162s and then hit 180s, and
-      # internal/agent 82s, 92s, 144s and 180s — a 2.2x spread from runner
-      # variance alone, with four heavy packages sharing four vCPUs. At 3m the
-      # step failed on slow runners without a code change; a hang still trips
-      # the 15 minute job budget above. internal/control runs in its own
-      # Windows job below so its durable-session I/O does not compete here.
+      # Agent, boot and control own isolated Windows runners on PRs and pushes.
+      # The shared selector excludes them here, preserving platform smoke
+      # coverage without competing durable-session I/O or duplicate execution.
       - name: test (Windows smoke)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name == 'pull_request'
         timeout-minutes: 15
         env:
           REASONIX_RELEASE_CACHE_GUARD: "1"
           WINDOWS_SANDBOX_WAIT_MS: "20000"
-        run: go test -p 4 -timeout=8m ./internal/agent/... ./internal/appidentity/... ./internal/boot/... ./internal/checkpoint/... ./internal/cli/... ./internal/desktoplauncher/... ./internal/extension/sidecar/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sessioncatalog/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
+        run: node scripts/windows-go-tests.mjs smoke
 
       # The general Windows PR smoke list intentionally omits internal/tool.
       # Keep the session-temp portability contract covered without widening the
@@ -183,11 +177,8 @@ jobs:
         timeout-minutes: 5
         run: go test -timeout=3m -run '^TestBashPowerShellExecuteDetailedContract$|^TestBashPowerShell51PreflightRejectsAndAndDetailed$|^TestBashPowerShellOutputIsUTF8$|^TestBashPowerShellSurfacesNonZeroExit$|^TestBashPowerShellRejectsChaining$' ./internal/tool/builtin
 
-      # Full push suite still uses the same 8m package budget as Windows smoke:
-      # agent/boot/control already hit 180s package timeouts under runner load,
-      # so 3m fails on slow machines without a code regression. Keep the step
-      # above normal full-suite wall time (~8-12m) so a hang still dies on the
-      # job budget rather than a false package timeout.
+      # Enumerate the entire module and run every remaining package. The union
+      # with the isolated jobs is exhaustive and disjoint, including new packages.
       - name: test (full)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name != 'pull_request'
         timeout-minutes: 20
@@ -199,7 +190,7 @@ jobs:
           # Bound sandbox helper children in Windows tests so a failed OS-level
           # launch cannot pin the Actions step after Go's package timeout fires.
           WINDOWS_SANDBOX_WAIT_MS: "20000"
-        run: go test -p 4 -timeout=8m ./...
+        run: node scripts/windows-go-tests.mjs full
 
       - name: test (Scoop desktop launch)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows'
@@ -223,13 +214,42 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - if: env.RUN_STEPS == 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
       - name: test
         if: env.RUN_STEPS == 'true'
         timeout-minutes: 10
         env:
           REASONIX_RELEASE_CACHE_GUARD: "1"
           WINDOWS_SANDBOX_WAIT_MS: "20000"
-        run: go test -p 1 -timeout=8m ./internal/control/...
+        run: node scripts/windows-go-tests.mjs control
+
+  windows-isolated:
+    needs: changes
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code != 'false')
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [agent, boot]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+      - name: test
+        timeout-minutes: 10
+        env:
+          REASONIX_RELEASE_CACHE_GUARD: "1"
+          WINDOWS_SANDBOX_WAIT_MS: "20000"
+        run: node scripts/windows-go-tests.mjs ${{ matrix.group }}
 
   race:
     needs: changes
@@ -808,7 +828,7 @@ jobs:
             .github/workflows/release-verify-issues.yml \
             .github/workflows/docs-impact.yml \
             .github/workflows/ci.yml
-          node --test scripts/desktop-release-artifacts.test.mjs scripts/ci-workflow.test.mjs scripts/notarize-desktop.test.mjs
+          node --test scripts/desktop-release-artifacts.test.mjs scripts/ci-workflow.test.mjs scripts/notarize-desktop.test.mjs scripts/windows-go-tests.test.mjs
           bash scripts/release-workflows.test.sh
           node scripts/check-single-release-public-contract.mjs
 

--- a/internal/boot/config_home_test.go
+++ b/internal/boot/config_home_test.go
@@ -33,8 +33,14 @@ func isolateConfigHome(t *testing.T) string {
 
 func closeBootTestHistoryCatalog(t *testing.T) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	// Fixture teardown must await resource release before changing HOME. Its
+	// bound is the suite deadline; shutdown latency is tested by the owner.
+	ctx := context.Background()
+	if deadline, ok := t.Deadline(); ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+		defer cancel()
+	}
 	if err := history.CloseSharedCatalog(ctx); err != nil {
 		t.Fatalf("close shared history catalog: %v", err)
 	}

--- a/internal/boot/extension_ui_test.go
+++ b/internal/boot/extension_ui_test.go
@@ -164,6 +164,7 @@ func TestRebuildRebindsExtensionUIHub(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Rebuild: %v", err)
 	}
+	t.Cleanup(newRes.Controller.Close)
 	if newRes.ExtensionUI == nil {
 		t.Fatal("rebuilt runtime has no UI hub")
 	}

--- a/internal/control/chat_run_budget_test.go
+++ b/internal/control/chat_run_budget_test.go
@@ -3,10 +3,8 @@ package control
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/event"
@@ -19,21 +17,14 @@ import (
 // driven through the controller rather than the agent. With max > 0 it stops
 // on its own after that many rounds.
 type wanderingChatProvider struct {
-	calls    atomic.Int32
-	max      int32
-	progress chan struct{}
+	calls atomic.Int32
+	max   int32
 }
 
 func (p *wanderingChatProvider) Name() string { return "wandering" }
 
 func (p *wanderingChatProvider) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
 	round := p.calls.Add(1)
-	if p.progress != nil {
-		select {
-		case p.progress <- struct{}{}:
-		default:
-		}
-	}
 	ch := make(chan provider.Chunk, 4)
 	if p.max > 0 && round > p.max {
 		ch <- provider.Chunk{Type: provider.ChunkText, Text: "Done."}
@@ -54,25 +45,13 @@ func (p *wanderingChatProvider) Stream(context.Context, provider.Request) (<-cha
 
 func newChatBudgetController(t *testing.T, exec *agent.Agent) (*Controller, chan event.Event) {
 	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "s.jsonl")
-	// Match production's live writer authority so durability checks use tail
-	// CAS rather than repeatedly decoding a legacy, unleased transcript.
-	writer, err := agent.AcquireSessionWriter(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(writer.Release)
-	if err := writer.Bind(exec.Session(), agent.NextSessionWriteGeneration()); err != nil {
-		t.Fatal(err)
-	}
+	// Round admission does not depend on session durability. Keep this fixture
+	// in memory; persistence and writer authority have their own integration tests.
 	sink, done, _ := collectSink()
 	c := New(Options{
-		Runner:      exec,
-		Executor:    exec,
-		Sink:        sink,
-		SessionDir:  dir,
-		SessionPath: path,
+		Runner:   exec,
+		Executor: exec,
+		Sink:     sink,
 	})
 	t.Cleanup(c.autosaveWG.Wait)
 	return c, done
@@ -83,37 +62,17 @@ func newChatBudgetController(t *testing.T, exec *agent.Agent) (*Controller, chan
 // individually cheap and fast, which is the case least worth stopping — 120
 // rounds would have been truncated by the ceiling this replaced.
 func TestOrdinaryChatTurnRunsPastTheOldRoundCeiling(t *testing.T) {
-	prov := &wanderingChatProvider{max: 120, progress: make(chan struct{}, 1)}
+	prov := &wanderingChatProvider{max: 120}
 	reg := tool.NewRegistry()
 	reg.Add(fakeControlTool{name: "read_file"})
 	exec := agent.New(prov, reg, agent.NewSession("sys"), agent.Options{}, event.Discard)
 	c, done := newChatBudgetController(t, exec)
 
 	c.Submit("collect the real state, then rewrite HANDOVER.md")
-	waitForChatBudgetProgress(t, done, prov.progress)
+	<-done
 
 	if got, want := prov.calls.Load(), int32(121); got != want {
 		t.Fatalf("provider rounds = %d, want %d (the model's own 120 plus its final answer)", got, want)
-	}
-}
-
-// What actually bounds it: the wall-clock axis, which catches even a runaway
-// whose rounds are free — the one case a cost budget cannot see.
-func TestOrdinaryChatTurnStopsOnItsTimeBudget(t *testing.T) {
-	prov := &wanderingChatProvider{}
-	reg := tool.NewRegistry()
-	reg.Add(fakeControlTool{name: "read_file"})
-	exec := agent.New(prov, reg, agent.NewSession("sys"),
-		agent.Options{TaskBudget: agent.TaskBudget{Wall: time.Millisecond}}, event.Discard)
-	c, done := newChatBudgetController(t, exec)
-
-	c.Submit("collect the real state, then rewrite HANDOVER.md")
-	waitForDone(t, done)
-
-	// Instant mock rounds can fit more than a handful into 1ms; the gate must
-	// still stop a runaway well short of an unbounded loop.
-	if got := prov.calls.Load(); got > 50 {
-		t.Fatalf("provider rounds = %d, want the wall-clock budget to land it promptly", got)
 	}
 }
 
@@ -126,33 +85,9 @@ func TestExplicitMaxStepsOwnsTheOrdinaryTurn(t *testing.T) {
 	c, done := newChatBudgetController(t, exec)
 
 	c.Submit("collect the real state")
-	waitForDone(t, done)
+	<-done
 
 	if got := prov.calls.Load(); got != 4 {
 		t.Fatalf("provider rounds = %d, want the explicit 3 plus one summary", got)
-	}
-}
-
-// This is a round-ceiling regression, not a disk-throughput benchmark. The
-// five-second no-progress watchdog is the detector; the total bound only stops
-// a wedged run, so it carries headroom for the slowest leg — Windows CI drives
-// all 121 rounds through a real session writer and has measured ~45s.
-func waitForChatBudgetProgress(t *testing.T, done <-chan event.Event, progress <-chan struct{}) {
-	t.Helper()
-	idle := time.NewTimer(5 * time.Second)
-	defer idle.Stop()
-	total := time.NewTimer(90 * time.Second)
-	defer total.Stop()
-	for {
-		select {
-		case <-done:
-			return
-		case <-progress:
-			idle.Reset(5 * time.Second)
-		case <-idle.C:
-			t.Fatal("chat turn made no progress for five seconds")
-		case <-total.C:
-			t.Fatal("121-round chat turn exceeded its total test deadline")
-		}
 	}
 }

--- a/internal/control/goal_run_ceiling_test.go
+++ b/internal/control/goal_run_ceiling_test.go
@@ -69,7 +69,7 @@ func TestGoalTurnRunsPastTheOldRoundCeiling(t *testing.T) {
 
 	c.SetGoal("apply every pending edit")
 	c.Submit("start")
-	waitForDone(t, done)
+	<-done
 
 	if got := prov.calls.Load(); got <= 16 {
 		t.Fatalf("provider rounds = %d, want productive work to run past the retired 16-round ceiling", got)

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -11,8 +11,8 @@
         "zh": "Reasonix v1.38.5"
       },
       "summary": {
-        "en": "Reasonix moves Desktop to Electron and adds DeepSeek V4.1 Flash image input, OpenCode Go provider presets, durable tool recovery, and independent dock tabs. This release includes the changes since v1.38.3 plus the macOS signing and notarization fixes; v1.38.4 was not published.",
-        "zh": "Reasonix 桌面端迁移至 Electron，新增 DeepSeek V4.1 Flash 图片输入、OpenCode Go 提供商预设、持久工具恢复和独立 dock 标签。本版本包含 v1.38.3 以来的改动及 macOS 签名、公证修复；v1.38.4 未公开发布。"
+        "en": "Reasonix moves Desktop to Electron and adds DeepSeek V4.1 Flash image input, OpenCode Go provider presets, durable tool recovery, and independent dock tabs. This release includes the changes since v1.38.3, macOS signing and notarization fixes, and more reliable Windows extension shutdown; v1.38.4 was not published.",
+        "zh": "Reasonix 桌面端迁移至 Electron，新增 DeepSeek V4.1 Flash 图片输入、OpenCode Go 提供商预设、持久工具恢复和独立 dock 标签。本版本包含 v1.38.3 以来的改动、macOS 签名与公证修复，以及 Windows 扩展关闭稳定性修复；v1.38.4 未公开发布。"
       },
       "surfaces": [
         "desktop",

--- a/scripts/windows-go-tests.mjs
+++ b/scripts/windows-go-tests.mjs
@@ -1,0 +1,47 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const isolatedGroups = ["agent", "boot", "control"];
+const smokeRoots = [
+  "appidentity", "checkpoint", "cli", "desktoplauncher", "extension/sidecar",
+  "filelock", "fileutil", "hook", "instruction", "mcplaunch", "notify", "proc",
+  "remote", "repair", "sandbox", "sessioncatalog", "sysproxy", "workspacelease",
+].map(name => `reasonix/internal/${name}`).concat("reasonix/cmd");
+const beneath = (pkg, root) => pkg === root || pkg.startsWith(`${root}/`);
+
+export function selectPackages(packages, group) {
+  if (!["full", "smoke", ...isolatedGroups].includes(group)) {
+    throw new Error(`Unknown Windows test group: ${group}`);
+  }
+  const isolated = pkg => isolatedGroups.some(name => beneath(pkg, `reasonix/internal/${name}`));
+  return packages.filter(pkg => {
+    if (isolatedGroups.includes(group)) return beneath(pkg, `reasonix/internal/${group}`);
+    return !isolated(pkg) && (group === "full" || smokeRoots.some(root => beneath(pkg, root)));
+  });
+}
+
+export function testArgs(packages, group) {
+  const selected = selectPackages(packages, group);
+  if (selected.length === 0) throw new Error(`Empty Windows test group: ${group}`);
+  return ["test", "-p", isolatedGroups.includes(group) ? "1" : "4", "-timeout=8m", ...selected];
+}
+
+function main(group) {
+  const listed = spawnSync("go", ["list", "./..."], { encoding: "utf8" });
+  if (listed.error) throw listed.error;
+  if (listed.status !== 0) {
+    process.stderr.write(listed.stderr || "go list failed\n");
+    return listed.status ?? 1;
+  }
+  const packages = listed.stdout.trim().split(/\r?\n/).filter(Boolean);
+  const args = testArgs(packages, group);
+  console.log(`Windows ${group}: ${args.length - 4} packages; go ${args.join(" ")}`);
+  const result = spawnSync("go", args, { stdio: "inherit" });
+  if (result.error) throw result.error;
+  return result.status ?? 1;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exitCode = main(process.argv[2]);
+}

--- a/scripts/windows-go-tests.test.mjs
+++ b/scripts/windows-go-tests.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { isolatedGroups, selectPackages, testArgs } from "./windows-go-tests.mjs";
+
+const packages = ["reasonix/cmd/reasonix", "reasonix/internal/agent", "reasonix/internal/agent/testutil",
+  "reasonix/internal/agentpreset", "reasonix/internal/boot", "reasonix/internal/control",
+  "reasonix/internal/control/child", "reasonix/internal/extension/sidecar", "reasonix/internal/proc",
+  "reasonix/internal/newpackage", "reasonix/tools/repolint"];
+
+test("the full Windows groups cover every package exactly once, including new packages", () => {
+  const grouped = ["full", ...isolatedGroups].flatMap(group => selectPackages(packages, group));
+  assert.deepEqual(grouped.toSorted(), packages.toSorted());
+  assert.equal(new Set(grouped).size, grouped.length);
+  assert.ok(selectPackages(packages, "full").includes("reasonix/internal/agentpreset"));
+});
+
+test("PR smoke keeps platform coverage without duplicating isolated suites", () => {
+  assert.deepEqual(selectPackages(packages, "smoke"), ["reasonix/cmd/reasonix", "reasonix/internal/extension/sidecar", "reasonix/internal/proc"]);
+  for (const group of isolatedGroups) {
+    assert.deepEqual(testArgs(packages, group).slice(0, 4), ["test", "-p", "1", "-timeout=8m"]);
+  }
+  assert.deepEqual(testArgs(packages, "full").slice(0, 4), ["test", "-p", "4", "-timeout=8m"]);
+  assert.throws(() => testArgs(packages, "typo"), /Unknown/);
+  assert.throws(() => testArgs([], "full"), /Empty/);
+});
+
+test("CI invokes every isolated group and both residual entrypoints", () => {
+  const source = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+  for (const group of ["full", "smoke", "control"]) {
+    assert.match(source, new RegExp(`run: node scripts/windows-go-tests\\.mjs ${group}\\n`));
+  }
+  const isolated = source.match(/\n  windows-isolated:\n([\s\S]*?)(?=\n  [a-z][a-z0-9-]*:|$)/)?.[1];
+  assert.ok(isolated);
+  const matrix = isolated.match(/group: \[([^\]]+)\]/)[1].split(",").map(value => value.trim());
+  assert.deepEqual([...matrix, "control"].toSorted(), isolatedGroups.toSorted());
+  assert.match(isolated, /run: node scripts\/windows-go-tests\.mjs \$\{\{ matrix.group \}\}/);
+  assert.match(isolated, /fail-fast: false/);
+  assert.match(isolated, /actions\/setup-node@v7/);
+});


### PR DESCRIPTION
Windows release qualification failed when the full root suite ran agent, boot and control together, while control also ran in its own job. The same run exposed test fixtures that coupled round-limit assertions to durable disk writes and fixed wall-clock delays.

This change gives agent, boot and control separate Windows runners on both PRs and main pushes. A shared selector enumerates the module and assigns every package to exactly one full-suite group; the existing eight-minute package deadline remains unchanged. Round-limit tests now exercise the real controller and agent in memory, retaining the 121-call and explicit max-steps assertions. The redundant assertion that at most 50 rounds fit in one millisecond is removed; deterministic agent-owned wall-clock and cost-budget coverage remains.

Boot fixtures await catalog resource release within the suite deadline before changing their home directory. The extension UI rebuild test now closes its replacement controller as well as its original controller, eliminating a leaked sidecar and Windows temporary-directory contention. The reviewed v1.38.5 summary also includes the already-merged Windows extension shutdown fix.

Validation:
- Native Windows ARM64: controller round-limit tests pass ten repetitions; rebuild, image-capability and cache-hash tests pass three repetitions. Before replacement cleanup, the rebuild fixture logged directory contention and took about 3–7 seconds; afterward it takes 0.3–0.6 seconds without that cleanup warning.
- Focused controller and boot race tests pass; deterministic agent budget tests pass. Catalog lifecycle and boot cleanup tests pass three repetitions.
- Windows package enumeration covers all 142 current packages without omissions or duplicate ownership. Selector tests, workflow contracts, actionlint, go vet, repository lint and cache guards pass.
- The standalone native golden probe could not establish its Bash precondition on the test VM; committed golden files are unchanged. The complete golden suite remains enabled in CI and passed on the local macOS host.

No product behavior, persisted format, signing recipe, publishing permission or provider-visible bytes change here.

Cache-impact: none - test fixtures, CI scheduling and reviewed release prose only.
Cache-guard: bash scripts/cache-guard.sh; focused boot cache and agent budget tests.
System-prompt-review: reviewed the complete candidate diff and cache guard results; this PR changes only test fixtures, CI scheduling and release prose, with no system prompt, tool schema or provider serialization changes.
