### PR TITLE
fix(desktop): restore packaged startup identity / 修复正式安装包启动版本不匹配

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -714,7 +714,7 @@ jobs:
         timeout-minutes: 15
         run: |
           pnpm install --frozen-lockfile
-          go build -trimpath -ldflags "-s -w" -o build/bin/reasonix-desktop.exe .
+          go build -trimpath -ldflags "-s -w -X main.version=v0.0.0-ci -X main.channel=canary" -o build/bin/reasonix-desktop.exe .
           node packaging/package.mjs windows/amd64 v0.0.0-ci canary
 
       - name: Smoke-test Electron native startup

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -436,11 +436,23 @@ jobs:
       # the packaged shell and require the shell -> Go service handshake before
       # signing or publication.
       - name: Smoke-test packaged Electron startup
-        if: matrix.platform == 'windows/amd64'
+        if: runner.os == 'Windows'
         run: |
           node desktop/packaging/smoke.mjs \
-            desktop/build/electron/windows-amd64/app \
+            desktop/build/electron/${{ matrix.name }}/app \
             --service desktop/build/bin/reasonix-desktop.exe
+
+      - name: Smoke-test macOS archive startup
+        if: runner.os == 'macOS'
+        run: |
+          ditto -xk dist/Reasonix-darwin-arm64.zip "$RUNNER_TEMP/desktop-startup"
+          node desktop/packaging/smoke.mjs "$RUNNER_TEMP/desktop-startup/Reasonix.app"
+
+      - name: Smoke-test packaged Linux startup
+        if: runner.os == 'Linux'
+        run: |
+          xvfb-run -a node desktop/packaging/smoke.mjs \
+            desktop/build/bin/app --service desktop/build/bin/reasonix-desktop
 
       # Sign every executable that users actually run before rebuilding the
       # portable archive and NSIS installer. Signing only the finished NSIS

--- a/desktop/electron/README.md
+++ b/desktop/electron/README.md
@@ -99,6 +99,13 @@ recomputes its digest the way `hostrpc.Contract.Canonical` defines it
 set `REASONIX_ELECTRON_ALLOW_MISSING_CONTRACT=1` to build without it (every
 `desktop/invoke` is then rejected and the hello digest is empty).
 
+Packaged shells read the full version tag, channel and commit from
+`resources/build.json` for `desktop/hello`. `app.getVersion()` and
+`package.json.version` are numeric native metadata and must not identify the
+RPC build. The packaged startup smoke runs without development overrides and
+requires the renderer's `Version` command to match that manifest; the service
+used by CI must also be linked with the same non-development version.
+
 ## Run
 
 ```sh

--- a/desktop/electron/src/main/buildIdentity.test.ts
+++ b/desktop/electron/src/main/buildIdentity.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test, type TestContext } from "node:test";
+import { loadBuildIdentity } from "./buildIdentity.js";
+import { buildHelloParams } from "./handshake.js";
+
+function resources(t: TestContext, content?: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), "reasonix-identity-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  if (content !== undefined) writeFileSync(join(dir, "build.json"), JSON.stringify(content));
+  return dir;
+}
+
+for (const version of ["v1.38.5", "v1.38.6-rc.1", "v0.0.0-ci"]) {
+  test(`packaged hello preserves the complete ${version} identity without environment overrides`, (t) => {
+    const build = { version, channel: "canary", commit: "abc123def456" };
+    const dir = resources(t, { schemaVersion: 1, ...build, electron: "44.2.0", platform: "windows/amd64" });
+    const identity = loadBuildIdentity(true, dir, { REASONIX_CHANNEL: "wrong", REASONIX_COMMIT: "wrong" });
+    const hello = buildHelloParams({ ...identity, contractDigest: "sha256:fixture", hostVersion: "44.2.0", chromeVersion: "152", platform: "win32", arch: "x64", home: dir, dev: false });
+    assert.deepEqual(hello.build, build);
+    assert.equal(hello.instance.dev, false);
+  });
+}
+
+test("unpackaged development needs no manifest", () => {
+  assert.deepEqual(loadBuildIdentity(false, "unused", {}), { version: "dev", channel: "dev", commit: "dev" });
+  assert.deepEqual(loadBuildIdentity(false, "unused", { REASONIX_CHANNEL: "canary", REASONIX_COMMIT: "local" }), { version: "dev", channel: "canary", commit: "local" });
+});
+
+test("missing or invalid packaged metadata cannot silently fall back to dev", (t) => {
+  const good = { schemaVersion: 1, version: "v1.38.5", channel: "stable", commit: "abc123" };
+  assert.throws(() => loadBuildIdentity(true, resources(t), {}), /ENOENT/);
+  for (const bad of [null, [], {}, { ...good, schemaVersion: 2 }, { ...good, version: "dev" }, { ...good, version: "1.38.5" }, { ...good, version: "v1.38.5 " }, { ...good, channel: "" }, { ...good, commit: " " }]) {
+    assert.throws(() => loadBuildIdentity(true, resources(t, bad), {}), /build/);
+  }
+  const dir = resources(t);
+  writeFileSync(join(dir, "build.json"), "{");
+  assert.throws(() => loadBuildIdentity(true, dir, {}), SyntaxError);
+});

--- a/desktop/electron/src/main/buildIdentity.ts
+++ b/desktop/electron/src/main/buildIdentity.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface BuildIdentity {
+  version: string;
+  channel: string;
+  commit: string;
+}
+
+// Native version resources are numeric and may discard both the tag prefix
+// and prerelease suffix. The package manifest owns the RPC build identity.
+export function loadBuildIdentity(packaged: boolean, resourcesPath: string, env: NodeJS.ProcessEnv): BuildIdentity {
+  if (!packaged) {
+    return { version: "dev", channel: env.REASONIX_CHANNEL || "dev", commit: env.REASONIX_COMMIT || "dev" };
+  }
+  const value: unknown = JSON.parse(readFileSync(join(resourcesPath, "build.json"), "utf8"));
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Invalid packaged build identity");
+  const info = value as Record<string, unknown>;
+  if (info.schemaVersion !== 1) throw new Error("Unsupported packaged build identity schema");
+  for (const field of ["version", "channel", "commit"] as const) {
+    if (typeof info[field] !== "string" || info[field].trim() === "") throw new Error(`Missing packaged build identity: ${field}`);
+  }
+  const { version, channel, commit } = info as unknown as BuildIdentity;
+  if (!/^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error("Invalid packaged build version");
+  }
+  return { version, channel, commit };
+}

--- a/desktop/electron/src/main/index.ts
+++ b/desktop/electron/src/main/index.ts
@@ -10,6 +10,7 @@ import { GrantRegistry } from "./browser/grants.js";
 import { buildBrowserHostCalls } from "./browser/hostCalls.js";
 import { browserLayoutInDIP } from "./browser/layout.js";
 import { BrowserSurfaceManager } from "./browser/surfaceManager.js";
+import { loadBuildIdentity } from "./buildIdentity.js";
 import { emptyContract, loadContract, type LoadedContract } from "./contract.js";
 import { DialogHost } from "./dialogs.js";
 import { renderFailurePage, type ShellAction } from "./failurePage.js";
@@ -236,9 +237,7 @@ function bootstrap(dataHome: string): void {
     {
       hello: async (client) => validateHelloResult(await client.request("desktop/hello", buildHelloParams({
         contractDigest: contract.digest,
-        version: app.isPackaged ? app.getVersion() : "dev",
-        channel: process.env.REASONIX_CHANNEL || "dev",
-        commit: process.env.REASONIX_COMMIT || "dev",
+        ...loadBuildIdentity(app.isPackaged, process.resourcesPath, process.env),
         hostVersion: process.versions.electron,
         chromeVersion: process.versions.chrome,
         platform: process.platform,

--- a/desktop/packaging/lib.mjs
+++ b/desktop/packaging/lib.mjs
@@ -52,8 +52,8 @@ export function versionTag(tag) {
 }
 
 // Windows version resources, CFBundleVersion and the NSIS VIProductVersion only
-// accept X.Y.Z; the full tag still identifies the build through package.json,
-// build.json and the Go -X main.version ldflag.
+// accept X.Y.Z; the full tag identifies the build through build.json and the
+// Go -X main.version ldflag. Packager also writes appVersion to package.json.
 export function numericVersion(tag) {
   return versionTag(tag).slice(1).split("-")[0];
 }
@@ -80,7 +80,7 @@ export function sanitizeShellPackageJson(pkg, { version, productName }) {
   const out = {};
   for (const key of keep) if (key in pkg) out[key] = pkg[key];
   out.productName = productName;
-  out.version = version;
+  out.version = numericVersion(version);
   return out;
 }
 

--- a/desktop/packaging/lib.test.mjs
+++ b/desktop/packaging/lib.test.mjs
@@ -84,12 +84,12 @@ test("only the shell bundle and its package.json enter the asar", () => {
   }
 });
 
-test("the bundled package.json carries the release tag app.getVersion() reports", () => {
+test("package.json uses the numeric native version; build.json owns the full release identity", () => {
   const pkg = sanitizeShellPackageJson(
     { name: "reasonix-desktop-shell", private: true, version: "0.0.0", type: "module", main: "dist/main.cjs", description: "shell", scripts: { build: "x" }, devDependencies: { electron: "44.2.0" }, engines: { node: ">=24" } },
     { version: "v1.2.3-rc.1", productName: "Reasonix" },
   );
-  assert.deepEqual(pkg, { name: "reasonix-desktop-shell", description: "shell", main: "dist/main.cjs", type: "module", productName: "Reasonix", version: "v1.2.3-rc.1" });
+  assert.deepEqual(pkg, { name: "reasonix-desktop-shell", description: "shell", main: "dist/main.cjs", type: "module", productName: "Reasonix", version: "1.2.3" });
 });
 
 test("packager options pin the product identity and layout for every target", () => {

--- a/desktop/packaging/package.mjs
+++ b/desktop/packaging/package.mjs
@@ -75,8 +75,8 @@ try {
   mkdirSync(join(staging, "icons"), { recursive: true });
   cpSync(join(desktop, "build", "appicon.png"), join(staging, "icons", "appicon.png"));
   cpSync(join(desktop, "build", "linux", "icons"), join(staging, "icons", "linux", "icons"), { recursive: true });
-  // The shell reads REASONIX_CHANNEL / REASONIX_COMMIT from the environment; this
-  // file carries the same identity inside the package for launches without one.
+  // Packaged launches always read this identity, including the full version
+  // tag. Environment overrides belong only to the unpackaged development shell.
   writeFileSync(join(staging, "build.json"), JSON.stringify(buildInfo({ version, channel, commit, electronVersion, target, buildTime }), null, 2) + "\n");
 
   const icon = { darwin: join(desktop, "build", "darwin", "icon.icns"), win32: join(desktop, "build", "windows", "icon.ico") }[target.packagerPlatform];

--- a/desktop/packaging/smoke-env.mjs
+++ b/desktop/packaging/smoke-env.mjs
@@ -1,0 +1,16 @@
+import { join } from "node:path";
+
+// A disposable home is sufficient isolation. Development mode would bypass
+// the very build mismatch that a production startup smoke must catch.
+export function packagedSmokeEnv(parent, home) {
+  const env = { ...parent };
+  for (const key of Object.keys(env)) {
+    if (/^REASONIX_/i.test(key) || /^(NODE_OPTIONS|ELECTRON_RUN_AS_NODE)$/i.test(key)) delete env[key];
+  }
+  return {
+    ...env,
+    REASONIX_HOME: home,
+    REASONIX_STATE_HOME: home,
+    REASONIX_CACHE_HOME: join(home, "cache"),
+  };
+}

--- a/desktop/packaging/smoke-env.test.mjs
+++ b/desktop/packaging/smoke-env.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { test } from "node:test";
+import { packagedSmokeEnv } from "./smoke-env.mjs";
+
+test("packaged startup uses an isolated home without inherited development or service overrides", () => {
+  const parent = {
+    PATH: "system-path", DISPLAY: ":99", HOME: "system-home",
+    REASONIX_DEV: "1", Reasonix_Dev: "1", REASONIX_CHANNEL: "dev", REASONIX_COMMIT: "old",
+    REASONIX_DESKTOP_SERVICE: "old-service", REASONIX_ELECTRON_DEV_URL: "http://localhost:5173",
+    REASONIX_HOME: "real-user-data", REASONIX_STATE_HOME: "real-state", REASONIX_CACHE_HOME: "real-cache",
+    NODE_OPTIONS: "--require development-hook", ELECTRON_RUN_AS_NODE: "1",
+  };
+  assert.deepEqual(packagedSmokeEnv(parent, "fixture"), {
+    PATH: "system-path", DISPLAY: ":99", HOME: "system-home",
+    REASONIX_HOME: "fixture", REASONIX_STATE_HOME: "fixture", REASONIX_CACHE_HOME: join("fixture", "cache"),
+  });
+  assert.equal(parent.REASONIX_DEV, "1", "the caller environment is not mutated");
+});

--- a/desktop/packaging/smoke.mjs
+++ b/desktop/packaging/smoke.mjs
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { isDirectory, PRODUCT } from "./lib.mjs";
 import { closeAndVerify, processAlive, sleep, waitForProcessesToExit } from "./smoke-lifecycle.mjs";
+import { packagedSmokeEnv } from "./smoke-env.mjs";
 
 // Playwright belongs to the Electron workspace, not the shipped application.
 const require = createRequire(new URL("../electron/package.json", import.meta.url));
@@ -46,13 +47,7 @@ const executable = executableOf(targetArg);
 if (!existsSync(executable)) throw new Error(`shell executable is missing: ${executable}`);
 const home = mkdtempSync(join(tmpdir(), "reasonix-smoke-"));
 const logs = join(home, "desktop-shell", "logs");
-const env = {
-  ...process.env,
-  REASONIX_HOME: home,
-  REASONIX_STATE_HOME: home,
-  REASONIX_CACHE_HOME: join(home, "cache"),
-  REASONIX_DEV: "1",
-};
+const env = packagedSmokeEnv(process.env, home);
 if (service !== "") env.REASONIX_DESKTOP_SERVICE = resolve(service);
 const stdio = join(home, "smoke-stdio.log");
 const started = Date.now();
@@ -95,6 +90,8 @@ try {
   // On Windows Playwright may own a cmd.exe wrapper. Read the Electron main
   // PID itself so a wrapper exit cannot pass the shell-liveness assertion.
   shellPid = await application.evaluate(() => process.pid);
+  const identity = await application.evaluate(({ app }) => ({ packaged: app.isPackaged, dev: process.env.REASONIX_DEV ?? "", resourcesPath: process.resourcesPath }));
+  if (!identity.packaged || identity.dev !== "") throw new Error("startup smoke must exercise a packaged app without development mode");
   while (!ready) {
     if (exit || !processAlive(shellPid)) throw new Error("shell exited before the handshake");
     if (Date.now() - started > timeout) throw new Error(`no handshake within ${timeout / 1000}s`);
@@ -106,6 +103,12 @@ try {
     else await sleep(250);
   }
   console.log(`PASS  handshake ready after ${((Date.now() - started) / 1000).toFixed(1)}s: ${ready.line}`);
+  const page = await application.firstWindow({ timeout });
+  await page.waitForFunction(() => Boolean(window.reasonixDesktop), null, { timeout });
+  const version = await page.evaluate(() => window.reasonixDesktop.invoke("Version", []));
+  const expected = JSON.parse(readFileSync(join(identity.resourcesPath, "build.json"), "utf8")).version;
+  if (version === "dev" || version !== expected) throw new Error(`packaged service version ${version} differs from manifest ${expected}`);
+  console.log(`PASS  renderer invokes the production service: Version=${version}`);
   await sleep(hold);
   if (exit || !processAlive(shellPid)) throw new Error(`shell exited during the ${hold / 1000}s hold`);
   if (!processAlive(ready.pid)) throw new Error(`Go service pid ${ready.pid} exited during the hold`);

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -109,9 +109,13 @@ grep -Eq '^  resolve:$' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Eq 'sha:.*steps\.candidate\.outputs\.sha' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'bash scripts/resolve-desktop-candidate.sh' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'name: Smoke-test packaged Electron startup' "$repo_root/.github/workflows/release-desktop.yml"
-grep -Fq "if: matrix.platform == 'windows/amd64'" "$repo_root/.github/workflows/release-desktop.yml"
+sed -n '/name: Smoke-test packaged Electron startup/,/name: Upload unsigned Windows payload/p' \
+	"$repo_root/.github/workflows/release-desktop.yml" | grep -Fq "if: runner.os == 'Windows'"
+grep -Fq 'desktop/build/electron/${{ matrix.name }}/app' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'node desktop/packaging/smoke.mjs' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq -- '--service desktop/build/bin/reasonix-desktop.exe' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq 'node desktop/packaging/smoke.mjs "$RUNNER_TEMP/desktop-startup/Reasonix.app"' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq 'xvfb-run -a node desktop/packaging/smoke.mjs' "$repo_root/.github/workflows/release-desktop.yml"
 test ! -e "$repo_root/scripts/test-webview2-approval-smoke.ps1"
 # The Wails-era WebView2/WebKitGTK native smoke harnesses are retired with the
 # old shell; the packaged Electron startup smoke replaces them.
@@ -122,6 +126,7 @@ grep -Fq 'name: Package Electron shell for native startup smoke' "$repo_root/.gi
 grep -Fq 'name: Smoke-test Electron native startup' "$repo_root/.github/workflows/ci.yml"
 grep -Fq 'node packaging/package.mjs windows/amd64 v0.0.0-ci canary' \
 	"$repo_root/.github/workflows/ci.yml"
+grep -Fq -- '-X main.version=v0.0.0-ci -X main.channel=canary' "$repo_root/.github/workflows/ci.yml"
 grep -Fq 'node packaging/smoke.mjs build/electron/windows-amd64/app --service build/bin/reasonix-desktop.exe' \
 	"$repo_root/.github/workflows/ci.yml"
 grep -Fq 'node packaging/verify.mjs ../dist/Reasonix-darwin-arm64.zip' \


### PR DESCRIPTION
## Summary

Official v1.38.5 Desktop packages stop at `build_mismatch`: Electron sends `1.38.5` while the bundled Go service reports `v1.38.5`. Packager overwrites package.json with its numeric appVersion after sanitization. The already-shipped resources/build.json contains the correct complete identity, but the shell never read it.

Read packaged version, channel and commit from build.json, fail closed on missing/invalid metadata, and preserve unpackaged development behavior. Keep the service's exact build comparison. Make package.json explicitly carry the native numeric version instead of claiming its sanitizer output survives packager.

The packaged smoke previously set REASONIX_DEV=1, and PR CI also compiled a dev-version service. Both bypassed the production build check. Remove inherited development/service overrides, link the matching CI version, require a packaged runtime and a renderer-to-service Version call matching build.json, and run release startup gates on both Windows architectures, the macOS archive and Linux.

## Verification

- Electron typecheck; all 112 shell tests and 20 packaging tests passed.
- Go hostrpc tests passed, including rejection of genuinely different builds.
- Full macOS packaging through desktop-build.sh, followed by extraction and ordinary packaged startup: handshake, renderer Version=v1.38.5, and normal shell/service exit passed without development mode.
- Downloaded public v1.38.5 macOS archive matched its published SHA-256 and reproduced the reported build_mismatch.
- Downloaded public Windows ARM64 portable package reproduced the same failure in a disposable Windows 11 data home. An isolated copy with only the rebuilt shell bundle substituted passed handshake, renderer Version and normal exit against the unchanged published service. This is runtime regression evidence, not a claim of a newly signed Windows release.
- Release workflow contracts, desktop build contract and actionlint passed with the repository's existing windows-11-arm label exception.
- Exact-head CI run 34541630990 completed successfully. Windows x64 built the actual package and passed production startup, renderer Version=v0.0.0-ci and normal process exit; its full Desktop and update-helper Go suite also passed.
- Linux Electron native startup was not executed locally and remains an acceptance item for the newly added release gate; Linux unit tests are not a substitute for that native check.

The older v1.38.3 updater's rejection of electron-v1 is the documented one-time manual full-package migration barrier, separate from this post-install startup failure. No user-data formats, updater layout guards, public release artifacts or published tags change here.

## Documentation impact

Documentation-impact: none - restores the documented Desktop startup contract; the internal Electron README now explains build identity and production smoke requirements. Existing bilingual migration documentation already explains the one-time full-package installation.

## Cache impact

Cache-impact: none - shell build metadata and packaging verification only; no provider-visible prompts, tools, messages or serialization change.
Cache-guard: not applicable - no cache-sensitive execution path changes; focused shell, handshake and packaging suites validate the affected boundaries.
System-prompt-review: reviewed - no system prompt, memory prefix, output style or skill index bytes change.
