### PR TITLE
fix(desktop): stop transcript no-drag from punching the Electron titlebar / 修复对话区挖穿 Electron 标题栏拖动

### DIFF
--- a/desktop/frontend/scripts/shell-css.mjs
+++ b/desktop/frontend/scripts/shell-css.mjs
@@ -1,8 +1,13 @@
-// The stylesheet marks OS drag regions once, with the --reasonix-draggable
-// custom property. Chromium ignores var() for -webkit-app-region, so the
-// Electron build rewrites the declaration at bundle time instead of carrying
-// both forms in the source. The plain browser build keeps the inert marker.
-const DRAG_PROPERTY = /--reasonix-draggable\s*:/g;
+// --reasonix-draggable marks OS drag regions. Electron rewrites chrome
+// drag/no-drag to -webkit-app-region. Transcript content must not become
+// native no-drag or Chromium punches a hole in the titlebar (#10105).
+
+const DRAG_VALUE = /--reasonix-draggable(\s*:\s*)(drag|no-drag)/g;
+const APP_REGION_DECL = /\s*-webkit-app-region\s*:\s*(?:no-)?drag;?/g;
+const CHROME_NO_DRAG_SELECTOR =
+  /(^|[,{\s])\.(?:topicbar|topbar|sidebar[\w-]*|windows-window-control[\w-]*|management-screen[\w-]*|heartbeat[\w-]*|app-chrome[\w-]*|tabbar[\w-]*|chip|modal-close-button|[\w-]*backdrop|theme-gallery__editor-overlay)\b/i;
+const CONTENT_APP_REGION_SELECTOR =
+  /(^|[,{\s])\.(?:msg|transcript|reasoning|tool|process-card|composer|compaction|turn-collapse)(?:__|-|[\s,{.#:]|$)/i;
 
 export function shellFromEnv(env = process.env) {
   const shell = (env.REASONIX_SHELL ?? "").trim().toLowerCase();
@@ -11,7 +16,31 @@ export function shellFromEnv(env = process.env) {
   throw new Error(`REASONIX_SHELL must be "electron" or unset, got ${JSON.stringify(shell)}`);
 }
 
+function enclosingSelector(css, offset) {
+  const open = css.lastIndexOf("{", offset);
+  if (open < 0) return "";
+  const close = css.lastIndexOf("}", open);
+  return css.slice(close + 1, open);
+}
+
+function rewriteNoDrag(css) {
+  return css.replace(DRAG_VALUE, (match, sep, value, offset) => {
+    if (value === "drag") return `-webkit-app-region${sep}drag`;
+    const selector = enclosingSelector(css, offset);
+    if (CONTENT_APP_REGION_SELECTOR.test(selector)) return match;
+    if (CHROME_NO_DRAG_SELECTOR.test(selector)) return `-webkit-app-region${sep}no-drag`;
+    return match;
+  });
+}
+
+function stripContentAppRegion(css) {
+  return css.replace(/([^{}]+)\{([^{}]*)\}/g, (rule, selector, body) => {
+    if (!CONTENT_APP_REGION_SELECTOR.test(selector) || !body.includes("-webkit-app-region")) return rule;
+    return `${selector}{${body.replace(APP_REGION_DECL, "")}}`;
+  });
+}
+
 export function rewriteDragRegions(css, shell) {
   if (shell !== "electron") return css;
-  return css.replace(DRAG_PROPERTY, "-webkit-app-region:");
+  return stripContentAppRegion(rewriteNoDrag(css));
 }

--- a/desktop/frontend/scripts/shell-css.mjs
+++ b/desktop/frontend/scripts/shell-css.mjs
@@ -5,7 +5,7 @@
 const DRAG_VALUE = /--reasonix-draggable(\s*:\s*)(drag|no-drag)/g;
 const APP_REGION_DECL = /\s*-webkit-app-region\s*:\s*(?:no-)?drag;?/g;
 const CHROME_NO_DRAG_SELECTOR =
-  /(^|[,{\s])\.(?:topicbar[\w-]*|topbar[\w-]*|sidebar[\w-]*|windows-window-control[\w-]*|management-screen[\w-]*|heartbeat[\w-]*|app-chrome[\w-]*|tabbar[\w-]*|chip|modal-close-button|[\w-]*backdrop|theme-gallery__editor-overlay)\b/i;
+  /(^|[,{\s])\.(?:topicbar(?:__|--)[\w-]*|topbar(?:__|--)[\w-]*|topicbar|topbar|sidebar[\w-]*|windows-window-control[\w-]*|management-screen[\w-]*|heartbeat[\w-]*|app-chrome[\w-]*|tabbar[\w-]*|chip|modal-close-button|[\w-]*backdrop|theme-gallery__editor-overlay)\b/i;
 const CONTENT_APP_REGION_SELECTOR =
   /(^|[,{\s])\.(?:msg|transcript|reasoning|tool|process-card|composer|compaction|turn-collapse)(?:__|-|[\s,{.#:]|$)/i;
 

--- a/desktop/frontend/scripts/shell-css.mjs
+++ b/desktop/frontend/scripts/shell-css.mjs
@@ -5,7 +5,7 @@
 const DRAG_VALUE = /--reasonix-draggable(\s*:\s*)(drag|no-drag)/g;
 const APP_REGION_DECL = /\s*-webkit-app-region\s*:\s*(?:no-)?drag;?/g;
 const CHROME_NO_DRAG_SELECTOR =
-  /(^|[,{\s])\.(?:topicbar|topbar|sidebar[\w-]*|windows-window-control[\w-]*|management-screen[\w-]*|heartbeat[\w-]*|app-chrome[\w-]*|tabbar[\w-]*|chip|modal-close-button|[\w-]*backdrop|theme-gallery__editor-overlay)\b/i;
+  /(^|[,{\s])\.(?:topicbar[\w-]*|topbar[\w-]*|sidebar[\w-]*|windows-window-control[\w-]*|management-screen[\w-]*|heartbeat[\w-]*|app-chrome[\w-]*|tabbar[\w-]*|chip|modal-close-button|[\w-]*backdrop|theme-gallery__editor-overlay)\b/i;
 const CONTENT_APP_REGION_SELECTOR =
   /(^|[,{\s])\.(?:msg|transcript|reasoning|tool|process-card|composer|compaction|turn-collapse)(?:__|-|[\s,{.#:]|$)/i;
 

--- a/desktop/frontend/scripts/shell-css.test.mjs
+++ b/desktop/frontend/scripts/shell-css.test.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 import { rewriteDragRegions, shellFromEnv } from "./shell-css.mjs";
+
+const stylesPath = resolve(dirname(fileURLToPath(import.meta.url)), "../src/styles.css");
 
 test("browser build keeps the custom property byte-for-byte", () => {
   const css = ".tabbar{--reasonix-draggable:drag}.tabbar *{--reasonix-draggable: no-drag}";
@@ -13,6 +18,40 @@ test("electron build rewrites every drag declaration", () => {
     rewriteDragRegions(css, "electron"),
     ".tabbar{-webkit-app-region:drag}.tabbar *{-webkit-app-region: no-drag}/* --reasonix-draggable marks */",
   );
+});
+
+test("electron keeps chrome no-drag but does not punch the titlebar with transcript boxes", () => {
+  const css = [
+    ".topicbar{--reasonix-draggable:drag}",
+    ".topicbar button{--reasonix-draggable:no-drag}",
+    ".msg{--reasonix-draggable:no-drag}",
+    ".reasoning__head{-webkit-app-region:no-drag}",
+    ".tool__head{-webkit-app-region:no-drag}",
+    ".management-screen{--reasonix-draggable:no-drag}",
+    ".settings-modal-backdrop{--reasonix-draggable:no-drag}",
+    ".workbench-dock__tools{--reasonix-draggable:no-drag}",
+  ].join("");
+  const out = rewriteDragRegions(css, "electron");
+  assert.match(out, /\.topicbar\{-webkit-app-region:\s*drag\}/);
+  assert.match(out, /\.topicbar button\{-webkit-app-region:\s*no-drag\}/);
+  assert.match(out, /\.management-screen\{-webkit-app-region:\s*no-drag\}/);
+  assert.match(out, /\.settings-modal-backdrop\{-webkit-app-region:\s*no-drag\}/);
+  assert.doesNotMatch(out, /\.msg\{[^}]*-webkit-app-region/);
+  assert.doesNotMatch(out, /\.reasoning__head\{[^}]*-webkit-app-region/);
+  assert.doesNotMatch(out, /\.tool__head\{[^}]*-webkit-app-region/);
+  assert.doesNotMatch(out, /\.workbench-dock__tools\{[^}]*-webkit-app-region/);
+});
+
+test("electron stylesheet rewrite leaves transcript boxes out of app-region", () => {
+  const out = rewriteDragRegions(readFileSync(stylesPath, "utf8"), "electron");
+  assert.match(out, /\.topicbar\s*\{[^}]*-webkit-app-region:\s*drag/);
+  assert.match(out, /\.topicbar button\s*\{[^}]*-webkit-app-region:\s*no-drag/);
+  assert.doesNotMatch(out, /\.msg\s*\{[^}]*-webkit-app-region/);
+  assert.doesNotMatch(out, /\.reasoning__head\s*\{[^}]*-webkit-app-region/);
+  assert.doesNotMatch(out, /\.tool__head\s*\{[^}]*-webkit-app-region/);
+  assert.doesNotMatch(out, /\.process-card__head\s*\{[^}]*-webkit-app-region/);
+  assert.doesNotMatch(out, /\.composer-modebar\s*\{[^}]*-webkit-app-region/);
+  assert.doesNotMatch(out, /\.transcript__jump-bottom[^{]*\{[^}]*-webkit-app-region/);
 });
 
 test("shell selection is explicit", () => {

--- a/desktop/frontend/scripts/shell-css.test.mjs
+++ b/desktop/frontend/scripts/shell-css.test.mjs
@@ -46,6 +46,12 @@ test("electron keeps chrome no-drag but does not punch the titlebar with transcr
   assert.doesNotMatch(out, /\.workbench-dock__tools\{[^}]*-webkit-app-region/);
 });
 
+test("chrome selector does not match unrelated topicbar or topbar class names", () => {
+  const css = ".topicbarfoo{--reasonix-draggable:no-drag}.topbar2{--reasonix-draggable:no-drag}";
+  const out = rewriteDragRegions(css, "electron");
+  assert.equal(out, css);
+});
+
 test("electron stylesheet rewrite leaves transcript boxes out of app-region", () => {
   const out = rewriteDragRegions(readFileSync(stylesPath, "utf8"), "electron");
   assert.match(out, /\.topicbar\s*\{[^}]*-webkit-app-region:\s*drag/);

--- a/desktop/frontend/scripts/shell-css.test.mjs
+++ b/desktop/frontend/scripts/shell-css.test.mjs
@@ -24,6 +24,8 @@ test("electron keeps chrome no-drag but does not punch the titlebar with transcr
   const css = [
     ".topicbar{--reasonix-draggable:drag}",
     ".topicbar button{--reasonix-draggable:no-drag}",
+    ".topicbar__title-edit{--reasonix-draggable:no-drag}",
+    ".topicbar__title-input{--reasonix-draggable:no-drag}",
     ".msg{--reasonix-draggable:no-drag}",
     ".reasoning__head{-webkit-app-region:no-drag}",
     ".tool__head{-webkit-app-region:no-drag}",
@@ -34,6 +36,8 @@ test("electron keeps chrome no-drag but does not punch the titlebar with transcr
   const out = rewriteDragRegions(css, "electron");
   assert.match(out, /\.topicbar\{-webkit-app-region:\s*drag\}/);
   assert.match(out, /\.topicbar button\{-webkit-app-region:\s*no-drag\}/);
+  assert.match(out, /\.topicbar__title-edit\{-webkit-app-region:\s*no-drag\}/);
+  assert.match(out, /\.topicbar__title-input\{-webkit-app-region:\s*no-drag\}/);
   assert.match(out, /\.management-screen\{-webkit-app-region:\s*no-drag\}/);
   assert.match(out, /\.settings-modal-backdrop\{-webkit-app-region:\s*no-drag\}/);
   assert.doesNotMatch(out, /\.msg\{[^}]*-webkit-app-region/);
@@ -46,6 +50,8 @@ test("electron stylesheet rewrite leaves transcript boxes out of app-region", ()
   const out = rewriteDragRegions(readFileSync(stylesPath, "utf8"), "electron");
   assert.match(out, /\.topicbar\s*\{[^}]*-webkit-app-region:\s*drag/);
   assert.match(out, /\.topicbar button\s*\{[^}]*-webkit-app-region:\s*no-drag/);
+  assert.match(out, /\.topicbar__title-edit\s*\{[^}]*-webkit-app-region:\s*no-drag/);
+  assert.match(out, /\.topicbar__title-input\s*\{[^}]*-webkit-app-region:\s*no-drag/);
   assert.doesNotMatch(out, /\.msg\s*\{[^}]*-webkit-app-region/);
   assert.doesNotMatch(out, /\.reasoning__head\s*\{[^}]*-webkit-app-region/);
   assert.doesNotMatch(out, /\.tool__head\s*\{[^}]*-webkit-app-region/);

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -382,6 +382,29 @@ ok(
 );
 
 ok(
+  finalDeclaration(".topicbar", "--reasonix-draggable") === "drag" &&
+    finalDeclaration(".topicbar button", "--reasonix-draggable") === "no-drag" &&
+    finalDeclaration(".topicbar__actions", "--reasonix-draggable") === "no-drag",
+  "the shell bar is the window drag surface and opts its controls out",
+);
+
+ok(
+  finalDeclaration(".msg", "--reasonix-draggable") === undefined &&
+    finalDeclaration(".msg", "-webkit-app-region") === undefined &&
+    finalDeclaration(".reasoning__head", "-webkit-app-region") === undefined &&
+    finalDeclaration(".tool__head", "-webkit-app-region") === undefined &&
+    finalDeclaration(".process-card__head", "-webkit-app-region") === undefined &&
+    finalDeclaration(".compaction", "-webkit-app-region") === undefined,
+  "transcript content does not participate in native app-region subtraction",
+);
+
+ok(
+  finalDeclaration(".chat-pane", "overflow") === "hidden" &&
+    finalDeclaration(".chat-pane", "min-height") === "0",
+  "the chat pane clips overflow so zoomed transcript boxes cannot paint into the shell bar",
+);
+
+ok(
   finalDeclaration(".app--windows.app--creation .topicbar", "position") === "relative" &&
     finalDeclaration(".app--windows.app--creation .topicbar", "z-index") === "var(--z-app-chrome)" &&
     finalDeclaration(".app--windows.app--creation .topicbar", "min-height") === "40px" &&

--- a/desktop/frontend/src/components/SubagentDetails.css
+++ b/desktop/frontend/src/components/SubagentDetails.css
@@ -24,7 +24,6 @@
   background: none;
   text-align: left;
   cursor: pointer;
-  -webkit-app-region: no-drag;
 }
 
 .tool__subagent-preview-label--toggle:hover {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10,6 +10,8 @@
  *  - Colors via CSS variables + prefers-color-scheme so the webview follows the OS.
  *  - --reasonix-draggable marks the title region as an OS drag handle (macOS inset
  *    title bar); interactive children opt out with --reasonix-draggable: no-drag.
+ *    Transcript content must not set it: Electron's app-region subtraction
+ *    would punch a hole in the titlebar (#10105).
  */
 
 @font-face {
@@ -2780,6 +2782,7 @@ a[href] {
   flex-direction: column;
   min-width: 0;
   min-height: 0;
+  overflow: hidden;
   background: var(--chat-bg);
 }
 
@@ -3541,7 +3544,6 @@ a[href] {
   contain-intrinsic-size: none;
 }
 .transcript__jump-bottom:not([hidden]) {
-  --reasonix-draggable: no-drag;
   position: absolute;
   left: 50%;
   bottom: 34px;
@@ -4169,7 +4171,6 @@ a[href] {
 
 /* ── messages ────────────────────────────────────────────────────────────── */
 .msg {
-  --reasonix-draggable: no-drag;
   margin: 18px auto;
   user-select: text;
   -webkit-user-select: text;
@@ -4730,7 +4731,6 @@ a[href] {
   font-weight: 560;
   color: var(--fg-faint);
   border-radius: 6px;
-  -webkit-app-region: no-drag;
 }
 .reasoning__head:hover {
   color: var(--fg);
@@ -4782,7 +4782,6 @@ button.reasoning-summary {
   border-radius: 0;
   background: none;
   cursor: pointer;
-  -webkit-app-region: no-drag;
 }
 button.reasoning-summary:hover {
   color: var(--fg);
@@ -4814,7 +4813,6 @@ button.reasoning-summary:focus-visible {
   line-height: 1.4;
   text-align: left;
   cursor: pointer;
-  -webkit-app-region: no-drag;
 }
 .turn-collapse__reasoning-head:hover {
   color: var(--fg);
@@ -4848,7 +4846,6 @@ button.reasoning-summary:focus-visible {
   background: transparent;
   color: var(--fg-faint);
   cursor: pointer;
-  -webkit-app-region: no-drag;
 }
 .msg-search-sources__toggle:hover,
 .msg-search-sources__toggle:focus-visible {
@@ -4921,7 +4918,6 @@ button.reasoning-summary:focus-visible {
   background: transparent;
   color: var(--fg-faint);
   cursor: pointer;
-  -webkit-app-region: no-drag;
 }
 .msg-search-source__copy:hover,
 .msg-search-source__copy:focus-visible {
@@ -4993,7 +4989,6 @@ button.reasoning-summary:focus-visible {
   background: transparent;
   color: var(--fg-faint);
   cursor: pointer;
-  -webkit-app-region: no-drag;
 }
 .msg-memory-citations__toggle:hover {
   color: var(--fg);
@@ -5116,7 +5111,6 @@ button.reasoning-summary:focus-visible {
   text-align: left;
   cursor: pointer;
   border-radius: 4px;
-  -webkit-app-region: no-drag;
 }
 .process-card__head:hover {
   color: var(--fg);
@@ -6315,7 +6309,6 @@ body > .mermaid-diagram--fullscreen {
   text-align: left;
   cursor: pointer;
   border-radius: 4px;
-  -webkit-app-region: no-drag;
   overflow: hidden;
 }
 .tool__head:hover {
@@ -6655,7 +6648,6 @@ body > .mermaid-diagram--fullscreen {
    reasoning__head geometry instead of the folded process-card chrome. */
 .compaction {
   margin: 4px auto;
-  -webkit-app-region: no-drag;
 }
 .compaction--pending,
 .compaction__head {
@@ -31758,7 +31750,6 @@ body > .mermaid-diagram--fullscreen {
   font: inherit;
   text-align: left;
   cursor: pointer;
-  -webkit-app-region: no-drag;
 }
 
 .app--creation .tool-group__title,
@@ -35205,7 +35196,7 @@ body > .mermaid-diagram--fullscreen {
   background: color-mix(in srgb, #000 58%, transparent);
   display: grid; place-items: center; padding: 20px;
   overflow: hidden;
-  -webkit-app-region: no-drag;
+  --reasonix-draggable: no-drag;
 }
 .theme-gallery__editor {
   width: min(1180px, 100%);


### PR DESCRIPTION
## Summary

Windows frameless and macOS hiddenInset Desktop windows are dragged through Chromium `-webkit-app-region`. After the Wails→Electron migration, the bundle rewrote every `--reasonix-draggable: no-drag` marker into a native no-drag rectangle. Chromium subtracts those rectangles from the titlebar drag region.

Transcript `.msg` boxes punch a hole in the shell bar above the conversation column. The hole appears when a session has messages and gets worse at app zoom other than 100% (at 150% a message box reported `y=-706` while the topicbar stayed at `y=0,h=45`). Wails 1.38.3 used hit-testing of the element under the cursor, so the same CSS was harmless.

Only window chrome and covering overlays become `-webkit-app-region`. Transcript, composer, and tool content keep the inert custom property. `.chat-pane` clips overflow so zoomed message boxes cannot paint into the shell bar.

Fixes #10105
Fixes #10104
Fixes #10123
Fixes #10108

The titlebar-drag symptom in #10131 is the same hole. That issue also reports window restore / off-screen placement, which this PR does not change.

## Verification

- `node --test desktop/frontend/scripts/shell-css.test.mjs` (5 passed)
- `tsx src/__tests__/app-chrome-tabs.test.ts` (73 passed)
- `node scripts/check-css-syntax.mjs src/styles.css src/components/SubagentDetails.css`

Packaged Desktop v1.38.6 on macOS (Electron 44.2.0): confirmed `.msg { -webkit-app-region: no-drag }` in the installed CSS, live computed style `no-drag` on injected messages, and 150% zoom `getBoundingClientRect().y = -706` overlapping the topicbar. Playwright / HID synthetic mouse events do not drive Chromium app-region window moves, so native click-drag of the packaged window was not automated. Windows frameless drag remains an external verification item.

Heartbeat / automation is a full-window management overlay (not this punch). The in-app browser panel in this layout sits below the topicbar.

## Documentation impact

Documentation-impact: none - restores the existing frameless/hiddenInset titlebar drag contract. The Electron CSS rewrite comment documents the chrome-only app-region rule. No public docs or user-facing settings change.

## Cache impact

Cache-impact: none - Desktop CSS and Electron bundle rewrite only; no provider-visible prompts, tools, messages or serialization change.
Cache-guard: not applicable - no cache-sensitive execution path changes; focused shell-css and app-chrome tests cover the rewrite and clip.
System-prompt-review: reviewed - no system prompt, memory prefix, output style or skill index bytes change.
