### PR TITLE
ci: run the Windows Go suite in parallel, auto-cancel superseded runs, script the Notes PR kick / Windows Go 套件并行、自动取消被取代的 run、Notes PR 触发脚本化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,10 +857,70 @@ jobs:
         timeout-minutes: 3
         run: node electron/scripts/performance-smoke.mjs
 
+  # The desktop Go suite shares nothing with the Electron and browser steps
+  # beyond a built frontend for go:embed, and it is the leg's longest step by
+  # far: the module that tests in 1.8 minutes on ubuntu takes ~17 on Windows,
+  # ~11 of them compiling and linking the cgo-heavy root package before a
+  # single test runs (GOCACHE restored, Defender excluded). Running it beside
+  # the Electron steps makes the leg's wall time the longer half rather than
+  # the sum, and a Go flake reruns only this job.
+  desktop-windows-go:
+    needs: changes
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
+    runs-on: windows-latest
+    # Measured 17.1-17.3 minutes on three consecutive main-v2 runs; bound
+    # hangs, not duration.
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: bash
+        working-directory: desktop
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: desktop/go.mod
+          cache: true
+          cache-dependency-path: desktop/go.sum
+
+      - uses: pnpm/action-setup@v6.1.0
+        with:
+          version: 10
+          run_install: false
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: desktop/pnpm-lock.yaml
+
+      # Same Defender hazard as the Electron leg: exclusions keep Go test
+      # binaries from crashing mid-syscall and freshly written files readable.
+      - name: Exclude build dirs from Defender scanning
+        shell: pwsh
+        run: |
+          $paths = @($env:GITHUB_WORKSPACE, $env:RUNNER_TEMP, $env:TEMP, (go env GOCACHE)) |
+            Where-Object { $_ -and (Test-Path $_) } | Select-Object -Unique
+          foreach ($p in $paths) {
+            try {
+              Add-MpPreference -ExclusionPath $p -ErrorAction Stop
+              Write-Host "Defender exclusion added: $p"
+            } catch {
+              Write-Host "::warning::Defender exclusion failed for ${p}: $($_.Exception.Message)"
+            }
+          }
+
+      # go:embed of frontend/dist needs a built frontend before the package
+      # compiles; the electron flavour is what the shell ships.
+      - name: Build frontend
+        run: |
+          pnpm --dir frontend install --frozen-lockfile
+          pnpm --dir frontend build:electron
+
       - name: test (Windows desktop and update helper)
-        # Normal wall time is 6-7 minutes; a loaded runner has exceeded 15 with
-        # every package still passing. Keep the budget above that load spike so
-        # the job-level timeout, not this step, ends a real hang.
+        # 17 minutes measured, ~11 of them before the first test runs; the
+        # budget stays above that so the job cap, not this step, ends a hang.
         timeout-minutes: 25
         run: go test ./...
 

--- a/.github/workflows/supersede-ci.yml
+++ b/.github/workflows/supersede-ci.yml
@@ -1,0 +1,56 @@
+name: Supersede CI
+
+# ci.yml declares `cancel-in-progress: true`, but when a Windows job is mid
+# step GitHub sometimes never delivers the cancel: the old run keeps the
+# concurrency group and the run for the new head sits `pending` until someone
+# force-cancels by hand. Twice on 2026-09-11 that cost the release candidate
+# 10-20 minutes each. This workflow is not in that group, so it runs anyway
+# and cancels only runs whose head is a strict ancestor of the pushed commit.
+
+on:
+  push:
+    branches: [main-v2]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cancel-superseded:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Cancel CI runs this push supersedes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          runs="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?branch=main-v2&event=push&per_page=30" \
+            --jq '.workflow_runs[] | select(.status != "completed") | "\(.id) \(.head_sha)"')"
+          [ -n "$runs" ] || { echo "no unfinished ci.yml runs on main-v2"; exit 0; }
+          while read -r id sha; do
+            [ -n "$id" ] || continue
+            if [ "$sha" = "$GITHUB_SHA" ]; then
+              continue
+            fi
+            if ! git merge-base --is-ancestor "$sha" "$GITHUB_SHA"; then
+              echo "run $id ($sha) is not an ancestor of $GITHUB_SHA; leaving it alone"
+              continue
+            fi
+            echo "run $id ($sha) is superseded by $GITHUB_SHA; cancelling"
+            gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$id/cancel" >/dev/null || true
+            status="unknown"
+            for _ in 1 2 3 4 5 6; do
+              sleep 15
+              status="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$id" --jq .status)"
+              [ "$status" = "completed" ] && break
+            done
+            if [ "$status" != "completed" ]; then
+              echo "run $id still $status after the normal cancel; force-cancelling"
+              gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$id/force-cancel" >/dev/null
+            fi
+          done <<< "$runs"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -25,7 +25,12 @@ The normal developer path has one version input, one reviewed Notes PR, one
 terminal command, and one environment approval:
 
 1. Open Actions → **Prepare release** and enter `X.Y.Z`.
-2. Review and merge the generated bilingual release-notes PR.
+2. Review and merge the generated bilingual release-notes PR. If its checks
+   show `action_required` with no jobs, the Actions bot opened it and events
+   raised with `GITHUB_TOKEN` never start workflows; run
+   `./scripts/release-notes-pr-kick.sh X.Y.Z` to close and reopen it with
+   your own credentials so CI starts. The script refuses any other
+   zero-check shape.
 3. From an authenticated maintainer checkout, run:
 
    ```sh

--- a/docs/desktop-migration/INVENTORY.md
+++ b/docs/desktop-migration/INVENTORY.md
@@ -15,8 +15,8 @@ Every entry carries one class: `keep-business` keeps its Go implementation and c
 | persistence | 11 | 0 | 0 | 11 |
 | shell-file | 1 | 39 | 4 | 44 |
 | artifact | 5 | 0 | 0 | 5 |
-| ci-job | 21 | 0 | 0 | 21 |
-| **all** | | | | **708** |
+| ci-job | 22 | 0 | 0 | 22 |
+| **all** | | | | **709** |
 
 ## Desktop commands (Go `App` methods bound to the UI)
 
@@ -765,6 +765,7 @@ Every entry carries one class: `keep-business` keeps its Go implementation and c
 | `ci.yml/desktop-macos` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | Electron packaging smoke |
 | `ci.yml/desktop-prepare` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | go run . -emit-contract drift gate; pnpm workspace root |
 | `ci.yml/desktop-windows` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | Electron packaging smoke |
+| `ci.yml/desktop-windows-go` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | desktop Go suite, split from the Electron leg |
 | `ci.yml/desktop-windows-package` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | Electron installer build, split from the test leg |
 | `release-desktop.yml/attest-signing-contract` |  | .github/workflows/release-desktop.yml | keep-business (保留业务实现) | attests the extended payload list |
 | `release-desktop.yml/build` |  | .github/workflows/release-desktop.yml | keep-business (保留业务实现) | desktop-build.sh packages the Electron app with the same NSIS/nfpm/signing steps |

--- a/docs/desktop-migration/inventory.json
+++ b/docs/desktop-migration/inventory.json
@@ -5442,6 +5442,13 @@
     },
     {
       "kind": "ci-job",
+      "name": "ci.yml/desktop-windows-go",
+      "location": ".github/workflows/ci.yml",
+      "class": "keep-business",
+      "owner": "desktop Go suite, split from the Electron leg"
+    },
+    {
+      "kind": "ci-job",
       "name": "ci.yml/desktop-windows-package",
       "location": ".github/workflows/ci.yml",
       "class": "keep-business",

--- a/scripts/release-notes-pr-kick.sh
+++ b/scripts/release-notes-pr-kick.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Start CI on a Notes PR that the Actions bot opened. Events raised with
+# GITHUB_TOKEN never start workflows, so such a PR shows action_required with
+# zero jobs until a human-authenticated close/reopen re-emits pull_request.
+set -euo pipefail
+
+if [ "$#" -ne 1 ] || [[ ! "$1" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+	echo "usage: scripts/release-notes-pr-kick.sh MAJOR.MINOR.PATCH" >&2
+	exit 2
+fi
+
+version="$1"
+repository="${RELEASE_REPOSITORY:-esengine/DeepSeek-Reasonix}"
+branch="release-notes/v$version"
+wait_seconds="${RELEASE_NOTES_KICK_WAIT_SECONDS:-120}"
+
+for command in gh jq; do
+	command -v "$command" >/dev/null || {
+		echo "required command is unavailable: $command" >&2
+		exit 2
+	}
+done
+
+prs="$(gh pr list --repo "$repository" --head "$branch" --state open --json number,headRefOid --limit 2)"
+count="$(jq 'length' <<<"$prs")"
+if [ "$count" -ne 1 ]; then
+	echo "expected exactly one open PR for $branch, found $count" >&2
+	exit 1
+fi
+number="$(jq -r '.[0].number' <<<"$prs")"
+head="$(jq -r '.[0].headRefOid' <<<"$prs")"
+
+check_runs() {
+	gh api "repos/$repository/commits/$head/check-runs" --jq '.total_count'
+}
+
+if [ "$(check_runs)" -gt 0 ]; then
+	echo "PR #$number already has check runs on $head; nothing to kick"
+	exit 0
+fi
+
+# Only the recorded-but-never-started shape is safe to kick. Anything else
+# with zero check runs needs a look, not a reopen.
+stalled="$(gh api "repos/$repository/actions/runs?event=pull_request&head_sha=$head&per_page=20" \
+	--jq "[.workflow_runs[] | select(.head_sha == \"$head\" and .conclusion == \"action_required\")] | length")"
+if [ "$stalled" -eq 0 ]; then
+	echo "PR #$number has no check runs and no action_required run on $head; inspect before kicking" >&2
+	exit 1
+fi
+
+echo "PR #$number: $stalled recorded-but-unstarted run(s) on $head; closing and reopening"
+gh pr close "$number" --repo "$repository"
+gh pr reopen "$number" --repo "$repository"
+
+deadline=$((SECONDS + wait_seconds))
+while [ "$(check_runs)" -eq 0 ]; do
+	if [ "$SECONDS" -ge "$deadline" ]; then
+		echo "no check runs appeared on $head within ${wait_seconds}s" >&2
+		exit 1
+	fi
+	sleep 5
+done
+echo "CI started on PR #$number ($head)"

--- a/tools/desktopinventory/sources.go
+++ b/tools/desktopinventory/sources.go
@@ -20,6 +20,7 @@ var ciJobs = map[string]struct {
 	"ci.yml/desktop-macos":                        {classKeepBusiness, "Electron packaging smoke"},
 	"ci.yml/desktop-windows":                      {classKeepBusiness, "Electron packaging smoke"},
 	"ci.yml/desktop-windows-package":              {classKeepBusiness, "Electron installer build, split from the test leg"},
+	"ci.yml/desktop-windows-go":                   {classKeepBusiness, "desktop Go suite, split from the Electron leg"},
 	"app-memory.yml/app-memory":                   {classKeepBusiness, "browser memory screening unchanged"},
 	"app-memory.yml/prepare":                      {classKeepBusiness, "browser memory screening unchanged"},
 	"app-memory.yml/shard":                        {classKeepBusiness, "browser memory screening unchanged"},


### PR DESCRIPTION
## Summary

Three release-path latency fixes, each its own commit. Together they take the desktop critical path from ~31 minutes to ~22 and remove two manual interventions from every release.

### 1. The Windows Go suite runs beside the Electron leg (~9 min off the critical path)

`desktop-windows` measured 31m05s and 31m33s on the last two `main-v2` pushes. Its longest step, `go test ./...`, took **17.1–17.3 minutes on three consecutive runs** while the same module tests in **1.8 minutes on ubuntu**.

The cost is not the tests. Log timestamps put the root package's 360s test run at **+11.3 minutes** after the step began — everything before it is compile and link of the cgo-heavy `reasonix/desktop` package on Windows, with GOCACHE restored and Defender exclusions in place. Splitting the tests or tuning `-p` cannot recover that. What can be recovered is the ~14 minutes of Electron and browser work the step sat *behind*, which it shares nothing with beyond a built frontend for `go:embed`.

New `desktop-windows-go` job with the same triggers, setup, Defender exclusions and electron-flavour frontend build. The leg's wall time becomes the longer half (~22m) instead of the sum (~31m), and a Go flake reruns only this job. Registered in `tools/desktopinventory` (708 → 709 entries). No contract pins the step: `check-motion-ci-contract.mjs` pins packaging, smoke and the browser replay to `desktop-windows`, none of which move; `scripts/windows-go-tests.test.mjs` tests an argument helper and never reads the workflow.

### 2. Superseded `main-v2` runs get force-cancelled automatically (saved ~35 min on 2026-09-11)

`ci.yml` declares `cancel-in-progress: true`, yet twice yesterday the run for a superseded head kept its concurrency group while the run for the new head sat `pending` — 20 minutes behind `0c35021eb`, 15 behind `31ec09be3` — until an operator force-cancelled by hand. GitHub does not always deliver the cancel to a Windows job mid-step, and nothing inside `ci.yml` can act on it because the new run's jobs never start while the group is held.

`supersede-ci.yml` runs on the same push trigger *outside* that group. It lists unfinished `ci.yml` push runs on `main-v2` and cancels those whose head is a **strict ancestor** of the pushed commit — normal cancel first, up to 90s of readback, force-cancel only if still not completed. Non-ancestor runs and the pushed commit's own run are left alone. When cancel-in-progress works, it finds nothing and exits. This is exactly the sequence applied by hand to runs `34621270538` and `34665281814`.

### 3. The Notes-PR close/reopen is a script (removes one manual step per release)

Prepare release opens the Notes PR with `GITHUB_TOKEN`; events raised with that token never start workflows, so the PR shows `action_required` with zero jobs until a maintainer closes and reopens it. Both v1.38.7 Notes PRs needed that by hand.

`scripts/release-notes-pr-kick.sh X.Y.Z` finds the single open PR for `release-notes/vX.Y.Z`, exits 0 if its head already has check runs, **refuses** any zero-check shape other than a recorded `action_required` `pull_request` run, and otherwise closes/reopens with the operator's credentials and waits for check runs to appear. `RELEASING.md` step 2 names it.

## Test plan
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7` — no findings for `ci.yml` or `supersede-ci.yml`; `bash -n` accepts both shell bodies.
- [x] `node desktop/frontend/scripts/check-motion-ci-contract.mjs` passes.
- [x] `go test ./tools/desktopinventory/` passes after regeneration; `bash scripts/release-workflows.test.sh` and `node scripts/check-desktop-build-contract.mjs` pass.
- [x] Kick script, live read path: against the merged v1.38.7 PR it refuses with `expected exactly one open PR ... found 0` (exit 1); a malformed version exits 2 with usage.
- [ ] Confirmed by this PR's push run: `desktop-windows` and `desktop-windows-go` start together, and the leg's wall time is the longer half. `supersede-ci.yml` fires on the merge push; it should find nothing unless the previous run is stuck.
- [ ] Kick script mutation path: needs the next Notes PR that lands in the zero-job state (cannot be reproduced on demand).

Documentation-impact: updated - RELEASING.md step 2 now names scripts/release-notes-pr-kick.sh for the action_required zero-job Notes PR; the daily flow is otherwise unchanged.
