### PR TITLE
fix(desktop): locate the portable CLI by its flat name in the legacy migrator / 修复便携版 tar.gz 首次启动失败

### DIFF
--- a/cmd/reasonix-legacy-migrator/main_test.go
+++ b/cmd/reasonix-legacy-migrator/main_test.go
@@ -48,8 +48,8 @@ func writeInstallerStaging(t *testing.T, root, label string, includeLauncher boo
 
 func TestMigrateFlatInstallToVersioned(t *testing.T) {
 	root := t.TempDir()
-	// Flat release unit.
-	for _, name := range installlayout.AllowedVersionMembers() {
+	// Flat release unit, named the way a portable archive actually ships it.
+	for _, name := range installlayout.FlatMemberNames() {
 		if err := os.WriteFile(filepath.Join(root, name), []byte("flat-"+name), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -105,7 +105,7 @@ func TestMigrateRefusesCorruptCurrentPointerWithoutOverwritingIt(t *testing.T) {
 	if err := os.WriteFile(current, corrupt, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	for _, name := range installlayout.AllowedVersionMembers() {
+	for _, name := range installlayout.FlatMemberNames() {
 		if err := os.WriteFile(filepath.Join(root, name), []byte("stale-"+name), 0o755); err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/reasonix-legacy-migrator/shell_test.go
+++ b/cmd/reasonix-legacy-migrator/shell_test.go
@@ -54,7 +54,7 @@ func TestInstallerRejectsIncompleteShellBeforePointerCommit(t *testing.T) {
 
 func TestPortableFirstLaunchMigrationCarriesShellIntoActiveVersion(t *testing.T) {
 	root := t.TempDir()
-	for _, name := range installlayout.AllowedVersionMembers() {
+	for _, name := range installlayout.FlatMemberNames() {
 		if err := os.WriteFile(filepath.Join(root, name), []byte(name), 0755); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/installlayout/current.go
+++ b/internal/installlayout/current.go
@@ -251,13 +251,25 @@ func DesktopBinaryName() string {
 	return "reasonix-desktop"
 }
 
-// CLIBinaryName is the platform-specific CLI executable base name inside a
-// version directory.
+// CLIBinaryName is the platform-specific CLI executable base name, the same in
+// a flat portable tree and inside a version directory. Unix ships "reasonix";
+// Windows uses "reasonix-cli.exe" because "Reasonix.exe" and "reasonix.exe"
+// collide on a case-insensitive filesystem.
 func CLIBinaryName() string {
 	if runtime.GOOS == "windows" {
 		return "reasonix-cli.exe"
 	}
-	return "reasonix-cli"
+	return "reasonix"
+}
+
+// FlatMemberNames is the member set a flat portable tree carries before the
+// legacy migrator moves it into a version directory.
+func FlatMemberNames() []string {
+	names := []string{DesktopBinaryName(), CLIBinaryName()}
+	if runtime.GOOS == "windows" {
+		names = append(names, UpdateHelperBinaryName())
+	}
+	return names
 }
 
 // UpdateHelperBinaryName is the platform-specific update helper name.

--- a/internal/installlayout/current_test.go
+++ b/internal/installlayout/current_test.go
@@ -143,3 +143,36 @@ func TestHasActiveShell(t *testing.T) {
 		t.Fatal("shell tree not detected beside the active desktop")
 	}
 }
+
+// CLIBinaryName is a cross-subsystem contract, not an internal detail: the
+// desktop probes exactly this name for its bundled CLI (desktop/remote_app.go,
+// desktop/updater.go) and the Linux updater publishes it beside
+// reasonix-desktop (desktop/updater_linux_tree.go). Assert the literal so a
+// rename cannot stay green by agreeing with itself.
+func TestCLIBinaryNameMatchesTheReleaseContract(t *testing.T) {
+	want := "reasonix"
+	if runtime.GOOS == "windows" {
+		want = "reasonix-cli.exe" // "Reasonix.exe" collides with "reasonix.exe" there.
+	}
+	if got := CLIBinaryName(); got != want {
+		t.Fatalf("CLIBinaryName() = %q, want %q", got, want)
+	}
+}
+
+// A flat portable archive carries the same CLI name the version directory gets,
+// which is also the name the desktop looks for beside itself.
+func TestFlatMemberNamesMatchThePortableArchive(t *testing.T) {
+	want := []string{DesktopBinaryName(), "reasonix"}
+	if runtime.GOOS == "windows" {
+		want = []string{DesktopBinaryName(), "reasonix-cli.exe", UpdateHelperBinaryName()}
+	}
+	got := FlatMemberNames()
+	if len(got) != len(want) {
+		t.Fatalf("FlatMemberNames() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("FlatMemberNames() = %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Fixes #10146 — every Linux/macOS portable archive (`Reasonix-linux-<arch>.tar.gz`) dies on its first launch:

```console
$ ./reasonix-launcher
error: migrate: flat CLI binary reasonix-cli is required
error: legacy layout migration failed: exit status 1
```

## Why

The launcher calls the legacy migrator when a tree has no `current.json` but does ship `reasonix-guard` (`internal/desktoplauncher/launcher.go`). The migrator then looked the CLI source up with `installlayout.CLIBinaryName()`, which by its own doc names a member **inside a version directory**:

```go
// CLIBinaryName is the platform-specific CLI executable base name inside a
// version directory.
func CLIBinaryName() string { ... return "reasonix-cli" }
```

A flat portable tree ships it as `reasonix` on Unix, so the lookup could never succeed and the migrator failed closed.

Three expectations disagreed:

| Owner | flat CLI name | Evidence |
| --- | --- | --- |
| `cmd/reasonix-legacy-migrator` | `reasonix-cli` | this lookup + `AllowedVersionMembers()` fixtures |
| `desktop/updater_linux_tree.go` | `reasonix` | `case "reasonix-desktop", "reasonix", ...`; `RequiredRootNames: {"reasonix-launcher","reasonix"}` |
| packaging / released archives | `reasonix` | `scripts/desktop-build.sh:38 CLINAME="reasonix"`; unpacked archive |

Timeline: `reasonix` since #6673 (07-19); `reasonix-cli` is the Windows-only name from #6806 (07-22); the migrator landed 08-02 and reused the versioned name.

## Change

- `installlayout`: add `FlatCLIBinaryName()` (Unix `reasonix`, Windows `reasonix-cli.exe`) and `FlatMemberNames()`.
- migrator: locate the source with the flat name; keep `CLIBinaryName()` as the member name written into `versions/<version>/`, so the migration output is unchanged.
- migrator tests: build flat fixtures from `FlatMemberNames()`. They previously used `AllowedVersionMembers()` — the version-directory whitelist — so the suite passed while every real portable archive failed, which is why this shipped.

## Verification

```
go build ./...                                                      ok
go test ./internal/installlayout/ ./cmd/reasonix-legacy-migrator/    ok
```

End-to-end: rebuilt migrator dropped into an unpacked `Reasonix-linux-amd64.tar.gz`:

```console
$ ./reasonix-launcher
# before: error: migrate: flat CLI binary reasonix-cli is required
# after:  migrates successfully (current.json + versions/ created) and proceeds to Electron startup
```

Cache-impact: none - only the desktop migrator's flat-tree lookup and its unit fixtures change; no provider request bytes, tool schemas or system-prompt content are touched.
Cache-guard: n/a - desktop install-layout code only, outside every cache-sensitive path (internal/provider, internal/tool, internal/boot, internal/agent).
Documentation-impact: none - no docs/*.md change is warranted; the migrator's documented behaviour (flat tree to version directory) is unchanged, only the flat source name is corrected.
