### PR TITLE
Fix npm publication convergence and recovery / 修复 npm 发布收敛与恢复

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -149,8 +149,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.approved_sha || inputs.tag || github.ref }}
-      - name: Load approved standalone recovery control plane
-        if: ${{ !inputs.orchestrated }}
+      - name: Load approved npm publication control plane
         env:
           RECOVERY_CONTROL_SHA: ${{ github.workflow_sha }}
         run: |

--- a/npm/publish.mjs
+++ b/npm/publish.mjs
@@ -187,23 +187,29 @@ function readDistTag(runner, name, distTag) {
   return value;
 }
 
-function waitForPackage(
+function waitForPackages(
   runner,
-  entry,
+  packages,
   version,
   candidateSha,
   attempts,
   sleep,
+  log,
 ) {
+  const pending = new Map(packages.map((entry) => [entry.name, entry]));
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const metadata = registryPackage(runner, entry.name, version);
-    if (metadata) {
-      verifyRegistryPackage(metadata, entry.name, version, candidateSha);
-      return;
+    for (const [name] of pending) {
+      const metadata = registryPackage(runner, name, version);
+      if (metadata) {
+        verifyRegistryPackage(metadata, name, version, candidateSha);
+        pending.delete(name);
+      }
     }
+    if (pending.size === 0) return;
+    log(`waiting for npm registry visibility (${attempt}/${attempts}): ${[...pending.keys()].join(", ")}`);
     if (attempt < attempts) sleep(10_000);
   }
-  throw new Error(`${entry.name}@${version} did not become visible in the npm registry`);
+  throw new Error(`npm packages did not become visible at ${version}: ${[...pending.keys()].join(", ")}`);
 }
 
 function ensurePackage(
@@ -212,8 +218,6 @@ function ensurePackage(
   version,
   candidateSha,
   stagingTag,
-  attempts,
-  sleep,
   log,
 ) {
   readLocalPackage(entry, version, candidateSha);
@@ -237,14 +241,6 @@ function ensurePackage(
     if (!raced) throw error;
     verifyRegistryPackage(raced, entry.name, version, candidateSha);
   }
-  waitForPackage(
-    runner,
-    entry,
-    version,
-    candidateSha,
-    attempts,
-    sleep,
-  );
 }
 
 function advanceDistTag(runner, name, version, distTag, attempts, sleep, log) {
@@ -296,9 +292,10 @@ export function publishPackages({
   runner = defaultRunner,
   sleep = defaultSleep,
   // npm's public registry can lag a successful immutable publish by several
-  // minutes. Keep this bounded, but allow enough time for normal replication
-  // before recovery treats the package as missing.
-  attempts = 31,
+  // minutes (v1.38.6 exceeded the old five-minute window). Submit the whole
+  // set first, then poll pending packages together for up to twenty minutes
+  // of scheduled waits, plus registry request time. Never republish on E404.
+  attempts = 121,
   log = console.log,
 }) {
   if (!Array.isArray(packages) || packages.length === 0) {
@@ -309,44 +306,18 @@ export function publishPackages({
   }
   const distTag = distTagForVersion(version);
   const stagingTag = `${distTag}-staging`;
-  let failure;
-
-  try {
-    for (const entry of packages) {
-      ensurePackage(
-        runner,
-        entry,
-        version,
-        candidateSha,
-        stagingTag,
-        attempts,
-        sleep,
-        log,
-      );
-    }
-    for (const entry of packages) {
-      advanceDistTag(
-        runner,
-        entry.name,
-        version,
-        distTag,
-        attempts,
-        sleep,
-        log,
-      );
-    }
-  } catch (error) {
-    failure = error;
+  for (const entry of packages) {
+    ensurePackage(runner, entry, version, candidateSha, stagingTag, log);
   }
-
-  try {
-    for (const entry of packages) {
-      cleanupStagingTag(runner, entry.name, version, stagingTag, log);
-    }
-  } catch (error) {
-    if (!failure) failure = error;
+  // A delayed platform must not prevent the remaining immutable uploads.
+  // All packages must prove the candidate before any official alias moves.
+  waitForPackages(runner, packages, version, candidateSha, attempts, sleep, log);
+  for (const entry of packages) {
+    advanceDistTag(runner, entry.name, version, distTag, attempts, sleep, log);
   }
-
-  if (failure) throw failure;
+  // Keep staging evidence on failure so recovery can inspect and reuse it.
+  for (const entry of packages) {
+    cleanupStagingTag(runner, entry.name, version, stagingTag, log);
+  }
   return { distTag, version };
 }

--- a/npm/publish.test.mjs
+++ b/npm/publish.test.mjs
@@ -103,7 +103,7 @@ function fixture(
       version,
       candidateSha,
       runner,
-      sleep: () => {},
+      sleep: (milliseconds) => calls.push({ args: ["sleep", String(milliseconds)] }),
       log: () => {},
     };
     if (attempts !== null) options.attempts = attempts;
@@ -119,7 +119,7 @@ function fixture(
     });
   }
 
-  return { packages, registry, calls, publish, addVersion };
+  return { packages, registry, calls, publish, addVersion, revealPackages: () => hiddenReads.clear() };
 }
 
 test("reuses a fully published npm candidate without republishing", (t) => {
@@ -155,11 +155,37 @@ test("fills a partially published package set before advancing canary", (t) => {
 });
 
 test("waits through multi-minute npm registry visibility lag", (t) => {
-  const fx = fixture(t, "1.5.0-canary.42", { visibilityDelayReads: 18 });
+  const fx = fixture(t, "1.5.0-canary.42", { visibilityDelayReads: 45 });
 
   assert.doesNotThrow(() => fx.publish({ attempts: null }));
+  const firstSleep = fx.calls.findIndex(({ args }) => args[0] === "sleep");
+  assert.equal(fx.calls.slice(0, firstSleep).filter(({ args }) => args[0] === "publish").length, fx.packages.length);
+  // One shared visibility window, not one sequential wait per package.
+  assert.equal(fx.calls.filter(({ args }) => args[0] === "sleep").length, 45);
   for (const { name } of fx.packages) {
     assert.equal(fx.registry.get(name).tags.get("canary"), "1.5.0-canary.42");
+  }
+});
+
+test("a visibility timeout uploads the full set but preserves aliases and staging for recovery", (t) => {
+  const fx = fixture(t, "1.5.0-canary.42", { visibilityDelayReads: 5 });
+  for (const { name } of fx.packages) fx.registry.get(name).tags.set("canary", "1.5.0-canary.41");
+
+  assert.throws(() => fx.publish(), /did not become visible/);
+  assert.equal(fx.calls.filter(({ args }) => args[0] === "publish").length, fx.packages.length);
+  assert.equal(fx.calls.some(({ args }) => args[0] === "dist-tag"), false);
+  for (const { name } of fx.packages) {
+    assert.equal(fx.registry.get(name).tags.get("canary"), "1.5.0-canary.41");
+    assert.equal(fx.registry.get(name).tags.get("canary-staging"), "1.5.0-canary.42");
+  }
+  const uploaded = fx.calls.filter(({ args }) => args[0] === "publish").length;
+  // Once npm exposes the uploaded versions, recovery reuses them.
+  fx.revealPackages();
+  assert.doesNotThrow(() => fx.publish());
+  assert.equal(fx.calls.filter(({ args }) => args[0] === "publish").length, uploaded);
+  for (const { name } of fx.packages) {
+    assert.equal(fx.registry.get(name).tags.get("canary"), "1.5.0-canary.42");
+    assert.equal(fx.registry.get(name).tags.has("canary-staging"), false);
   }
 });
 

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -223,6 +223,14 @@ for recovery_script in npm/publish.mjs scripts/finalize-npm-official-release.mjs
 	sed -n '/^  npm:/,$p' "$repo_root/.github/workflows/release-npm.yml" |
 		grep -Fq "$recovery_script"
 done
+# Orchestrated Stable recovery needs the same protected publisher repair as a
+# standalone run; the immutable product checkout must not select the old helper.
+npm_control_step="$(sed -n '/      - name: Load approved npm publication control plane/,/      - uses: actions\/setup-go@v7/p' "$repo_root/.github/workflows/release-npm.yml")"
+[ -n "$npm_control_step" ]
+if printf '%s\n' "$npm_control_step" | grep -q 'if:'; then
+	echo "npm publication control plane must load for orchestrated recovery too" >&2
+	exit 1
+fi
 grep -Fq 'publishPackages' "$repo_root/npm/build.mjs"
 grep -Eq 'signing-policy-slug: release-signing' "$repo_root/.github/workflows/release-desktop.yml"
 if grep -Eq 'signing-policy-slug:.*test-signing' "$repo_root/.github/workflows/release-desktop.yml"; then


### PR DESCRIPTION
The v1.38.6 npm publisher stopped after a successful upload stayed invisible for more than its five-minute polling window. Because it waited after each upload, the remaining five packages were never submitted. Both uploaded packages are now visible and match the immutable release candidate.

Submit missing packages first, then poll the entire pending set within one bounded visibility window (up to twenty minutes of scheduled waits, plus registry request time). Verify every package's candidate identity before advancing official aliases, and preserve staging tags on failure so recovery can reuse published versions. Existing immutable package conflicts still fail closed.

Load the approved npm publication helpers after the product checkout in orchestrated recovery as well as standalone publication. This allows a protected workflow repair to recover npm without changing the product candidate or rebuilding already published Desktop/CLI releases.

Validation: nine npm publication tests pass, including delayed visibility, timeout without alias movement, and reuse after visibility recovers; release workflow contracts and actionlint pass. This changes publication control only, with no runtime, provider, cache, or persisted-data format changes.

Recovery scope: npm only for v1.38.6. The three existing release tags remain at `e2145b031deef603d9ec1acc9d30f9a1e1ac9325`; already published Desktop and CLI artifacts are preserved.

Documentation-impact: none - this repairs internal publication and recovery timing; installation commands and documented product behavior remain correct.

Cache-impact: none - publication tooling does not change model prompts, cache keys, or runtime storage.
