### PR TITLE
ci(desktop): run Windows packaging beside the tests instead of after them / Windows 打包与测试并行而非串行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,8 +736,9 @@ jobs:
     if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
     runs-on: windows-latest
     # A hung native step must not hold the workflow's concurrency group for the
-    # six-hour default. main-v2 push runs measured 34-47 minutes on 2026-09-11,
-    # so 45 sat inside the job's own spread; every step keeps its own cap.
+    # six-hour default. This bounds hangs, not duration: the leg's own spread on
+    # 2026-09-11 was 34-47 minutes, so a cap near the mean cancels healthy runs.
+    # Every step keeps its own tighter budget.
     timeout-minutes: 60
     defaults:
       run:
@@ -872,20 +873,71 @@ jobs:
         timeout-minutes: 2
         run: go test -timeout=60s fyne.io/systray
 
-      # Installer packaging is packaging validation, not a code gate: run it
-      # on pushes to main-v2 (the release pipeline builds installers again
-      # anyway), but let pull requests stop after the test step.
+  # Installer packaging is packaging validation, not a code gate, and it shares
+  # no state with the test steps above. It runs beside them instead of after
+  # them so the Windows leg's wall time is the longer half rather than the sum,
+  # and so a packaging failure costs a short rerun instead of the whole leg.
+  # Pushes to main-v2 only: the release pipeline builds installers again anyway.
+  desktop-windows-package:
+    needs: changes
+    if: always() && github.event_name != 'pull_request'
+    runs-on: windows-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+        working-directory: desktop
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: desktop/go.mod
+          cache: true
+          cache-dependency-path: desktop/go.sum
+
+      - uses: pnpm/action-setup@v6.1.0
+        with:
+          version: 10
+          run_install: false
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: desktop/pnpm-lock.yaml
+
+      # Same Defender hazard as the test leg: exclusions keep packaging from
+      # tripping over freshly written files that are still held open.
+      - name: Exclude build dirs from Defender scanning
+        shell: pwsh
+        run: |
+          $paths = @($env:GITHUB_WORKSPACE, $env:RUNNER_TEMP, $env:TEMP, (go env GOCACHE)) |
+            Where-Object { $_ -and (Test-Path $_) } | Select-Object -Unique
+          foreach ($p in $paths) {
+            try {
+              Add-MpPreference -ExclusionPath $p -ErrorAction Stop
+              Write-Host "Defender exclusion added: $p"
+            } catch {
+              Write-Host "::warning::Defender exclusion failed for ${p}: $($_.Exception.Message)"
+            }
+          }
+
+      # go:embed of frontend/dist needs a built frontend before the package
+      # compiles, same as the test leg.
+      - name: Build frontend
+        run: |
+          pnpm --dir frontend install --frozen-lockfile
+          pnpm --dir frontend build
+
       - name: Install NSIS
-        if: github.event_name != 'pull_request'
         run: pwsh -NoProfile -File ../scripts/install-nsis.ps1
 
       - name: Build Windows installer and portable archive
-        if: github.event_name != 'pull_request'
         timeout-minutes: 20
         run: ../scripts/desktop-build.sh windows/amd64 v0.0.0-ci canary
 
       - name: Verify packaged Windows artifacts
-        if: github.event_name != 'pull_request'
         run: |
           node packaging/verify.mjs ../dist/Reasonix-windows-amd64.zip
           node packaging/signing-files.mjs build/windows/signing-payload --check

--- a/docs/desktop-migration/INVENTORY.md
+++ b/docs/desktop-migration/INVENTORY.md
@@ -15,8 +15,8 @@ Every entry carries one class: `keep-business` keeps its Go implementation and c
 | persistence | 11 | 0 | 0 | 11 |
 | shell-file | 1 | 39 | 4 | 44 |
 | artifact | 5 | 0 | 0 | 5 |
-| ci-job | 20 | 0 | 0 | 20 |
-| **all** | | | | **707** |
+| ci-job | 21 | 0 | 0 | 21 |
+| **all** | | | | **708** |
 
 ## Desktop commands (Go `App` methods bound to the UI)
 
@@ -765,6 +765,7 @@ Every entry carries one class: `keep-business` keeps its Go implementation and c
 | `ci.yml/desktop-macos` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | Electron packaging smoke |
 | `ci.yml/desktop-prepare` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | go run . -emit-contract drift gate; pnpm workspace root |
 | `ci.yml/desktop-windows` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | Electron packaging smoke |
+| `ci.yml/desktop-windows-package` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | Electron installer build, split from the test leg |
 | `release-desktop.yml/attest-signing-contract` |  | .github/workflows/release-desktop.yml | keep-business (保留业务实现) | attests the extended payload list |
 | `release-desktop.yml/build` |  | .github/workflows/release-desktop.yml | keep-business (保留业务实现) | desktop-build.sh packages the Electron app with the same NSIS/nfpm/signing steps |
 | `release-desktop.yml/cache-guard` |  | .github/workflows/release-desktop.yml | keep-business (保留业务实现) | unchanged |

--- a/docs/desktop-migration/inventory.json
+++ b/docs/desktop-migration/inventory.json
@@ -5442,6 +5442,13 @@
     },
     {
       "kind": "ci-job",
+      "name": "ci.yml/desktop-windows-package",
+      "location": ".github/workflows/ci.yml",
+      "class": "keep-business",
+      "owner": "Electron installer build, split from the test leg"
+    },
+    {
+      "kind": "ci-job",
       "name": "release-desktop.yml/attest-signing-contract",
       "location": ".github/workflows/release-desktop.yml",
       "class": "keep-business",

--- a/tools/desktopinventory/sources.go
+++ b/tools/desktopinventory/sources.go
@@ -19,6 +19,7 @@ var ciJobs = map[string]struct {
 	"ci.yml/desktop-go":                           {classKeepBusiness, "hostrpc + module tests; no WebKitGTK toolchain"},
 	"ci.yml/desktop-macos":                        {classKeepBusiness, "Electron packaging smoke"},
 	"ci.yml/desktop-windows":                      {classKeepBusiness, "Electron packaging smoke"},
+	"ci.yml/desktop-windows-package":              {classKeepBusiness, "Electron installer build, split from the test leg"},
 	"app-memory.yml/app-memory":                   {classKeepBusiness, "browser memory screening unchanged"},
 	"app-memory.yml/prepare":                      {classKeepBusiness, "browser memory screening unchanged"},
 	"app-memory.yml/shard":                        {classKeepBusiness, "browser memory screening unchanged"},


### PR DESCRIPTION
## Summary

`desktop-windows` is one serial chain, so its wall time is the sum of two unrelated halves. On `main-v2` pushes it measured 34–47 minutes on 2026-09-11, **twice hit its own cap during the v1.38.7 release**, and any failure — including an unrelated flake in the Go suite — costs a rerun of the whole leg before the installer is ever built.

**Root cause** — the three packaging steps already carry `if: github.event_name != 'pull_request'`, which is why pull requests finish ~10 minutes sooner than pushes. They share no state with the test steps: they need only a checked-out tree, the toolchains, and a built frontend. Sequencing them behind the 17-minute Go suite buys nothing.

Measured step profile of a completing push run (`0055038b4`, 42m56s total):

| step | time |
| --- | --- |
| setup + `Build frontend` | ~11m |
| native Electron / Playwright steps | ~11m |
| `test (Windows desktop and update helper)` | 14.7m |
| `Install NSIS` + `Build Windows installer` + verify | ~9m |

**Fix** — move `Install NSIS`, the installer build, and artifact verification into a new `desktop-windows-package` job with the same triggers, toolchain setup, Defender exclusions, and frontend build. Both jobs now run in parallel:

- the leg's wall time becomes the longer half (~35m) rather than the sum (~46m);
- a packaging failure reruns ~16 minutes instead of ~46;
- a Go-suite flake no longer blocks the installer from being built at all.

`desktop-windows` keeps its steps and budgets unchanged. No job `needs:` either of them, so no aggregate gate moves.

CI jobs are tracked entries in the desktop migration inventory, so the new job is registered in `tools/desktopinventory` and `docs/desktop-migration/{INVENTORY.md,inventory.json}` are regenerated — the `ci-job` count goes 20 → 21 and the total 707 → 708. Without that, `TestInventoryIsClassifiedAndCurrent` fails with `unclassified entries: [ci-job ci.yml/desktop-windows-package]` and the committed docs go stale.

The job-level cap stays at **60**; only its comment changes, to say what the cap is for: it bounds hangs, not duration. A cap near the mean cancels healthy runs, which is exactly what happened to the v1.38.7 candidate at 45.

## Test plan
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml` — the pinned version this repo's own lint job uses — reports no findings.
- [x] `bash scripts/release-workflows.test.sh` passes all four contract suites.
- [x] `go test ./tools/desktopinventory/` passes; the inventory grows by exactly one `ci-job` entry.
- [x] The packaging steps are copied verbatim; only their `if` guards move up to the job level, where the same condition now lives.
- [ ] Confirmed by this PR's push run on `main-v2`: `desktop-windows` and `desktop-windows-package` both green, with the leg's wall time the longer half. (On `pull_request` the packaging job is skipped by design, so the PR run cannot show it.)

Documentation-impact: none - this reorganizes CI job boundaries in `.github/workflows/ci.yml`; no documented product behavior, interface, or release contract changes.
