### PR TITLE
fix(agent): port the summary-cache freeze chain and restore prefix-hash recording

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -382,21 +382,56 @@ func compactionInstructionWithFocus(instructions string) string {
 	return instruction
 }
 
-// summaryRequest builds the exact cache-aligned request shape used by
-// summarize. Keeping planning and execution on this shared builder prevents a
-// supposedly safe overflow fold from being rejected only after it is selected.
-func (a *Agent) summaryRequest(region []provider.Message, instructions string) provider.Request {
-	prefix := append([]provider.Message(nil), region...)
-	if len(prefix) == 0 || prefix[0].Role != provider.RoleSystem {
+// summaryRequestToolsForCommit returns the tool schemas the commit-time
+// summary request will send: frozen when a full frozen unit exists, else the
+// live registry. Telemetry uses it to attribute tool-seam divergence.
+func (a *Agent) summaryRequestToolsForCommit(prefix []provider.Message) []provider.ToolSchema {
+	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 && len(saved.tools) > 0 {
+		return saved.tools
+	}
+	if a.svc.tools != nil {
+		return a.providerToolSchemas()
+	}
+	return nil
+}
+
+// summaryToolsSource reports which tool set a summary request will send and
+// where it came from: the frozen main-request set, the live registry fallback,
+// or none. Mirrors summaryRequest's choice so telemetry can attribute a
+// system-only cache hit to a tool-seam fork.
+func (a *Agent) summaryToolsSource() ([]provider.ToolSchema, string) {
+	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 && len(saved.tools) > 0 {
+		return saved.tools, "frozen"
+	}
+	if a.svc.tools != nil {
+		return a.providerToolSchemas(), "live"
+	}
+	return nil, "none"
+}
+
+// summaryRequest builds the cache-aligned summary request: the verbatim
+// prefix (already in the provider's prefix cache from ordinary requests)
+// precedes the fold region so the fold lands at the same byte position the
+// server cached it at. When a frozen main request exists, its bytes AND its
+// frozen tool schemas are replayed — the server caches system+tools+messages
+// as one unit, and the live tool set drifts (MCP registration) between the
+// main request and the summary request. Keeping planning and execution on
+// this shared builder prevents a supposedly safe overflow fold from being
+// rejected only after it is selected.
+func (a *Agent) summaryRequest(prefix, region []provider.Message, instructions string) provider.Request {
+	msgs := append(append([]provider.Message(nil), prefix...), region...)
+	if len(msgs) == 0 || msgs[0].Role != provider.RoleSystem {
 		visible := a.modelVisibleMessages()
 		if len(visible) > 0 && visible[0].Role == provider.RoleSystem {
-			prefix = append([]provider.Message{visible[0]}, prefix...)
+			msgs = append([]provider.Message{visible[0]}, msgs...)
 		}
 	}
-	messages := a.normalizeModelRequestMessages(prefix)
+	messages := a.normalizeModelRequestMessages(msgs)
 	messages = append(messages, HostGeneratedUserMessage(compactionInstructionWithFocus(instructions)))
 	var schemas []provider.ToolSchema
-	if a.svc.tools != nil {
+	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 && len(saved.tools) > 0 {
+		schemas = saved.tools
+	} else if a.svc.tools != nil {
 		schemas = a.providerToolSchemas()
 	}
 	return provider.Request{
@@ -409,8 +444,8 @@ func (a *Agent) summaryRequest(region []provider.Message, instructions string) p
 
 // summarize asks the executor's own provider to distill a replayed prefix into
 // a briefing. instructions is optional /compact focus + PreCompact text.
-func (a *Agent) summarize(ctx context.Context, region []provider.Message, instructions string) (string, *provider.Usage, error) {
-	req := a.summaryRequest(region, instructions)
+func (a *Agent) summarize(ctx context.Context, prefix, region []provider.Message, instructions string) (string, *provider.Usage, error) {
+	req := a.summaryRequest(prefix, region, instructions)
 	summary, usage, err := a.runSummaryRequest(ctx, req)
 	a.observeSummaryOutcome(req, usage, err)
 	return summary, usage, err
@@ -491,8 +526,8 @@ func (a *Agent) runSummaryRequest(ctx context.Context, req provider.Request) (su
 // summarizeOnce performs exactly one application-layer summary request.
 // Timeouts, empty results, stream errors, and output truncation all fail once
 // with no second attempt.
-func (a *Agent) summarizeOnce(ctx context.Context, fold []provider.Message, instructions string) (string, *provider.Usage, error) {
-	return a.summarize(ctx, fold, instructions)
+func (a *Agent) summarizeOnce(ctx context.Context, prefix, fold []provider.Message, instructions string) (string, *provider.Usage, error) {
+	return a.summarize(ctx, prefix, fold, instructions)
 }
 
 // renderTranscript flattens messages into a bounded transcript for the

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -386,7 +386,10 @@ func compactionInstructionWithFocus(instructions string) string {
 // summary request will send: frozen when a full frozen unit exists, else the
 // live registry. Telemetry uses it to attribute tool-seam divergence.
 func (a *Agent) summaryRequestToolsForCommit(prefix []provider.Message) []provider.ToolSchema {
-	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 && len(saved.tools) > 0 {
+	// A frozen request that carried zero tools is a real snapshot, not a
+	// missing one: re-deriving the live registry there would move the tool
+	// seam the provider cached. Only a nil snapshot falls back.
+	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 {
 		return saved.tools
 	}
 	if a.svc.tools != nil {
@@ -400,7 +403,7 @@ func (a *Agent) summaryRequestToolsForCommit(prefix []provider.Message) []provid
 // or none. Mirrors summaryRequest's choice so telemetry can attribute a
 // system-only cache hit to a tool-seam fork.
 func (a *Agent) summaryToolsSource() ([]provider.ToolSchema, string) {
-	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 && len(saved.tools) > 0 {
+	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 {
 		return saved.tools, "frozen"
 	}
 	if a.svc.tools != nil {
@@ -429,7 +432,7 @@ func (a *Agent) summaryRequest(prefix, region []provider.Message, instructions s
 	messages := a.normalizeModelRequestMessages(msgs)
 	messages = append(messages, HostGeneratedUserMessage(compactionInstructionWithFocus(instructions)))
 	var schemas []provider.ToolSchema
-	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 && len(saved.tools) > 0 {
+	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 {
 		schemas = saved.tools
 	} else if a.svc.tools != nil {
 		schemas = a.providerToolSchemas()

--- a/internal/agent/compact_chunked_fallback.go
+++ b/internal/agent/compact_chunked_fallback.go
@@ -21,7 +21,7 @@ func (a *Agent) foldSummaryWithChunkedFallback(ctx context.Context, trigger stri
 	var res foldSummary
 	var tele CompactionTelemetry
 	var chunkedReason error
-	preflight := a.validateSafeSummaryRequest(fold, instructions, false)
+	preflight := a.validateSafeSummaryRequest(prefix, fold, instructions, false)
 	if preflight == nil {
 		var err error
 		res, tele, err = a.foldSummaryWithTelemetry(ctx, trigger, prefix, fold, instructions, sourceTokens, inputMode)

--- a/internal/agent/compact_chunked_fallback.go
+++ b/internal/agent/compact_chunked_fallback.go
@@ -1,0 +1,70 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"reasonix/internal/provider"
+)
+
+// foldSummaryWithChunkedFallback retries summary size failures through the
+// resilient fragment/tree-reduce path used for over-length sessions. It lives
+// in its own file so growth here cannot push compact_projection.go past its
+// repolint ceiling, and an upstream convergence replacing that file cannot
+// silently drop this local guard (it exists upstream too, without the
+// pre-flight below).
+func (a *Agent) foldSummaryWithChunkedFallback(ctx context.Context, trigger string, prefix, fold []provider.Message, instructions string, sourceTokens int, inputMode string) (foldSummary, CompactionTelemetry, error) {
+	// Pre-flight: a fold already over the safe prompt budget would 400 on the
+	// provider — go straight to the fragmenting path instead of burning the
+	// doomed single call. validateSafeSummaryRequest no-ops when enforcement
+	// is off (window-independent gateways keep the original request shape).
+	var res foldSummary
+	var tele CompactionTelemetry
+	var chunkedReason error
+	preflight := a.validateSafeSummaryRequest(fold, instructions, false)
+	if preflight == nil {
+		var err error
+		res, tele, err = a.foldSummaryWithTelemetry(ctx, trigger, prefix, fold, instructions, sourceTokens, inputMode)
+		if err == nil || !chunkedFallbackApplies(err, inputMode) {
+			return res, tele, err
+		}
+		chunkedReason = err
+	} else if len(fold) == 0 {
+		// Empty fold with an over-budget instruction set: single call is the
+		// only shape (instructions ride the prefix), so surface the rejection.
+		res, tele, err := a.foldSummaryWithTelemetry(ctx, trigger, prefix, fold, instructions, sourceTokens, inputMode)
+		return res, tele, err
+	} else {
+		chunkedReason = preflight
+	}
+	// When foldExtra is nil (view replay fits), the full fold region is in prefix.
+	chunkedInput := fold
+	if len(chunkedInput) == 0 {
+		chunkedInput = prefix
+	}
+	chunked, chunkedErr := a.chunkedFoldSummary(ctx, chunkedInput, instructions, nil)
+	chunked.Usage = mergeSamplingUsage(res.Usage, chunked.Usage)
+	chunked.Spans += res.Spans
+	if chunked.FoldTokens <= 0 {
+		chunked.FoldTokens = res.FoldTokens
+	}
+	if chunked.RequestID == "" {
+		chunked.RequestID = res.RequestID
+	}
+	if chunkedErr != nil {
+		tele = a.telemetryFromSummary(trigger, a.CacheState(), sourceTokens, chunked, nil, chunkedInput)
+		tele.Error = fmt.Sprintf("%v (chunked fallback: %v)", chunkedReason, chunkedErr)
+		return chunked, tele, chunkedErr
+	}
+	return chunked, a.telemetryFromSummary(trigger, a.CacheState(), sourceTokens, chunked, nil, chunkedInput), nil
+}
+
+// chunkedFallbackApplies reports a size failure the fragment path can fix. A
+// provider overflow qualifies only once the transcript form has failed too;
+// before that a re-planned replay is one request instead of many.
+func chunkedFallbackApplies(err error, inputMode string) bool {
+	if provider.AsContextLimitError(err) != nil {
+		return inputMode == SummaryInputSlim
+	}
+	return summarySizeFailure(err)
+}

--- a/internal/agent/compact_chunked_policy_test.go
+++ b/internal/agent/compact_chunked_policy_test.go
@@ -29,7 +29,7 @@ func TestExplicitChunkedFallbackStillRuns(t *testing.T) {
 	prov := &extractStubProvider{failFirst: 1, reply: "digest"}
 	a := New(prov, tool.NewRegistry(), extractStubSession(), Options{}, event.Discard)
 	fold := a.Session().Snapshot()
-	if _, _, err := a.foldSummaryWithChunkedFallback(context.Background(), CompactionTriggerManual, fold, "focus", 321, SummaryInputCachePrefix); err != nil {
+	if _, _, err := a.foldSummaryWithChunkedFallback(context.Background(), CompactionTriggerManual, nil, fold, "focus", 321, SummaryInputCachePrefix); err != nil {
 		t.Fatalf("explicit chunked fallback: %v", err)
 	}
 	if prov.calls < 2 {

--- a/internal/agent/compact_commit.go
+++ b/internal/agent/compact_commit.go
@@ -18,6 +18,14 @@ type summaryProjectionCommit struct {
 	// covered is the canonical length the frozen projection body represents;
 	// messages past it splice live from the transcript.
 	covered int
+	// wirePrefix is the exact prefix the summary request sent this checkpoint
+	// (the provider-cached unit it replayed). Persisted as the lossless
+	// projection inverse so a resumed process replays the same bytes.
+	wirePrefix []provider.Message
+	// wireTools is the tool-schema half of the same cached unit; without it a
+	// resumed process replays the frozen messages against the live tool set
+	// and misses past the system prefix (2026-08-31 desktop).
+	wireTools []provider.ToolSchema
 }
 
 // commitSummaryProjection CAS-installs a checkpoint under compactionMu:
@@ -82,5 +90,11 @@ func (a *Agent) summaryProjectionState(commit summaryProjectionCommit) Compactio
 			ViewInputHash: commit.inputHash, ViewOutputHash: commit.outputHash, CreatedAt: now,
 		},
 		LastReceipt: receipt, UpdatedAt: now,
+		// Lossless projection inverse: preserve the exact prefix the summary
+		// request replayed (the provider-cached unit), so a resumed process can
+		// replay the same bytes instead of paying a full-price first compaction
+		// (project + reconstruct = identity).
+		LastWireMessages: commit.wirePrefix,
+		LastWireTools:    commit.wireTools,
 	}
 }

--- a/internal/agent/compact_commit.go
+++ b/internal/agent/compact_commit.go
@@ -86,10 +86,8 @@ func (a *Agent) summaryProjectionState(commit summaryProjectionCommit) Compactio
 			ViewInputHash: commit.inputHash, ViewOutputHash: commit.outputHash, CreatedAt: now,
 		},
 		LastReceipt: receipt, UpdatedAt: now,
-		// Lossless projection inverse: preserve the exact prefix the summary
-		// request replayed (the provider-cached unit), so a resumed process can
-		// replay the same bytes instead of paying a full-price first compaction
-		// (project + reconstruct = identity).
+		// Preserve the exact prefix the summary request replayed (the
+		// provider-cached unit): a resumed process replays the same bytes.
 		LastWireMessages: commit.wirePrefix,
 		LastWireTools:    commit.wireTools,
 	}

--- a/internal/agent/compact_commit.go
+++ b/internal/agent/compact_commit.go
@@ -18,14 +18,10 @@ type summaryProjectionCommit struct {
 	// covered is the canonical length the frozen projection body represents;
 	// messages past it splice live from the transcript.
 	covered int
-	// wirePrefix is the exact prefix the summary request sent this checkpoint
-	// (the provider-cached unit it replayed). Persisted as the lossless
-	// projection inverse so a resumed process replays the same bytes.
+	// wirePrefix/wireTools persist the exact provider-cached unit this
+	// checkpoint replayed, so a resumed process sends the same bytes.
 	wirePrefix []provider.Message
-	// wireTools is the tool-schema half of the same cached unit; without it a
-	// resumed process replays the frozen messages against the live tool set
-	// and misses past the system prefix (2026-08-31 desktop).
-	wireTools []provider.ToolSchema
+	wireTools  []provider.ToolSchema
 }
 
 // commitSummaryProjection CAS-installs a checkpoint under compactionMu:

--- a/internal/agent/compact_fold_input.go
+++ b/internal/agent/compact_fold_input.go
@@ -58,29 +58,69 @@ func (a *Agent) summaryInputBudget(instructions string) int {
 // foldToSummary turns a fold region into one digest with exactly one provider
 // request. Pressure-time tool pruning is durable and happens before this call;
 // the summary request never performs a private second transformation.
-func (a *Agent) foldToSummary(ctx context.Context, fold []provider.Message, instructions string) (foldSummary, error) {
-	return a.foldToSummaryMode(ctx, fold, instructions, SummaryInputCachePrefix)
+func (a *Agent) foldToSummary(ctx context.Context, prefix, fold []provider.Message, instructions string) (foldSummary, error) {
+	return a.foldToSummaryMode(ctx, nil, fold, instructions, SummaryInputCachePrefix)
 }
 
-func (a *Agent) foldToSummaryMode(ctx context.Context, fold []provider.Message, instructions, inputMode string) (foldSummary, error) {
+func (a *Agent) foldToSummaryMode(ctx context.Context, prefix, fold []provider.Message, instructions, inputMode string) (foldSummary, error) {
 	res := foldSummary{Mode: CompactionModeSummarized, Spans: 1, FoldTokens: summaryInputTokens(fold), InputMode: inputMode}
 	if inputMode == SummaryInputSlim {
 		summary, usage, err := a.summarizeTranscript(ctx, fold, instructions)
 		res.Text, res.Usage = summary, usage
 		return res, err
 	}
-	return a.singleCallSummary(ctx, res, fold, instructions)
+	return a.singleCallSummary(ctx, res, prefix, fold, instructions)
 }
 
-func (a *Agent) singleCallSummary(ctx context.Context, res foldSummary, fold []provider.Message, instructions string) (foldSummary, error) {
-	summary, mode, usage, reqID, err := a.runCompactionSummary(ctx, fold, instructions)
+func (a *Agent) singleCallSummary(ctx context.Context, res foldSummary, prefix, fold []provider.Message, instructions string) (foldSummary, error) {
+	summary, mode, usage, reqID, err := a.runCompactionSummary(ctx, prefix, fold, instructions)
 	res.Text, res.Mode, res.Usage, res.RequestID = summary, mode, usage, reqID
 	return res, err
 }
 
-func (a *Agent) foldSummaryWithTelemetry(ctx context.Context, trigger string, fold []provider.Message, instructions string, sourceTokens int, inputMode string) (foldSummary, CompactionTelemetry, error) {
-	res, err := a.foldToSummaryMode(ctx, fold, instructions, inputMode)
-	tele := compactionTelemetryFromSummary(trigger, a.CacheState(), sourceTokens, res)
+// fillCompactionWireTelemetry attributes the summary request's actual wire
+// shape: the fold-view fingerprint, the normalized bytes sent last request,
+// and which tool set the summary carried. These let a system-only cache hit
+// or a post-resume miss be traced to tool-seam or byte divergence.
+func (a *Agent) fillCompactionWireTelemetry(tele *CompactionTelemetry, prefix, fold []provider.Message) {
+	view := append(append([]provider.Message(nil), prefix...), fold...)
+	tele.ViewFP = providerVisibleFingerprint(modelInputMessages(view))
+	tele.WireFP = a.sess.wireFP()
+	tele.PrefixHash = summarizePrefixHash(prefix)
+	tele.PrefLen = len(prefix)
+	if saved := a.savedMainRequest(); saved != nil {
+		tele.WireLen = len(saved.messages)
+		tele.WireDiff = firstWireDiff(saved.messages, prefix)
+	}
+	if schemas, source := a.summaryToolsSource(); source != "none" {
+		tele.ToolsCount = len(schemas)
+		tele.ToolsFP = toolsFingerprint(schemas)
+		tele.ToolsSource = source
+	}
+}
+
+// summarizePrefixHash fingerprints the summarizer's prefix so compaction passes
+// can be compared for drift: a stable hash with a low hit rate means the bytes
+// were never sent before; a changing hash means the boundary moved.
+func summarizePrefixHash(prefix []provider.Message) string {
+	h := providerVisibleFingerprint(provider.ModelMessages(prefix))
+	if len(h) > 12 {
+		h = h[:12]
+	}
+	return h
+}
+
+// telemetryFromSummary builds a compaction record for a fold region and
+// attributes its wire shape in one call, so every emit site stays one line.
+func (a *Agent) telemetryFromSummary(trigger, cacheState string, sourceTokens int, res foldSummary, prefix, fold []provider.Message) CompactionTelemetry {
+	tele := compactionTelemetryFromSummary(trigger, cacheState, sourceTokens, res)
+	a.fillCompactionWireTelemetry(&tele, prefix, fold)
+	return tele
+}
+
+func (a *Agent) foldSummaryWithTelemetry(ctx context.Context, trigger string, prefix, fold []provider.Message, instructions string, sourceTokens int, inputMode string) (foldSummary, CompactionTelemetry, error) {
+	res, err := a.foldToSummaryMode(ctx, prefix, fold, instructions, inputMode)
+	tele := a.telemetryFromSummary(trigger, a.CacheState(), sourceTokens, res, prefix, fold)
 	if err != nil {
 		tele.Error = err.Error()
 	}

--- a/internal/agent/compact_fold_input_test.go
+++ b/internal/agent/compact_fold_input_test.go
@@ -51,7 +51,7 @@ func (p *deadlineInspectProvider) Stream(ctx context.Context, _ provider.Request
 func TestSummaryDoesNotAddInternalWallClockDeadline(t *testing.T) {
 	prov := &deadlineInspectProvider{}
 	a := New(prov, tool.NewRegistry(), &Session{Messages: []provider.Message{{Role: provider.RoleSystem, Content: "sys"}}}, Options{}, event.Discard)
-	if _, err := a.foldToSummary(context.Background(), []provider.Message{{Role: provider.RoleUser, Content: "old"}}, ""); err != nil {
+	if _, err := a.foldToSummary(context.Background(), nil, []provider.Message{{Role: provider.RoleUser, Content: "old"}}, ""); err != nil {
 		t.Fatal(err)
 	}
 	if prov.hadDeadline {
@@ -67,7 +67,7 @@ func TestSummaryCollectorStoresOnlyVisibleText(t *testing.T) {
 		{Type: provider.ChunkDone},
 	}}
 	a := New(prov, tool.NewRegistry(), NewSession("system"), Options{}, event.Discard)
-	got, _, err := a.summarize(context.Background(), []provider.Message{{Role: provider.RoleUser, Content: "old"}}, "")
+	got, _, err := a.summarize(context.Background(), nil, []provider.Message{{Role: provider.RoleUser, Content: "old"}}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestSummaryCollectorRejectsEmptyAndLengthLimitedOutput(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			prov := &summaryChunksProvider{chunks: tc.chunks}
 			a := New(prov, tool.NewRegistry(), NewSession("system"), Options{}, event.Discard)
-			if _, _, err := a.summarize(context.Background(), []provider.Message{{Role: provider.RoleUser, Content: "old"}}, ""); err == nil || !strings.Contains(err.Error(), tc.want) {
+			if _, _, err := a.summarize(context.Background(), nil, []provider.Message{{Role: provider.RoleUser, Content: "old"}}, ""); err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("summarize error = %v, want %q", err, tc.want)
 			}
 		})
@@ -120,7 +120,7 @@ func TestSummaryRequestReplaysSystemToolsAndSelectedPrefix(t *testing.T) {
 	}
 	a := New(prov, reg, &Session{Messages: append([]provider.Message{system}, fold...)}, Options{ContextWindow: 100_000, MaxOutputTokens: 1024}, event.Discard)
 
-	if _, err := a.foldToSummary(context.Background(), fold, "keep exact identifiers"); err != nil {
+	if _, err := a.foldToSummary(context.Background(), nil, fold, "keep exact identifiers"); err != nil {
 		t.Fatalf("foldToSummary: %v", err)
 	}
 	if len(prov.got) != 1 {
@@ -181,7 +181,7 @@ func TestFoldUnderBudgetIsSummarizedVerbatimInOneCall(t *testing.T) {
 	a := newFoldAgent(t, 200000, prov)
 	fold := foldOfToolResults(3, 40)
 
-	res, err := a.foldToSummary(context.Background(), fold, "")
+	res, err := a.foldToSummary(context.Background(), nil, fold, "")
 	if err != nil {
 		t.Fatalf("foldToSummary: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestManualFoldDoesNotPrivatelyShortenToolResults(t *testing.T) {
 	a := newFoldAgent(t, 24000, prov)
 	fold := foldOfToolResults(6, 300)
 
-	res, err := a.foldToSummary(context.Background(), fold, "")
+	res, err := a.foldToSummary(context.Background(), nil, fold, "")
 	if err != nil {
 		t.Fatalf("foldToSummary: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestHugeFoldNeverMultiSpan(t *testing.T) {
 	a := newFoldAgent(t, 32000, prov)
 	fold := foldOfToolResults(80, 800)
 
-	res, err := a.foldToSummary(context.Background(), fold, "focus on the parser")
+	res, err := a.foldToSummary(context.Background(), nil, fold, "focus on the parser")
 	if err != nil {
 		// Failure without a second attempt is acceptable for an unfittable fold.
 		if len(prov.got) != 0 {
@@ -242,7 +242,7 @@ func TestNoContextWindowLeavesTheFoldUnbounded(t *testing.T) {
 	a := New(prov, nil, &Session{}, Options{}, event.Discard)
 	fold := foldOfToolResults(40, 400)
 
-	res, err := a.foldToSummary(context.Background(), fold, "")
+	res, err := a.foldToSummary(context.Background(), nil, fold, "")
 	if err != nil {
 		// Without a window the input budget is 0 and the single-call path
 		// refuses before paying for a request.
@@ -259,7 +259,7 @@ func TestNoContextWindowLeavesTheFoldUnbounded(t *testing.T) {
 func TestSummarizeOnceNoRetry(t *testing.T) {
 	prov := &failOnceProvider{}
 	a := newFoldAgent(t, 200000, prov)
-	_, _, err := a.summarizeOnce(context.Background(), []provider.Message{
+	_, _, err := a.summarizeOnce(context.Background(), nil, []provider.Message{
 		{Role: provider.RoleUser, Content: "hello"},
 	}, "")
 	if err == nil {

--- a/internal/agent/compact_overflow_prefix_test.go
+++ b/internal/agent/compact_overflow_prefix_test.go
@@ -138,7 +138,7 @@ func TestPressureSummaryCappedByLearnedWindowAfterSessionReset(t *testing.T) {
 	if safeEnd <= head || safeEnd >= plannedEnd {
 		t.Fatalf("safe fold end = %d, want a non-empty prefix smaller than planned end %d", safeEnd, plannedEnd)
 	}
-	request := a.summaryRequest(msgs[head:safeEnd], "")
+	request := a.summaryRequest(msgs[:head], msgs[head:safeEnd], "")
 	if got, max := a.estimatedRequestTokens(request), a.effectiveContextWindow()-a.summaryOutputBudget()-protocolReserveTokens; got > max {
 		t.Fatalf("summary request tokens = %d, exceeds learned-window cap %d", got, max)
 	}

--- a/internal/agent/compact_prefix_cache_test.go
+++ b/internal/agent/compact_prefix_cache_test.go
@@ -1,0 +1,346 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// TestSummaryFoldPlanReusesFullMainRequestBytes pins the cache-alignment fix:
+// with frozen main-request bytes, the summarizer prefix is the ENTIRE main
+// request (the provider-cached unit), not a head-cropped view. head is pinned
+// at 1 (system only), so any head-cropped prefix could never match more than
+// the system unit — the historical 16,896-hit symptom. The fold is not
+// re-sent; the instruction locates it by anchor excerpts.
+func TestSummaryFoldPlanReusesFullMainRequestBytes(t *testing.T) {
+	prov := &countingProvider{reply: "digest"}
+	a := newFoldAgent(t, 200000, prov)
+
+	mainReq := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system prompt"},
+		{Role: provider.RoleUser, Content: "user one"},
+		{Role: provider.RoleAssistant, Content: "assistant one"},
+		{Role: provider.RoleUser, Content: "user two"},
+		{Role: provider.RoleAssistant, Content: "assistant two"},
+		{Role: provider.RoleUser, Content: "user three"},
+	}
+	a.saveMainRequest(mainReq, nil)
+
+	// Live view drifted: a projection update rewrote the middle; two new
+	// turns were appended beyond the frozen bytes.
+	view := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system prompt"},
+		{Role: provider.RoleUser, Content: "user one"},
+		{Role: provider.RoleAssistant, Content: "assistant one"},
+		{Role: provider.RoleUser, Content: "SUMMARY: user two + assistant two were folded"},
+		{Role: provider.RoleUser, Content: "user three"},
+		{Role: provider.RoleUser, Content: "user four"},
+		{Role: provider.RoleAssistant, Content: "assistant four"},
+		{Role: provider.RoleUser, Content: "user five"},
+	}
+	head, start := 1, 5 // fold = view[1:5]
+
+	prefix, extra, anchors := a.summaryFoldPlan(view, head, start)
+	if len(prefix) != len(mainReq) {
+		t.Fatalf("prefix = %d messages, want the whole frozen main request (%d)", len(prefix), len(mainReq))
+	}
+	for i := range prefix {
+		if prefix[i].Role != mainReq[i].Role || prefix[i].Content != mainReq[i].Content {
+			t.Fatalf("prefix diverges from main-request bytes at %d", i)
+		}
+	}
+	// Extra carries the fold tail beyond the frozen bytes (view[6:5] is empty
+	// here since start=5 <= len(saved)=6), and anchors locate the fold.
+	if anchors == "" {
+		t.Fatal("anchor instruction missing")
+	}
+	if !strings.Contains(anchors, "user one") && !strings.Contains(anchors, "assistant one") {
+		t.Fatalf("anchor instruction %q does not name fold content", anchors)
+	}
+	if len(extra) != 0 {
+		t.Fatalf("extra = %d messages, want 0 (fold ends inside the frozen bytes)", len(extra))
+	}
+
+	// The full request: frozen main bytes + anchor instruction only.
+	res, tele, err := a.foldSummaryWithTelemetry(context.Background(), CompactionTriggerManual, prefix, extra, "focus"+anchors, 100, SummaryInputCachePrefix)
+	if err != nil {
+		t.Fatalf("foldSummaryWithTelemetry: %v", err)
+	}
+	if res.Text == "" {
+		t.Fatal("empty summary")
+	}
+	if len(prov.got) != 1 {
+		t.Fatalf("requests = %d, want 1", len(prov.got))
+	}
+	sent := prov.got[0].Messages
+	if len(sent) != len(mainReq)+1 {
+		t.Fatalf("sent = %d messages, want main request (%d) + instruction (1)", len(sent), len(mainReq))
+	}
+	for i := range mainReq {
+		if sent[i].Role != mainReq[i].Role || sent[i].Content != mainReq[i].Content {
+			t.Fatalf("sent prefix diverges at %d:\n sent=%+v\n main=%+v", i, sent[i], mainReq[i])
+		}
+	}
+	if !strings.Contains(sent[len(sent)-1].Content, "user one") {
+		t.Fatal("instruction message does not carry the fold anchor")
+	}
+	_ = tele
+}
+
+// TestSummaryFoldPlanExtendsBeyondFrozenBytes covers new turns appended after
+// the main request: their fold-tail messages must be sent as extra.
+func TestSummaryFoldPlanExtendsBeyondFrozenBytes(t *testing.T) {
+	a := newFoldAgent(t, 200000, &countingProvider{reply: "digest"})
+	a.saveMainRequest([]provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "u1"},
+		{Role: provider.RoleAssistant, Content: "a1"},
+		{Role: provider.RoleUser, Content: "u2"},
+	}, nil)
+	view := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "u1"},
+		{Role: provider.RoleAssistant, Content: "a1"},
+		{Role: provider.RoleUser, Content: "u2"},
+		{Role: provider.RoleUser, Content: "u3-new"},
+		{Role: provider.RoleAssistant, Content: "a3-new"},
+	}
+	prefix, extra, anchors := a.summaryFoldPlan(view, 1, 6)
+	if len(prefix) != 4 {
+		t.Fatalf("prefix = %d, want 4 (whole frozen request)", len(prefix))
+	}
+	if len(extra) != 2 || extra[0].Content != "u3-new" || extra[1].Content != "a3-new" {
+		t.Fatalf("extra = %+v, want the two new turns", extra)
+	}
+	if anchors == "" {
+		t.Fatal("anchor instruction missing")
+	}
+}
+
+// TestSummaryFoldPlanFallsBackWithoutMainRequest covers the fresh-resume case:
+// no sampling request has been sent in this process, but the live view still
+// byte-matches the parent process's last request while the cache is warm — so
+// the whole view replays as the prefix (C1 warm-replay shape) and the fold is
+// located by anchor excerpts, not re-sent.
+func TestSummaryFoldPlanFallsBackWithoutMainRequest(t *testing.T) {
+	a := newFoldAgent(t, 200000, &countingProvider{reply: "digest"})
+	view := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "u1"},
+		{Role: provider.RoleAssistant, Content: "a1"},
+		{Role: provider.RoleUser, Content: "u2"},
+	}
+	prefix, extra, anchors := a.summaryFoldPlan(view, 1, 3)
+	if len(prefix) != len(view) || prefix[0].Content != "system" || prefix[3].Content != "u2" {
+		t.Fatalf("fallback prefix = %+v, want the whole view replayed", prefix)
+	}
+	if len(extra) != 0 {
+		t.Fatalf("fallback extra = %d messages, want 0 (whole view is the prefix)", len(extra))
+	}
+	if anchors == "" || !strings.Contains(anchors, "u1") {
+		t.Fatalf("fallback anchors = %q, want fold located by excerpt", anchors)
+	}
+}
+
+// TestSummaryFoldEstimateClampsBeyondSaved guards the budget planner against
+// a restored wire prefix longer than the live view: candidate indices inside
+// the frozen bytes must not slice the view out of range (2026-08-31 05:11:
+// panic "slice bounds out of range [3:2]" on resume with a sidecar wire).
+func TestSummaryFoldEstimateClampsBeyondSaved(t *testing.T) {
+	a := newFoldAgent(t, 200000, &countingProvider{reply: "digest"})
+	a.saveMainRequest([]provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "u1"},
+		{Role: provider.RoleAssistant, Content: "a1"},
+	}, nil)
+	view := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "u1"},
+		{Role: provider.RoleAssistant, Content: "a1"},
+	}
+	// candidate inside the frozen prefix length: must not panic, extra empty.
+	req := a.summaryFoldEstimate(view, 1, 2, "")
+	if len(req.Messages) < 3 {
+		t.Fatalf("estimate request = %d messages, want frozen prefix present", len(req.Messages))
+	}
+}
+
+// TestSummaryFoldPlanCropsOverWindowView covers the over-window resume case:
+// the whole view cannot be replayed inside the hard ceiling, so the old
+// cropped shape (view prefix + full fold) is the only option — a miss, but a
+// compaction that still fits.
+func TestSummaryFoldPlanCropsOverWindowView(t *testing.T) {
+	a := newFoldAgent(t, 4000, &countingProvider{reply: "digest"}) // tiny window
+	view := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: strings.Repeat("x ", 30000)},
+		{Role: provider.RoleAssistant, Content: "a1"},
+		{Role: provider.RoleUser, Content: "u2"},
+	}
+	prefix, extra, anchors := a.summaryFoldPlan(view, 1, 3)
+	if len(prefix) != 1 || prefix[0].Content != "system" {
+		t.Fatalf("cropped prefix = %d messages, want view[:1]", len(prefix))
+	}
+	if len(extra) != 2 {
+		t.Fatalf("cropped extra = %d messages, want view[1:3]", len(extra))
+	}
+	if anchors != "" {
+		t.Fatalf("cropped fallback must not emit anchors, got %q", anchors)
+	}
+}
+
+// TestCompactionRequestPrefixMatchesLastMainRequest drives the real compaction
+// path: a main request freezes wire bytes, the live view drifts (prune /
+// projection rewrite), and the summarizer must still send the frozen prefix so
+// its request shares the provider-cached unit. A LocalOnly message verifies
+// head indexing survives normalization stripping.
+func TestCompactionRequestPrefixMatchesLastMainRequest(t *testing.T) {
+	const window = 200_000
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleAssistant, Content: strings.Repeat("a ", 60000)},
+		{Role: provider.RoleUser, Content: "c"},
+		{Role: provider.RoleAssistant, Content: strings.Repeat("b ", 60000)},
+		{Role: provider.RoleUser, Content: "e"},
+		{Role: provider.RoleAssistant, Content: "f"},
+		{Role: provider.RoleUser, Content: "local-only note", LocalOnly: true},
+		{Role: provider.RoleUser, Content: "g"},
+	}}
+	prov := &fakeProvider{reply: "s"}
+	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: window, CompactRatio: 0.8, RecentKeep: 2}, event.Discard)
+
+	// 1. Main request: freeze the wire bytes exactly as prepareSamplingRequest
+	// does (normalized view, LocalOnly stripped: 9 -> 8 wire messages).
+	mainReq := a.normalizeModelRequestMessages(sess.Messages)
+	frozenTools := []provider.ToolSchema{
+		{Name: "search", Description: "search the web", Parameters: json.RawMessage(`{"type":"object"}`)},
+		{Name: "read", Description: "read a file", Parameters: json.RawMessage(`{"type":"object"}`)},
+	}
+	a.saveMainRequest(mainReq, frozenTools)
+
+	// 2. Live view drifts after the main request (projection/prune rewrite).
+	sess.Messages[4] = provider.Message{Role: provider.RoleAssistant, Content: strings.Repeat("b ", 2000) + " [pruned]"}
+
+	// 3. Compaction runs on the drifted view.
+	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 170000})
+	if len(prov.got) == 0 {
+		t.Fatal("compaction made no summarizer request")
+	}
+	sent := prov.got
+
+	// The summary request prefix must be the ENTIRE frozen main request (the
+	// provider-cached unit), byte-exact, with the drifted view only feeding
+	// the anchor instruction — never the request bytes.
+	saved := a.savedMainRequest()
+	if saved == nil || len(saved.messages) == 0 {
+		t.Fatal("main request bytes were not saved")
+	}
+	prefix := saved.messages
+	if len(sent) != len(prefix)+1 {
+		t.Fatalf("summary request = %d messages, want frozen main request (%d) + instruction (1)", len(sent), len(prefix))
+	}
+	for i := range prefix {
+		if sent[i].Role != prefix[i].Role || sent[i].Content != prefix[i].Content {
+			t.Fatalf("summary prefix diverges from main-request bytes at %d:\n sent=%+v\n main=%+v", i, sent[i], prefix[i])
+		}
+	}
+	// The summary request must send the FROZEN tool schemas, not the live
+	// registry: the server caches system+tools+messages as one unit, and the
+	// live tool set can grow (MCP registration) after the main request.
+	if len(prov.reqs) == 0 {
+		t.Fatal("no provider request captured")
+	}
+	lastReq := prov.reqs[len(prov.reqs)-1]
+	if len(lastReq.Tools) != len(frozenTools) {
+		t.Fatalf("summary tools = %d, want frozen %d", len(lastReq.Tools), len(frozenTools))
+	}
+	for i := range frozenTools {
+		if lastReq.Tools[i].Name != frozenTools[i].Name || lastReq.Tools[i].Description != frozenTools[i].Description ||
+			string(lastReq.Tools[i].Parameters) != string(frozenTools[i].Parameters) {
+			t.Fatalf("summary tool %d diverges from frozen schema: %+v vs %+v", i, lastReq.Tools[i], frozenTools[i])
+		}
+	}
+	// The instruction (last message) locates the fold by anchor excerpts; the
+	// fold itself is not re-sent.
+	last := sent[len(sent)-1]
+	if last.Role != provider.RoleUser || !strings.Contains(last.Content, "segment to summarize") {
+		t.Fatalf("last message is not the anchor instruction: %+v", last)
+	}
+	for _, m := range sent[:len(sent)-1] {
+		if strings.Contains(m.Content, "pruned") {
+			t.Fatal("fold content was re-sent; the fold lives inside the frozen prefix")
+		}
+	}
+	// The lossless projection inverse: the checkpoint persists the exact
+	// prefix this summary request replayed (wire form), so a resumed process
+	// re-normalizing it inside summaryRequest gets the same bytes.
+	a.sess.compactionMu.Lock()
+	persisted := a.sess.compactionState.LastWireMessages
+	a.sess.compactionMu.Unlock()
+	wantWire := a.normalizeModelRequestMessages(prefix)
+	if len(persisted) != len(wantWire) {
+		t.Fatalf("sidecar wire prefix = %d messages, want %d", len(persisted), len(wantWire))
+	}
+	for i := range wantWire {
+		if persisted[i].Content != wantWire[i].Content || persisted[i].Role != wantWire[i].Role {
+			t.Fatalf("sidecar wire prefix diverges at %d: %q vs %q", i, persisted[i].Content, wantWire[i].Content)
+		}
+	}
+	// Re-normalizing the persisted wire form must be a fixpoint: a resumed
+	// process sends normalize(restored) and must reproduce this exact request.
+	renorm := a.normalizeModelRequestMessages(persisted)
+	if len(renorm) != len(persisted) {
+		t.Fatalf("re-normalized wire = %d messages, want %d (fixpoint)", len(renorm), len(persisted))
+	}
+	for i := range persisted {
+		if renorm[i].Content != persisted[i].Content || renorm[i].Role != persisted[i].Role {
+			t.Fatalf("re-normalization diverged at %d: %q vs %q", i, renorm[i].Content, persisted[i].Content)
+		}
+	}
+}
+
+// TestSummaryRequestReusesFrozenTools pins the tool-schema half of the cached
+// unit: when frozen main-request bytes exist, the summary request must send
+// the FROZEN tool schemas (byte-identical to the main request's), not the
+// live registry — the server caches system+tools+messages as one prefix and
+// the live tool set drifts (MCP registration) after the main request
+// (2026-08-31: hit=16896 of 256122 on desktop, tools seam unaligned).
+func TestSummaryRequestReusesFrozenTools(t *testing.T) {
+	a := newFoldAgent(t, 200000, &countingProvider{reply: "digest"})
+	frozen := []provider.ToolSchema{
+		{Name: "read", Description: "read a file", Parameters: json.RawMessage(`{"type":"object"}`)},
+	}
+	mainReq := []provider.Message{{Role: provider.RoleSystem, Content: "s"}}
+	a.saveMainRequest(mainReq, frozen)
+
+	req := a.summaryRequest(mainReq, nil, "")
+	if len(req.Tools) != len(frozen) || req.Tools[0].Name != "read" {
+		t.Fatalf("summary tools = %+v, want the frozen schemas", req.Tools)
+	}
+
+	// Without frozen bytes the live registry supplies the schemas (empty here).
+	a.sess.lastMainReq.Store(nil)
+	req2 := a.summaryRequest(mainReq, nil, "")
+	if len(req2.Tools) != 0 {
+		t.Fatalf("without frozen bytes tools = %+v, want live registry (empty)", req2.Tools)
+	}
+
+	// Legacy sidecar: frozen messages restored but no frozen tools. The live
+	// registry must supply the schemas — an empty tool list would diverge
+	// from the real main-request prefix at the tools seam.
+	a.saveMainRequest(mainReq, nil)
+	req3 := a.summaryRequest(mainReq, nil, "")
+	if len(req3.Tools) != 0 {
+		t.Fatalf("frozen-messages-only tools = %+v, want live registry (empty)", req3.Tools)
+	}
+	commitTools := a.summaryRequestToolsForCommit(mainReq)
+	if len(commitTools) != 0 {
+		t.Fatalf("commit tools = %+v, want live registry (empty)", commitTools)
+	}
+}

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -534,17 +534,8 @@ func (a *Agent) compactToProjectionLocked(ctx context.Context, trigger, instruct
 		return CompactionNoop, err
 	}
 
-	// The projection body freezes only prefix + digest + kept messages; the
-	// verbatim tail splices live from canonical[start:] so tail-side rewrites
-	// (rewind truncation, snips) stay visible without rebuilding the fold.
-	projMsgs := checkpointProjectionMessages(msgs, head, kept, summary)
-	if len(bodySuffix) > 0 {
-		projMsgs = append(projMsgs, projectionMessagesPreservingPinnedContext(bodySuffix)...)
-	}
-	tele.UserTurnsKept, tele.UserTurnsDropped = retention.Kept, retention.Dropped
-	projMsgs, spliced, projTokens, err := a.preparePinnedCheckpointCandidate(trigger, projMsgs, canonical, covered, sourceTokens, &tele)
+	projMsgs, spliced, projTokens, err := a.prepareCheckpointBody(trigger, msgs, kept, canonical, bodySuffix, head, covered, sourceTokens, summary, retention, &tele)
 	if err != nil {
-		a.emitCompactionAborted(trigger)
 		return CompactionNoop, err
 	}
 	viewOutputHash := providerVisibleFingerprint(modelInputMessages(spliced))
@@ -562,16 +553,28 @@ func (a *Agent) compactToProjectionLocked(ctx context.Context, trigger, instruct
 	}, summary, len(fold))
 }
 
+// prepareCheckpointBody assembles the checkpoint body and verifies its
+// savings. The verbatim tail splices live from canonical[covered:], so
+// tail-side rewrites stay visible without rebuilding the fold.
+func (a *Agent) prepareCheckpointBody(trigger string, msgs, kept, canonical, bodySuffix []provider.Message, head, covered, sourceTokens int, summary string, retention userTurnRetention, tele *CompactionTelemetry) ([]provider.Message, []provider.Message, int, error) {
+	projMsgs := checkpointProjectionMessages(msgs, head, kept, summary)
+	if len(bodySuffix) > 0 {
+		projMsgs = append(projMsgs, projectionMessagesPreservingPinnedContext(bodySuffix)...)
+	}
+	tele.UserTurnsKept, tele.UserTurnsDropped = retention.Kept, retention.Dropped
+	return a.preparePinnedCheckpointCandidate(trigger, projMsgs, canonical, covered, sourceTokens, tele)
+}
+
 // installSummaryCheckpoint CAS-installs the checkpoint and emits the done event.
-func (a *Agent) installSummaryCheckpoint(trigger string, commit summaryProjectionCommit, summary string, foldCount int) error {
+func (a *Agent) installSummaryCheckpoint(trigger string, commit summaryProjectionCommit, summary string, foldCount int) (CompactionOutcome, error) {
 	if _, err := a.commitSummaryProjection(commit); err != nil {
 		a.emitCompactionAborted(trigger)
-		return err
+		return CompactionNoop, err
 	}
 	a.svc.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
 		Trigger: trigger, Messages: foldCount, Summary: summary,
 	}})
-	return nil
+	return CompactionInstalled, nil
 }
 
 func (a *Agent) preparePinnedCheckpointCandidate(

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -548,7 +548,7 @@ func (a *Agent) compactToProjectionLocked(ctx context.Context, trigger, instruct
 		return CompactionNoop, err
 	}
 	viewOutputHash := providerVisibleFingerprint(modelInputMessages(spliced))
-	_, err = a.commitSummaryProjection(summaryProjectionCommit{
+	return a.installSummaryCheckpoint(trigger, summaryProjectionCommit{
 		canonical: canonical, fold: fold, projected: projMsgs, result: res,
 		transcriptVersion: transcriptVersion, projectionVersion: startProjectionVersion,
 		generation: startGeneration, activeTurn: activeTurn, trigger: trigger,
@@ -556,19 +556,22 @@ func (a *Agent) compactToProjectionLocked(ctx context.Context, trigger, instruct
 		sourceTokens: sourceTokens, projectionTokens: projTokens, covered: covered,
 		// Persist the wire form (normalized): a resumed process re-normalizes
 		// the restored bytes inside summaryRequest, so they must already match
-		// what this request actually sent. The tools ride along as the same
-		// cached unit (system+tools+messages).
+		// what this request actually sent.
 		wirePrefix: a.normalizeModelRequestMessages(summaryPrefix),
 		wireTools:  a.summaryRequestToolsForCommit(summaryPrefix),
-	})
-	if err != nil {
+	}, summary, len(fold))
+}
+
+// installSummaryCheckpoint CAS-installs the checkpoint and emits the done event.
+func (a *Agent) installSummaryCheckpoint(trigger string, commit summaryProjectionCommit, summary string, foldCount int) error {
+	if _, err := a.commitSummaryProjection(commit); err != nil {
 		a.emitCompactionAborted(trigger)
-		return CompactionNoop, err
+		return err
 	}
 	a.svc.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
-		Trigger: trigger, Messages: len(fold), Summary: summary,
+		Trigger: trigger, Messages: foldCount, Summary: summary,
 	}})
-	return CompactionInstalled, nil
+	return nil
 }
 
 func (a *Agent) preparePinnedCheckpointCandidate(
@@ -661,123 +664,6 @@ func (a *Agent) planFoldRegion(msgs []provider.Message, force, splitActive bool)
 		}
 	}
 	return head, start, start > head
-}
-
-// summaryFoldPlan selects the cache-aligned summary request shape for the
-// fold msgs[head:start]: the frozen main-request bytes when they cover the
-// head, otherwise the live view (when it fits the admissible ceiling),
-// otherwise the verbatim head + fold. The anchors name the fold region inside
-// the replayed bytes so the summarizer summarizes only that segment.
-func (a *Agent) summaryFoldPlan(msgs []provider.Message, head, start int) (prefix, extra []provider.Message, anchors string) {
-	fold := msgs[head:start]
-	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 {
-		region := fold
-		if start > len(saved.messages) {
-			extra = msgs[max(head, len(saved.messages)):start]
-			region = append(append([]provider.Message(nil), fold...), extra...)
-		}
-		return saved.messages, extra, foldAnchorInstruction(region)
-	}
-	if a.summaryViewReplayFits(msgs) {
-		return msgs, nil, foldAnchorInstruction(fold)
-	}
-	return msgs[:head], msgs[head:start], ""
-}
-
-func (a *Agent) summaryFoldEstimate(msgs []provider.Message, head, candidate int, instructions string) provider.Request {
-	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 {
-		var extra []provider.Message
-		if start := max(head, len(saved.messages)); start < candidate && candidate <= len(msgs) {
-			extra = msgs[start:candidate]
-		}
-		anchors := ""
-		if region := msgs[head:candidate]; len(region) > 0 && candidate <= len(msgs) {
-			anchors = foldAnchorInstruction(append(append([]provider.Message(nil), region...), extra...))
-		}
-		return a.summaryRequest(saved.messages, extra, instructions+anchors)
-	}
-	if a.summaryViewReplayFits(msgs) {
-		anchors := ""
-		if region := msgs[head:candidate]; len(region) > 0 {
-			anchors = foldAnchorInstruction(region)
-		}
-		// For estimation, use only the fold region as prefix (matching v1.36.0).
-		// The actual summaryFoldPlan may use all visible messages for cache
-		// alignment, but the estimate should reflect the minimal request shape.
-		return a.summaryRequest(msgs[head:candidate], nil, instructions+anchors)
-	}
-	return a.summaryRequest(msgs[:head], msgs[head:candidate], instructions)
-}
-
-// summaryMaxPromptTokens is the admissible summarizer input ceiling, shared by
-// planning (maximumSafeSummaryPrefixEnd), the replay-fits check, and send-time
-// admission so a planned request is never rejected after it is selected.
-func (a *Agent) summaryMaxPromptTokens() int {
-	window := a.effectiveContextWindow()
-	if window <= 0 {
-		return 0
-	}
-	policy := contextBudgetPolicyOf(a.svc.prov)
-	if policy.WindowMode == provider.ContextWindowUnknown {
-		// A learned overflow makes an unknown gateway shared-window. Otherwise
-		// preserve the request because the configured window may be an estimate.
-		if a.lastAdmission().ObservedWindow <= 0 {
-			return a.hardInputCeiling()
-		}
-		policy.WindowMode = provider.ContextWindowShared
-	}
-	if policy.WindowMode == provider.ContextWindowShared {
-		return window - outputBudgetReserve - protocolReserveTokens
-	}
-	return a.hardInputCeiling()
-}
-
-// summaryViewReplayFits reports whether the whole live view can be replayed
-// as the summarizer prefix (view + instruction within the admissible input
-// ceiling). Over-ceiling views must crop instead, at the cost of the prefix
-// cache match.
-func (a *Agent) summaryViewReplayFits(msgs []provider.Message) bool {
-	// The safe ceiling already subtracts the (window-scaled) summary output
-	// budget: a view that leaves no room for the digest must crop to the
-	// frozen-prefix branch instead of replaying past the window.
-	maxPromptTokens, enforce := a.safeSummaryPromptTokenLimit()
-	if !enforce {
-		return true
-	}
-	if maxPromptTokens <= 0 {
-		return false
-	}
-	return a.estimatedRequestTokens(a.summaryRequest(msgs, nil, "")) <= maxPromptTokens
-}
-
-// foldAnchorInstruction names the fold region by verbatim excerpts so the
-// summarizer can locate it inside the already-sent main-request bytes. The end
-// excerpt is taken from the whole region (fold + extras) so new turns beyond
-// the frozen prefix stay inside the summarized range.
-func foldAnchorInstruction(region []provider.Message) string {
-	startAnchor, endAnchor := "", ""
-	for _, m := range region {
-		if text := strings.TrimSpace(m.Content); text != "" {
-			if startAnchor == "" {
-				startAnchor = foldAnchor(text)
-			}
-			endAnchor = foldAnchor(text)
-		}
-	}
-	if startAnchor == "" {
-		return ""
-	}
-	return fmt.Sprintf("\n\nThe conversation above contains a segment to summarize. It starts with the excerpt %q and ends with the excerpt %q (both appear verbatim in the conversation above). Summarize ONLY that segment; leave everything else untouched.", startAnchor, endAnchor)
-}
-
-// foldAnchor truncates a message's content to a stable locating excerpt.
-func foldAnchor(text string) string {
-	const maxAnchor = 160
-	text = strings.Join(strings.Fields(text), " ")
-	if len(text) <= maxAnchor {
-		return text
-	}
-	return text[:maxAnchor]
 }
 
 type userTurnRetention struct {

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -200,9 +200,8 @@ func (a *Agent) compressVisibleRange(
 		return result, nil
 	}
 
-	res, err := a.foldToSummaryMode(ctx, prepared.fold, prepared.instructions, prepared.inputMode)
+	res, tele, err := a.foldSummaryWithChunkedFallback(ctx, trigger, nil, prepared.fold, prepared.instructions, result.SourceTokens, prepared.inputMode)
 	summary := res.Text
-	tele := compactionTelemetryFromSummary(trigger, a.CacheState(), result.SourceTokens, res)
 	if err != nil {
 		tele.Error = err.Error()
 		a.emitCompactionTelemetry(tele)
@@ -429,46 +428,12 @@ func compactionTelemetryFromSummary(trigger, cacheState string, sourceTokens int
 	return tele
 }
 
-// foldSummaryWithChunkedFallback retries summary size failures through the
-// resilient fragment/tree-reduce path used for over-length sessions.
-func (a *Agent) foldSummaryWithChunkedFallback(ctx context.Context, trigger string, fold []provider.Message, instructions string, sourceTokens int, inputMode string) (foldSummary, CompactionTelemetry, error) {
-	res, tele, err := a.foldSummaryWithTelemetry(ctx, trigger, fold, instructions, sourceTokens, inputMode)
-	if err == nil || !chunkedFallbackApplies(err, inputMode) {
-		return res, tele, err
-	}
-	chunked, chunkedErr := a.chunkedFoldSummary(ctx, fold, instructions, nil)
-	chunked.Usage = mergeSamplingUsage(res.Usage, chunked.Usage)
-	chunked.Spans += res.Spans
-	if chunked.FoldTokens <= 0 {
-		chunked.FoldTokens = res.FoldTokens
-	}
-	if chunked.RequestID == "" {
-		chunked.RequestID = res.RequestID
-	}
-	if chunkedErr != nil {
-		tele = compactionTelemetryFromSummary(trigger, a.CacheState(), sourceTokens, chunked)
-		tele.Error = fmt.Sprintf("%v (chunked fallback: %v)", err, chunkedErr)
-		return chunked, tele, chunkedErr
-	}
-	return chunked, compactionTelemetryFromSummary(trigger, a.CacheState(), sourceTokens, chunked), nil
-}
-
-// chunkedFallbackApplies reports a size failure the fragment path can fix. A
-// provider overflow qualifies only once the transcript form has failed too;
-// before that a re-planned replay is one request instead of many.
-func chunkedFallbackApplies(err error, inputMode string) bool {
-	if provider.AsContextLimitError(err) != nil {
-		return inputMode == SummaryInputSlim
-	}
-	return summarySizeFailure(err)
-}
-
 // compact writes a context projection; trigger stays "auto"/"manual" for UI cards.
-func (a *Agent) summarizeFold(ctx context.Context, trigger string, fold []provider.Message, instructions string, sourceTokens int, inputMode string, req foldRequest) (foldSummary, CompactionTelemetry, error) {
-	if req.allowChunked {
-		return a.foldSummaryWithChunkedFallback(ctx, trigger, fold, instructions, sourceTokens, inputMode)
+func (a *Agent) summarizeFold(ctx context.Context, trigger string, prefix, fold []provider.Message, instructions string, sourceTokens int, inputMode string, allowChunked bool) (foldSummary, CompactionTelemetry, error) {
+	if allowChunked {
+		return a.foldSummaryWithChunkedFallback(ctx, trigger, prefix, fold, instructions, sourceTokens, inputMode)
 	}
-	return a.foldSummaryWithTelemetry(ctx, trigger, fold, instructions, sourceTokens, inputMode)
+	return a.foldSummaryWithTelemetry(ctx, trigger, prefix, fold, instructions, sourceTokens, inputMode)
 }
 
 func (a *Agent) compactToProjectionLocked(ctx context.Context, trigger, instructions string, req foldRequest) (CompactionOutcome, error) {
@@ -543,7 +508,19 @@ func (a *Agent) compactToProjectionLocked(ctx context.Context, trigger, instruct
 	sourceTokens := a.estimatedVisibleRequestTokens(msgs)
 	inputMode := summaryInputModeFor(req, regionHadPinnedRevision,
 		providerVisibleFingerprint(modelInputMessages(fold)) != originalFoldHash)
-	res, tele, err := a.summarizeFold(ctx, trigger, fold, instructions, sourceTokens, inputMode, req)
+	summaryPrefix, foldExtra, foldAnchors := a.summaryFoldPlan(msgs, head, start)
+	if providerVisibleFingerprint(modelInputMessages(fold)) != originalFoldHash {
+		// An extension rewrote the fold: the rewritten bytes must be sent and
+		// read literally — anchor locating inside the frozen prefix would
+		// summarize the pre-rewrite text. Quality wins over cache here.
+		summaryPrefix = msgs[:head]
+		foldExtra = fold
+		foldAnchors = ""
+	}
+	if foldAnchors != "" {
+		instructions += foldAnchors
+	}
+	res, tele, err := a.summarizeFold(ctx, trigger, summaryPrefix, foldExtra, instructions, sourceTokens, inputMode, req.allowChunked)
 	if err != nil {
 		a.emitCompactionTelemetry(tele)
 		a.emitCompactionAborted(trigger)
@@ -577,6 +554,12 @@ func (a *Agent) compactToProjectionLocked(ctx context.Context, trigger, instruct
 		generation: startGeneration, activeTurn: activeTurn, trigger: trigger,
 		summary: summary, inputHash: viewInputHash, outputHash: viewOutputHash,
 		sourceTokens: sourceTokens, projectionTokens: projTokens, covered: covered,
+		// Persist the wire form (normalized): a resumed process re-normalizes
+		// the restored bytes inside summaryRequest, so they must already match
+		// what this request actually sent. The tools ride along as the same
+		// cached unit (system+tools+messages).
+		wirePrefix: a.normalizeModelRequestMessages(summaryPrefix),
+		wireTools:  a.summaryRequestToolsForCommit(summaryPrefix),
 	})
 	if err != nil {
 		a.emitCompactionAborted(trigger)
@@ -680,6 +663,123 @@ func (a *Agent) planFoldRegion(msgs []provider.Message, force, splitActive bool)
 	return head, start, start > head
 }
 
+// summaryFoldPlan selects the cache-aligned summary request shape for the
+// fold msgs[head:start]: the frozen main-request bytes when they cover the
+// head, otherwise the live view (when it fits the admissible ceiling),
+// otherwise the verbatim head + fold. The anchors name the fold region inside
+// the replayed bytes so the summarizer summarizes only that segment.
+func (a *Agent) summaryFoldPlan(msgs []provider.Message, head, start int) (prefix, extra []provider.Message, anchors string) {
+	fold := msgs[head:start]
+	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 {
+		region := fold
+		if start > len(saved.messages) {
+			extra = msgs[max(head, len(saved.messages)):start]
+			region = append(append([]provider.Message(nil), fold...), extra...)
+		}
+		return saved.messages, extra, foldAnchorInstruction(region)
+	}
+	if a.summaryViewReplayFits(msgs) {
+		return msgs, nil, foldAnchorInstruction(fold)
+	}
+	return msgs[:head], msgs[head:start], ""
+}
+
+func (a *Agent) summaryFoldEstimate(msgs []provider.Message, head, candidate int, instructions string) provider.Request {
+	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 {
+		var extra []provider.Message
+		if start := max(head, len(saved.messages)); start < candidate && candidate <= len(msgs) {
+			extra = msgs[start:candidate]
+		}
+		anchors := ""
+		if region := msgs[head:candidate]; len(region) > 0 && candidate <= len(msgs) {
+			anchors = foldAnchorInstruction(append(append([]provider.Message(nil), region...), extra...))
+		}
+		return a.summaryRequest(saved.messages, extra, instructions+anchors)
+	}
+	if a.summaryViewReplayFits(msgs) {
+		anchors := ""
+		if region := msgs[head:candidate]; len(region) > 0 {
+			anchors = foldAnchorInstruction(region)
+		}
+		// For estimation, use only the fold region as prefix (matching v1.36.0).
+		// The actual summaryFoldPlan may use all visible messages for cache
+		// alignment, but the estimate should reflect the minimal request shape.
+		return a.summaryRequest(msgs[head:candidate], nil, instructions+anchors)
+	}
+	return a.summaryRequest(msgs[:head], msgs[head:candidate], instructions)
+}
+
+// summaryMaxPromptTokens is the admissible summarizer input ceiling, shared by
+// planning (maximumSafeSummaryPrefixEnd), the replay-fits check, and send-time
+// admission so a planned request is never rejected after it is selected.
+func (a *Agent) summaryMaxPromptTokens() int {
+	window := a.effectiveContextWindow()
+	if window <= 0 {
+		return 0
+	}
+	policy := contextBudgetPolicyOf(a.svc.prov)
+	if policy.WindowMode == provider.ContextWindowUnknown {
+		// A learned overflow makes an unknown gateway shared-window. Otherwise
+		// preserve the request because the configured window may be an estimate.
+		if a.lastAdmission().ObservedWindow <= 0 {
+			return a.hardInputCeiling()
+		}
+		policy.WindowMode = provider.ContextWindowShared
+	}
+	if policy.WindowMode == provider.ContextWindowShared {
+		return window - outputBudgetReserve - protocolReserveTokens
+	}
+	return a.hardInputCeiling()
+}
+
+// summaryViewReplayFits reports whether the whole live view can be replayed
+// as the summarizer prefix (view + instruction within the admissible input
+// ceiling). Over-ceiling views must crop instead, at the cost of the prefix
+// cache match.
+func (a *Agent) summaryViewReplayFits(msgs []provider.Message) bool {
+	// The safe ceiling already subtracts the (window-scaled) summary output
+	// budget: a view that leaves no room for the digest must crop to the
+	// frozen-prefix branch instead of replaying past the window.
+	maxPromptTokens, enforce := a.safeSummaryPromptTokenLimit()
+	if !enforce {
+		return true
+	}
+	if maxPromptTokens <= 0 {
+		return false
+	}
+	return a.estimatedRequestTokens(a.summaryRequest(msgs, nil, "")) <= maxPromptTokens
+}
+
+// foldAnchorInstruction names the fold region by verbatim excerpts so the
+// summarizer can locate it inside the already-sent main-request bytes. The end
+// excerpt is taken from the whole region (fold + extras) so new turns beyond
+// the frozen prefix stay inside the summarized range.
+func foldAnchorInstruction(region []provider.Message) string {
+	startAnchor, endAnchor := "", ""
+	for _, m := range region {
+		if text := strings.TrimSpace(m.Content); text != "" {
+			if startAnchor == "" {
+				startAnchor = foldAnchor(text)
+			}
+			endAnchor = foldAnchor(text)
+		}
+	}
+	if startAnchor == "" {
+		return ""
+	}
+	return fmt.Sprintf("\n\nThe conversation above contains a segment to summarize. It starts with the excerpt %q and ends with the excerpt %q (both appear verbatim in the conversation above). Summarize ONLY that segment; leave everything else untouched.", startAnchor, endAnchor)
+}
+
+// foldAnchor truncates a message's content to a stable locating excerpt.
+func foldAnchor(text string) string {
+	const maxAnchor = 160
+	text = strings.Join(strings.Fields(text), " ")
+	if len(text) <= maxAnchor {
+		return text
+	}
+	return text[:maxAnchor]
+}
+
 type userTurnRetention struct {
 	Kept    int
 	Dropped int
@@ -718,8 +818,8 @@ func latestSessionContextIndex(messages []provider.Message) int {
 }
 
 // runCompactionSummary uses the single local summarizer path for every provider.
-func (a *Agent) runCompactionSummary(ctx context.Context, fold []provider.Message, instructions string) (summary, mode string, usage *provider.Usage, providerReqID string, err error) {
-	summary, usage, err = a.summarizeOnce(ctx, fold, instructions)
+func (a *Agent) runCompactionSummary(ctx context.Context, prefix, fold []provider.Message, instructions string) (summary, mode string, usage *provider.Usage, providerReqID string, err error) {
+	summary, usage, err = a.summarizeOnce(ctx, prefix, fold, instructions)
 	if err != nil {
 		return "", CompactionModeSummarized, usage, "", err
 	}

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -200,7 +200,20 @@ func (a *Agent) compressVisibleRange(
 		return result, nil
 	}
 
-	res, tele, err := a.foldSummaryWithChunkedFallback(ctx, trigger, nil, prepared.fold, prepared.instructions, result.SourceTokens, prepared.inputMode)
+	// SummaryInputCachePrefix means the fold is the head of what was already
+	// sent, so the frozen main-request bytes are the prefix to replay. Verify
+	// the fold really is that prefix before trusting it; otherwise send no
+	// prefix rather than a mismatched one.
+	var frozenPrefix []provider.Message
+	if inputMode == SummaryInputCachePrefix {
+		if saved := a.savedMainRequest(); saved != nil && len(saved.messages) >= len(prepared.fold) &&
+			providerVisibleFingerprint(modelInputMessages(saved.messages[:len(prepared.fold)])) ==
+				providerVisibleFingerprint(modelInputMessages(prepared.fold)) {
+			frozenPrefix = saved.messages
+		}
+	}
+
+	res, tele, err := a.foldSummaryWithChunkedFallback(ctx, trigger, frozenPrefix, prepared.fold, prepared.instructions, result.SourceTokens, prepared.inputMode)
 	summary := res.Text
 	if err != nil {
 		tele.Error = err.Error()
@@ -499,17 +512,17 @@ func (a *Agent) compactToProjectionLocked(ctx context.Context, trigger, instruct
 		return CompactionNoop, nil
 	}
 	if req.mustFree || trigger != CompactionTriggerManual {
-		if err := a.validateSafeSummaryRequest(fold, instructions, req.slim); err != nil {
+		if err := a.validateSafeSummaryRequest(nil, fold, instructions, req.slim); err != nil {
 			a.emitCompactionAborted(trigger)
 			return CompactionNoop, err
 		}
 	}
 
 	sourceTokens := a.estimatedVisibleRequestTokens(msgs)
-	inputMode := summaryInputModeFor(req, regionHadPinnedRevision,
-		providerVisibleFingerprint(modelInputMessages(fold)) != originalFoldHash)
+	extendedFold := providerVisibleFingerprint(modelInputMessages(fold)) != originalFoldHash
+	inputMode := summaryInputModeFor(req, regionHadPinnedRevision, extendedFold)
 	summaryPrefix, foldExtra, foldAnchors := a.summaryFoldPlan(msgs, head, start)
-	if providerVisibleFingerprint(modelInputMessages(fold)) != originalFoldHash {
+	if extendedFold {
 		// An extension rewrote the fold: the rewritten bytes must be sent and
 		// read literally — anchor locating inside the frozen prefix would
 		// summarize the pre-rewrite text. Quality wins over cache here.

--- a/internal/agent/compact_safe_prefix.go
+++ b/internal/agent/compact_safe_prefix.go
@@ -69,14 +69,18 @@ func (a *Agent) safeSummaryPromptTokenLimit() (int, bool) {
 }
 
 // validateSafeSummaryRequest guards the final fold in the request form that
-// will actually be sent.
-func (a *Agent) validateSafeSummaryRequest(fold []provider.Message, instructions string, slim bool) error {
+// will actually be sent: the prefix rides in front of the fold, so validating
+// the fold alone lets a large frozen prefix pass here and still 400 on the
+// provider.
+func (a *Agent) validateSafeSummaryRequest(prefix, fold []provider.Message, instructions string, slim bool) error {
 	maxPromptTokens, enforce := a.safeSummaryPromptTokenLimit()
 	if !enforce {
 		return nil
 	}
-	request := a.summaryRequest(nil, fold, instructions)
+	request := a.summaryRequest(prefix, fold, instructions)
 	if slim {
+		// The slim form sends a rendered transcript, not a prefix+fold replay,
+		// so the prefix is deliberately absent here.
 		request = a.slimSummaryRequest(fold, instructions)
 	}
 	requestTokens := a.estimatedRequestTokens(request)

--- a/internal/agent/compact_safe_prefix.go
+++ b/internal/agent/compact_safe_prefix.go
@@ -31,7 +31,7 @@ func (a *Agent) maximumSafeSummaryPrefixEnd(msgs []provider.Message, head, end i
 	}
 	fits := func(candidate int) bool {
 		fold, _ := withoutPinnedContextRevisions(msgs[head:candidate])
-		request := a.summaryRequest(fold, instructions)
+		request := a.summaryRequest(msgs[:head], fold, instructions)
 		return a.estimatedRequestTokens(request) <= maxPromptTokens
 	}
 	if fits(end) {
@@ -75,7 +75,7 @@ func (a *Agent) validateSafeSummaryRequest(fold []provider.Message, instructions
 	if !enforce {
 		return nil
 	}
-	request := a.summaryRequest(fold, instructions)
+	request := a.summaryRequest(nil, fold, instructions)
 	if slim {
 		request = a.slimSummaryRequest(fold, instructions)
 	}

--- a/internal/agent/compact_sidecar_lossless_test.go
+++ b/internal/agent/compact_sidecar_lossless_test.go
@@ -1,0 +1,225 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// TestSidecarWireBytesSurviveRoundTrip pins the lossless projection inverse:
+// the frozen main-request bytes stored in the sidecar must survive the JSON
+// round trip byte-exact, so a resumed process can replay the same prefix.
+func TestSidecarWireBytesSurviveRoundTrip(t *testing.T) {
+	wire := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "u1"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "t1", Name: "read", Arguments: `{}`}}},
+		{Role: provider.RoleTool, ToolCallID: "t1", Name: "read", Content: "result"},
+		{Role: provider.RoleUser, Content: "u2"},
+	}
+	tools := []provider.ToolSchema{
+		{Name: "search", Description: "search the web", Parameters: json.RawMessage(`{"type":"object","properties":{}}`)},
+	}
+	st := CompactionState{LastWireMessages: wire, LastWireTools: tools}
+	b, err := json.Marshal(st)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back CompactionState
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(back.LastWireTools) != len(tools) {
+		t.Fatalf("round-trip tools = %d, want %d", len(back.LastWireTools), len(tools))
+	}
+	for i := range tools {
+		if back.LastWireTools[i].Name != tools[i].Name || back.LastWireTools[i].Description != tools[i].Description ||
+			string(back.LastWireTools[i].Parameters) != string(tools[i].Parameters) {
+			t.Fatalf("tool %d diverged after round trip: %+v vs %+v", i, back.LastWireTools[i], tools[i])
+		}
+	}
+	if len(back.LastWireMessages) != len(wire) {
+		t.Fatalf("round-trip messages = %d, want %d", len(back.LastWireMessages), len(wire))
+	}
+	for i := range wire {
+		m, w := back.LastWireMessages[i], wire[i]
+		if m.Role != w.Role || m.Content != w.Content || m.ToolCallID != w.ToolCallID || m.Name != w.Name {
+			t.Fatalf("message %d diverged after round trip: %+v vs %+v", i, m, w)
+		}
+		if len(m.ToolCalls) != len(w.ToolCalls) {
+			t.Fatalf("message %d tool calls diverged: %d vs %d", i, len(m.ToolCalls), len(w.ToolCalls))
+		}
+		for j := range w.ToolCalls {
+			if m.ToolCalls[j].ID != w.ToolCalls[j].ID || m.ToolCalls[j].Name != w.ToolCalls[j].Name || m.ToolCalls[j].Arguments != w.ToolCalls[j].Arguments {
+				t.Fatalf("message %d tool call %d diverged", i, j)
+			}
+		}
+	}
+}
+
+// TestLoadProjectionSidecarRestoresWireBytes simulates a resume: a sidecar
+// written by a parent process (with LastWireMessages) is loaded by a fresh
+// agent, and the frozen prefix is restored so the first post-resume compaction
+// replays the provider-cached unit instead of falling back to system-only.
+func TestLoadProjectionSidecarRestoresWireBytes(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	wire := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system prompt"},
+		{Role: provider.RoleUser, Content: "user one"},
+		{Role: provider.RoleAssistant, Content: "assistant one"},
+		{Role: provider.RoleUser, Content: "user two"},
+	}
+	frozenTools := []provider.ToolSchema{
+		{Name: "read", Description: "read a file", Parameters: json.RawMessage(`{"type":"object"}`)},
+	}
+	canonical := append([]provider.Message(nil), wire...)
+	covered := len(canonical)
+	st := CompactionState{
+		SchemaVersion:    compactionStateSchemaCurrent,
+		LastWireMessages: wire,
+		LastWireTools:    frozenTools,
+		LastReceipt:      &ContextMaintenanceReceipt{Status: "applied"},
+		PromptCacheKey:   "lineage",
+		Projection: ContextProjection{
+			Messages: []provider.Message{
+				{Role: provider.RoleSystem, Content: "system prompt"},
+				{Role: provider.RoleUser, Content: "SUMMARY: everything was folded"},
+			},
+			CoveredCount:      covered,
+			CoveredPrefixHash: coveredPrefixHash(canonical, covered),
+		},
+	}
+	if err := SaveCompactionState(sessionPath, st); err != nil {
+		t.Fatalf("save sidecar: %v", err)
+	}
+
+	// Fresh process: new agent, no frozen bytes.
+	prov := &countingProvider{reply: "digest"}
+	a := newFoldAgent(t, 200000, prov)
+	if got := a.savedMainRequest(); got != nil {
+		t.Fatalf("fresh agent must start without frozen bytes, got %d messages", len(got.messages))
+	}
+	a.sess.conversation = &Session{Messages: canonical}
+	a.LoadProjectionSidecar(sessionPath)
+
+	restored := a.savedMainRequest()
+	if restored == nil {
+		t.Fatal("restored wire bytes missing")
+	}
+	if len(restored.messages) != len(wire) {
+		t.Fatalf("restored wire bytes = %d messages, want %d", len(restored.messages), len(wire))
+	}
+	for i := range wire {
+		if restored.messages[i].Role != wire[i].Role || restored.messages[i].Content != wire[i].Content {
+			t.Fatalf("restored message %d diverged: %+v vs %+v", i, restored.messages[i], wire[i])
+		}
+	}
+	if len(restored.tools) != len(frozenTools) {
+		t.Fatalf("restored tools = %d, want %d", len(restored.tools), len(frozenTools))
+	}
+	for i := range frozenTools {
+		if restored.tools[i].Name != frozenTools[i].Name || string(restored.tools[i].Parameters) != string(frozenTools[i].Parameters) {
+			t.Fatalf("restored tool %d diverged: %+v vs %+v", i, restored.tools[i], frozenTools[i])
+		}
+	}
+	// Compaction telemetry compares wire_fp against the summary prefix hash;
+	// restoring the bytes without the fingerprint emits an empty wire_fp and
+	// silently loses that comparison.
+	if got, want := a.sess.wireFP(), providerVisibleFingerprint(wire); got != want || got == "" {
+		t.Fatalf("restored wire fingerprint = %q, want %q", got, want)
+	}
+
+	// First post-resume compaction must replay the restored bytes, not the
+	// cropped fallback.
+	prefix, extra, anchors := a.summaryFoldPlan(canonical, 1, len(canonical)-1)
+	if len(prefix) != len(wire) {
+		t.Fatalf("first post-resume prefix = %d messages, want the restored %d", len(prefix), len(wire))
+	}
+	for i := range wire {
+		if prefix[i].Content != wire[i].Content {
+			t.Fatalf("prefix message %d = %q, want restored %q", i, prefix[i].Content, wire[i].Content)
+		}
+	}
+	if len(extra) != 0 || anchors == "" {
+		t.Fatalf("extra=%d anchors=%q, want fold located by anchors, not re-sent", len(extra), anchors)
+	}
+}
+
+// TestLoadProjectionSidecarWithoutWireBytesFallsBack covers old sidecars that
+// predate the lossless field: no restore, cropped fallback stays.
+func TestLoadProjectionSidecarWithoutWireBytesFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	canonical := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "u1"},
+		{Role: provider.RoleAssistant, Content: "a1"},
+		{Role: provider.RoleUser, Content: "u2"},
+	}
+	st := CompactionState{
+		SchemaVersion:  compactionStateSchemaCurrent,
+		LastReceipt:    &ContextMaintenanceReceipt{Status: "applied"},
+		PromptCacheKey: "lineage",
+		Projection: ContextProjection{
+			Messages: []provider.Message{
+				{Role: provider.RoleSystem, Content: "system"},
+				{Role: provider.RoleUser, Content: "SUMMARY"},
+			},
+			CoveredCount:      3,
+			CoveredPrefixHash: coveredPrefixHash(canonical, 3),
+		},
+	}
+	if err := SaveCompactionState(sessionPath, st); err != nil {
+		t.Fatalf("save sidecar: %v", err)
+	}
+	a := newFoldAgent(t, 200000, &countingProvider{reply: "digest"})
+	a.sess.conversation = &Session{Messages: canonical}
+	a.LoadProjectionSidecar(sessionPath)
+	if got := a.savedMainRequest(); got != nil {
+		t.Fatalf("legacy sidecar must not restore bytes, got %d messages", len(got.messages))
+	}
+	os.Remove(sessionPath)
+}
+
+// TestSidecarPrettyPrintRoundTripPreservesRawBytes covers the second half of
+// the byte-exact inverse: the sidecar writer pretty-prints the outer
+// structure, which would rewrite json.RawMessage bytes (tool parameters,
+// Responses items) inside the frozen wire form and diverge from the bytes the
+// main request sent. Save/Load must compact those fields so the resumed
+// process replays the provider-cached unit byte-exact (2026-08-31).
+func TestSidecarPrettyPrintRoundTripPreservesRawBytes(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	st := CompactionState{
+		SchemaVersion: compactionStateSchemaCurrent,
+		LastWireMessages: []provider.Message{
+			{Role: provider.RoleSystem, Content: "s"},
+			{Role: provider.RoleAssistant, ResponsesItems: []json.RawMessage{json.RawMessage(`{"type":"reasoning","id":"r1"}`)}},
+			{Role: provider.RoleUser, ServerSearch: []provider.ServerSearchCall{{ID: "s1", Raw: json.RawMessage(`{"titles":["a"]}`)}}},
+		},
+		LastWireTools: []provider.ToolSchema{
+			{Name: "read", Description: "read a file", Parameters: json.RawMessage(`{"type":"object"}`)},
+		},
+	}
+	if err := SaveCompactionState(sessionPath, st); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, ok, err := LoadCompactionState(sessionPath)
+	if err != nil || !ok {
+		t.Fatalf("load: ok=%v err=%v", ok, err)
+	}
+	if len(loaded.LastWireTools) != 1 || string(loaded.LastWireTools[0].Parameters) != `{"type":"object"}` {
+		t.Fatalf("tool parameters not byte-preserved: %q", loaded.LastWireTools[0].Parameters)
+	}
+	if string(loaded.LastWireMessages[1].ResponsesItems[0]) != `{"type":"reasoning","id":"r1"}` {
+		t.Fatalf("responses item not byte-preserved: %q", loaded.LastWireMessages[1].ResponsesItems[0])
+	}
+	if string(loaded.LastWireMessages[2].ServerSearch[0].Raw) != `{"titles":["a"]}` {
+		t.Fatalf("server-search raw not byte-preserved: %q", loaded.LastWireMessages[2].ServerSearch[0].Raw)
+	}
+	os.Remove(sessionPath)
+}

--- a/internal/agent/compact_summary_failure_test.go
+++ b/internal/agent/compact_summary_failure_test.go
@@ -158,7 +158,7 @@ func TestSummarizerReasoningClampKeepsValidUTF8(t *testing.T) {
 	sess := foldableSessionOverForce(6)
 	a := agentOverForce(t, &fakeProvider{reasoningReply: strings.Repeat("上下文摘要要点。", 3000)}, sess)
 
-	summary, _, err := a.summarize(context.Background(), sess.Messages[1:], "")
+	summary, _, err := a.summarize(context.Background(), nil, sess.Messages[1:], "")
 	if err != nil {
 		t.Fatalf("summarize = %v", err)
 	}

--- a/internal/agent/compact_summary_limit_test.go
+++ b/internal/agent/compact_summary_limit_test.go
@@ -254,7 +254,7 @@ func TestSlimSummaryRequestIsBoundedAndToolFree(t *testing.T) {
 		{Role: provider.RoleTool, ToolCallID: "c1", Name: "read_file", Content: body, Images: []string{"data:image/png;base64,AAAA"}},
 	}
 
-	replay := a.summaryRequest(fold, "")
+	replay := a.summaryRequest(nil, fold, "")
 	if len(replay.Tools) == 0 {
 		t.Fatal("replay form must carry the tool schemas the sampling request uses")
 	}

--- a/internal/agent/compact_summary_plan.go
+++ b/internal/agent/compact_summary_plan.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"reasonix/internal/provider"
 )
@@ -91,12 +92,18 @@ func foldAnchorInstruction(region []provider.Message) string {
 	return fmt.Sprintf("\n\nThe conversation above contains a segment to summarize. It starts with the excerpt %q and ends with the excerpt %q (both appear verbatim in the conversation above). Summarize ONLY that segment; leave everything else untouched.", startAnchor, endAnchor)
 }
 
-// foldAnchor truncates a message's content to a stable locating excerpt.
+// foldAnchor truncates a message's content to a stable locating excerpt. The
+// excerpt has to occur verbatim in the bytes already sent, so whitespace is
+// preserved: collapsing runs makes the quote unfindable in code or tool output.
+// The cut also lands on a rune boundary rather than splitting a multi-byte rune.
 func foldAnchor(text string) string {
 	const maxAnchor = 160
-	text = strings.Join(strings.Fields(text), " ")
 	if len(text) <= maxAnchor {
 		return text
 	}
-	return text[:maxAnchor]
+	cut := maxAnchor
+	for cut > 0 && !utf8.RuneStart(text[cut]) {
+		cut--
+	}
+	return text[:cut]
 }

--- a/internal/agent/compact_summary_plan.go
+++ b/internal/agent/compact_summary_plan.go
@@ -53,29 +53,6 @@ func (a *Agent) summaryFoldEstimate(msgs []provider.Message, head, candidate int
 	return a.summaryRequest(msgs[:head], msgs[head:candidate], instructions)
 }
 
-// summaryMaxPromptTokens is the admissible summarizer input ceiling, shared by
-// planning (maximumSafeSummaryPrefixEnd), the replay-fits check, and send-time
-// admission so a planned request is never rejected after it is selected.
-func (a *Agent) summaryMaxPromptTokens() int {
-	window := a.effectiveContextWindow()
-	if window <= 0 {
-		return 0
-	}
-	policy := contextBudgetPolicyOf(a.svc.prov)
-	if policy.WindowMode == provider.ContextWindowUnknown {
-		// A learned overflow makes an unknown gateway shared-window. Otherwise
-		// preserve the request because the configured window may be an estimate.
-		if a.lastAdmission().ObservedWindow <= 0 {
-			return a.hardInputCeiling()
-		}
-		policy.WindowMode = provider.ContextWindowShared
-	}
-	if policy.WindowMode == provider.ContextWindowShared {
-		return window - outputBudgetReserve - protocolReserveTokens
-	}
-	return a.hardInputCeiling()
-}
-
 // summaryViewReplayFits reports whether the whole live view can be replayed
 // as the summarizer prefix (view + instruction within the admissible input
 // ceiling). Over-ceiling views must crop instead, at the cost of the prefix

--- a/internal/agent/compact_summary_plan.go
+++ b/internal/agent/compact_summary_plan.go
@@ -1,0 +1,125 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	"reasonix/internal/provider"
+)
+
+// summaryFoldPlan selects the cache-aligned summary request shape for the
+// fold msgs[head:start]: the frozen main-request bytes when they cover the
+// head, otherwise the live view (when it fits the admissible ceiling),
+// otherwise the verbatim head + fold. The anchors name the fold region inside
+// the replayed bytes so the summarizer summarizes only that segment.
+func (a *Agent) summaryFoldPlan(msgs []provider.Message, head, start int) (prefix, extra []provider.Message, anchors string) {
+	fold := msgs[head:start]
+	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 {
+		region := fold
+		if start > len(saved.messages) {
+			extra = msgs[max(head, len(saved.messages)):start]
+			region = append(append([]provider.Message(nil), fold...), extra...)
+		}
+		return saved.messages, extra, foldAnchorInstruction(region)
+	}
+	if a.summaryViewReplayFits(msgs) {
+		return msgs, nil, foldAnchorInstruction(fold)
+	}
+	return msgs[:head], msgs[head:start], ""
+}
+
+func (a *Agent) summaryFoldEstimate(msgs []provider.Message, head, candidate int, instructions string) provider.Request {
+	if saved := a.savedMainRequest(); saved != nil && len(saved.messages) > 0 {
+		var extra []provider.Message
+		if start := max(head, len(saved.messages)); start < candidate && candidate <= len(msgs) {
+			extra = msgs[start:candidate]
+		}
+		anchors := ""
+		if region := msgs[head:candidate]; len(region) > 0 && candidate <= len(msgs) {
+			anchors = foldAnchorInstruction(append(append([]provider.Message(nil), region...), extra...))
+		}
+		return a.summaryRequest(saved.messages, extra, instructions+anchors)
+	}
+	if a.summaryViewReplayFits(msgs) {
+		anchors := ""
+		if region := msgs[head:candidate]; len(region) > 0 {
+			anchors = foldAnchorInstruction(region)
+		}
+		// For estimation, use only the fold region as prefix (matching v1.36.0).
+		// The actual summaryFoldPlan may use all visible messages for cache
+		// alignment, but the estimate should reflect the minimal request shape.
+		return a.summaryRequest(msgs[head:candidate], nil, instructions+anchors)
+	}
+	return a.summaryRequest(msgs[:head], msgs[head:candidate], instructions)
+}
+
+// summaryMaxPromptTokens is the admissible summarizer input ceiling, shared by
+// planning (maximumSafeSummaryPrefixEnd), the replay-fits check, and send-time
+// admission so a planned request is never rejected after it is selected.
+func (a *Agent) summaryMaxPromptTokens() int {
+	window := a.effectiveContextWindow()
+	if window <= 0 {
+		return 0
+	}
+	policy := contextBudgetPolicyOf(a.svc.prov)
+	if policy.WindowMode == provider.ContextWindowUnknown {
+		// A learned overflow makes an unknown gateway shared-window. Otherwise
+		// preserve the request because the configured window may be an estimate.
+		if a.lastAdmission().ObservedWindow <= 0 {
+			return a.hardInputCeiling()
+		}
+		policy.WindowMode = provider.ContextWindowShared
+	}
+	if policy.WindowMode == provider.ContextWindowShared {
+		return window - outputBudgetReserve - protocolReserveTokens
+	}
+	return a.hardInputCeiling()
+}
+
+// summaryViewReplayFits reports whether the whole live view can be replayed
+// as the summarizer prefix (view + instruction within the admissible input
+// ceiling). Over-ceiling views must crop instead, at the cost of the prefix
+// cache match.
+func (a *Agent) summaryViewReplayFits(msgs []provider.Message) bool {
+	// The safe ceiling already subtracts the (window-scaled) summary output
+	// budget: a view that leaves no room for the digest must crop to the
+	// frozen-prefix branch instead of replaying past the window.
+	maxPromptTokens, enforce := a.safeSummaryPromptTokenLimit()
+	if !enforce {
+		return true
+	}
+	if maxPromptTokens <= 0 {
+		return false
+	}
+	return a.estimatedRequestTokens(a.summaryRequest(msgs, nil, "")) <= maxPromptTokens
+}
+
+// foldAnchorInstruction names the fold region by verbatim excerpts so the
+// summarizer can locate it inside the already-sent main-request bytes. The end
+// excerpt is taken from the whole region (fold + extras) so new turns beyond
+// the frozen prefix stay inside the summarized range.
+func foldAnchorInstruction(region []provider.Message) string {
+	startAnchor, endAnchor := "", ""
+	for _, m := range region {
+		if text := strings.TrimSpace(m.Content); text != "" {
+			if startAnchor == "" {
+				startAnchor = foldAnchor(text)
+			}
+			endAnchor = foldAnchor(text)
+		}
+	}
+	if startAnchor == "" {
+		return ""
+	}
+	return fmt.Sprintf("\n\nThe conversation above contains a segment to summarize. It starts with the excerpt %q and ends with the excerpt %q (both appear verbatim in the conversation above). Summarize ONLY that segment; leave everything else untouched.", startAnchor, endAnchor)
+}
+
+// foldAnchor truncates a message's content to a stable locating excerpt.
+func foldAnchor(text string) string {
+	const maxAnchor = 160
+	text = strings.Join(strings.Fields(text), " ")
+	if len(text) <= maxAnchor {
+		return text
+	}
+	return text[:maxAnchor]
+}

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -26,13 +26,16 @@ func prepareForObservedUsage(a *Agent, ctx context.Context, usage *provider.Usag
 // fakeProvider returns a fixed reply and records the messages it was asked to
 // complete, so tests can drive summarization without a network call.
 type fakeProvider struct {
-	reply          string
-	reasoningReply string // set (with empty reply) to emit ChunkReasoning: thinking-model shape
-	reasoningTool  bool   // with reasoningReply: also open a tool call, the shape that stays rejected
-	promptTokens   int
-	got            []provider.Message
-	streamErr      error // when set, Stream emits a ChunkError instead of the reply
-	hang           bool  // when true, Stream returns a channel that never sends or closes
+	reply        string
+	promptTokens int
+	got          []provider.Message
+	reqs         []provider.Request // full request surface, incl. Tools
+	streamErr    error              // when set, Stream emits a ChunkError instead of the reply
+	hang         bool               // when true, Stream returns a channel that never sends or closes
+	// reasoningReply (set with empty reply) emits ChunkReasoning: the
+	// thinking-model shape; reasoningTool that also opens a tool call.
+	reasoningReply string
+	reasoningTool  bool
 }
 
 func (f *fakeProvider) Name() string { return "fake" }
@@ -43,6 +46,7 @@ func (f *fakeProvider) ContextBudgetPolicy() provider.ContextBudgetPolicy {
 
 func (f *fakeProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
 	f.got = req.Messages
+	f.reqs = append(f.reqs, req)
 	if f.hang {
 		return make(chan provider.Chunk), nil
 	}
@@ -180,7 +184,7 @@ func TestSummarizeRespectsContextCancel(t *testing.T) {
 	a := New(&fakeProvider{hang: true}, tool.NewRegistry(), &Session{}, Options{}, event.Discard)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if _, _, err := a.summarize(ctx, []provider.Message{{Role: provider.RoleUser, Content: "x"}}, ""); err == nil {
+	if _, _, err := a.summarize(ctx, nil, []provider.Message{{Role: provider.RoleUser, Content: "x"}}, ""); err == nil {
 		t.Fatal("summarize must return when ctx is cancelled, not hang")
 	}
 }

--- a/internal/agent/context_receipt.go
+++ b/internal/agent/context_receipt.go
@@ -152,21 +152,25 @@ func (a *Agent) recordContextMaintenanceOutcome(inputHash, trigger, action, stat
 	a.emitContextMaintenance(state.LastReceipt)
 }
 
-func (a *Agent) emitCompactionTelemetry(t CompactionTelemetry) {
-	detail := fmt.Sprintf("trigger=%s mode=%s summary_input=%s cache=%s src=%d fold=%d spans=%d proj=%d in=%d out=%d hit=%d miss=%d write=%d reqs=%d user_kept=%d user_dropped=%d",
+func compactionDetailString(t CompactionTelemetry) string {
+	detail := fmt.Sprintf("trigger=%s mode=%s summary_input=%s cache=%s src=%d fold=%d spans=%d proj=%d in=%d out=%d hit=%d miss=%d write=%d reqs=%d user_kept=%d user_dropped=%d view_fp=%s wire_fp=%s tools_count=%d tools_fp=%s tools_source=%s pref_hash=%s pref_len=%d wire_len=%d wire_diff=%s",
 		t.Trigger, t.Mode, t.SummaryInputMode, t.CacheState, t.SourceTokens, t.FoldTokens, t.Spans, t.ProjectionTokens,
 		t.InputTokens, t.OutputTokens, t.CacheHitTokens, t.CacheMissTokens, t.CacheWriteTokens, t.RequestCount,
-		t.UserTurnsKept, t.UserTurnsDropped)
+		t.UserTurnsKept, t.UserTurnsDropped, t.ViewFP, t.WireFP, t.ToolsCount, t.ToolsFP, t.ToolsSource, t.PrefixHash,
+		t.PrefLen, t.WireLen, t.WireDiff)
 	if t.ProviderRequestID != "" {
 		detail += " provider_request_id=" + t.ProviderRequestID
 	}
+	return detail
+}
+
+func (a *Agent) emitCompactionTelemetry(t CompactionTelemetry) {
+	detail := compactionDetailString(t)
 	if t.Error != "" {
-		// CompactionModeDegraded remains readable for legacy telemetry, although
-		// new summarizer failures never install a degraded projection.
 		if t.Mode != CompactionModeDegraded {
-			slog.Warn("agent: compaction failed", "detail", detail+" err_type="+t.Error)
-			return
+			slog.Warn("agent: compaction failed", "detail", detail, "err_type", t.Error)
 		}
+		// Failed compactions still emit so the stats recorder persists them.
 		detail += " err_type=" + t.Error
 	}
 	a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "compaction telemetry", Detail: detail})

--- a/internal/agent/main_request_freeze.go
+++ b/internal/agent/main_request_freeze.go
@@ -1,0 +1,92 @@
+package agent
+
+import (
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+// mainRequestBytes freezes the exact provider-visible byte unit of the last
+// sampling request. The server caches system+tools+messages as one prefix, so
+// the summarizer replays all three to hit the cached unit; messages alone
+// leaves the tools seam unaligned whenever the live tool set changes.
+type mainRequestBytes struct {
+	messages []provider.Message
+	tools    []provider.ToolSchema
+}
+
+// saveMainRequest freezes the provider-visible request unit right before send,
+// so a later summarizer can reuse that byte prefix instead of the live view
+// (which drifts after prune/projection updates) or the live tool set (which
+// grows as MCP servers finish registering). Deep-copied: the request payload
+// is frozen and must not alias session storage.
+func (a *Agent) saveMainRequest(msgs []provider.Message, tools []provider.ToolSchema) {
+	cp := make([]provider.Message, len(msgs))
+	for i, m := range msgs {
+		cp[i] = m
+		cp[i].ToolCalls = append([]provider.ToolCall(nil), m.ToolCalls...)
+		cp[i].Images = append([]string(nil), m.Images...)
+		cp[i].ResponsesItems = append([]json.RawMessage(nil), m.ResponsesItems...)
+		cp[i].ServerSearch = append([]provider.ServerSearchCall(nil), m.ServerSearch...)
+	}
+	var toolCP []provider.ToolSchema
+	if len(tools) > 0 {
+		toolCP = make([]provider.ToolSchema, len(tools))
+		for i, s := range tools {
+			toolCP[i] = s
+			if len(s.Parameters) > 0 {
+				toolCP[i].Parameters = append(json.RawMessage(nil), s.Parameters...)
+			}
+		}
+	}
+	a.sess.lastMainReq.Store(&mainRequestBytes{messages: cp, tools: toolCP})
+	a.sess.setWireFP(providerVisibleFingerprint(cp))
+	a.maybePersistFreshMainRequest()
+}
+
+// savedMainRequest returns the frozen bytes of the last sampling request, or
+// nil when none was sent in this process (fresh resume included).
+func (a *Agent) savedMainRequest() *mainRequestBytes {
+	p := a.sess.lastMainReq.Load()
+	if p == nil {
+		return nil
+	}
+	return p
+}
+
+// freshWireSidecarInterval throttles how often a main request refreshes the
+// sidecar's frozen wire bytes. Rewriting the sidecar at per-request frequency
+// would make disk IO a per-turn cost; the interval amortizes it while still
+// leaving a recently-active session with a recent prefix for the next resume.
+const freshWireSidecarInterval = 60 * time.Second
+
+// maybePersistFreshMainRequest refreshes the sidecar's last_wire_* fields with
+// the current frozen main-request bytes, throttled. The sidecar otherwise only
+// updates on compaction commits, so a long-lived session resumes with a stale
+// prefix whose server-side cache has already been evicted (2026-08-31 23:01:
+// 0% hit after 15h of activity).
+func (a *Agent) maybePersistFreshMainRequest() {
+	if a == nil || a.sess.path == "" {
+		return
+	}
+	if time.Since(time.Unix(0, a.sess.lastMainReqPersist.Load())) < freshWireSidecarInterval {
+		return
+	}
+	saved := a.savedMainRequest()
+	if saved == nil || len(saved.messages) == 0 {
+		return
+	}
+	a.sess.compactionMu.Lock()
+	a.sess.compactionState.LastWireMessages = append([]provider.Message(nil), saved.messages...)
+	a.sess.compactionState.LastWireTools = append([]provider.ToolSchema(nil), saved.tools...)
+	a.sess.compactionState.UpdatedAt = time.Now().UTC()
+	err := a.persistCompactionStateLocked()
+	a.sess.compactionMu.Unlock()
+	if err != nil {
+		slog.Warn("agent: refresh frozen-wire sidecar", "err", err)
+		return
+	}
+	a.sess.lastMainReqPersist.Store(time.Now().UnixNano())
+}

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -203,7 +203,7 @@ func TestSharedWindowFoldDoesNotPrivatelyShortenOversizedInput(t *testing.T) {
 		{Role: provider.RoleTool, ToolCallID: "2", Name: "read_file", Content: toolBody},
 	}
 
-	if _, err := a.foldToSummary(context.Background(), fold, ""); !errors.Is(err, ErrCompactionRequired) {
+	if _, err := a.foldToSummary(context.Background(), nil, fold, ""); !errors.Is(err, ErrCompactionRequired) {
 		t.Fatalf("foldToSummary = %v, want admission failure", err)
 	}
 	if prov.calls != 0 {
@@ -217,7 +217,7 @@ func TestSharedWindowFoldRejectsUnshortenableOverBudgetInput(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
 	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, svc: agentServices{prov: prov, sink: event.Discard}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	fold := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 200_000)}}
-	_, err := a.foldToSummary(context.Background(), fold, "")
+	_, err := a.foldToSummary(context.Background(), nil, fold, "")
 	if !errors.Is(err, ErrCompactionRequired) {
 		t.Fatalf("foldToSummary err = %v, want context admission failure", err)
 	}
@@ -453,7 +453,7 @@ func TestSummarizeClipsSharedWindowOutputBudget(t *testing.T) {
 	a.sess.output.lastUsage.Store(&provider.Usage{PromptTokens: 50_000})
 	a.setPromptTokenCalibration(50_000, requestCalibrationShapeOf(provider.Request{Messages: region}))
 
-	if _, _, err := a.summarize(context.Background(), region, ""); err != nil {
+	if _, _, err := a.summarize(context.Background(), nil, region, ""); err != nil {
 		t.Fatalf("summarize: %v", err)
 	}
 	if prov.last.MaxTokens <= 0 || prov.last.MaxTokens >= prov.budget {
@@ -465,7 +465,7 @@ func TestSummarizeRejectsLengthTruncation(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true, finish: "length"}
 	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, svc: agentServices{prov: prov, sink: event.Discard}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 
-	_, _, err := a.summarizeOnce(context.Background(), []provider.Message{{
+	_, _, err := a.summarizeOnce(context.Background(), nil, []provider.Message{{
 		Role: provider.RoleUser, Content: "retain every durable fact",
 	}}, "")
 	if err == nil || !strings.Contains(err.Error(), "truncated") {

--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -181,6 +181,17 @@ func (a *Agent) LoadProjectionSidecar(sessionPath string) {
 	}
 	a.sess.compactionState = st
 	if valid {
+		// Lossless projection inverse: the sidecar preserved the parent
+		// process's last wire bytes; replay them as the frozen main-request
+		// prefix so the first post-resume compaction hits the provider-cached
+		// unit.
+		if len(st.LastWireMessages) > 0 {
+			a.sess.lastMainReq.Store(&mainRequestBytes{messages: st.LastWireMessages, tools: st.LastWireTools})
+			// The frozen bytes are also the last wire unit; without this the
+			// compaction telemetry reports an empty wire_fp and the summary
+			// prefix can no longer be compared against what was sent.
+			a.sess.setWireFP(providerVisibleFingerprint(st.LastWireMessages))
+		}
 		a.sess.checkpointState = "restored"
 		if needsNormalization {
 			if err := a.persistCompactionStateLocked(); err != nil {
@@ -257,6 +268,34 @@ func (a *Agent) SetSessionPath(path string) {
 	a.sess.compactionMu.Lock()
 	a.sess.path = path
 	a.sess.compactionMu.Unlock()
+}
+
+// ModelVisibleFingerprint fingerprints the agent's current model-visible view.
+// Resume telemetry compares it across reopens to separate view divergence from
+// server-side cache expiry.
+func (a *Agent) ModelVisibleFingerprint() string {
+	if a == nil {
+		return ""
+	}
+	return providerVisibleFingerprint(modelInputMessages(a.modelVisibleMessages()))
+}
+
+// ProjectionCoveredMatch reports whether the sidecar projection's covered
+// prefix byte-matches the transcript. True means the first send after resume
+// transmits projection + tail instead of the full history.
+func (a *Agent) ProjectionCoveredMatch() (match bool, covered int) {
+	if a == nil || a.sess.conversation == nil {
+		return false, 0
+	}
+	msgs, _ := a.sess.conversation.snapshotMessagesVersion()
+	a.sess.compactionMu.Lock()
+	st := a.sess.compactionState
+	a.sess.compactionMu.Unlock()
+	covered = st.Projection.CoveredCount
+	if covered <= 0 || covered > len(msgs) || st.Projection.CoveredPrefixHash == "" {
+		return false, covered
+	}
+	return coveredPrefixHash(msgs, covered) == st.Projection.CoveredPrefixHash, covered
 }
 
 // SessionPath returns the bound transcript path.

--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -181,17 +181,7 @@ func (a *Agent) LoadProjectionSidecar(sessionPath string) {
 	}
 	a.sess.compactionState = st
 	if valid {
-		// Lossless projection inverse: the sidecar preserved the parent
-		// process's last wire bytes; replay them as the frozen main-request
-		// prefix so the first post-resume compaction hits the provider-cached
-		// unit.
-		if len(st.LastWireMessages) > 0 {
-			a.sess.lastMainReq.Store(&mainRequestBytes{messages: st.LastWireMessages, tools: st.LastWireTools})
-			// The frozen bytes are also the last wire unit; without this the
-			// compaction telemetry reports an empty wire_fp and the summary
-			// prefix can no longer be compared against what was sent.
-			a.sess.setWireFP(providerVisibleFingerprint(st.LastWireMessages))
-		}
+		a.restoreFrozenWire(st)
 		a.sess.checkpointState = "restored"
 		if needsNormalization {
 			if err := a.persistCompactionStateLocked(); err != nil {
@@ -202,6 +192,17 @@ func (a *Agent) LoadProjectionSidecar(sessionPath string) {
 		a.sess.checkpointState = "none"
 	}
 	a.sess.compactionMu.Unlock()
+}
+
+// restoreFrozenWire re-adopts the sidecar's frozen main-request unit as this
+// process's prefix, so the first post-resume compaction replays the
+// provider-cached bytes instead of a cropped view.
+func (a *Agent) restoreFrozenWire(st CompactionState) {
+	if len(st.LastWireMessages) == 0 {
+		return
+	}
+	a.sess.lastMainReq.Store(&mainRequestBytes{messages: st.LastWireMessages, tools: st.LastWireTools})
+	a.sess.setWireFP(providerVisibleFingerprint(st.LastWireMessages))
 }
 
 // lineageKeyCompatible reports whether a stored PromptCacheKey still belongs to

--- a/internal/agent/projection.go
+++ b/internal/agent/projection.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -121,6 +122,21 @@ const (
 	CompactionNoop
 )
 
+// toolsFingerprint fingerprints a tool schema set. A system-only summary hit
+// means the prefix broke at the tool seam; this hash distinguishes the frozen
+// main-request set from the live registry in that diagnosis.
+func toolsFingerprint(tools []provider.ToolSchema) string {
+	if len(tools) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(tools)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:16])
+}
+
 // CompactionState is the session context sidecar payload.
 type CompactionState struct {
 	SchemaVersion      int                        `json:"schema_version"`
@@ -140,9 +156,16 @@ type CompactionState struct {
 	// NativeContextEditingAccepted latches the first successful native request.
 	// ContextEditingFallbackLocal persists the only allowed request-shape switch:
 	// an explicit unsupported response before that latch was set.
-	NativeContextEditingAccepted bool      `json:"native_context_editing_accepted,omitempty"`
-	ContextEditingFallbackLocal  bool      `json:"context_editing_fallback_local,omitempty"`
-	UpdatedAt                    time.Time `json:"updated_at"`
+	NativeContextEditingAccepted bool `json:"native_context_editing_accepted,omitempty"`
+	ContextEditingFallbackLocal  bool `json:"context_editing_fallback_local,omitempty"`
+	// LastWireMessages/LastWireTools freeze the most recent main request's
+	// provider-visible unit (local extension, 2026-08-31 lesson: a resumed
+	// session whose sidecar lacks the last wire unit replays a stale prefix
+	// and pays a full-price summary). omitempty keeps old sidecars loadable;
+	// LoadProjectionSidecar restores them with the rest of the struct.
+	LastWireMessages []provider.Message    `json:"last_wire_messages,omitempty"`
+	LastWireTools    []provider.ToolSchema `json:"last_wire_tools,omitempty"`
+	UpdatedAt        time.Time             `json:"updated_at"`
 }
 
 // CompactionTelemetry is the structured observability record for one
@@ -166,6 +189,15 @@ type CompactionTelemetry struct {
 	RequestCount      int    `json:"request_count"`
 	ProviderRequestID string `json:"provider_request_id,omitempty"`
 	SummaryInputMode  string `json:"summary_input_mode,omitempty"`
+	ViewFP            string `json:"view_fp,omitempty"`     // fold view fingerprint (resume-divergence diagnosis)
+	WireFP            string `json:"wire_fp,omitempty"`     // normalized bytes actually sent (vs view_fp)
+	ToolsCount        int    `json:"tools_count,omitempty"` // tool schema set the summary sent
+	ToolsFP           string `json:"tools_fp,omitempty"`
+	ToolsSource       string `json:"tools_source,omitempty"` // frozen | live | none
+	PrefixHash        string `json:"pref_hash,omitempty"`    // summarize-prefix fingerprint (drift vs expiry)
+	PrefLen           int    `json:"pref_len,omitempty"`     // messages the summary prefix carries
+	WireLen           int    `json:"wire_len,omitempty"`     // messages the frozen wire unit carries
+	WireDiff          string `json:"wire_diff,omitempty"`    // first field diverging from the frozen bytes
 	Error             string `json:"error,omitempty"`
 }
 
@@ -199,7 +231,39 @@ func LoadCompactionState(sessionPath string) (CompactionState, bool, error) {
 	if st.SchemaVersion == 0 {
 		st.SchemaVersion = compactionStateSchemaV1
 	}
+	// Load must undo the writer's pretty-print for the frozen wire form's
+	// json.RawMessage bytes; re-compact them so the resumed frozen wire unit
+	// byte-matches the main request the provider actually cached.
+	compactSidecarRawMessages(&st)
 	return st, true, nil
+}
+
+// compactSidecarRawMessages compacts RawMessage bytes inside the frozen wire
+// form: pretty-printing the outer structure must not rewrite them, they are
+// part of the provider-cached prefix and must survive the round trip
+// byte-exact.
+func compactSidecarRawMessages(st *CompactionState) {
+	compact := func(raw json.RawMessage) json.RawMessage {
+		if len(raw) == 0 {
+			return raw
+		}
+		var buf bytes.Buffer
+		if err := json.Compact(&buf, raw); err != nil {
+			return raw
+		}
+		return append(json.RawMessage(nil), buf.Bytes()...)
+	}
+	for i := range st.LastWireMessages {
+		for j := range st.LastWireMessages[i].ResponsesItems {
+			st.LastWireMessages[i].ResponsesItems[j] = compact(st.LastWireMessages[i].ResponsesItems[j])
+		}
+		for j := range st.LastWireMessages[i].ServerSearch {
+			st.LastWireMessages[i].ServerSearch[j].Raw = compact(st.LastWireMessages[i].ServerSearch[j].Raw)
+		}
+	}
+	for i := range st.LastWireTools {
+		st.LastWireTools[i].Parameters = compact(st.LastWireTools[i].Parameters)
+	}
 }
 
 // SaveCompactionState writes the sidecar via strict atomic publish (temp +
@@ -218,6 +282,7 @@ func SaveCompactionState(sessionPath string, st CompactionState) error {
 	if st.UpdatedAt.IsZero() {
 		st.UpdatedAt = time.Now().UTC()
 	}
+	compactSidecarRawMessages(&st)
 	// LastReceipt is authoritative. Drop mirrored top-level last_*/blocked_*
 	// writer fields so new sidecars do not re-emit the pre-v3 dual schema.
 	// Old files with those keys still decode into the struct for readers.

--- a/internal/agent/projection.go
+++ b/internal/agent/projection.go
@@ -159,10 +159,7 @@ type CompactionState struct {
 	NativeContextEditingAccepted bool `json:"native_context_editing_accepted,omitempty"`
 	ContextEditingFallbackLocal  bool `json:"context_editing_fallback_local,omitempty"`
 	// LastWireMessages/LastWireTools freeze the most recent main request's
-	// provider-visible unit (local extension, 2026-08-31 lesson: a resumed
-	// session whose sidecar lacks the last wire unit replays a stale prefix
-	// and pays a full-price summary). omitempty keeps old sidecars loadable;
-	// LoadProjectionSidecar restores them with the rest of the struct.
+	// provider-visible unit so a resumed process replays the cached prefix.
 	LastWireMessages []provider.Message    `json:"last_wire_messages,omitempty"`
 	LastWireTools    []provider.ToolSchema `json:"last_wire_tools,omitempty"`
 	UpdatedAt        time.Time             `json:"updated_at"`

--- a/internal/agent/projection_valid_test.go
+++ b/internal/agent/projection_valid_test.go
@@ -336,7 +336,7 @@ func TestSummarizeOnceDoesNotRetry(t *testing.T) {
 		usage2:   &provider.Usage{PromptTokens: 11, CompletionTokens: 3, TotalTokens: 14, RequestCount: 1},
 	}
 	a := New(fp, tool.NewRegistry(), NewSession("sys"), Options{}, event.Discard)
-	_, _, err := a.summarizeOnce(context.Background(), []provider.Message{
+	_, _, err := a.summarizeOnce(context.Background(), nil, []provider.Message{
 		{Role: provider.RoleUser, Content: "fold me"},
 	}, "")
 	if err == nil {

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -96,11 +96,15 @@ func (a *Agent) prepareSamplingRequest(ctx context.Context) (samplingRequest, er
 		}
 		shape := a.requestCalibrationShape(rebuilt.req)
 		a.sess.output.activeReqShape.Store(&shape)
-		return samplingRequest{req: freezeProviderRequest(rebuilt.req)}, nil
+		wire := freezeProviderRequest(rebuilt.req)
+		a.saveMainRequest(wire.Messages, wire.Tools)
+		return samplingRequest{req: wire}, nil
 	}
 	shape := a.requestCalibrationShape(frozen.req)
 	a.sess.output.activeReqShape.Store(&shape)
-	return samplingRequest{req: freezeProviderRequest(frozen.req)}, nil
+	wire := freezeProviderRequest(frozen.req)
+	a.saveMainRequest(wire.Messages, wire.Tools)
+	return samplingRequest{req: wire}, nil
 }
 
 func (a *Agent) buildSamplingRequest(ctx context.Context, trigger string) (samplingRequest, error) {

--- a/internal/agent/session_extract.go
+++ b/internal/agent/session_extract.go
@@ -128,7 +128,7 @@ func (r *chunkedSummaryRun) summarize(ctx context.Context, fold []provider.Messa
 		return foldSummary{}, err
 	}
 	r.calls++
-	res, err := r.a.foldToSummary(ctx, fold, instructions)
+	res, err := r.a.foldToSummary(ctx, nil, fold, instructions)
 	r.usage = mergeSamplingUsage(r.usage, res.Usage)
 	return res, err
 }

--- a/internal/agent/session_extract_test.go
+++ b/internal/agent/session_extract_test.go
@@ -447,7 +447,7 @@ func TestChunkedFallbackPreservesFocusAndAggregatesTelemetry(t *testing.T) {
 	prov := &extractStubProvider{failFirst: 2, reply: "digest"}
 	a := New(prov, tool.NewRegistry(), extractStubSession(), Options{}, event.Discard)
 	fold := a.Session().Snapshot()
-	res, tele, err := a.foldSummaryWithChunkedFallback(context.Background(), CompactionTriggerManual, fold, focus, 321, SummaryInputCachePrefix)
+	res, tele, err := a.foldSummaryWithChunkedFallback(context.Background(), CompactionTriggerManual, nil, fold, focus, 321, SummaryInputCachePrefix)
 	if err != nil {
 		t.Fatalf("foldSummaryWithChunkedFallback: %v", err)
 	}

--- a/internal/agent/sessionstate.go
+++ b/internal/agent/sessionstate.go
@@ -29,12 +29,8 @@ type sessionRuntime struct {
 	// wire fp it separates payload divergence from server-side expiry.
 	lastWireFP atomic.Pointer[string]
 
-	// lastMainReq freezes the last main (sampling) request's provider-visible
-	// unit — messages AND tool schemas. The server caches system+tools+messages
-	// as one prefix, so the summarizer must replay all three; freezing only
-	// messages left the tools seam unaligned when the live tool set changed
-	// (MCP registration, interceptors) and every summary missed past the
-	// system prefix (2026-08-31: hit=16896 of 256122 on desktop).
+	// lastMainReq freezes the last sampling request's provider-visible unit
+	// (messages AND tool schemas): the server caches all three as one prefix.
 	lastMainReq atomic.Pointer[mainRequestBytes]
 
 	// lastMainReqPersist is the last time the frozen main-request bytes were

--- a/internal/agent/sessionstate.go
+++ b/internal/agent/sessionstate.go
@@ -25,6 +25,22 @@ type sessionRuntime struct {
 
 	missingReasoning missingReasoningWatch
 
+	// lastWireFP: normalized bytes actually sent last request; vs the next
+	// wire fp it separates payload divergence from server-side expiry.
+	lastWireFP atomic.Pointer[string]
+
+	// lastMainReq freezes the last main (sampling) request's provider-visible
+	// unit — messages AND tool schemas. The server caches system+tools+messages
+	// as one prefix, so the summarizer must replay all three; freezing only
+	// messages left the tools seam unaligned when the live tool set changed
+	// (MCP registration, interceptors) and every summary missed past the
+	// system prefix (2026-08-31: hit=16896 of 256122 on desktop).
+	lastMainReq atomic.Pointer[mainRequestBytes]
+
+	// lastMainReqPersist is the last time the frozen main-request bytes were
+	// written to the sidecar (unix nano), throttling fresh-wire refreshes.
+	lastMainReqPersist atomic.Int64
+
 	// reasoningReplayStrongProjection records the provider-visible history cutoff
 	// after thinking-400 repair; later messages use normal replay. Its anchor
 	// resolves the cutoff after old tool-result messages are removed.
@@ -73,6 +89,9 @@ func (r *sessionRuntime) reset(s *Session) {
 	r.missingReasoning = missingReasoningWatch{}
 	r.reasoningReplayStrongProjection = 0
 	r.reasoningReplayStrongProjectionAnchor = ""
+	r.lastWireFP.Store(nil)
+	r.lastMainReq.Store(nil) // a new conversation starts with no sent prefix
+	r.lastMainReqPersist.Store(0)
 	r.compactionMu.Lock()
 	r.compactionState = CompactionState{} // lineage change; disk reloaded on Resume
 	r.cacheState = CacheStateUnknown
@@ -93,6 +112,19 @@ func (r *sessionRuntime) clearReasoningReplayStrongProjection() {
 	}
 	r.reasoningReplayStrongProjection = 0
 	r.reasoningReplayStrongProjectionAnchor = ""
+}
+
+// wireFP returns the fingerprint of the normalized bytes sent last request.
+func (r *sessionRuntime) wireFP() string {
+	if p := r.lastWireFP.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// setWireFP records the normalized bytes about to go on the wire.
+func (r *sessionRuntime) setWireFP(fp string) {
+	r.lastWireFP.Store(&fp)
 }
 
 // session returns the bound conversation under the lock that guards the

--- a/internal/agent/sessionstate_test.go
+++ b/internal/agent/sessionstate_test.go
@@ -19,6 +19,12 @@ var sessionReset = map[string]bool{
 	"cacheHit":         true,
 	"cacheMiss":        true,
 	"missingReasoning": true,
+	// The frozen main-request unit belongs to the conversation that sent it; a
+	// new conversation starts with no sent prefix (lastWireFP/lastMainReq) and
+	// no persisted-wire timestamp (lastMainReqPersist).
+	"lastWireFP":         true,
+	"lastMainReq":        true,
+	"lastMainReqPersist": true,
 	// A strong-projection repair belongs to the corrupted conversation; a new
 	// conversation starts without it.
 	"reasoningReplayStrongProjection":       true,

--- a/internal/agent/tool_result_capability_test.go
+++ b/internal/agent/tool_result_capability_test.go
@@ -442,7 +442,7 @@ func TestProviderRequestsNeverUploadToolRawContent(t *testing.T) {
 		{Role: provider.RoleTool, ToolCallID: "call-1", Name: "read", Content: "bounded", RawContent: rawSentinel},
 	}
 	a := New(nil, tool.NewRegistry(), &Session{Messages: msgs}, Options{}, event.Discard)
-	req := a.summaryRequest(msgs, "")
+	req := a.summaryRequest(nil, msgs, "")
 	b, err := json.Marshal(req)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/agent/wire_diff.go
+++ b/internal/agent/wire_diff.go
@@ -1,0 +1,41 @@
+package agent
+
+import (
+	"fmt"
+	"reflect"
+
+	"reasonix/internal/provider"
+)
+
+// firstWireDiff names the first field that differs between the frozen wire
+// bytes and the prefix rebuilt after a resume. providerVisibleFingerprint
+// covers only the provider-visible subset, so two message sets can share a
+// fingerprint and still serialize to different bytes — a resumed session then
+// misses a cache the previous process was hitting at 99%. Reporting the field
+// name turns that miss into a pointer instead of a guess.
+func firstWireDiff(frozen, rebuilt []provider.Message) string {
+	for i := 0; i < len(frozen) && i < len(rebuilt); i++ {
+		if f := firstFieldDiff(frozen[i], rebuilt[i]); f != "" {
+			return fmt.Sprintf("i%d:%s", i, f)
+		}
+	}
+	if len(frozen) != len(rebuilt) {
+		return fmt.Sprintf("len%d/%d", len(frozen), len(rebuilt))
+	}
+	return ""
+}
+
+func firstFieldDiff(a, b provider.Message) string {
+	va, vb := reflect.ValueOf(a), reflect.ValueOf(b)
+	t := va.Type()
+	for i := range t.NumField() {
+		fa, fb := va.Field(i), vb.Field(i)
+		if fa.Type() != fb.Type() {
+			return t.Field(i).Tag.Get("json")
+		}
+		if !reflect.DeepEqual(fa.Interface(), fb.Interface()) {
+			return t.Field(i).Tag.Get("json")
+		}
+	}
+	return ""
+}

--- a/internal/stats/query.go
+++ b/internal/stats/query.go
@@ -129,6 +129,9 @@ func (w *Writer) queryJSONL(f SourceFilter) (RangeStats, error) {
 				dayTurns++
 				continue
 			}
+			if rec.Compaction != nil {
+				continue // compaction diagnostics are queried separately, not billed usage
+			}
 			t := int64(rec.Total)
 			// Tokens keeps the provider's TotalTokens value as-is (input +
 			// output, provider-specific); the cache hit-rate is derived only
@@ -325,5 +328,43 @@ func providersSorted(totals map[string]int64) []ProviderUsage {
 		}
 		return out[i].Tokens > out[j].Tokens
 	})
+	return out
+}
+
+// CompactionRecordRow is one persisted compaction telemetry row, newest first.
+type CompactionRecordRow struct {
+	Timestamp time.Time `json:"ts"`
+	Source    string    `json:"source,omitempty"`
+	CompactionRecord
+}
+
+// QueryCompactions returns the persisted compaction passes for a source
+// (empty = all), newest first. A user reporting "compaction misbehaved" can be
+// diagnosed from these rows alone: trigger/mode/cache reveal the path, src vs
+// proj show whether the fold shrank, Error pins provider or estimator failures,
+// and the wire-shape fingerprints separate an expired prefix from a rewritten
+// one.
+func (w *Writer) QueryCompactions(source string, from, to time.Time) []CompactionRecordRow {
+	if w == nil || w.dir == "" {
+		return nil
+	}
+	var out []CompactionRecordRow
+	for _, day := range daysInRange(from, to) {
+		recs, err := readDaily(w.dir, day)
+		if err != nil {
+			continue
+		}
+		for _, rec := range recs {
+			if rec.Compaction == nil || !matchesSource(rec.Source, source) {
+				continue
+			}
+			out = append(out, CompactionRecordRow{
+				Timestamp:        rec.Timestamp,
+				Source:           rec.Source,
+				CompactionRecord: *rec.Compaction,
+			})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Timestamp.After(out[j].Timestamp) })
 	return out
 }

--- a/internal/stats/record.go
+++ b/internal/stats/record.go
@@ -49,6 +49,11 @@ type record struct {
 	Total      int       `json:"total,omitempty"`
 	Requests   int       `json:"requests,omitempty"` // provider requests represented by this row
 	Turn       bool      `json:"turn,omitempty"`     // true for TurnDone marker rows
+	// PrefixHash fingerprints the sent request prefix (CacheDiagnostics),
+	// distinguishing a miss from a changed prefix vs server-side expiry.
+	PrefixHash    string   `json:"prefix_hash,omitempty"`
+	PrefixChanged bool     `json:"prefix_changed,omitempty"`
+	PrefixReasons []string `json:"prefix_reasons,omitempty"`
 	// Cost quote fields (additive; older readers ignore them).
 	UsageSource        string   `json:"usage_source,omitempty"`
 	CostAmount         string   `json:"cost_amount,omitempty"`     // original amount decimal

--- a/internal/stats/record.go
+++ b/internal/stats/record.go
@@ -78,6 +78,58 @@ type record struct {
 	ValuationUSD string `json:"valuation_usd,omitempty"`
 	// SelectedCost is a float compatibility mirror of SelectedAmount.
 	SelectedCost float64 `json:"selected_cost,omitempty"`
+	// Compaction records one context-compaction pass (agent compaction
+	// telemetry). Nil on usage/turn rows; Query aggregation skips them.
+	Compaction *CompactionRecord `json:"compaction,omitempty"`
+}
+
+// CompactionRecord is the structured form of the agent's compaction telemetry
+// detail line: a failed pass can be diagnosed from the stats file alone, and
+// RequestID links back to provider logs when present.
+type CompactionRecord struct {
+	Trigger   string `json:"trigger,omitempty"`
+	Mode      string `json:"mode,omitempty"`
+	Cache     string `json:"cache,omitempty"`
+	SourceTok int    `json:"src,omitempty"`
+	FoldTok   int    `json:"fold,omitempty"`
+	Spans     int    `json:"spans,omitempty"`
+	ProjTok   int    `json:"proj,omitempty"`
+	InputTok  int    `json:"in,omitempty"`
+	OutTok    int    `json:"out,omitempty"`
+	HitTok    int    `json:"hit,omitempty"`
+	MissTok   int    `json:"miss,omitempty"`
+	WriteTok  int    `json:"write,omitempty"`
+	Reqs      int    `json:"reqs,omitempty"`
+	// UserTurnsKept/Dropped split the retained turns against those folded into
+	// the summary-only region past the retention budget.
+	UserTurnsKept    int `json:"user_kept,omitempty"`
+	UserTurnsDropped int `json:"user_dropped,omitempty"`
+	// Results/SavedChars describe a no-AI fast compression pass (mode=prune):
+	// elided tool results, saved chars; Status records the pass outcome
+	// (installed/noop/aborted/refused).
+	Results    int    `json:"results,omitempty"`
+	SavedChars int    `json:"saved_chars,omitempty"`
+	Status     string `json:"status,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+	// TokPerChar is the usage-calibrated token/char factor at fold time
+	// (0 until a turn reports usage). It makes src/proj values verifiable:
+	// src ≈ chars × tpc. Fast-compress (prune) passes leave it zero.
+	TokPerChar float64 `json:"tpc,omitempty"`
+	RequestID  string  `json:"provider_request_id,omitempty"`
+	Error      string  `json:"err_type,omitempty"`
+	// Wire-shape fingerprints: the bytes actually sent (wire_fp) against the
+	// fold meant to be sent (view_fp), plus the tool set that rode along.
+	// Together they separate "the prefix expired" from "it was rewritten".
+	SummaryInputMode string `json:"summary_input,omitempty"`
+	ViewFP           string `json:"view_fp,omitempty"`
+	WireFP           string `json:"wire_fp,omitempty"`
+	ToolsCount       int    `json:"tools_count,omitempty"`
+	ToolsFP          string `json:"tools_fp,omitempty"`
+	ToolsSource      string `json:"tools_source,omitempty"`
+	PrefixFP         string `json:"pref_hash,omitempty"`
+	PrefLen          int    `json:"pref_len,omitempty"`
+	WireLen          int    `json:"wire_len,omitempty"`
+	WireDiff         string `json:"wire_diff,omitempty"`
 }
 
 // Writer appends records to the daily stats file for a given stats dir.

--- a/internal/stats/recorder.go
+++ b/internal/stats/recorder.go
@@ -136,7 +136,7 @@ func (r *Recorder) Emit(e event.Event) {
 	if r != nil && r.writer != nil && e.Kind == event.Usage {
 		r.recordUsage(e)
 	} else if r != nil && r.writer != nil && e.Kind == event.GuardianAssessment && e.Guardian.Usage != nil {
-		r.recordProviderUsage(e.ModelRef, e.Guardian.Usage, nil, "")
+		r.recordProviderUsage(e.ModelRef, e.Guardian.Usage, nil, "", nil)
 	} else if r != nil && r.writer != nil && e.Kind == event.TurnDone {
 		r.recordTurnCompletion()
 	}
@@ -247,10 +247,10 @@ func (r *Recorder) RecordSubagentLifecycle(info event.SubagentLifecycleInfo) {
 }
 
 func (r *Recorder) recordUsage(e event.Event) {
-	r.recordProviderUsage(e.ModelRef, e.Usage, e.CostQuote, e.UsageSource)
+	r.recordProviderUsage(e.ModelRef, e.Usage, e.CostQuote, e.UsageSource, e.CacheDiagnostics)
 }
 
-func (r *Recorder) recordProviderUsage(modelRef string, usage *provider.Usage, quote *billing.CostQuote, usageSource string) {
+func (r *Recorder) recordProviderUsage(modelRef string, usage *provider.Usage, quote *billing.CostQuote, usageSource string, diag *event.CacheDiagnostics) {
 	if usage == nil || (usage.TotalTokens <= 0 && usage.RequestCount <= 0) {
 		return
 	}
@@ -300,6 +300,11 @@ func (r *Recorder) recordProviderUsage(modelRef string, usage *provider.Usage, q
 		if v, ok := quote.Valuations["USD"]; ok {
 			rec.ValuationUSD = v.Money.Amount
 		}
+	}
+	if diag != nil {
+		rec.PrefixHash = diag.PrefixHash
+		rec.PrefixChanged = diag.PrefixChanged
+		rec.PrefixReasons = diag.PrefixChangeReasons
 	}
 	r.dispatcher.enqueue(rec)
 }

--- a/internal/stats/recorder.go
+++ b/internal/stats/recorder.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -12,9 +13,9 @@ import (
 	"reasonix/internal/provider"
 )
 
-// Recorder is a passthrough event.Sink that snapshots token usage (event.Usage)
-// and completed turns (event.TurnDone) into the daily stats files. It observes
-// only; it never alters the event stream.
+// Recorder is a passthrough event.Sink that snapshots token usage
+// (event.Usage), completed turns (event.TurnDone), and compaction telemetry
+// into the daily stats files. It observes only; it never alters the stream.
 //
 // Wire it around the frontend sink at the boot layer so every entry point
 // (desktop, CLI, serve) records consistently; Source distinguishes them.
@@ -133,12 +134,138 @@ func (r *Recorder) Emit(e event.Event) {
 	if r != nil && r.inner != nil && !requestOnly {
 		r.inner.Emit(e)
 	}
-	if r != nil && r.writer != nil && e.Kind == event.Usage {
+	if r == nil || r.writer == nil {
+		return
+	}
+	switch {
+	case e.Kind == event.Usage:
 		r.recordUsage(e)
-	} else if r != nil && r.writer != nil && e.Kind == event.GuardianAssessment && e.Guardian.Usage != nil {
+	case e.Kind == event.GuardianAssessment && e.Guardian.Usage != nil:
 		r.recordProviderUsage(e.ModelRef, e.Guardian.Usage, nil, "", nil)
-	} else if r != nil && r.writer != nil && e.Kind == event.TurnDone {
-		r.recordTurnCompletion()
+	case e.Kind == event.TurnDone:
+		r.RecordTurnCompletion()
+	case e.Kind == event.Notice && isCompactionTelemetry(e.Text):
+		r.recordCompaction(e)
+	}
+}
+
+// isCompactionTelemetry matches the agent's compaction telemetry notices, so
+// every pass (success or failure, from any trigger) lands in the stats file
+// for post-hoc diagnosis even when the frontend swallows the notice.
+func isCompactionTelemetry(text string) bool {
+	return text == "compaction telemetry" || text == "compaction failed"
+}
+
+// recordCompaction parses the agent's compaction telemetry detail line into a
+// structured record, so a compaction problem can be pinned from the stats file
+// alone. Parsing is best-effort and never interrupts the event stream.
+func (r *Recorder) recordCompaction(e event.Event) {
+	if r == nil || r.dispatcher == nil {
+		return
+	}
+	rec := CompactionRecord{Trigger: "unknown", Mode: "unknown"}
+	for tok := range strings.FieldsSeq(e.Detail) {
+		k, v, ok := strings.Cut(tok, "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "trigger":
+			rec.Trigger = v
+		case "mode":
+			rec.Mode = v
+		case "cache":
+			rec.Cache = v
+		case "provider_request_id":
+			rec.RequestID = v
+		case "status":
+			rec.Status = v
+		case "reason":
+			rec.Reason = v
+		case "summary_input":
+			rec.SummaryInputMode = v
+		case "view_fp":
+			rec.ViewFP = v
+		case "wire_fp":
+			rec.WireFP = v
+		case "tools_fp":
+			rec.ToolsFP = v
+		case "tools_source":
+			rec.ToolsSource = v
+		case "pref_hash":
+			rec.PrefixFP = v
+		case "wire_diff":
+			// wire_diff names the drifting field; it never contains spaces.
+			rec.WireDiff = v
+		case "tpc":
+			if f, err := strconv.ParseFloat(v, 64); err == nil {
+				rec.TokPerChar = f
+			}
+		case "err_type":
+			// err may contain spaces; the detail line puts it last, so take
+			// everything after the marker verbatim.
+			if i := strings.Index(e.Detail, "err_type="); i >= 0 {
+				rec.Error = strings.TrimSpace(e.Detail[i+len("err_type="):])
+			}
+			r.dispatcher.enqueue(record{
+				Timestamp:  time.Now(),
+				ModelRef:   e.ModelRef,
+				Source:     r.source,
+				Compaction: &rec,
+			})
+			return
+		default:
+			setCompactionInt(&rec, k, v)
+		}
+	}
+	r.dispatcher.enqueue(record{
+		Timestamp:  time.Now(),
+		ModelRef:   e.ModelRef,
+		Source:     r.source,
+		Compaction: &rec,
+	})
+}
+
+func setCompactionInt(rec *CompactionRecord, key, val string) {
+	n, err := strconv.Atoi(val)
+	if err != nil {
+		return
+	}
+	switch key {
+	case "src":
+		rec.SourceTok = n
+	case "fold":
+		rec.FoldTok = n
+	case "spans":
+		rec.Spans = n
+	case "proj":
+		rec.ProjTok = n
+	case "in":
+		rec.InputTok = n
+	case "out":
+		rec.OutTok = n
+	case "hit":
+		rec.HitTok = n
+	case "miss":
+		rec.MissTok = n
+	case "write":
+		rec.WriteTok = n
+	case "reqs":
+		rec.Reqs = n
+	case "user_kept":
+		rec.UserTurnsKept = n
+	case "user_dropped":
+		rec.UserTurnsDropped = n
+	case "results":
+		rec.Results = n
+	case "saved_chars":
+		rec.SavedChars = n
+	case "tools_count":
+		rec.ToolsCount = n
+	case "pref_len":
+		rec.PrefLen = n
+	case "wire_len":
+		rec.WireLen = n
 	}
 }
 

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -545,3 +545,32 @@ func usageEvent(model string, prompt, completion, reasoning, hit, miss, total in
 }
 
 func turnEvent() event.Event { return event.Event{Kind: event.TurnDone} }
+
+// TestRecorderPersistsPrefixHash pins the TTL-diagnosis field: each usage row
+// carries CacheDiagnostics.PrefixHash so post-hoc analysis can tell a cache
+// miss from a changed prefix (hash differs) apart from one caused by
+// server-side cache expiry (hash identical across the gap).
+func TestRecorderPersistsPrefixHash(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(&spySink{}, dir, "desktop")
+	u := usageEvent("deepseek/deepseek-v4-flash", 1000, 50, 10, 900, 100, 1050)
+	u.CacheDiagnostics = &event.CacheDiagnostics{
+		PrefixHash: "abc123", PrefixChanged: true, PrefixChangeReasons: []string{"log_rewrite"},
+	}
+	r.Emit(u)
+	flushRecorder(t, r)
+
+	data, err := os.ReadFile(filepath.Join(dir, dailyJSONLFiles(t, dir)[0].Name()))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), `"prefix_hash":"abc123"`) {
+		t.Fatalf("row missing prefix_hash: %s", data)
+	}
+	if !strings.Contains(string(data), `"prefix_changed":true`) {
+		t.Fatalf("row missing prefix_changed: %s", data)
+	}
+	if !strings.Contains(string(data), `"prefix_reasons":["log_rewrite"]`) {
+		t.Fatalf("row missing prefix_reasons: %s", data)
+	}
+}

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -574,3 +574,186 @@ func TestRecorderPersistsPrefixHash(t *testing.T) {
 		t.Fatalf("row missing prefix_reasons: %s", data)
 	}
 }
+
+func TestRecorderPersistsCompactionTelemetry(t *testing.T) {
+	dir := t.TempDir()
+	inner := &spySink{}
+	r := NewRecorder(inner, dir, "desktop")
+	// Compaction notices must reach the frontend unchanged.
+	detail := "trigger=manual mode=summarized cache=warm src=5108937 proj=0 in=0 out=0 hit=0 miss=0 write=0 reqs=2 provider_request_id=req-abc err_type=deepseek-responses: status 400: over window"
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction failed", Detail: detail})
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry", Detail: "trigger=auto mode=summarized cache=warm src=2666458 proj=297000 in=10 out=20 hit=30 miss=40 write=50 reqs=1 tpc=0.250"})
+	flushRecorder(t, r)
+
+	w := NewWriter(dir)
+	rows := w.QueryCompactions("desktop", time.Now().Add(-time.Hour), time.Now())
+	if len(rows) != 2 {
+		t.Fatalf("want 2 compaction rows, got %d", len(rows))
+	}
+	// Newest first: the auto row landed after the failed row.
+	failed, auto := rows[1], rows[0]
+	if failed.Trigger != "manual" || failed.Mode != "summarized" || failed.Cache != "warm" {
+		t.Fatalf("failed row: trigger=%s mode=%s cache=%s", failed.Trigger, failed.Mode, failed.Cache)
+	}
+	if failed.SourceTok != 5108937 || failed.Reqs != 2 {
+		t.Fatalf("failed row numbers: src=%d reqs=%d", failed.SourceTok, failed.Reqs)
+	}
+	if failed.RequestID != "req-abc" {
+		t.Fatalf("failed row request id: %q", failed.RequestID)
+	}
+	if !strings.Contains(failed.Error, "status 400") || !strings.Contains(failed.Error, "over window") {
+		t.Fatalf("failed row error should keep the full multi-word message: %q", failed.Error)
+	}
+	if auto.Trigger != "auto" || auto.SourceTok != 2666458 || auto.ProjTok != 297000 {
+		t.Fatalf("auto row: trigger=%s src=%d proj=%d", auto.Trigger, auto.SourceTok, auto.ProjTok)
+	}
+	if auto.TokPerChar != 0.25 {
+		t.Fatalf("auto row tpc: %v, want 0.250 (calibrated factor must survive the stats round-trip)", auto.TokPerChar)
+	}
+	if auto.InputTok != 10 || auto.OutTok != 20 || auto.HitTok != 30 || auto.MissTok != 40 || auto.WriteTok != 50 {
+		t.Fatalf("auto row tokens: in=%d out=%d hit=%d miss=%d write=%d", auto.InputTok, auto.OutTok, auto.HitTok, auto.MissTok, auto.WriteTok)
+	}
+	// Compaction rows must not leak into billed usage aggregation.
+	got, err := w.Query(SourceFilter{From: time.Now().Add(-time.Hour), To: time.Now()})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if got.Tokens != 0 || got.Requests != 0 {
+		t.Fatalf("compaction rows leaked into usage: tokens=%d requests=%d", got.Tokens, got.Requests)
+	}
+	// Non-compaction notices (e.g. context-warning) are not persisted.
+	before := len(rows)
+	r.Emit(event.Event{Kind: event.Notice, Text: "Context is getting large; preserving cache until cleanup is needed.", Detail: "context reached 50% of window"})
+	flushRecorder(t, r)
+	if got := len(w.QueryCompactions("desktop", time.Now().Add(-time.Hour), time.Now())); got != before {
+		t.Fatalf("unrelated notice persisted as compaction: %d rows", got)
+	}
+}
+
+// TestRecorderPersistsCompactionWireFingerprints pins the summary-cache
+// diagnosis keys: the row must carry the wire-shape fingerprints, otherwise a
+// low summarizer hit rate cannot be attributed to an expired prefix versus a
+// rewritten one.
+func TestRecorderPersistsCompactionWireFingerprints(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(&spySink{}, dir, "desktop")
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry",
+		Detail: "trigger=auto mode=summarized summary_input=cache_prefix cache=warm src=455955 fold=449000 spans=1 proj=62862 in=143934 out=460 hit=143360 miss=574 write=0 reqs=1 " +
+			"view_fp=aaaa1111 wire_fp=bbbb2222 tools_count=15 tools_fp=cccc3333 tools_source=frozen pref_hash=dddd4444 pref_len=143000 wire_len=143930 wire_diff=message[7].content",
+	})
+	flushRecorder(t, r)
+
+	rows := NewWriter(dir).QueryCompactions("desktop", time.Now().Add(-time.Hour), time.Now())
+	if len(rows) != 1 {
+		t.Fatalf("want 1 compaction row, got %d", len(rows))
+	}
+	rec := rows[0]
+	if rec.SummaryInputMode != "cache_prefix" {
+		t.Fatalf("summary_input=%q, want cache_prefix", rec.SummaryInputMode)
+	}
+	if rec.ViewFP != "aaaa1111" || rec.WireFP != "bbbb2222" || rec.ToolsFP != "cccc3333" {
+		t.Fatalf("fingerprints: view=%q wire=%q tools=%q", rec.ViewFP, rec.WireFP, rec.ToolsFP)
+	}
+	if rec.ToolsCount != 15 || rec.ToolsSource != "frozen" {
+		t.Fatalf("tools: count=%d source=%q", rec.ToolsCount, rec.ToolsSource)
+	}
+	if rec.PrefixFP != "dddd4444" || rec.PrefLen != 143000 || rec.WireLen != 143930 {
+		t.Fatalf("prefix: hash=%q len=%d wire_len=%d", rec.PrefixFP, rec.PrefLen, rec.WireLen)
+	}
+	if rec.WireDiff != "message[7].content" {
+		t.Fatalf("wire_diff=%q", rec.WireDiff)
+	}
+	if rec.FoldTok != 0 {
+		t.Logf("fold is not persisted on CompactionRecord; got %d", rec.FoldTok)
+	}
+}
+
+func TestRecorderCompactionDoesNotForwardZeroReceipt(t *testing.T) {
+	dir := t.TempDir()
+	inner := &spySink{}
+	r := NewRecorder(inner, dir, "desktop")
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry", Detail: "trigger=overflow mode=summarized cache=cold src=100 proj=50 in=1 out=2 hit=3 miss=4 write=5 reqs=1"})
+	flushRecorder(t, r)
+	if len(inner.events) != 1 {
+		t.Fatalf("frontend must receive the compaction notice, got %d events", len(inner.events))
+	}
+}
+
+func TestRecorderPersistsFastCompressTelemetry(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(&spySink{}, dir, "desktop")
+	// A successful no-AI fast-compression pass (mode=prune).
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry",
+		Detail: "trigger=manual mode=prune cache=cold results=3 saved_chars=12000"})
+	// A refused pass: warm cache, no rewrite.
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry",
+		Detail: "trigger=manual mode=prune cache=warm results=0 saved_chars=0 status=refused"})
+	flushRecorder(t, r)
+
+	w := NewWriter(dir)
+	rows := w.QueryCompactions("desktop", time.Now().Add(-time.Hour), time.Now())
+	if len(rows) != 2 {
+		t.Fatalf("want 2 compaction rows, got %d", len(rows))
+	}
+	// Newest first: the refused pass landed after the successful one.
+	ok, refused := rows[1], rows[0]
+	if ok.Mode != "prune" || ok.Cache != "cold" || ok.Results != 3 || ok.SavedChars != 12000 {
+		t.Fatalf("success row: mode=%s cache=%s results=%d saved_chars=%d", ok.Mode, ok.Cache, ok.Results, ok.SavedChars)
+	}
+	if ok.Status != "" {
+		t.Fatalf("success row status must be empty, got %q", ok.Status)
+	}
+	if refused.Mode != "prune" || refused.Cache != "warm" || refused.Status != "refused" {
+		t.Fatalf("refused row: mode=%s cache=%s status=%q", refused.Mode, refused.Cache, refused.Status)
+	}
+	if refused.Results != 0 || refused.SavedChars != 0 {
+		t.Fatalf("refused row must not claim savings: results=%d saved_chars=%d", refused.Results, refused.SavedChars)
+	}
+}
+
+func TestRecorderParsesOverflowCacheToken(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(&spySink{}, dir, "desktop")
+	// Overflow bypass: single-token cache label must survive parsing whole.
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry",
+		Detail: "trigger=manual mode=prune cache=warm_over_window results=2 saved_chars=9000"})
+	flushRecorder(t, r)
+
+	w := NewWriter(dir)
+	rows := w.QueryCompactions("desktop", time.Now().Add(-time.Hour), time.Now())
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	if rows[0].Cache != "warm_over_window" {
+		t.Fatalf("cache label = %q, want warm_over_window (single token)", rows[0].Cache)
+	}
+	if rows[0].Results != 2 || rows[0].SavedChars != 9000 {
+		t.Fatalf("row numbers: results=%d saved_chars=%d", rows[0].Results, rows[0].SavedChars)
+	}
+}
+
+// TestRecorderPersistsCompactionNoop pins the telemetry blind spot fixed
+// 2026-08-09: a compaction that folds nothing (planFold empty / intercept
+// rejection) previously emitted no record, so /compact reported "compacted"
+// while the stats file showed nothing — the exact stall that took three days
+// to find. Every compaction pass must land one row, including status=noop.
+func TestRecorderPersistsCompactionNoop(t *testing.T) {
+	dir := t.TempDir()
+	inner := &spySink{}
+	r := NewRecorder(inner, dir, "desktop")
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry", Detail: "trigger=manual mode=summarized status=noop cache=warm src=2180242 proj=0 in=0 out=0 hit=0 miss=0 write=0 reqs=0"})
+	flushRecorder(t, r)
+
+	w := NewWriter(dir)
+	rows := w.QueryCompactions("desktop", time.Now().Add(-time.Hour), time.Now())
+	if len(rows) != 1 {
+		t.Fatalf("want 1 compaction row, got %d", len(rows))
+	}
+	rec := rows[0]
+	if rec.Status != "noop" {
+		t.Fatalf("status=%q, want noop", rec.Status)
+	}
+	if rec.Trigger != "manual" || rec.Mode != "summarized" || rec.SourceTok != 2180242 {
+		t.Fatalf("record fields wrong: %+v", rec.CompactionRecord)
+	}
+}


### PR DESCRIPTION
# Port the summary-cache freeze chain onto main-v2 (+ restore prefix-hash recording)

Two related things land here, both about being able to *see* what the cache is
doing on the Electron line.

## 1. The summary-cache freeze chain

A compaction summary request previously replayed the **live** message view as
its prefix. That view drifts from what the provider actually saw — a prune, a
projection install, or a tool-schema change between the sampling request and
the summarizer moves the bytes, and the server-side prefix cache misses on the
whole message region. The summarizer then pays full price for input it had just
sent.

The chain freezes the provider-visible request unit at send time
(`saveMainRequest`) and has the summarizer replay those exact bytes, messages
**and** tools:

- `internal/agent/main_request_freeze.go` — freezes the deep-copied
  `messages`+`tools` unit right before send, and throttles a sidecar refresh so
  a resumed session can re-adopt it.
- `internal/agent/compact_summary_plan.go` — `summaryFoldPlan` returns the
  frozen unit as the summary prefix when one exists, appending only the messages
  the main request never carried; `summaryViewReplayFits` decides when the whole
  live view can still be replayed within the admissible input ceiling.
- `internal/agent/compact.go` — `summaryRequest` reuses the frozen tool schemas
  instead of re-deriving them from the live registry.
- `internal/agent/preflight.go` — re-adopts the sidecar's frozen unit on load so
  the first post-resume compaction does not replay a cropped view.
- `internal/agent/compact_chunked_fallback.go` — keeps the frozen prefix as the
  chunked fallback input when the first attempt truncates.
- `internal/agent/wire_diff.go` — first-divergence helper used to attribute a
  mismatch to a field when the fingerprints differ.

Telemetry for the wire shape is emitted on every compaction notice: `view_fp`,
`wire_fp`, `tools_count`, `tools_fp`, `tools_source`, `pref_hash`, `pref_len`,
`wire_len`, `wire_diff`. Failed (non-degraded) compactions now emit instead of
logging and returning, so the stats recorder persists them with `err_type=`.

### What was measured

Two `usage_source=compaction` calls on the Electron build:

| prompt | cache_hit | miss | hit rate |
| --- | --- | --- | --- |
| 455,955 | 455,424 | 531 | **99.88%** |
| 143,934 | 143,360 | 574 | **99.60%** |

For contrast, a summary call that replays only the system+tools segment lands
near 15.7k tokens of credit against a 450k input — the failure mode this chain
removes.

### What this does not claim

The low-hit observations that motivated the port (a 3.70% entry) turned out to
be **`usage_source=executor`**, not a summary call: it sat 15 minutes after the
previous request with a prompt 3,646 tokens *shorter* than it, i.e. a rewritten
prefix, not an expired one. Separating those two causes is what part 2 below
makes possible; the summary path itself was already correct.

## 2. Restore `prefix_hash` recording on usage rows

`3472eb3df` ("persist request prefix hash for cache-TTL diagnosis") added
`PrefixHash`/`PrefixChanged`/`PrefixReasons` to the stats usage row, threaded
from `event.CacheDiagnostics`, with zero send-side change. That field is the
only way to separate the two causes of a cache miss: an **identical** hash
across a gap proves server-side expiry, a **differing** hash proves a
content/parameter change.

It was dropped at the recorder boundary during a later merge: `event.CacheDiagnostics`
is still populated send-side (`internal/agent/run_usage.go`) and the type is
still defined (`internal/event/session_context_diagnostics.go`), but
`record.go` no longer had the fields and `recordProviderUsage` no longer took
the diagnostics. Measured coverage before this change: **0/245 rows** on
2026-09-12 and **0/888** on 2026-09-11.

Restored by threading `*event.CacheDiagnostics` through `recordProviderUsage`
alongside the existing `quote`/`usageSource` parameters and writing the three
fields when present. `TestRecorderPersistsPrefixHash` returns as the guard.

## Also in this series

- `10a63f113` — `installSummaryCheckpoint` returns `(CompactionOutcome, error)`
  instead of swallowing the outcome, matching the caller contract.
- `0cf1943b9` — splits the plan helpers out of `compact_projection.go` and
  trims the lint overruns the port introduced.
- `04001f03c` — drops `summaryMaxPromptTokens`, a duplicate input ceiling whose
  only upstream caller is a debug probe that prints without asserting. The
  production path uses `safeSummaryPromptTokenLimit`.

Cache-impact: low - the sampling request's provider-visible bytes are unchanged;
the diff is confined to the summarizer (which now replays the frozen unit
instead of the live view) plus read-only recording in `internal/stats`. Measured
effect is an increase in summarizer cache hits, not a change to the main prefix.
Cache-guard: go test ./internal/stats/ ./internal/agent/ -run 'PrefixHash|Summary|Compaction|CachePrefix' (new: internal/stats TestRecorderPersistsPrefixHash, internal/agent/compact_prefix_cache_test.go, internal/agent/compact_sidecar_lossless_test.go)
Documentation-impact: none - behaviour fix on an internal request path and a read-only stats field; no CLI flags, config keys, protocol fields or docs claims change.
