### PR TITLE
fix(desktop): ship the Linux app/ directory with 0755, not 0700 / 修复 Linux 安装包 app/ 目录权限

### DIFF
--- a/desktop/packaging/package.mjs
+++ b/desktop/packaging/package.mjs
@@ -7,7 +7,7 @@
 // usage: node desktop/packaging/package.mjs <os/arch> <version> [channel]
 import { defaultSanitizePackageJson, packager } from "@electron/packager";
 import { execFileSync } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -99,6 +99,10 @@ try {
   mkdirSync(outDir, { recursive: true });
   const bundle = target.os === "darwin" ? join(outDir, `${PRODUCT.name}.app`) : join(outDir, "app");
   renameSync(target.os === "darwin" ? join(finalPath, `${PRODUCT.name}.app`) : finalPath, bundle);
+  // @electron/packager stages through mkdtemp (0700) and rename() keeps that
+  // mode; the bundle ships verbatim into the .deb and .tar.gz, where a 0700
+  // app/ is unreadable for regular users, so the launcher never finds the shell.
+  chmodSync(bundle, 0o755);
   rmSync(options.out, { recursive: true, force: true });
 
   if (target.os === "windows") {


### PR DESCRIPTION
## What

`desktop/packaging/package.mjs` now forces the packaged bundle directory to `0755`; it was reaching the Linux `.deb` and the portable `.tar.gz` as `0700`.

## Why

`@electron/packager` stages its output through `mkdtemp()` (mode 0700), and `rename()` preserves that mode — so the bundle directory carried 0700 all the way into both Linux artifacts:

```
@electron/packager output                  0700
  -> scripts/desktop-build.sh:365  cp -R     (mode preserved)
  -> desktop/build/bin/app                   still 0700
  -> nfpm.yaml  src: ./build/bin/app         (type: tree, no file_info.mode -> source mode)
  -> /usr/lib/reasonix/app                   (0700 in the installed .deb)
```

Installed that way, regular users cannot read the Electron shell, and `reasonix-launcher` aborts with `no Electron desktop shell (app/) is installed beside this binary` — the desktop never starts. The field workaround is `sudo chmod 755 /usr/lib/reasonix/app`, needed again after every package upgrade.

Note this is the one directory in the package without an explicit mode: every other `contents` entry in `desktop/build/linux/nfpm.yaml` declares `file_info.mode`.

## Verification (linux/amd64)

A/B run, same command, only the code switched:

| code | packaged `app/` |
| --- | --- |
| before | `drwx------` (700) |
| after | `drwxr-xr-x` (755) |

End-to-end `scripts/desktop-build.sh linux/amd64`:

```
deb:    drwxr-xr-x root/root 0 ./usr/lib/reasonix/app/
tar.gz: drwxr-xr-x          0 app/
```

The installed desktop then starts with no manual `chmod`.

Fixes #10139

Cache-impact: none - only the Electron packaging script's directory mode changes; no provider request bytes, tool schemas or system-prompt content are touched.
Cache-guard: n/a - desktop packaging only, outside every cache-sensitive path (internal/provider, internal/tool, internal/boot, internal/agent); existing guards are unaffected.
Documentation-impact: none - no docs/*.md change is warranted; desktop packaging behaviour is unchanged apart from the directory mode.
