### PR TITLE
docs(config-paths): correct the disposable session catalog path to v8.sqlite

### DIFF
--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -42,7 +42,7 @@ non-destructively when `<Reasonix home>/.env` is missing them.
 | Memory | `<state root>/memory/` and `<state root>/projects/` |
 | Global Desktop topic metadata | `<state root>/desktop/topic-state-v1.sqlite` |
 | Project Desktop topic metadata | `<state root>/projects/<workspace slug>/desktop/topic-state-v1.sqlite` |
-| Disposable session catalog | `<cache root>/session-catalog/v6.sqlite` |
+| Disposable session catalog | `<cache root>/session-catalog/v8.sqlite` |
 | Disposable history search catalog | `<cache root>/history-search/v1.sqlite` |
 | Disposable usage catalog | `<cache root>/usage-catalog/v1.sqlite` |
 | Disposable task catalog | `<cache root>/task-catalog/v1.sqlite` |

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -35,7 +35,7 @@ Legacy 迁移、OS home 约定目录扫描以及其他 fallback 路径都会跳�
 | 记忆 | `<state root>/memory/` 与 `<state root>/projects/` |
 | 全局 Desktop Topic 元数据 | `<state root>/desktop/topic-state-v1.sqlite` |
 | 项目 Desktop Topic 元数据 | `<state root>/projects/<workspace slug>/desktop/topic-state-v1.sqlite` |
-| 可丢弃的会话 Catalog | `<cache root>/session-catalog/v6.sqlite` |
+| 可丢弃的会话 Catalog | `<cache root>/session-catalog/v8.sqlite` |
 | 可丢弃的 Task Catalog | `<cache root>/task-catalog/v1.sqlite` |
 
 `<state root>` 默认等于 `<Reasonix home>`；只有设置 `REASONIX_STATE_HOME`


### PR DESCRIPTION
## Summary

- `docs/CONFIG_PATHS.md` and `docs/CONFIG_PATHS.zh-CN.md` list the disposable session
  catalog as `<cache root>/session-catalog/v6.sqlite`. The generation file has been
  `v8.sqlite` since cf7c896cc, so both tables point at a file the implementation never
  creates.
- This PR updates those two table rows to `v8.sqlite`. No other row of the table moved.

Evidence from the implementation and from the rest of the documentation:

- `internal/sessioncatalog/types.go:255` — `DefaultPath()` returns
  `filepath.Join(cache, "session-catalog", "v8.sqlite")`.
- `internal/sessioncatalog/schema.go:216` — "The generation file moved to v8.sqlite, and
  clearing the directory scans forces a rescan so every existing row learns its log
  format."
- cf7c896cc `feat(sessioncatalog): project schema-2 heads without replaying the log`
  updated `docs/SESSION_CATALOG.md` and `docs/SESSION_CATALOG.zh-CN.md` in the same
  commit, which is how the remaining documentation already reads
  (`docs/SESSION_CATALOG.md:6`, `docs/SESSION_RECOVERY_AND_PARALLELISM.md:90`).

## Issues

No linked issue — this was found by comparing the path table against the implementation.
Refs: cf7c896cc (the commit that moved the generation file and missed these two tables).

## Verification

- `git diff` contains two changed lines, one per language edition:

  `docs/CONFIG_PATHS.md:45` — `v6.sqlite` -> `v8.sqlite`
  `docs/CONFIG_PATHS.zh-CN.md:38` — `v6.sqlite` -> `v8.sqlite`

- Residue check for the stale literal: `git grep -n 'session-catalog/v6.sqlite'` returns
  no hits. The only other `v6.sqlite` occurrence in the tree is the historical migration
  comment at `internal/sessioncatalog/schema.go:144`, which describes what migration v9
  did at the time and is intentionally left alone.
- Every other row of the same table was re-checked against its implementation path and
  still matches: `<state root>/desktop/topic-state-v1.sqlite`
  (`internal/config/paths.go:475`), `<cache root>/history-search/v1.sqlite`
  (`internal/historycatalog/types.go:108`), `<cache root>/usage-catalog/v1.sqlite`
  (`internal/usagecatalog/catalog.go:108`), `<cache root>/task-catalog/v1.sqlite`
  (`internal/taskcatalog/catalog.go:125`).
- Not run: `go test ./...`. This is a markdown-only diff, and the change-detection step in
  `.github/workflows/ci.yml:17-56` classifies `docs/**` as non-code, so the Go and desktop
  jobs are skipped for it by design. There is also no Markdown formatter or linter gate on
  `docs/*.md` in this repository (no root `package.json`, no prettier/markdownlint config),
  so no formatting command applies.

## Documentation impact

Documentation-impact: updated - corrected the disposable session catalog path from v6.sqlite to v8.sqlite in the English and Chinese CONFIG_PATHS tables.

## Cache impact

Cache-impact: none - documentation-only change; no provider-visible prompt, tool schema, standing instruction file, or cache-sensitive source path is touched.

Cache-guard: n/a - the diff is confined to docs/CONFIG_PATHS.md and docs/CONFIG_PATHS.zh-CN.md, which the `paths-ignore` list in `.github/workflows/cache-impact.yml` excludes.

System-prompt-review: N/A
