### PR TITLE
fix(desktop): keep the /compact receipt visible outside the process fold / 修复桌面端 /compact 压缩后界面无显示

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-rows.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-rows.test.ts
@@ -20,7 +20,7 @@ import {
   type FoldMap,
   type TranscriptRow,
 } from "../lib/transcriptRows";
-import type { Item } from "../lib/useController";
+import { initialState, reducer, type Item } from "../lib/useController";
 
 let passed = 0;
 let failed = 0;
@@ -453,6 +453,54 @@ const keys = (rows: TranscriptRow[]) => rows.map((row) => row.key).join(",");
   const rows = buildTranscriptRows(buildTurnModels(localOnly), rowOptions(EMPTY_FOLDS, "expanded"));
   const rowKeys = rows.map((row) => row.key);
   eq(new Set(rowKeys).size, rowKeys.length, "two local-only recoveries cannot share ph:/t: row keys");
+}
+
+// ── Compaction receipts stay visible ─────────────────────────────────────────
+// A manual /compact is a management submit: the optimistic "/compact" bubble
+// is removed on confirmation, so the compaction card lands after the previous
+// turn's answer. It must render as its own visible row in the default
+// (standard) experience instead of vanishing into a collapsed process fold.
+
+{
+  let s = reducer(initialState, { type: "user", text: "hello", seq: initialState.seq, submissionId: "s1" });
+  s = reducer(s, { type: "event", e: { kind: "turn_started" } });
+  s = reducer(s, { type: "event", e: { kind: "text", text: "answer body" } });
+  s = reducer(s, { type: "event", e: { kind: "turn_done" } });
+  s = reducer(s, { type: "user", text: "/compact", seq: s.seq, submissionId: "s2" });
+  s = reducer(s, { type: "management_confirmed", submissionId: "s2" });
+  s = reducer(s, { type: "event", e: { kind: "compaction_started", compaction: { trigger: "manual" } } });
+  const pendingRows = buildTranscriptRows(buildTurnModels(s.items, undefined, s.running), rowOptions(EMPTY_FOLDS));
+  eq(kinds(pendingRows), "user,answer,compaction", "a pending compaction after a finished turn renders as a visible row");
+  s = reducer(s, { type: "event", e: { kind: "compaction_done", compaction: { trigger: "manual", messages: 6, summary: "kept the task" } } });
+  eq(s.items.map((item) => item.kind).join(","), "user,assistant,compaction", "management confirmation removed the /compact bubble; the card follows the last answer");
+  const models = buildTurnModels(s.items, undefined, s.running);
+  const rows = buildTranscriptRows(models, rowOptions(EMPTY_FOLDS));
+  eq(kinds(rows), "user,answer,compaction", "the finished compaction card is visible in the standard experience without a process fold");
+  const compactionRow = rows.find((row) => row.kind === "compaction");
+  eq(compactionRow?.layoutVariant, "compaction-collapsed", "the visible compaction row keeps its collapsed card geometry");
+  ok(!rows.some((row) => row.kind === "process-header"), "a compaction alone never manufactures a collapsed 'worked for' fold header");
+}
+
+{
+  // Mid-turn automatic compaction. The receipt is visible and does not change
+  // fold defaults; like every outside item it follows its segment's whole fold,
+  // including the tool work that ran after the compaction.
+  const autoCompact: Item[] = [
+    { kind: "user", id: "u1", text: "first" },
+    { kind: "assistant", id: "a1", text: "", reasoning: "thinking", streaming: false },
+    { kind: "tool", id: "t1", name: "bash", args: "{}", readOnly: false, status: "done" },
+    { kind: "compaction", id: "c1", pending: false, trigger: "pressure", messages: 12, summary: "folded", archive: "" },
+    { kind: "tool", id: "t2", name: "bash", args: "{}", readOnly: false, status: "done" },
+    { kind: "assistant", id: "a2", text: "answer", reasoning: "", streaming: false },
+  ];
+  const models = buildTurnModels(autoCompact);
+  const segment = models[0].segments[0];
+  ok(!segment.displayItems.some((item) => item.kind === "compaction"), "compaction receipts are not fold material");
+  const rows = buildTranscriptRows(models, rowOptions(EMPTY_FOLDS));
+  eq(kinds(rows), "user,process-header,compaction,answer,turn-actions", "an automatic compaction renders between the process fold and the answer");
+  const noAnswer = buildTurnModels(autoCompact.slice(0, 4));
+  eq(noAnswer[0].segments[0].hasOutsideContent, false, "a compaction receipt alone does not count as conversation for fold defaults");
+  eq(defaultFoldOpen(noAnswer[0].segments[0], "auto"), true, "a turn whose only visible material is a compaction keeps its fold open");
 }
 
 // ── Size estimates ────────────────────────────────────────────────────────────

--- a/desktop/frontend/src/components/useTranscriptRowRenderer.tsx
+++ b/desktop/frontend/src/components/useTranscriptRowRenderer.tsx
@@ -97,7 +97,7 @@ export function useTranscriptRowRenderer({
       case "tool-group": return <div className="turn-collapse__body"><ToolGroup kind={row.groupKind} items={[...row.items]} subcalls={subcallsByParent} tabId={tabId} /></div>;
       case "phase": return <div className="turn-collapse__body"><PhaseCard id={row.item.id} text={row.item.text} /></div>;
       case "process-notice": return <div className="turn-collapse__body"><NoticeCard item={row.item} /></div>;
-      case "compaction": return <div className="turn-collapse__body"><CompactionCard item={row.item} /></div>;
+      case "compaction": return <CompactionCard item={row.item} />;
       case "answer": return <LiveAssistantMessage item={assistantAnswerOnly(row.item)} creationMode={creationMode} />;
       case "notice": {
         if (isSteerNoticeText(row.item.text)) return <SteerCard id={row.item.id} text={row.item.text} />;

--- a/desktop/frontend/src/lib/transcriptRows.ts
+++ b/desktop/frontend/src/lib/transcriptRows.ts
@@ -48,7 +48,7 @@ export const NO_LIVE: TranscriptLiveFlags = { hasAnswerText: false, hasReasoning
 
 export type TurnDisplayParts = {
   processItems: Item[];
-  outsideItems: Array<NoticeItem | AssistantItem | ExtensionItem>;
+  outsideItems: Array<NoticeItem | AssistantItem | ExtensionItem | CompactionItem>;
 };
 
 function assistantHasVisibleAnswer(item: AssistantItem, live: TranscriptLiveFlags): boolean {
@@ -56,12 +56,14 @@ function assistantHasVisibleAnswer(item: AssistantItem, live: TranscriptLiveFlag
   return live.id === item.id && live.hasAnswerText;
 }
 
-// Splits a turn by channel, not by position: reasoning, tools, phases, info
-// notices, and compaction cards are process material and fold; every assistant
-// message with answer text is model output addressed to the user and stays
-// outside the fold. Warnings must survive the fold auto-closing on completion,
-// and steers are the user's own words — neither belongs to the model's work
-// process.
+// Splits a turn by channel, not by position: reasoning, tools, phases, and info
+// notices are process material and fold; every assistant message with answer
+// text is model output addressed to the user and stays outside the fold.
+// Warnings must survive the fold auto-closing on completion, and steers are the
+// user's own words — neither belongs to the model's work process. Compaction
+// cards mark a session-level context boundary: they stay visible outside the
+// fold (the card owns its own summary disclosure) but, like extension cards,
+// are not a conversational boundary and do not affect fold defaults.
 //
 // The turn is returned as ordered segments so the conversation keeps its real
 // timeline: process that ran after an answer or steer opens a new segment
@@ -104,10 +106,11 @@ export function partitionTurnItems(items: readonly Item[], live: TranscriptLiveF
       }
       continue;
     }
-    if (item.kind === "extension") {
-      // Extension cards carry their own actions and progress — keep them
-      // visible like warnings instead of folding them into the process
-      // collapse, but never treat them as a conversational boundary.
+    if (item.kind === "extension" || item.kind === "compaction") {
+      // Extension cards carry their own actions and progress; compaction cards
+      // are the only visible receipt of a context rewrite. Keep both visible
+      // like warnings instead of folding them into the process collapse, but
+      // never treat them as a conversational boundary.
       current.outsideItems.push(item);
       continue;
     }
@@ -206,7 +209,6 @@ function foldDisplayItems(items: readonly Item[], live: TranscriptLiveFlags, hid
     }
     if (it.kind === "phase") return true;
     if (it.kind === "notice") return true;
-    if (it.kind === "compaction") return true;
     if (it.kind !== "tool") return false;
     if (it.parentId || it.name === "todo_write" || it.name === "exit_plan_mode") return false;
     return true;
@@ -261,7 +263,10 @@ export function buildTurnModels(
     const model = turns[index];
     model.isActive = running && index === turns.length - 1;
     const segments = partitionTurnItems(model.turnItems, live);
-    const turnHasOutsideContent = segments.some((segment) => segment.outsideItems.length > 0);
+    // Compaction cards stay outside the fold but do not count as conversation:
+    // a turn whose only visible material is a compaction receipt keeps its
+    // process fold open by default exactly like a turn with no answer.
+    const turnHasOutsideContent = segments.some((segment) => segment.outsideItems.some((item) => item.kind !== "compaction"));
     const turnIdentity = turnStableIdentity(model);
     model.segments = segments.map((segment, segmentIndex) => {
       const isLastSegment = segmentIndex === segments.length - 1;
@@ -564,7 +569,7 @@ export function userRowKey(itemId: string): string {
 }
 
 /** Body rows of one expanded process fold: read-only batches, creation tool
- *  groups, single tool cards, phases, info notices, compactions, reasoning. */
+ *  groups, single tool cards, phases, info notices, reasoning. */
 function processBodyRows(
   segment: SegmentModel,
   creationMode: boolean,
@@ -647,14 +652,6 @@ function processBodyRows(
       case "notice":
         rows.push({ kind: "process-notice", key: `pn:${it.id}`, item: it as NoticeItem, layoutVariant: "static" });
         break;
-      case "compaction":
-        rows.push({
-          kind: "compaction",
-          key: `c:${it.id}`,
-          item: it as CompactionItem,
-          layoutVariant: (it as CompactionItem).pending ? "static" : "compaction-collapsed",
-        });
-        break;
       case "assistant":
         // Answer text renders outside the fold (partitionTurnItems strips it),
         // so the fold only ever shows the reasoning segment.
@@ -724,6 +721,8 @@ export function buildTranscriptRowBlocks(models: readonly TurnModel[], options: 
       for (const item of segment.outsideItems) {
         if (item.kind === "extension") {
           modelRows.push({ kind: "extension", key: `x:${item.id}`, item, layoutVariant: "text-flow" });
+        } else if (item.kind === "compaction") {
+          modelRows.push({ kind: "compaction", key: `c:${item.id}`, item, layoutVariant: item.pending ? "static" : "compaction-collapsed" });
         } else if (item.kind === "notice") {
           modelRows.push({ kind: "notice", key: `n:${item.id}`, item, layoutVariant: "text-flow" });
         } else {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6607,13 +6607,52 @@ body > .mermaid-diagram--fullscreen {
 .notice--warn .notice__body {
   color: color-mix(in srgb, var(--warn) 78%, var(--fg));
 }
-.compaction__summary {
-  margin: 0;
-  padding: 12px 16px;
+/* Compaction card: the visible receipt of a context rewrite. It renders
+   outside the process fold as its own fold line, so it shares the
+   reasoning__head geometry instead of the folded process-card chrome. */
+.compaction {
+  margin: 4px auto;
+  -webkit-app-region: no-drag;
+}
+.compaction--pending,
+.compaction__head {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 24px;
+  padding: 2px 7px;
+  font-size: var(--text-md);
+  color: var(--fg-faint);
+}
+.compaction__head {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-weight: 560;
+  border-radius: 6px;
+}
+.compaction__head:hover {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+}
+.compaction__head > svg:last-child {
+  flex: 0 0 auto;
+  color: color-mix(in srgb, var(--fg-faint) 76%, transparent);
+  transition: transform 0.2s;
+}
+.compaction__head > .compaction__chevron--open {
+  transform: rotate(90deg);
+}
+.compaction__meta {
+  font-weight: 400;
+}
+.compaction__body {
+  margin: 4px 0 8px;
+  padding: 0 11px 0 30px;
   color: var(--fg-dim);
-  font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 12px;
-  line-height: 1.5;
+  font-family: inherit;
+  font-size: var(--text-sm);
+  line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1562,13 +1562,12 @@ func (c *Controller) submitCommandOrTurnReady(trimmed, input, display string, sc
 	case trimmed == "/compact" || strings.HasPrefix(trimmed, "/compact "):
 		focus := strings.TrimSpace(strings.TrimPrefix(trimmed, "/compact"))
 		go func() {
+			// CompactionDone already carries the outcome card to every sink; a
+			// second "compacted" notice only adds a folded duplicate row.
 			if err := c.Compact(context.Background(), focus); err != nil {
 				c.notice("compaction failed: " + err.Error())
-			} else {
-				c.notice("compacted")
-				if err := c.SnapshotRewrite(); err != nil {
-					slog.Warn("controller: snapshot after compact", "err", err)
-				}
+			} else if err := c.SnapshotRewrite(); err != nil {
+				slog.Warn("controller: snapshot after compact", "err", err)
 			}
 		}()
 	case trimmed == "/context":

--- a/internal/control/submit_route.go
+++ b/internal/control/submit_route.go
@@ -49,6 +49,11 @@ func isSimpleManagementInput(trimmed string) bool {
 	if trimmed == "/reload" || trimmed == "/effort" || strings.HasPrefix(trimmed, "/effort ") {
 		return true
 	}
+	// Focus-guided "/compact <focus>" runs the same asynchronous compaction as
+	// the bare form and never admits a turn (see Submit).
+	if strings.HasPrefix(trimmed, "/compact ") {
+		return true
+	}
 	switch trimmed {
 	case "/compact", "/context", "/new", "/clear":
 		return true

--- a/internal/control/submit_route_test.go
+++ b/internal/control/submit_route_test.go
@@ -13,6 +13,7 @@ func TestClassifySubmitRouteSeparatesManagementFromTurns(t *testing.T) {
 		want  SubmitDisposition
 	}{
 		{input: "/compact", want: SubmitManagementHandled},
+		{input: "/compact keep the test plan", want: SubmitManagementHandled},
 		{input: "/new", want: SubmitManagementHandled},
 		{input: "/context", want: SubmitManagementHandled},
 		{input: "/model", want: SubmitManagementHandled},


### PR DESCRIPTION
## Summary

Users report that on Desktop `/compact` compresses the context (usage drops) but "the UI shows nothing". The compaction card was being appended to the **previous** turn and folded into a collapsed `worked for N s` process header that looks exactly like any other fold, so nothing visibly changed.

**Root cause** — since #e30b6af5 the bare `/compact` submit is `management_handled` and the optimistic `/compact` bubble is removed on confirmation. `compaction_started` / `compaction_done` therefore land after the previous answer, where `partitionTurnItems` treated compaction cards as process material. That trailing segment defaults to collapsed in the standard experience, hiding both the card and the duplicate `compacted` notice.

**Fix**
- `partitionTurnItems` keeps compaction items **outside** the fold (like extension cards): they render as their own row — pending or collapsed card — and do not count as conversation for fold defaults, so existing fold behavior is unchanged. Like every other outside item, the receipt follows its segment's whole fold rather than splitting it.
- `buildTranscriptRowBlocks` emits the compaction row from `outsideItems`; the renderer no longer wraps it in the fold body.
- Restore the compaction card CSS that had been orphaned since the card-style unification (`.compaction__head`, `.compaction__body`, `.compaction--pending`); the stale `.compaction__summary` rule is replaced. On `main-v2` those selectors carry no rules at all, so the card rendered unstyled even with the fold expanded.
- Classify `"/compact <focus>"` as `management_handled`, matching `Controller.Submit`'s `trimmed == "/compact" || HasPrefix(trimmed, "/compact ")`. Previously the focus-guided form went through turn admission and failed with `turn admission did not produce a durable turn id` while the compaction still ran.
- Drop the duplicate `"compacted"` notice; `CompactionDone` already carries the outcome to the desktop card, the chat TUI (`ingestCompactionDone`), `textsink`, the `serve` web client and ACP. The failure notice is kept. Bots never saw the notice either way — `internal/bot/render.go` only forwards `LevelWarn` notices.

**Scope note on #9806** — this removes one way to reach `turn admission did not produce a durable turn id` (submitting `/compact <focus>` itself), but it is not the failure #9806 documents. That report's repro is sending an ordinary message inside the compaction / runtime-rebuild window, whose root cause sits in `desktop/turn_admission.go` and `internal/turnevent/ledger.go` — untouched here. Refs #9806; the issue stays open for that path.

Prompt-cache / provider bytes: unaffected (presentation + submit routing only). No persisted format changes.

Documentation-impact: none - no doc describes the compaction receipt's placement, `/compact` submit routing, or the removed `compacted` notice, so the existing docs stay correct.

## Test plan
- [x] `desktop/frontend`: `transcript-rows.test.ts` adds the exact bug sequence (user turn → `/compact` → `management_confirmed` → compaction events) and asserts a visible `compaction` row with no manufactured fold header in the standard experience, plus a mid-turn automatic compaction case and fold-default invariance. Reverting only `transcriptRows.ts` to `main-v2` fails 6 of the new assertions with `user,answer,process-header` — the hidden-fold bug itself.
- [x] `tsc --noEmit` for both `tsconfig.json` and `tsconfig.test.json`; `check-css-syntax`, `check-z-index-tokens`, `check-theme-token-contract`; `vite build` + `check-bundle-budget.mjs` (initial JS 449.2 / 469.3 KiB, deferred app-shell CSS 115.2 / 121.2 KiB); the frontend test discovery runner (`run-tests.mjs`).
- [x] `go test ./internal/control ./internal/serve ./internal/acp` and `desktop` turn-runtime tests; `submit_route_test.go` covers `"/compact keep the test plan"`.
- [ ] Manual Desktop check: run `/compact` after a completed turn and confirm the "上下文已压缩 · N 条消息 · manual" line appears under the last answer and expands to the summary. `/process-preview` in mock mode exercises the pending → collapsed → expanded states without a packaged build.

Generated with [Devin](https://devin.ai)
