### PR TITLE
fix(desktop): let the packaged startup smoke survive the handshake window swap / 打包启动冒烟不再被握手时的窗口重建打断

### DIFF
--- a/desktop/packaging/smoke.mjs
+++ b/desktop/packaging/smoke.mjs
@@ -81,6 +81,24 @@ async function cleanupAfterFailure() {
   await waitForProcessesToExit(pids);
 }
 
+// Resolves once any live window's app bridge answers Version. A page that is
+// still on the starting page, mid-navigation, or already destroyed throws
+// from evaluate; every such throw is a reason to scan again, not to fail.
+async function appVersion(application, deadline) {
+  let lastError = "no window has exposed window.reasonixDesktop yet";
+  for (;;) {
+    for (const page of application.windows()) {
+      try {
+        return await page.evaluate(() => window.reasonixDesktop.invoke("Version", []));
+      } catch (error) {
+        lastError = error.message;
+      }
+    }
+    if (Date.now() > deadline) throw new Error(`renderer never invoked the production service: ${lastError}`);
+    await sleep(250);
+  }
+}
+
 try {
   const application = await electron.launch({ executablePath: executable, args: [], env, timeout });
   child = application.process();
@@ -103,9 +121,12 @@ try {
     else await sleep(250);
   }
   console.log(`PASS  handshake ready after ${((Date.now() - started) / 1000).toFixed(1)}s: ${ready.line}`);
-  const page = await application.firstWindow({ timeout });
-  await page.waitForFunction(() => Boolean(window.reasonixDesktop), null, { timeout });
-  const version = await page.evaluate(() => window.reasonixDesktop.invoke("Version", []));
+  // MainWindow.prepareApp replaces the starting-page window with a fresh
+  // BrowserWindow once the service reports its geometry, and onReady calls it
+  // right after logging the line polled above. A handle from firstWindow()
+  // taken in that gap is destroyed under us ("Target page, context or browser
+  // has been closed"). Wait for whichever live window answers instead.
+  const version = await appVersion(application, started + timeout);
   const expected = JSON.parse(readFileSync(join(identity.resourcesPath, "build.json"), "utf8")).version;
   if (version === "dev" || version !== expected) throw new Error(`packaged service version ${version} differs from manifest ${expected}`);
   console.log(`PASS  renderer invokes the production service: Version=${version}`);


### PR DESCRIPTION
## Summary

`packaging/smoke.mjs` intermittently fails right after a successful handshake:

```
PASS  handshake ready after 1.8s: desktop service ready: generation g-…, pid …
FAIL  page.waitForFunction: Target page, context or browser has been closed
```

It failed the v1.38.7 release build's `darwin-universal` job (every publisher was skipped; a native rerun of the same package passed the full chain including the renderer `Version` call) and once on `main-v2` today in `desktop-macos`, against four passes since the smoke was added there. A packaged app that starts fine is being reported as one that does not — on the path that gates releases.

**Root cause** — `MainWindow.prepareApp(geometry)` (`desktop/electron/src/main/window.ts:58`) returns early only when the window already shows the app; otherwise it creates a new `BrowserWindow` with the geometry the service reported and **destroys the previous one**. `index.ts` calls it from `onReady` immediately after logging `desktop service ready` — the exact line the smoke polls for. The smoke then takes `application.firstWindow()`, which is the starting-page window whenever the destroy has not landed yet, and waits on that handle. On a fast machine the swap always wins the race; on a loaded runner it sometimes does not. This predates the recent CI changes; #10167 only made it visible on `main-v2` instead of at publication time.

**Fix** — replace the single early handle with a wait on the postcondition: scan `application.windows()` until any live window's bridge answers `Version`, and treat every `evaluate` failure (starting page, mid-navigation, destroyed target) as a reason to scan again until the existing timeout. The hold, liveness and clean-exit assertions after it are unchanged. Only the workflows' *command lines* for the smoke are pinned by `release-workflows.test.sh`; the harness internals are free to change.

## Test plan
- [x] `node --check desktop/packaging/smoke.mjs`; no other reference to the removed page handle remains.
- [x] Run against the published v1.38.7 `Reasonix-darwin-arm64.zip` (SHA256 matches the manifest) on darwin/arm64: handshake, `Version`, hold, and the clean shell/service exit all pass, so the harness is not weakened.
- [ ] The race cannot be forced locally; the fix follows from the shell's window lifecycle. Evidence accrues on `main-v2` pushes (`desktop-macos` → `Smoke-test the packaged macOS startup`) and in the next release build.

Documentation-impact: none - a CI/packaging smoke harness change; no documented product behavior, interface, or release contract changes.
