### PR TITLE
ci: skip the code matrix for release-notes-only pushes and drop the Windows Chromium repeats / 仅改 release-notes 的 push 跳过代码矩阵；去掉 Windows 上重复的 Chromium 套件

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,14 @@ jobs:
       desktop: ${{ steps.filter.outputs.desktop }}
       site: ${{ steps.filter.outputs.site }}
       sdk: ${{ steps.filter.outputs.sdk }}
+      notes_only: ${{ steps.filter.outputs.notes_only }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - id: filter
         run: |
-          code=true; desktop=true; site=true; sdk=true
+          code=true; desktop=true; site=true; sdk=true; notes_only=false
           base=""
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             base="${{ github.event.pull_request.base.sha }}"
@@ -58,9 +59,13 @@ jobs:
               # its DTOs are generated from internal/extension/protocol, so
               # both paths must trigger the sdk job.
               if echo "$files" | grep -qE '^(sdk/|internal/extension/)'; then sdk=true; fi
+              # A push that touches only release-notes/ carries the parent's code
+              # byte for byte. Its heavy jobs skip; scripts/verify-release-push-ci.sh
+              # then requires the nearest ancestor that changed code to be green.
+              if ! echo "$files" | grep -qvE '^release-notes/'; then notes_only=true; fi
             fi
           fi
-          { echo "code=$code"; echo "desktop=$desktop"; echo "site=$site"; echo "sdk=$sdk"; } >> "$GITHUB_OUTPUT"
+          { echo "code=$code"; echo "desktop=$desktop"; echo "site=$site"; echo "sdk=$sdk"; echo "notes_only=$notes_only"; } >> "$GITHUB_OUTPUT"
 
   # The ruleset requires the per-OS check names (test (ubuntu-latest) etc.).
   # A matrix job skipped at job level reports no per-leg checks at all, so
@@ -82,7 +87,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
-      RUN_STEPS: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code != 'false' }}
+      RUN_STEPS: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.code != 'false' }}
     steps:
       - if: env.RUN_STEPS == 'true'
         uses: actions/checkout@v7
@@ -223,7 +228,7 @@ jobs:
     if: always()
     runs-on: windows-latest
     env:
-      RUN_STEPS: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code != 'false' }}
+      RUN_STEPS: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.code != 'false' }}
     steps:
       - if: env.RUN_STEPS == 'true'
         uses: actions/checkout@v7
@@ -268,7 +273,7 @@ jobs:
 
   windows-isolated:
     needs: changes
-    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code != 'false')
+    if: always() && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.code != 'false')
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -311,7 +316,7 @@ jobs:
 
   race:
     needs: changes
-    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code != 'false')
+    if: always() && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.code != 'false')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -364,7 +369,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
-      RUN_STEPS: ${{ github.event_name != 'pull_request' || needs.changes.outputs.sdk != 'false' }}
+      RUN_STEPS: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.sdk != 'false' }}
     defaults:
       run:
         working-directory: sdk/go
@@ -438,7 +443,7 @@ jobs:
       - name: Verify desktop validation jobs
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
-          SHOULD_RUN: ${{ github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false' }}
+          SHOULD_RUN: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false' }}
           PREPARE_RESULT: ${{ needs.desktop-prepare.result }}
           GO_RESULT: ${{ needs.desktop-go.result }}
           FRONTEND_RESULT: ${{ needs.desktop-frontend.result }}
@@ -454,7 +459,7 @@ jobs:
 
   desktop-frontend:
     needs: [changes, desktop-prepare]
-    if: always() && needs.desktop-prepare.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -492,7 +497,7 @@ jobs:
 
   desktop-browser:
     needs: [changes, desktop-prepare]
-    if: always() && needs.desktop-prepare.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -527,7 +532,7 @@ jobs:
 
   desktop-prepare:
     needs: changes
-    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
+    if: always() && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
     outputs:
       artifact_name: desktop-frontend-${{ github.run_id }}-${{ github.run_attempt }}
     runs-on: ubuntu-22.04
@@ -597,7 +602,7 @@ jobs:
 
   desktop-go:
     needs: [changes, desktop-prepare]
-    if: always() && needs.desktop-prepare.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -656,7 +661,7 @@ jobs:
   # compile or exercise the native PTY and FSEvents implementations.
   desktop-macos:
     needs: changes
-    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
+    if: always() && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
     runs-on: macos-latest
     defaults:
       run:
@@ -743,7 +748,7 @@ jobs:
   # run on the ubuntu leg above.
   desktop-windows:
     needs: changes
-    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
+    if: always() && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
     runs-on: windows-latest
     # A hung native step must not hold the workflow's concurrency group for the
     # six-hour default. This bounds hangs, not duration: the leg's own spread on
@@ -851,7 +856,7 @@ jobs:
   # the sum, and a Go flake reruns only this job.
   desktop-windows-go:
     needs: changes
-    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
+    if: always() && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
     runs-on: windows-latest
     # Measured 17.1-17.3 minutes on three consecutive main-v2 runs; bound
     # hangs, not duration.
@@ -920,7 +925,7 @@ jobs:
   # Pushes to main-v2 only: the release pipeline builds installers again anyway.
   desktop-windows-package:
     needs: changes
-    if: always() && github.event_name != 'pull_request'
+    if: always() && (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true')
     runs-on: windows-latest
     # Packaging measured 13m55s; the overhead benchmark and its workspace
     # install add about six more. Bound hangs, not duration.
@@ -1011,7 +1016,7 @@ jobs:
   # `code` filter would otherwise skip.
   lint:
     needs: changes
-    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code != 'false' || needs.changes.outputs.desktop != 'false' || needs.changes.outputs.sdk != 'false')
+    if: always() && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.code != 'false' || needs.changes.outputs.desktop != 'false' || needs.changes.outputs.sdk != 'false')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -1112,7 +1117,7 @@ jobs:
 
   govulncheck:
     needs: changes
-    if: github.event_name != 'pull_request'
+    if: (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true')
     runs-on: ubuntu-latest
     continue-on-error: true # informational — stdlib vulns need a Go patch release
     steps:
@@ -1131,7 +1136,7 @@ jobs:
 
   coverage:
     needs: changes
-    if: github.event_name != 'pull_request'
+    if: (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,25 +800,10 @@ jobs:
           pnpm --dir frontend install --frozen-lockfile
           pnpm --dir frontend build:electron
 
-      - name: Test native motion contracts
-        run: pnpm --dir frontend test:motion
-
-      # Chromium is the deterministic browser replay on the Windows runner; the
-      # shell-level Electron startup smoke below separately exercises the real
-      # packaged runtime.
-      - name: Test transcript browser replay on Windows
-        timeout-minutes: 10
-        env:
-          PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/desktop/frontend/.pw-browsers
-        run: |
-          pnpm --dir frontend exec playwright install chromium
-          pnpm --dir frontend test:transcript-browser
-
-      - name: Test settings layout on Windows
-        timeout-minutes: 5
-        env:
-          PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/desktop/frontend/.pw-browsers
-        run: pnpm --dir frontend test:settings-browser
+      # test:motion, test:transcript-browser and test:settings-browser run on
+      # ubuntu (desktop-frontend and desktop-browser). They were repeated here
+      # when each OS shipped its own engine; Electron ships one Chromium, so the
+      # Windows-specific renderer evidence is the native Electron step below.
 
       # Package the real Electron shell on every desktop PR and exercise the
       # production startup path (shell -> Go service handshake) in the packaged

--- a/desktop/frontend/scripts/check-motion-ci-contract.mjs
+++ b/desktop/frontend/scripts/check-motion-ci-contract.mjs
@@ -23,7 +23,6 @@ function jobBody(name) {
 
 for (const [job, body, command] of [
   ["desktop-frontend", jobBody("desktop-frontend"), "node frontend/scripts/run-ci-tests.mjs"],
-  ["desktop-windows", jobBody("desktop-windows", "lint"), "pnpm --dir frontend test:motion"],
   ["required lint", jobBody("lint", "site"), "pnpm --dir desktop/frontend test:motion"],
 ]) {
   if (!body.includes(command)) {
@@ -44,6 +43,14 @@ for (const required of [
 for (const retired of ["WebView2", "webview2", "test-transcript-selection"]) {
   if (windowsJob.includes(retired)) {
     throw new Error(`motion-ci-contract: desktop-windows must not reference the retired native smoke harness (${retired})`);
+  }
+}
+// Electron ships one Chromium on every OS, so the Playwright replays that
+// desktop-frontend and desktop-browser run on ubuntu are the renderer
+// evidence; the Windows leg keeps only the native Electron steps.
+for (const linuxOnly of ["test:motion", "test:transcript-browser", "test:settings-browser"]) {
+  if (windowsJob.includes(`pnpm --dir frontend ${linuxOnly}`)) {
+    throw new Error(`motion-ci-contract: desktop-windows must not repeat the ubuntu Chromium suite ${linuxOnly}`);
   }
 }
 
@@ -194,9 +201,6 @@ if (!desktopLinuxJob.includes(transcriptBrowserCommand) || transcriptBrowserRuns
 }
 if (!desktopLinuxJob.includes("PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend exec playwright install")) {
   throw new Error("motion-ci-contract: Chromium must install into the path used by frontend browser tests");
-}
-if (!windowsJob.includes(transcriptBrowserCommand)) {
-  throw new Error("motion-ci-contract: desktop-windows must run the transcript browser replay");
 }
 for (const required of ["transcript-selection.mjs", "transcript-scroll-stability.mjs"]) {
   if (!packageJSON.scripts?.["test:transcript-browser"]?.includes(required)) {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -59,7 +59,10 @@ Do not rerun Notes generation merely because PR creation was denied.
 - the version is canonical `MAJOR.MINOR.PATCH`;
 - remote `main-v2` is the commit that introduces or updates the complete,
   reviewed Stable catalog record;
-- exact-commit `main-v2` CI completed successfully;
+- exact-commit `main-v2` CI completed successfully. A commit that changes
+  only `release-notes/` skips the code matrix by design, so for such a
+  candidate the helper also requires green push CI on the nearest
+  first-parent ancestor that changed anything else (at most five hops);
 - `vX.Y.Z`, `npm-vX.Y.Z`, and `desktop-vX.Y.Z` are all absent.
 
 It then pushes a no-op guard for that exact `main-v2` SHA and all three

--- a/scripts/release-stable.test.sh
+++ b/scripts/release-stable.test.sh
@@ -22,11 +22,19 @@ if [ -n "${FAKE_ADVANCE_WORK:-}" ] && [ ! -e "$FAKE_ADVANCE_WORK/.advanced-by-fa
 	git -C "$FAKE_ADVANCE_WORK" commit -q -m "advance main during CI"
 	git -C "$FAKE_ADVANCE_WORK" push -q origin main-v2
 fi
-if [ "${FAKE_GH_CONCLUSION:-success}" = pending ]; then
-	printf '[{"headSha":"%s","status":"in_progress","conclusion":""}]\n' "$FAKE_CANDIDATE"
+# Answer for the commit the verifier asked about: the candidate itself, or a
+# release-notes-only candidate's code ancestor.
+sha="$FAKE_CANDIDATE"
+for i in "$@"; do
+	if [ "${prev:-}" = "--commit" ]; then sha="$i"; fi
+	prev="$i"
+done
+conclusion="${FAKE_GH_CONCLUSION:-success}"
+if [ -n "${FAKE_GH_FAIL_SHA:-}" ] && [ "$sha" = "$FAKE_GH_FAIL_SHA" ]; then conclusion=failure; fi
+if [ "$conclusion" = pending ]; then
+	printf '[{"headSha":"%s","status":"in_progress","conclusion":""}]\n' "$sha"
 else
-	printf '[{"headSha":"%s","status":"completed","conclusion":"%s"}]\n' \
-		"$FAKE_CANDIDATE" "${FAKE_GH_CONCLUSION:-success}"
+	printf '[{"headSha":"%s","status":"completed","conclusion":"%s"}]\n' "$sha" "$conclusion"
 fi
 EOF
 chmod +x "$test_root/bin/gh"
@@ -154,5 +162,22 @@ if "$release_script" 1.19.2-preview.1 >/dev/null 2>&1; then
 	echo "Preview version unexpectedly passed the Stable tag helper" >&2
 	exit 1
 fi
+
+# The reviewed Notes commit changes only release-notes/, so its own push run
+# skips the code matrix. The candidate's code is its first parent's; if that
+# ancestor's push CI failed, the release must not be tagged.
+ancestor_work="$(make_remote ancestor)"
+ancestor_sha="$(git -C "$ancestor_work" rev-parse HEAD)"
+ancestor_code_sha="$(git -C "$ancestor_work" rev-parse HEAD^)"
+if (
+	cd "$ancestor_work"
+	PATH="$test_root/bin:$PATH" FAKE_CANDIDATE="$ancestor_sha" FAKE_GH_FAIL_SHA="$ancestor_code_sha" \
+		RELEASE_CI_WAIT_SECONDS=0 RELEASE_REMOTE=origin \
+		"$release_script" 1.19.2
+); then
+	echo "release-notes-only candidate with red code ancestor unexpectedly created release tags" >&2
+	exit 1
+fi
+[ -z "$(git ls-remote --tags --refs "$test_root/ancestor.git" 'refs/tags/*')" ]
 
 echo "stable release tag helper tests: PASS"

--- a/scripts/verify-release-push-ci.sh
+++ b/scripts/verify-release-push-ci.sh
@@ -16,34 +16,64 @@ if [[ ! "$wait_seconds" =~ ^[0-9]+$ ]] || [[ ! "$poll_seconds" =~ ^[1-9][0-9]*$ 
 	echo "RELEASE_CI_WAIT_SECONDS must be non-negative and RELEASE_CI_POLL_SECONDS must be positive" >&2
 	exit 2
 fi
-for command in gh jq; do
+for command in gh jq git; do
 	command -v "$command" >/dev/null || {
 		echo "required command is unavailable: $command" >&2
 		exit 2
 	}
 done
 
-deadline=$((SECONDS + wait_seconds))
-while :; do
-	runs="$(gh run list --repo "$repository" --workflow ci.yml --commit "$candidate" \
-		--event push --limit 20 --json headSha,status,conclusion 2>/dev/null || true)"
-	run_status="$(jq -r --arg sha "$candidate" \
-		'[.[] | select(.headSha == $sha)][0].status // ""' <<<"$runs" 2>/dev/null || true)"
-	conclusion="$(jq -r --arg sha "$candidate" \
-		'[.[] | select(.headSha == $sha and .status == "completed")][0].conclusion // ""' <<<"$runs" 2>/dev/null || true)"
-	case "$conclusion" in
-	success)
-		echo "successful main-v2 push CI verified: $candidate"
-		exit 0
-		;;
-	failure | cancelled | timed_out | action_required | startup_failure)
-		echo "CI for $candidate concluded $conclusion" >&2
-		exit 1
-		;;
-	esac
-	if [ "$SECONDS" -ge "$deadline" ]; then
-		echo "timed out waiting for successful main-v2 CI on $candidate (last status: ${run_status:-missing})" >&2
+wait_for_success() {
+	local sha="$1" deadline runs run_status conclusion
+	deadline=$((SECONDS + wait_seconds))
+	while :; do
+		runs="$(gh run list --repo "$repository" --workflow ci.yml --commit "$sha" \
+			--event push --limit 20 --json headSha,status,conclusion 2>/dev/null || true)"
+		run_status="$(jq -r --arg sha "$sha" \
+			'[.[] | select(.headSha == $sha)][0].status // ""' <<<"$runs" 2>/dev/null || true)"
+		conclusion="$(jq -r --arg sha "$sha" \
+			'[.[] | select(.headSha == $sha and .status == "completed")][0].conclusion // ""' <<<"$runs" 2>/dev/null || true)"
+		case "$conclusion" in
+		success)
+			return 0
+			;;
+		failure | cancelled | timed_out | action_required | startup_failure)
+			echo "CI for $sha concluded $conclusion" >&2
+			return 1
+			;;
+		esac
+		if [ "$SECONDS" -ge "$deadline" ]; then
+			echo "timed out waiting for successful main-v2 CI on $sha (last status: ${run_status:-missing})" >&2
+			return 1
+		fi
+		sleep "$poll_seconds"
+	done
+}
+
+# A commit whose only changes are under release-notes/ skips the code matrix
+# in ci.yml (the `changes` job's notes_only output). Its code is identical to
+# its first parent, so the evidence is the nearest first-parent ancestor that
+# changed anything else. A root commit is treated as code.
+notes_only_commit() {
+	local sha="$1" files
+	git rev-parse --verify -q "$sha^" >/dev/null || return 1
+	files="$(git diff --name-only "$sha^" "$sha")"
+	[ -n "$files" ] || return 1
+	! grep -qvE '^release-notes/' <<<"$files"
+}
+
+wait_for_success "$candidate"
+echo "successful main-v2 push CI verified: $candidate"
+sha="$candidate"
+hops=0
+while notes_only_commit "$sha"; do
+	hops=$((hops + 1))
+	if [ "$hops" -gt 5 ]; then
+		echo "$candidate sits behind more than 5 release-notes-only commits; refusing to infer its code CI" >&2
 		exit 1
 	fi
-	sleep "$poll_seconds"
+	sha="$(git rev-parse "$sha^")"
+	echo "$candidate changes only release-notes/; requiring push CI on ancestor $sha"
+	wait_for_success "$sha"
+	echo "successful main-v2 push CI verified for code ancestor: $sha"
 done


### PR DESCRIPTION
## Summary

Two commits, reviewable separately. Together they remove ~50 minutes from every release and ~4.6 minutes from every Windows desktop run.

### Commit 1 — stop repeating the ubuntu Chromium suites on Windows

`desktop-windows` ran `test:motion`, `test:transcript-browser` and `test:settings-browser` (~4.6 min) although `desktop-frontend` schedules `test:motion` through `ciUnitScripts` and `desktop-browser` runs the two Playwright suites — all on ubuntu. `check-motion-ci-contract.mjs` required the repeats.

The repeats date from the Wails shell, where each OS rendered with its own engine (WebView2 / WKWebView / WebKitGTK) and a Chromium replay on Linux said nothing about Windows. Electron ships one Chromium on every platform, so a Playwright-Chromium replay is platform-invariant. What still differs per OS is the native shell, and that is what the Windows leg's Electron steps already cover: packaged startup smoke, window geometry, and transcript content bounds in native Electron.

The contract drops the two Windows pins and gains the inverse guard — `desktop-windows` must **not** repeat those three suites — so the decision is enforced, not merely applied. The ubuntu "exactly once" requirements are untouched.

**Trade-off stated plainly**: Playwright's Chromium and Electron's are different builds, and OS font/DPI/scrollbar differences can still affect layout benchmarks. The Windows-side evidence that remains (`test:transcript-electron`, real Electron) is stronger than Playwright-Chromium-on-Windows was.

### Commit 2 — a release-notes-only push skips the code matrix

The release candidate is the reviewed Notes merge, whose only change is `release-notes/releases.json`. Pull requests already skip the heavy jobs for that diff, but pushes to `main-v2` ran everything, so **every release waited ~50 minutes for a matrix that re-validated byte-identical code** — twice during v1.38.7, once straight into the Windows timeout.

**`ci.yml`** — the `changes` job emits `notes_only=true` when a push's diff is non-empty and confined to `release-notes/`. Every push-only job clause and the `RUN_STEPS` / `SHOULD_RUN` gates (17 sites) become `(push && !notes_only) || <path filter>`, which for such a push evaluates exactly like a docs-only pull request. `site` keeps running because release notes feed it. A failed or missing `changes` job leaves `notes_only` unset, so the documented fail-open (run the full matrix) is preserved.

**`scripts/verify-release-push-ci.sh`** — this is the part that keeps the gate honest. It no longer accepts the skipped run alone: after the candidate's own run is green, it walks first parents while the commit changes only `release-notes/` (root commits count as code; at most five hops) and requires green push CI on the first ancestor that changed anything else. Shallow checkouts are not a concern — `release-stable.yml` checks out with `fetch-depth: 0` and the maintainer path runs from a clone.

**Test harness** — the fake `gh` now answers for the commit the verifier asks about and can fail one specific SHA. A new scenario proves a release-notes-only candidate whose code ancestor is red creates no tags. The existing success scenario's candidate is itself release-notes-only, so it now also exercises the walk to its root ancestor.

`RELEASING.md` documents the extended rule under "What the tag helper proves".

## Test plan
- [x] `bash scripts/release-stable.test.sh` — passes, including the new red-ancestor scenario (log shows the walk and the refusal) and the existing success path.
- [x] `bash scripts/release-workflows.test.sh` — all four contract suites pass.
- [x] `node desktop/frontend/scripts/check-motion-ci-contract.mjs` — passes with the inverted Windows guard.
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml` — no findings; `bash -n` accepts the `changes` script.
- [x] `go run ./tools/desktopinventory -check` — current at 709 entries (no job added or removed).
- [ ] Confirmed by the next release: the Notes merge push shows the code matrix skipped, and `release-stable.sh` logs `changes only release-notes/; requiring push CI on ancestor <sha>` before tagging.

Documentation-impact: updated - RELEASING.md "What the tag helper proves" now states that a release-notes-only candidate also requires green push CI on its nearest code ancestor.
