### PR TITLE
fix(desktop): prevent Windows startup console flash / 修复 Windows 启动黑框闪现

### DIFF
--- a/internal/cli/gitstatus.go
+++ b/internal/cli/gitstatus.go
@@ -39,7 +39,11 @@ func fetchGitStatus() tea.Cmd {
 }
 
 func loadGitStatus(ctx context.Context, cwd string) (gitStatus, error) {
-	root, err := runGit(ctx, cwd, "rev-parse", "--show-toplevel")
+	return loadGitStatusWithRunner(ctx, cwd, runGit)
+}
+
+func loadGitStatusWithRunner(ctx context.Context, cwd string, run func(context.Context, string, ...string) (string, error)) (gitStatus, error) {
+	root, err := run(ctx, cwd, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return gitStatus{}, err
 	}
@@ -49,12 +53,12 @@ func loadGitStatus(ctx context.Context, cwd string) (gitStatus, error) {
 	}
 
 	status := gitStatus{Repo: filepath.Base(root)}
-	if branch, err := runGit(ctx, root, "symbolic-ref", "--quiet", "--short", "HEAD"); err == nil && strings.TrimSpace(branch) != "" {
+	if branch, err := run(ctx, root, "symbolic-ref", "--quiet", "--short", "HEAD"); err == nil && strings.TrimSpace(branch) != "" {
 		status.Branch = strings.TrimSpace(branch)
-	} else if sha, err := runGit(ctx, root, "rev-parse", "--short", "HEAD"); err == nil && strings.TrimSpace(sha) != "" {
+	} else if sha, err := run(ctx, root, "rev-parse", "--short", "HEAD"); err == nil && strings.TrimSpace(sha) != "" {
 		status.Branch = strings.TrimSpace(sha)
 		status.Detached = true
-	} else if ref, err := runGit(ctx, root, "symbolic-ref", "--short", "HEAD"); err == nil && strings.TrimSpace(ref) != "" {
+	} else if ref, err := run(ctx, root, "symbolic-ref", "--short", "HEAD"); err == nil && strings.TrimSpace(ref) != "" {
 		status.Branch = strings.TrimSpace(ref)
 	}
 	if status.Branch == "" {
@@ -62,11 +66,14 @@ func loadGitStatus(ctx context.Context, cwd string) (gitStatus, error) {
 		status.Detached = true
 	}
 
-	if out, err := runGit(ctx, root, "diff", "--numstat", "HEAD", "--"); err == nil {
+	if out, err := run(ctx, root, "diff", "--numstat", "HEAD", "--"); err == nil {
 		status.Added, status.Removed = parseGitNumstat(out)
 	}
-	if out, err := runGit(ctx, root, "status", "--porcelain=v1", "--untracked-files=normal"); err == nil {
+	if out, err := run(ctx, root, "status", "--porcelain=v1", "--untracked-files=normal"); err == nil {
 		status.Untracked = countUntracked(out)
+	}
+	if err := ctx.Err(); err != nil {
+		return gitStatus{}, err
 	}
 	return status, nil
 }

--- a/internal/cli/gitstatus_test.go
+++ b/internal/cli/gitstatus_test.go
@@ -2,13 +2,13 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/charmbracelet/x/ansi"
 )
@@ -107,9 +107,8 @@ func TestLoadGitStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	status, err := loadGitStatus(ctx, filepath.Join(root, "subdir"))
+	// This checks Git semantics, not subprocess speed on a shared CI runner.
+	status, err := loadGitStatus(t.Context(), filepath.Join(root, "subdir"))
 	if err != nil {
 		t.Fatalf("loadGitStatus: %v", err)
 	}
@@ -121,6 +120,40 @@ func TestLoadGitStatus(t *testing.T) {
 	}
 	if plain := ansi.Strip(status.Render()); !strings.Contains(plain, filepath.Base(root)+"@main") || !strings.Contains(plain, "+2 -1 ?1") {
 		t.Fatalf("rendered status = %q", plain)
+	}
+}
+
+func TestLoadGitStatusRejectsCanceledSnapshot(t *testing.T) {
+	for _, cancelAt := range []string{"symbolic-ref", "diff", "status"} {
+		t.Run(cancelAt, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			run := func(ctx context.Context, _ string, args ...string) (string, error) {
+				if args[0] == cancelAt {
+					cancel()
+				}
+				if err := ctx.Err(); err != nil {
+					return "", err
+				}
+				switch args[0] {
+				case "rev-parse":
+					return filepath.Join("workspace", "repo"), nil
+				case "symbolic-ref":
+					return "main", nil
+				case "diff":
+					return "2\t1\ttracked.txt\n", nil
+				case "status":
+					return "?? new.txt\n", nil
+				default:
+					t.Fatalf("unexpected git args: %v", args)
+					return "", nil
+				}
+			}
+			status, err := loadGitStatusWithRunner(ctx, "", run)
+			if !errors.Is(err, context.Canceled) || status != (gitStatus{}) {
+				t.Fatalf("canceled query returned status=%+v err=%v", status, err)
+			}
+		})
 	}
 }
 

--- a/internal/desktoplauncher/console_windows_test.go
+++ b/internal/desktoplauncher/console_windows_test.go
@@ -97,7 +97,7 @@ func TestLauncherDoesNotCreateConsoleWindow(t *testing.T) {
 					t.Fatalf("launcher: %v\n%s", err, output)
 				}
 				seen := make(map[string]bool)
-				for _, line := range bytes.Split(output, []byte{'\n'}) {
+				for line := range bytes.SplitSeq(output, []byte{'\n'}) {
 					if !bytes.HasPrefix(line, []byte("console-state ")) {
 						continue
 					}

--- a/internal/desktoplauncher/console_windows_test.go
+++ b/internal/desktoplauncher/console_windows_test.go
@@ -1,0 +1,159 @@
+//go:build windows
+
+package desktoplauncher
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"reasonix/internal/installlayout"
+)
+
+const consoleTestEnv = "REASONIX_LAUNCHER_CONSOLE_TEST"
+
+//go:embed testdata/console-probe/main.go
+var consoleProbeSource string
+
+// TestMain lets a GUI copy of the test executable run the installed launch path.
+func TestMain(m *testing.M) {
+	root := os.Getenv(consoleTestEnv)
+	if root == "" {
+		os.Exit(m.Run())
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	name := filepath.Base(exe)
+	kernel := syscall.NewLazyDLL("kernel32.dll")
+	cp, _, _ := kernel.NewProc("GetConsoleCP").Call()
+	window, _, _ := kernel.NewProc("GetConsoleWindow").Call()
+	fmt.Printf("console-state %s %d %d\n", name, cp, window)
+	switch name {
+	case "reasonix-launcher.exe", "Reasonix.exe":
+		os.Exit(Run(nil, "test"))
+	default:
+		panic("unexpected console test executable: " + name)
+	}
+}
+
+func TestLauncherDoesNotCreateConsoleWindow(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	executableBytes, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Match the shipped -H windowsgui launcher while keeping its children CUI.
+	// A CREATE_NO_WINDOW console parent can pass an invisible console onward,
+	// masking the missing creation flag in the launcher under test.
+	guiBytes := bytes.Clone(executableBytes)
+	peOffset := binary.LittleEndian.Uint32(guiBytes[0x3c:0x40])
+	binary.LittleEndian.PutUint16(guiBytes[peOffset+24+68:], 2)
+	probeBytes := buildConsoleProbe(t)
+	for _, entry := range []string{"reasonix-launcher.exe", "Reasonix.exe"} {
+		for _, legacy := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/legacy=%t", entry, legacy), func(t *testing.T) {
+				root := t.TempDir()
+				active := filepath.Join(root, "versions", "v1.0.0")
+				if err := os.MkdirAll(active, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				paths := []string{filepath.Join(root, entry), filepath.Join(active, "reasonix-desktop.exe")}
+				if legacy {
+					paths = append(paths, filepath.Join(root, "reasonix-guard.exe"))
+				} else if err := writeConsoleTestPointer(root); err != nil {
+					t.Fatal(err)
+				}
+				for _, path := range paths {
+					data := probeBytes
+					if path == paths[0] {
+						data = guiBytes
+					}
+					if err := os.WriteFile(path, data, 0o755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, paths[0])
+				cmd.Env = append(os.Environ(), consoleTestEnv+"="+root)
+				cmd.WaitDelay = 5 * time.Second
+				output, err := cmd.CombinedOutput()
+				if err != nil {
+					t.Fatalf("launcher: %v\n%s", err, output)
+				}
+				seen := make(map[string]bool)
+				for _, line := range bytes.Split(output, []byte{'\n'}) {
+					if !bytes.HasPrefix(line, []byte("console-state ")) {
+						continue
+					}
+					var name string
+					var cp, window uint64
+					if _, err := fmt.Sscanf(string(line), "console-state %s %d %d", &name, &cp, &window); err != nil {
+						t.Fatal(err)
+					}
+					seen[name] = true
+					// CREATE_NO_WINDOW still permits a console code page; the
+					// regression is creating a window, not having console I/O.
+					if window != 0 {
+						t.Errorf("%s created a console window: codepage=%d window=%d", name, cp, window)
+					}
+				}
+				for _, path := range paths {
+					if !seen[filepath.Base(path)] {
+						t.Errorf("missing process probe for %s: %s", filepath.Base(path), output)
+					}
+				}
+				if legacy {
+					if _, err := os.Stat(filepath.Join(root, "reasonix-guard.exe")); !os.IsNotExist(err) {
+						t.Errorf("completed legacy migrator was not removed: %v", err)
+					}
+				}
+				if strings.Contains(string(output), "error:") {
+					t.Fatalf("launcher reported an error: %s", output)
+				}
+			})
+		}
+	}
+}
+
+func writeConsoleTestPointer(root string) error {
+	return installlayout.WriteCurrent(root, installlayout.CurrentPointer{
+		SchemaVersion: 1, ActiveVersion: "v1.0.0", ActiveDir: "versions/v1.0.0",
+	})
+}
+
+func buildConsoleProbe(t *testing.T) []byte {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(consoleProbeSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", "probe.exe", "main.go")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOOS=windows", "GOARCH="+runtime.GOARCH, "CGO_ENABLED=0", "GO111MODULE=off")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build console probe: %v\n%s", err, output)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "probe.exe"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/internal/desktoplauncher/launcher.go
+++ b/internal/desktoplauncher/launcher.go
@@ -13,6 +13,7 @@ import (
 
 	"reasonix/internal/appidentity"
 	"reasonix/internal/installlayout"
+	"reasonix/internal/proc"
 )
 
 // Run resolves the active desktop, performs the one-time legacy handoff when
@@ -52,6 +53,7 @@ func Run(args []string, buildVersion string) int {
 	}
 
 	cmd := exec.Command(desktopPath, StripLegacyLaunchArgs(args)...)
+	proc.HideConsole(cmd)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	cmd.Dir = installRoot
 	if DetachByDefault() {
@@ -130,6 +132,7 @@ func runLegacyMigratorIfNeeded(installRoot string) error {
 	}
 
 	cmd := exec.Command(migratorPath, "--install-root", installRoot, "--no-relaunch")
+	proc.HideConsole(cmd)
 	cmd.Dir = installRoot
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/internal/desktoplauncher/testdata/console-probe/main.go
+++ b/internal/desktoplauncher/testdata/console-probe/main.go
@@ -1,0 +1,28 @@
+// Command console-probe is an independent console executable for launcher tests.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func main() {
+	exe, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	name := filepath.Base(exe)
+	kernel := syscall.NewLazyDLL("kernel32.dll")
+	cp, _, _ := kernel.NewProc("GetConsoleCP").Call()
+	window, _, _ := kernel.NewProc("GetConsoleWindow").Call()
+	fmt.Printf("console-state %s %d %d\n", name, cp, window)
+	if name == "reasonix-guard.exe" {
+		root := os.Getenv("REASONIX_LAUNCHER_CONSOLE_TEST")
+		pointer := `{"schemaVersion":1,"activeVersion":"v1.0.0","activeDir":"versions/v1.0.0"}`
+		if err := os.WriteFile(filepath.Join(root, "current.json"), []byte(pointer), 0o644); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/internal/proc/hide_other.go
+++ b/internal/proc/hide_other.go
@@ -6,3 +6,6 @@ import "os/exec"
 
 // HideWindow is a no-op off Windows.
 func HideWindow(*exec.Cmd) {}
+
+// HideConsole is a no-op off Windows.
+func HideConsole(*exec.Cmd) {}

--- a/internal/proc/hide_windows.go
+++ b/internal/proc/hide_windows.go
@@ -14,9 +14,15 @@ const createNoWindow = 0x08000000 // CREATE_NO_WINDOW
 // CREATE_NO_WINDOW suppresses the console a console child (git, rg, a shell)
 // would otherwise pop; HideWindow guards any GUI child that shows a window.
 func HideWindow(cmd *exec.Cmd) {
+	HideConsole(cmd)
+	cmd.SysProcAttr.HideWindow = true
+}
+
+// HideConsole prevents a console window without hiding a GUI application's
+// first window. Use it for launchers that can start either console or GUI code.
+func HideConsole(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
-	cmd.SysProcAttr.HideWindow = true
 	cmd.SysProcAttr.CreationFlags |= createNoWindow
 }

--- a/internal/proc/hide_windows_test.go
+++ b/internal/proc/hide_windows_test.go
@@ -48,3 +48,16 @@ func TestHideWindowPreservesStdoutCapture(t *testing.T) {
 		t.Fatalf("output = %q, want it to contain reasonix-ok", out)
 	}
 }
+
+func TestHideConsolePreservesGUIVisibilityAndExistingFlags(t *testing.T) {
+	const createNewProcessGroup = 0x00000200
+	cmd := exec.Command("desktop.exe")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNewProcessGroup}
+	HideConsole(cmd)
+	if cmd.SysProcAttr.HideWindow {
+		t.Fatal("console suppression must not hide the desktop GUI")
+	}
+	if got := cmd.SysProcAttr.CreationFlags; got != createNewProcessGroup|createNoWindow {
+		t.Fatalf("creation flags = %#x", got)
+	}
+}


### PR DESCRIPTION
## Summary

Launching the Windows desktop from its shortcut briefly opens a console before Electron appears. The GUI launcher starts the console-subsystem desktop bootstrap with a plain process creation call; the bootstrap then opens Electron and exits.

- Add `proc.HideConsole` to prevent console-window creation without hiding a GUI application's first window or changing existing creation flags.
- Apply it to both the active desktop bootstrap and the one-time legacy migrator. Preserve the stronger behavior of existing `HideWindow` callers and leave non-Windows launches unchanged.
- Add a Windows process-level regression covering the installed launcher, portable alias, and legacy migration. The fixture uses a GUI entry executable and independent console children, so it exercises the launch path bypassed by the Electron-only package smoke.
- Reject canceled CLI Git-status snapshots instead of displaying a fabricated detached HEAD or partial zero counts. Separate the real-Git functional test from the shared runner's subprocess timing; the production 700ms deadline stays unchanged. This addresses the Windows CI failure encountered while validating the launcher fix.

## Issues

Reported during v1.38.6 Windows startup verification; no linked GitHub issue.

## Verification

- Passed focused tests and `go test -race ./internal/cli ./internal/desktoplauncher ./internal/proc ./cmd/reasonix-launcher` on macOS.
- Passed focused `go vet`, Windows ARM64 `go vet`, `go run ./tools/repolint`, and `git diff --check`.
- Passed the full launcher and process suites on native Windows ARM64. All four launcher entry/migration combinations create no console window.
- Ran the same regression against the original launcher implementation on Windows ARM64: all four combinations fail by detecting console windows. This establishes that the regression catches the original defect.
- Passed Windows ARM64 and x64 cross-compilation. Native Windows x64 CI passed both launcher and process suites, including all four entry/migration cases. Under x64 emulation on Windows ARM64, ordinary launch passes, but both legacy migration cases fail when the unchanged cleanup path attempts to delete the completed migrator executable (`Access is denied`); the cause of this emulation-environment result is not yet established.
- The Git-status cancellation regression fails against the original implementation at branch, diff, and status queries. The corrected Git-status tests passed five consecutive local runs; Windows-tagged lint for all affected packages reports zero issues. Current-head CI is the final cross-platform gate.
- The GUI-visibility regression checks that console suppression does not set `HideWindow` and preserves existing creation flags. This is not a claim of full signed-installer UI acceptance; no new release has been published.

## Documentation impact

Documentation-impact: none - restores the expected windowless desktop launch and suppresses invalid canceled Git-status snapshots without changing user commands, settings, or installation instructions.

## Cache impact

Cache-impact: none - Windows process creation, CLI status display, and regression fixtures change; provider-visible prompts, tools, schemas, and serialization are untouched.
Cache-guard: N/A - no cache-sensitive source paths changed; focused launcher/proc and Git-status tests cover the changed boundaries.
System-prompt-review: N/A
