### PR TITLE
ci(desktop): move the overhead benchmark off the critical path and smoke the packaged macOS app / 基准移出关键路径并补齐 macOS 打包启动冒烟

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -684,7 +684,7 @@ jobs:
       - name: Build frontend
         run: |
           pnpm --dir frontend install --frozen-lockfile
-          pnpm --dir frontend build
+          pnpm --dir frontend build:electron
 
       - name: Test integrated terminal, PTY, and FSEvents lifecycle
         run: go test -race -run 'Test(DarwinWorkspaceWatcher|WorkspaceChangeHub|ResolveTerminal|Terminal|EmptyTerminal|UnixTerminalProcess)' .
@@ -726,6 +726,16 @@ jobs:
         run: |
           ../scripts/desktop-build.sh darwin/arm64 v0.0.0-ci canary
           node packaging/verify.mjs ../dist/Reasonix-darwin-arm64.zip
+
+      # Signing and bundle members do not prove the app starts. Until now the
+      # packaged macOS renderer path ran only in the release build, so a
+      # regression there surfaced at publication time instead of on main-v2.
+      - name: Smoke-test the packaged macOS startup
+        if: github.event_name != 'pull_request'
+        timeout-minutes: 5
+        run: |
+          ditto -xk ../dist/Reasonix-darwin-arm64.zip "$RUNNER_TEMP/desktop-startup"
+          node packaging/smoke.mjs "$RUNNER_TEMP/desktop-startup/Reasonix.app"
 
   # Desktop project-root matching is case-insensitive only on Windows
   # (sameDesktopPath folds case when os.PathSeparator is '\'), so the
@@ -788,7 +798,7 @@ jobs:
       - name: Build frontend
         run: |
           pnpm --dir frontend install --frozen-lockfile
-          pnpm --dir frontend build
+          pnpm --dir frontend build:electron
 
       - name: Test native motion contracts
         run: pnpm --dir frontend test:motion
@@ -847,21 +857,6 @@ jobs:
         timeout-minutes: 3
         run: node electron/scripts/performance-smoke.mjs
 
-      - name: Measure Electron diagnostic overhead
-        timeout-minutes: 10
-        run: node electron/scripts/performance-benchmark.mjs
-
-      - name: Upload diagnostic benchmark evidence
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: diagnostic-overhead-windows
-          if-no-files-found: ignore
-          retention-days: 7
-          path: |
-            desktop/electron/artifacts/performance/overhead.json
-            desktop/electron/artifacts/performance/diagnostic-report.png
-
       - name: test (Windows desktop and update helper)
         # Normal wall time is 6-7 minutes; a loaded runner has exceeded 15 with
         # every package still passing. Keep the budget above that load spike so
@@ -882,7 +877,9 @@ jobs:
     needs: changes
     if: always() && github.event_name != 'pull_request'
     runs-on: windows-latest
-    timeout-minutes: 30
+    # Packaging measured 13m55s; the overhead benchmark and its workspace
+    # install add about six more. Bound hangs, not duration.
+    timeout-minutes: 45
     defaults:
       run:
         shell: bash
@@ -928,7 +925,7 @@ jobs:
       - name: Build frontend
         run: |
           pnpm --dir frontend install --frozen-lockfile
-          pnpm --dir frontend build
+          pnpm --dir frontend build:electron
 
       - name: Install NSIS
         run: pwsh -NoProfile -File ../scripts/install-nsis.ps1
@@ -941,6 +938,29 @@ jobs:
         run: |
           node packaging/verify.mjs ../dist/Reasonix-windows-amd64.zip
           node packaging/signing-files.mjs build/windows/signing-payload --check
+
+      # The overhead benchmark asserts no threshold: it only records
+      # overhead.json as 7-day evidence. It ran on the test leg, where its ~5
+      # minutes sat on the critical path and its numbers came from the runner
+      # with the widest spread. Keep it on Windows for comparable history, but
+      # on the push-only leg that has the headroom.
+      - name: Install the Electron workspace
+        run: pnpm install --frozen-lockfile
+
+      - name: Measure Electron diagnostic overhead
+        timeout-minutes: 10
+        run: node electron/scripts/performance-benchmark.mjs
+
+      - name: Upload diagnostic benchmark evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: diagnostic-overhead-windows
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            desktop/electron/artifacts/performance/overhead.json
+            desktop/electron/artifacts/performance/diagnostic-report.png
 
   # repolint scans desktop/ and sdk/ too, so this job also runs for diffs the
   # `code` filter would otherwise skip.


### PR DESCRIPTION
## Summary

Three post-Electron CI adjustments. Items ② and ③ from the review; ① is **not** in this PR and ④ changed shape — see below.

### ② The overhead benchmark leaves the critical path

`electron/scripts/performance-benchmark.mjs` **asserts no threshold.** Its only `throw`s are validity checks (`capture was <status>`, `renderer bundles differ between benchmark modes`); it writes `overhead.json` as a 7-day artifact. Its own header says it measures diagnostic overhead, *"not the original Windows user workload"*. It cannot fail for being slow, yet it spent ~5 minutes on `desktop-windows` — the desktop critical path (31m05s measured after the packaging split) and the runner with the widest spread in the repo.

Moved to `desktop-windows-package`, which is push-only and finished in **13m55s** against a 30-minute cap. It stays on Windows so recorded numbers remain comparable with history. That job gains the workspace install the fixture needs (`_electron` + esbuild) and a 45-minute cap.

Side effect worth stating: the benchmark no longer runs on pull requests. Since it has no threshold, a PR could never fail on it — only the evidence artifact moves to push-only.

### ③ macOS finally smokes the packaged app

`desktop-windows` packages the shell and runs `packaging/smoke.mjs`. `desktop-macos` stopped after `packaging/verify.mjs` — so **the packaged macOS renderer path had no CI coverage at all.** That is why the v1.38.7 candidate's macOS startup smoke failed for the first time *inside the release build*, after the three tags were already immutable.

Signing and bundle members do not prove the shell/service handshake, the renderer→service call, or a clean exit. This adds the same extraction + smoke the Windows leg and the release job already run, guarded by the same push-only condition as the packaging it consumes. Cost is ~30s on a leg that already built the zip.

### ④ (revised) Native legs build the flavour production ships

The original proposal was to share `desktop-prepare`'s frontend artifact. **I measured it and it is a net loss**: on the reference run `desktop-prepare` finished at 13:17:43 while `desktop-windows` started at 13:15:25, so adding the dependency would delay the native legs ~2.3 minutes to save ~1.5 minutes of build.

What the investigation did turn up is a correctness mismatch. `desktop-macos`, `desktop-windows` and `desktop-windows-package` ran `pnpm --dir frontend build` — the **browser** flavour — while `desktop-prepare` and `packaging/package.mjs` build `build:electron`. Only the electron flavour rewrites the drag-region marker to `-webkit-app-region` (`vite.config.ts` `shellDragRegions`), so the native legs were exercising a bundle production never ships, and the Go `go:embed` on those legs embedded it. All three now use `build:electron`. Same cost, same gate chain (`build:electron` is `build-for-shell.mjs electron`, which spawns `pnpm build` with `REASONIX_SHELL` set).

### ① Deliberately not included

The plan was to delete three duplicated Windows steps (`test:motion`, `test:settings-browser`, `test:transcript-browser`), on the argument that Wails needed per-OS renderer coverage (WebView2 / WKWebView / WebKitGTK) while Electron ships one Chromium everywhere.

`desktop/frontend/scripts/check-motion-ci-contract.mjs` is a workflow contract that reads `ci.yml` and **explicitly requires all three**:

```
motion-ci-contract: desktop-windows must run test:motion
motion-ci-contract: desktop-windows must run the transcript browser replay
```

Crucially, that same file has already been revised for the Electron era — it rejects `WebView2`/`webview2` references as a "retired native smoke harness" — and the Windows duplication **survived that revision**. So this is a maintained decision, not a stale Wails leftover, and deleting the steps would mean editing the guard whose purpose is to prevent exactly that. Needs a maintainer decision on intent first, so it is out of this PR.

## Test plan
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml` — the pinned version this repo's lint job uses — no findings.
- [x] `node desktop/frontend/scripts/check-motion-ci-contract.mjs` passes; the contract pins packaging and smoke to `desktop-windows`, not the benchmark.
- [x] `bash scripts/release-workflows.test.sh` — all four contract suites pass.
- [x] `node scripts/check-desktop-build-contract.mjs` — PASS (the negative Wails contract still holds).
- [x] `go run ./tools/desktopinventory -check` — current at 708 entries; no job added or removed, so no classification change.
- [x] The macOS smoke command matches the one I ran by hand on darwin/arm64 against the published v1.38.7 artifact, which passed the full chain including the renderer `Version` call.
- [ ] Confirmed by this PR's push run on `main-v2`: `desktop-windows` shorter by ~5 min, `desktop-windows-package` carrying the benchmark, and `desktop-macos` running the new smoke. (On `pull_request` the packaging and smoke steps are skipped by design.)

Documentation-impact: none - this moves and adds CI steps in `.github/workflows/ci.yml`; no documented product behavior, interface, or release contract changes.
