### PR TITLE
ci(desktop): give the Windows desktop job headroom over its own spread / Windows 桌面 CI 任务上限抬到其真实耗时之上

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,8 +736,9 @@ jobs:
     if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
     runs-on: windows-latest
     # A hung native step must not hold the workflow's concurrency group for the
-    # six-hour default. Normal runs finish in ~25 minutes.
-    timeout-minutes: 45
+    # six-hour default. main-v2 push runs measured 34-47 minutes on 2026-09-11,
+    # so 45 sat inside the job's own spread; every step keeps its own cap.
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Summary

The v1.38.7 release candidate (`910afcd26`) cannot be tagged: its `main-v2` push CI concluded `cancelled` because `desktop-windows` hit `timeout-minutes: 45` **twice on the same SHA** — 45m00s (attempt 1) and 45m16s (attempt 2). All 21 other jobs in that run passed. `scripts/verify-release-push-ci.sh` requires a `success` conclusion, so the release is blocked by the cap, not by a product failure.

**Root cause** — 45 sits inside the job's own duration spread rather than above it. `main-v2` push runs on 2026-09-11, before the candidate:

| commit | desktop-windows | result |
| --- | --- | --- |
| `5fd5ca150` | 34m43s | pass |
| `35ed75bc6` | 35m20s | pass |
| `20c6b8677` | 41m33s | pass |
| `e5a025c5f` | 34m56s | pass |
| `0055038b4` | 42m56s | pass |
| `910afcd26` attempt 1 | 45m00s | **cap** |
| `910afcd26` attempt 2 | 45m16s | **cap** |

Adjacent commits differ by more than seven minutes, so the job had been finishing under the cap by margin rather than by design. Both candidate attempts show the same profile: `test (Windows desktop and update helper)` takes 17m, then `Build Windows installer and portable archive` is cut at 8.5m / 8.3m of the ~9m it needs on a completing run. The candidate needs ~46m. The inline comment claiming "Normal runs finish in ~25 minutes" was stale.

This is not caused by the candidate's content: relative to the last green push run it only adds #10132, which touches `desktop/frontend/**` and `internal/control/**` and cannot reach the desktop Go suite that step runs.

**Fix** — raise the job-level cap to 60 and record the measured range in the comment. Every step inside the job keeps its own timeout (the two longest are capped at 25 and 20 minutes), so a genuinely hung native step still fails fast and cannot hold the concurrency group for the six-hour default. No step, matrix, trigger, or permission changed.

## Test plan
- [x] `bash scripts/release-workflows.test.sh` — stable release tag helper, cache impact, documentation impact, and release workflow contract tests all pass.
- [x] Diff is a single job-level key plus its comment.
- [ ] Confirmed by this PR's own `desktop-windows` run completing within the new cap.

Documentation-impact: none - the change is a CI job timeout in `.github/workflows/ci.yml`; no documented product behavior, interface, or workflow contract is affected.
