### PR TITLE
ci: refresh the Go build cache per push, skip the memory soak for unrelated changes, parallelize the desktop race sweep / Go 构建缓存按 push 刷新、无关改动跳过内存 soak、desktop race 并行

### DIFF
--- a/.github/actions/go-build-cache/action.yml
+++ b/.github/actions/go-build-cache/action.yml
@@ -1,0 +1,48 @@
+name: Go build cache
+description: >-
+  Restore the newest Go build and module cache for this runner and module.
+  setup-go keys its cache on go.sum alone and GitHub never rewrites an existing
+  key, so that snapshot freezes at the last dependency change and every package
+  touched since misses. This cache is keyed per run and restored by prefix; a
+  main-v2 push saves it from one job per OS and module (actions/cache/save with
+  the outputs below), pull requests only restore.
+
+inputs:
+  module:
+    description: Cache namespace, e.g. root, root-race, desktop, desktop-race
+    required: true
+
+outputs:
+  key:
+    description: Exact key for this run's save step
+    value: ${{ steps.key.outputs.key }}
+  paths:
+    description: GOCACHE and GOMODCACHE, one per line
+    value: ${{ steps.key.outputs.paths }}
+
+runs:
+  using: composite
+  steps:
+    - id: key
+      shell: bash
+      run: |
+        set -euo pipefail
+        sums="$(git hash-object go.sum desktop/go.sum | git hash-object --stdin)"
+        base="go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.module }}"
+        {
+          echo "key=${base}-${sums:0:16}-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "sums=${base}-${sums:0:16}-"
+          echo "base=${base}-"
+          echo "paths<<EOF"
+          go env GOCACHE
+          go env GOMODCACHE
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.key.outputs.paths }}
+        key: ${{ steps.key.outputs.key }}
+        restore-keys: |
+          ${{ steps.key.outputs.sums }}
+          ${{ steps.key.outputs.base }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,7 +474,7 @@ jobs:
         run: go test -race ./...
 
   desktop:
-    needs: [changes, desktop-prepare, desktop-go, desktop-frontend, desktop-browser]
+    needs: [changes, desktop-prepare, desktop-go, desktop-go-race, desktop-frontend, desktop-browser]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -484,6 +484,7 @@ jobs:
           SHOULD_RUN: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false' }}
           PREPARE_RESULT: ${{ needs.desktop-prepare.result }}
           GO_RESULT: ${{ needs.desktop-go.result }}
+          GO_RACE_RESULT: ${{ needs.desktop-go-race.result }}
           FRONTEND_RESULT: ${{ needs.desktop-frontend.result }}
           BROWSER_RESULT: ${{ needs.desktop-browser.result }}
         run: |
@@ -492,6 +493,7 @@ jobs:
           if [ "$SHOULD_RUN" = true ]; then expected=success; fi
           test "$PREPARE_RESULT" = "$expected"
           test "$GO_RESULT" = "$expected"
+          test "$GO_RACE_RESULT" = "$expected"
           test "$FRONTEND_RESULT" = "$expected"
           test "$BROWSER_RESULT" = "$expected"
 
@@ -696,6 +698,57 @@ jobs:
 
       - name: test
         run: go test ./...
+
+      # Only main-v2 pushes save, one job per OS and module, so the cache
+      # stays a few pushes deep instead of churning on every pull request.
+      - uses: actions/cache/save@v4
+        if: always() && github.event_name == 'push' && steps.gocache.outputs.key != ''
+        with:
+          path: ${{ steps.gocache.outputs.paths }}
+          key: ${{ steps.gocache.outputs.key }}
+
+  # `go test -race ./...` is ~7 of desktop-go's ~11 minutes and shares nothing
+  # with vet, lint, build and the plain test run beyond the frontend artifact.
+  # Running it beside them makes the job's wall time the longer half without
+  # changing what is race-checked.
+  desktop-go-race:
+    needs: [changes, desktop-prepare]
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: desktop
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: desktop/go.mod
+          cache: false
+
+      - uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: desktop-race
+
+      - uses: pnpm/action-setup@v6.1.0
+        with:
+          version: 10
+          run_install: false
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: desktop/pnpm-lock.yaml
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.desktop-prepare.outputs.artifact_name }}
+          path: desktop/frontend/dist
+      - name: Verify frontend artifact layout
+        run: test -f frontend/dist/index.html
+      - run: pnpm --dir frontend install --frozen-lockfile
 
       # The extension work added new shared-state paths to the desktop
       # runtime (tab/rebuild fences, extension UI). Race-sweep the module so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,13 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
+
+      - if: env.RUN_STEPS == 'true'
+        uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: root
 
       - if: env.RUN_STEPS == 'true' && runner.os == 'Windows'
         uses: actions/setup-node@v7
@@ -223,6 +229,14 @@ jobs:
         shell: powershell
         run: .\scripts\test-scoop-desktop-launch.ps1
 
+      # Only main-v2 pushes save, one job per OS and module, so the cache
+      # stays a few pushes deep instead of churning on every pull request.
+      - uses: actions/cache/save@v4
+        if: always() && env.RUN_STEPS == 'true' && github.event_name == 'push' && steps.gocache.outputs.key != ''
+        with:
+          path: ${{ steps.gocache.outputs.paths }}
+          key: ${{ steps.gocache.outputs.key }}
+
   windows-control:
     needs: changes
     if: always()
@@ -237,7 +251,13 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
+
+      - if: env.RUN_STEPS == 'true'
+        uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: root
 
       - if: env.RUN_STEPS == 'true'
         uses: actions/setup-node@v7
@@ -284,7 +304,12 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
+
+      - uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: root
       - uses: actions/setup-node@v7
         with:
           node-version: "22"
@@ -324,7 +349,12 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
+
+      - uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: root-race
 
       - name: Install and verify Linux sandbox backend
         run: |
@@ -355,6 +385,14 @@ jobs:
         env:
           REASONIX_RELEASE_CACHE_GUARD: "1"
         run: go test -race ./...
+
+      # Only main-v2 pushes save, one job per OS and module, so the cache
+      # stays a few pushes deep instead of churning on every pull request.
+      - uses: actions/cache/save@v4
+        if: always() && github.event_name == 'push' && steps.gocache.outputs.key != ''
+        with:
+          path: ${{ steps.gocache.outputs.paths }}
+          key: ${{ steps.gocache.outputs.key }}
 
   # sdk/go is a nested stdlib-only module invisible to root `go test ./...`.
   # Its DTOs are generated from internal/extension/protocol, and the
@@ -545,8 +583,12 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: desktop/go.mod
-          cache: true
-          cache-dependency-path: desktop/go.sum
+          cache: false
+
+      - uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: desktop
 
       - uses: pnpm/action-setup@v6.1.0
         with:
@@ -613,8 +655,12 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: desktop/go.mod
-          cache: true
-          cache-dependency-path: desktop/go.sum
+          cache: false
+
+      - uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: desktop
 
       - uses: pnpm/action-setup@v6.1.0
         with:
@@ -657,6 +703,14 @@ jobs:
       - name: test -race
         run: go test -race ./...
 
+      # Only main-v2 pushes save, one job per OS and module, so the cache
+      # stays a few pushes deep instead of churning on every pull request.
+      - uses: actions/cache/save@v4
+        if: always() && github.event_name == 'push' && steps.gocache.outputs.key != ''
+        with:
+          path: ${{ steps.gocache.outputs.paths }}
+          key: ${{ steps.gocache.outputs.key }}
+
   # desktop/ is a separate module, so the root macOS matrix above does not
   # compile or exercise the native PTY and FSEvents implementations.
   desktop-macos:
@@ -672,8 +726,12 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: desktop/go.mod
-          cache: true
-          cache-dependency-path: desktop/go.sum
+          cache: false
+
+      - uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: desktop
 
       - uses: pnpm/action-setup@v6.1.0
         with:
@@ -742,6 +800,14 @@ jobs:
           ditto -xk ../dist/Reasonix-darwin-arm64.zip "$RUNNER_TEMP/desktop-startup"
           node packaging/smoke.mjs "$RUNNER_TEMP/desktop-startup/Reasonix.app"
 
+      # Only main-v2 pushes save, one job per OS and module, so the cache
+      # stays a few pushes deep instead of churning on every pull request.
+      - uses: actions/cache/save@v4
+        if: always() && github.event_name == 'push' && steps.gocache.outputs.key != ''
+        with:
+          path: ${{ steps.gocache.outputs.paths }}
+          key: ${{ steps.gocache.outputs.key }}
+
   # Desktop project-root matching is case-insensitive only on Windows
   # (sameDesktopPath folds case when os.PathSeparator is '\'), so the
   # regression tests for that contract are named *OnWindows and can never
@@ -765,8 +831,12 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: desktop/go.mod
-          cache: true
-          cache-dependency-path: desktop/go.sum
+          cache: false
+
+      - uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: desktop
 
       - uses: pnpm/action-setup@v6.1.0
         with:
@@ -871,8 +941,12 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: desktop/go.mod
-          cache: true
-          cache-dependency-path: desktop/go.sum
+          cache: false
+
+      - uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: desktop
 
       - uses: pnpm/action-setup@v6.1.0
         with:
@@ -918,6 +992,14 @@ jobs:
         timeout-minutes: 2
         run: go test -timeout=60s fyne.io/systray
 
+      # Only main-v2 pushes save, one job per OS and module, so the cache
+      # stays a few pushes deep instead of churning on every pull request.
+      - uses: actions/cache/save@v4
+        if: always() && github.event_name == 'push' && steps.gocache.outputs.key != ''
+        with:
+          path: ${{ steps.gocache.outputs.paths }}
+          key: ${{ steps.gocache.outputs.key }}
+
   # Installer packaging is packaging validation, not a code gate, and it shares
   # no state with the test steps above. It runs beside them instead of after
   # them so the Windows leg's wall time is the longer half rather than the sum,
@@ -940,8 +1022,12 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: desktop/go.mod
-          cache: true
-          cache-dependency-path: desktop/go.sum
+          cache: false
+
+      - uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: desktop
 
       - uses: pnpm/action-setup@v6.1.0
         with:
@@ -1024,7 +1110,12 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
+
+      - uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: root
 
       - if: github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false'
         uses: pnpm/action-setup@v6.1.0
@@ -1126,7 +1217,12 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
+
+      - uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: root
 
       - name: install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -1144,7 +1240,12 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
+
+      - uses: ./.github/actions/go-build-cache
+        id: gocache
+        with:
+          module: root
 
       - name: test with coverage
         run: go test -coverprofile=coverage.out -covermode=atomic ./...

--- a/desktop/frontend/bench/app-memory-paths.mjs
+++ b/desktop/frontend/bench/app-memory-paths.mjs
@@ -3,7 +3,13 @@ import { pathToFileURL } from "node:url";
 
 // The soak runs the production frontend against browser mocks. These source
 // trees cannot enter that build; native/backend behavior has separate gates.
-const knownIndependent = /^(?:internal\/|cmd\/|sdk\/|site\/|release-notes\/|docs\/[^\n]*\.md$|desktop\/(?:[^/]+\.go$|cmd\/|internal\/))/;
+// Paths that cannot reach the mock-hosted frontend bundle the soak measures:
+// Go modules, CLI/SDK/site sources, docs and notes, repository tooling and
+// workflows (app-memory.yml is claimed above), and the Electron shell,
+// packaging and installer trees the browser-mocked soak never loads. The
+// desktop workspace manifests (desktop/package.json, desktop/pnpm-lock.yaml)
+// stay unknown on purpose: they resolve the frontend's dependencies.
+const knownIndependent = /^(?:internal\/|cmd\/|sdk\/|site\/|release-notes\/|docs\/|scripts\/|tools\/|workers\/|\.github\/|go\.(?:mod|sum)$|Makefile$|\.golangci[^/]*$|desktop\/(?:[^/]+\.go$|go\.(?:mod|sum)$|cmd\/|internal\/|electron\/|packaging\/|build\/))/;
 export function memoryAffected(files) {
   return files.some(file => {
     if (file.startsWith("desktop/frontend/") || file === ".github/workflows/app-memory.yml") return true;

--- a/desktop/frontend/bench/app-memory-paths.test.mjs
+++ b/desktop/frontend/bench/app-memory-paths.test.mjs
@@ -8,7 +8,13 @@ test("all frontend consumers, configuration and tests trigger the soak", () => {
 test("known independent backend and documentation changes skip only this mock frontend soak", () => {
   assert.equal(memoryAffected(["internal/control/turn.go", "desktop/app.go", "sdk/types.ts", "docs/guide.md", "README.md"]), false);
 });
+test("repository tooling, workflows and the Electron shell do not reach the browser-mocked bundle", () => {
+  for (const path of [".github/workflows/ci.yml", ".github/actions/go-build-cache/action.yml", "scripts/release-stable.sh", "tools/desktopinventory/sources.go",
+    "workers/crash-report/src/index.ts", "docs/desktop-migration/inventory.json", "desktop/electron/src/main/dialogs.ts", "desktop/packaging/smoke.mjs",
+    "desktop/build/windows/installer/project.nsi", "desktop/go.sum", "go.mod", ".golangci.yml", "Makefile"])
+    assert.equal(memoryAffected([path]), false, path);
+});
 test("unknown paths fail closed and cannot be hidden by a documentation change", () => {
-  for (const path of [".npmrc", "shared/new-loader.js", ".github/workflows/ci.yml", "docs/build.js", "desktop/build/config.json"])
+  for (const path of [".npmrc", "shared/new-loader.js", "desktop/package.json", "desktop/pnpm-lock.yaml", "desktop/frontend/scripts/shell-css.mjs"])
     assert.equal(memoryAffected(["README.md", path]), true, path);
 });

--- a/docs/desktop-migration/INVENTORY.md
+++ b/docs/desktop-migration/INVENTORY.md
@@ -15,8 +15,8 @@ Every entry carries one class: `keep-business` keeps its Go implementation and c
 | persistence | 11 | 0 | 0 | 11 |
 | shell-file | 1 | 39 | 4 | 44 |
 | artifact | 5 | 0 | 0 | 5 |
-| ci-job | 22 | 0 | 0 | 22 |
-| **all** | | | | **709** |
+| ci-job | 23 | 0 | 0 | 23 |
+| **all** | | | | **710** |
 
 ## Desktop commands (Go `App` methods bound to the UI)
 
@@ -762,6 +762,7 @@ Every entry carries one class: `keep-business` keeps its Go implementation and c
 | `ci.yml/desktop-browser` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | Playwright browser gates unchanged |
 | `ci.yml/desktop-frontend` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | React gates unchanged |
 | `ci.yml/desktop-go` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | hostrpc + module tests; no WebKitGTK toolchain |
+| `ci.yml/desktop-go-race` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | desktop module race sweep, split from desktop-go |
 | `ci.yml/desktop-macos` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | Electron packaging smoke |
 | `ci.yml/desktop-prepare` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | go run . -emit-contract drift gate; pnpm workspace root |
 | `ci.yml/desktop-windows` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | Electron packaging smoke |

--- a/docs/desktop-migration/inventory.json
+++ b/docs/desktop-migration/inventory.json
@@ -5421,6 +5421,13 @@
     },
     {
       "kind": "ci-job",
+      "name": "ci.yml/desktop-go-race",
+      "location": ".github/workflows/ci.yml",
+      "class": "keep-business",
+      "owner": "desktop module race sweep, split from desktop-go"
+    },
+    {
+      "kind": "ci-job",
       "name": "ci.yml/desktop-macos",
       "location": ".github/workflows/ci.yml",
       "class": "keep-business",

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -42,13 +42,13 @@ test("macOS signing diagnostics require protected main and cannot publish", () =
 
 test("required desktop aggregate rejects every failed, cancelled or unexpectedly skipped child", () => {
   const script = shellStep(job(ci, "desktop"), "Verify desktop validation jobs");
-  const success = { CHANGES_RESULT: "success", SHOULD_RUN: "true", PREPARE_RESULT: "success", GO_RESULT: "success", FRONTEND_RESULT: "success", BROWSER_RESULT: "success" };
+  const success = { CHANGES_RESULT: "success", SHOULD_RUN: "true", PREPARE_RESULT: "success", GO_RESULT: "success", GO_RACE_RESULT: "success", FRONTEND_RESULT: "success", BROWSER_RESULT: "success" };
   const run = env => spawnSync("bash", ["-e", "-c", script], { env: { ...process.env, ...env } }).status;
   assert.equal(run(success), 0);
-  for (const key of ["PREPARE_RESULT", "GO_RESULT", "FRONTEND_RESULT", "BROWSER_RESULT", "CHANGES_RESULT"]) {
+  for (const key of ["PREPARE_RESULT", "GO_RESULT", "GO_RACE_RESULT", "FRONTEND_RESULT", "BROWSER_RESULT", "CHANGES_RESULT"]) {
     for (const value of ["failure", "cancelled", "skipped", ""]) assert.notEqual(run({ ...success, [key]: value }), 0, `${key}=${value}`);
   }
-  assert.equal(run({ ...success, SHOULD_RUN: "false", PREPARE_RESULT: "skipped", GO_RESULT: "skipped", FRONTEND_RESULT: "skipped", BROWSER_RESULT: "skipped" }), 0);
+  assert.equal(run({ ...success, SHOULD_RUN: "false", PREPARE_RESULT: "skipped", GO_RESULT: "skipped", GO_RACE_RESULT: "skipped", FRONTEND_RESULT: "skipped", BROWSER_RESULT: "skipped" }), 0);
   assert.notEqual(run({ ...success, SHOULD_RUN: "false" }), 0);
 });
 

--- a/tools/desktopinventory/sources.go
+++ b/tools/desktopinventory/sources.go
@@ -17,6 +17,7 @@ var ciJobs = map[string]struct {
 	"ci.yml/desktop-browser":                      {classKeepBusiness, "Playwright browser gates unchanged"},
 	"ci.yml/desktop-prepare":                      {classKeepBusiness, "go run . -emit-contract drift gate; pnpm workspace root"},
 	"ci.yml/desktop-go":                           {classKeepBusiness, "hostrpc + module tests; no WebKitGTK toolchain"},
+	"ci.yml/desktop-go-race":                      {classKeepBusiness, "desktop module race sweep, split from desktop-go"},
 	"ci.yml/desktop-macos":                        {classKeepBusiness, "Electron packaging smoke"},
 	"ci.yml/desktop-windows":                      {classKeepBusiness, "Electron packaging smoke"},
 	"ci.yml/desktop-windows-package":              {classKeepBusiness, "Electron installer build, split from the test leg"},


### PR DESCRIPTION
## Summary

Three commits, reviewable separately: a Go build cache that actually refreshes, a memory-soak path filter that stops running for changes it cannot see, and the desktop race sweep running beside the rest of `desktop-go`.

### Commit 1 — restore the newest Go build cache instead of the one frozen at `go.sum`

Every Go job restores setup-go's cache and still recompiles most of the tree. On the Windows desktop leg the root package's tests start **11 minutes** after `go test ./...` begins, with `Cache restored from key` in the log and Defender exclusions in place; ubuntu tests the same module in 1.8 minutes.

**Root cause** — setup-go keys its cache on `go.sum` alone, and GitHub never rewrites an existing cache key. `desktop/go.sum` and `go.sum` last changed on **2026-09-09; 131 commits have landed on `main-v2` since**, so every job restores a snapshot from before all of them and every package they touched — and everything that imports one — misses. The 13 `cache: true` sites had no `restore-keys`, so nothing newer could ever be picked up until a dependency changed.

**Fix** — `.github/actions/go-build-cache` computes a key from the runner, a module namespace, both `go.sum` hashes and the run id, restores by prefix (same `go.sum` first, then any), and exposes the key and the `GOCACHE`/`GOMODCACHE` paths. Every cached setup-go site now sets `cache: false` and uses the action. **One job per OS and module saves, on `main-v2` pushes only**: `test` ×3 (root), `race` (root-race), `desktop-go` / `desktop-macos` / `desktop-windows-go` (desktop), `desktop-go-race` (desktop-race). Pull requests only restore, so the cache stays a few pushes deep instead of churning. Each save is guarded on its restore having run.

**How to read the result** — this PR's own run will *miss* (nothing has been saved under the new keys yet). The merge push saves; the run after that is the first one that can hit. I'll report both.

### Commit 2 — stop running the memory soak for changes that cannot reach it

App memory screening ran its three ~18.5-minute shards — **58 runner-minutes, a ~20-minute wall clock equal to the desktop critical path** — for #10176, which touched only `.github/workflows/ci.yml`, `scripts/`, `tools/` and `docs/`.

`bench/app-memory-paths.mjs` fails closed: anything outside a narrow known-independent list runs the soak. That list covered Go modules, `sdk/`, `site/`, `release-notes/` and Markdown docs, so workflows, repository scripts and tooling, non-Markdown docs, and the Electron shell, packaging and installer trees all counted as "unknown dependency".

The list now also covers `.github/` (`app-memory.yml` is still claimed first), `scripts/`, `tools/`, `workers/`, all of `docs/`, the Go module manifests, `Makefile` and golangci config, and `desktop/electron`, `packaging` and `build`. The soak runs the production frontend against browser mocks, so none of these can change what it measures. `desktop/package.json` and `desktop/pnpm-lock.yaml` deliberately stay unknown: they resolve the frontend's dependencies. The tests move the three examples that used to prove fail-closed into the independent set and keep fail-closed proven with paths that really are unknown.

### Commit 3 — run the desktop race sweep beside the rest of `desktop-go`

`desktop-go` is the second-longest pull-request job at ~11.5 minutes, and `go test -race ./...` is ~7.3 of them, serially after vet, lint, build and the plain test run.

The root module splits its race job into a pull-request subset and a push-time full sweep, but that does not transfer here: the desktop module's concurrency surface *is* its root package, which is nearly all of the cost, and a name-guessed `-run` subset would silently drop coverage. So instead the race step moves into a new `desktop-go-race` job with the same trigger, setup, artifact download and frontend install, running beside `desktop-go`. **What is race-checked does not change.** The `desktop` aggregate gate needs both jobs and checks both results; the job is registered in `tools/desktopinventory` (709 → 710 entries).

## Test plan
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml` — no findings (this also validates the local action's inputs); `bash -n` accepts the composite's script.
- [x] The composite's key script run locally folds both `go.sum` hashes into one 16-hex prefix and resolves both cache directories.
- [x] `node --test desktop/frontend/bench/app-memory-paths.test.mjs` — 4/4.
- [x] The `release workflow contracts` step run locally end to end: actionlint over its workflow list, `node --test scripts/desktop-release-artifacts.test.mjs scripts/ci-workflow.test.mjs scripts/notarize-desktop.test.mjs scripts/windows-go-tests.test.mjs`, `bash scripts/release-workflows.test.sh`, `node scripts/check-single-release-public-contract.mjs` — plus `check-motion-ci-contract.mjs` and `check-desktop-build-contract.mjs`. `ci-workflow.test.mjs` pins the desktop aggregate's children; its fixture now includes `GO_RACE_RESULT` so the "every failed child rejects" contract covers the new job too.
- [x] `go test ./tools/desktopinventory/` passes after regeneration.
- [x] This PR's run: the composite restored with the expected miss (`Cache not found for input keys: go-Linux-X64-root-race-…`), and `desktop-go` / `desktop-go-race` started together. The shards *run* here by design because this diff touches `desktop/frontend/bench/`; the skip proves itself on the next PR that leaves `desktop/frontend/` alone.
- [ ] Merge push: six `actions/cache/save` steps succeed. Following run: `Cache restored from key: go-…` with a materially shorter `test (Windows desktop and update helper)`.

Documentation-impact: updated - docs/desktop-migration/INVENTORY.md and inventory.json are regenerated for the new desktop-go-race CI job (709 -> 710 tracked entries); no prose documentation changes.
