### PR TITLE
ci: keep the rolling Go cache off Windows and prune it to one per prefix / Windows 不再用滚动 Go 缓存，并按前缀只保留最新一份

### DIFF
--- a/.github/actions/go-build-cache/action.yml
+++ b/.github/actions/go-build-cache/action.yml
@@ -5,7 +5,8 @@ description: >-
   key, so that snapshot freezes at the last dependency change and every package
   touched since misses. This cache is keyed per run and restored by prefix; a
   main-v2 push saves it from one job per OS and module (actions/cache/save with
-  the outputs below), pull requests only restore.
+  the outputs below), pull requests only restore. Windows jobs do not use it:
+  restoring it there measured slower than setup-go's frozen cache.
 
 inputs:
   module:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,12 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: false
+          # Windows keeps setup-go's go.sum-keyed cache: restoring the per-run
+          # cache there measured slower (17m -> 21m, then a 25-minute step
+          # timeout), so the rolling cache serves only the Unix legs.
+          cache: ${{ runner.os == 'Windows' }}
 
-      - if: env.RUN_STEPS == 'true'
+      - if: env.RUN_STEPS == 'true' && runner.os != 'Windows'
         uses: ./.github/actions/go-build-cache
         id: gocache
         with:
@@ -232,7 +235,7 @@ jobs:
       # Only main-v2 pushes save, one job per OS and module, so the cache
       # stays a few pushes deep instead of churning on every pull request.
       - uses: actions/cache/save@v4
-        if: always() && env.RUN_STEPS == 'true' && github.event_name == 'push' && steps.gocache.outputs.key != ''
+        if: always() && env.RUN_STEPS == 'true' && runner.os != 'Windows' && github.event_name == 'push' && steps.gocache.outputs.key != ''
         with:
           path: ${{ steps.gocache.outputs.paths }}
           key: ${{ steps.gocache.outputs.key }}
@@ -251,13 +254,7 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: false
-
-      - if: env.RUN_STEPS == 'true'
-        uses: ./.github/actions/go-build-cache
-        id: gocache
-        with:
-          module: root
+          cache: true
 
       - if: env.RUN_STEPS == 'true'
         uses: actions/setup-node@v7
@@ -304,12 +301,7 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: false
-
-      - uses: ./.github/actions/go-build-cache
-        id: gocache
-        with:
-          module: root
+          cache: true
       - uses: actions/setup-node@v7
         with:
           node-version: "22"
@@ -884,12 +876,8 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: desktop/go.mod
-          cache: false
-
-      - uses: ./.github/actions/go-build-cache
-        id: gocache
-        with:
-          module: desktop
+          cache: true
+          cache-dependency-path: desktop/go.sum
 
       - uses: pnpm/action-setup@v6.1.0
         with:
@@ -994,12 +982,8 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: desktop/go.mod
-          cache: false
-
-      - uses: ./.github/actions/go-build-cache
-        id: gocache
-        with:
-          module: desktop
+          cache: true
+          cache-dependency-path: desktop/go.sum
 
       - uses: pnpm/action-setup@v6.1.0
         with:
@@ -1045,14 +1029,6 @@ jobs:
         timeout-minutes: 2
         run: go test -timeout=60s fyne.io/systray
 
-      # Only main-v2 pushes save, one job per OS and module, so the cache
-      # stays a few pushes deep instead of churning on every pull request.
-      - uses: actions/cache/save@v4
-        if: always() && github.event_name == 'push' && steps.gocache.outputs.key != ''
-        with:
-          path: ${{ steps.gocache.outputs.paths }}
-          key: ${{ steps.gocache.outputs.key }}
-
   # Installer packaging is packaging validation, not a code gate, and it shares
   # no state with the test steps above. It runs beside them instead of after
   # them so the Windows leg's wall time is the longer half rather than the sum,
@@ -1075,12 +1051,8 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: desktop/go.mod
-          cache: false
-
-      - uses: ./.github/actions/go-build-cache
-        id: gocache
-        with:
-          module: desktop
+          cache: true
+          cache-dependency-path: desktop/go.sum
 
       - uses: pnpm/action-setup@v6.1.0
         with:
@@ -1150,6 +1122,38 @@ jobs:
           path: |
             desktop/electron/artifacts/performance/overhead.json
             desktop/electron/artifacts/performance/diagnostic-report.png
+
+  # Every main-v2 push saves one Go cache per Unix OS and module (~2.6 GiB
+  # measured) against a 10 GiB repository limit shared with pnpm, CodeQL and
+  # setup-go caches; two pushes filled it. Keep only the newest cache per
+  # prefix once the savers are done; restore-keys pick the newest anyway.
+  prune-go-cache:
+    needs: [test, race, desktop-go, desktop-go-race, desktop-macos]
+    if: always() && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Keep the newest Go cache per OS and module
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          declare -A seen
+          while read -r id key; do
+            [ -n "$id" ] || continue
+            prefix="${key%-*-*-*}"
+            if [ -n "${seen[$prefix]:-}" ]; then
+              echo "deleting older cache $key"
+              gh api -X DELETE "repos/$GITHUB_REPOSITORY/actions/caches/$id" >/dev/null
+            else
+              seen[$prefix]=1
+              echo "keeping newest cache $key"
+            fi
+          done < <(gh api "repos/$GITHUB_REPOSITORY/actions/caches?per_page=100&sort=created_at&direction=desc" --paginate \
+            --jq '.actions_caches[] | select(.key | startswith("go-")) | "\(.id) \(.key)"')
 
   # repolint scans desktop/ and sdk/ too, so this job also runs for diffs the
   # `code` filter would otherwise skip.


### PR DESCRIPTION
## Summary

Two corrections to the per-run Go cache from #10178, both driven by what it measured on real runs.

### Windows gets slower with it, so Windows goes back to setup-go's cache

With `Cache restored from key: go-Windows-X64-desktop-…` in the log, `test (Windows desktop and update helper)` took **21m06s** on the next pull request and then **hit its 25-minute step timeout** on the next `main-v2` push — against a **17m** baseline with setup-go's frozen cache. The likely mechanism is that the ~300 MiB archive is extracted *before* the Defender exclusion step runs, and Go never caches the link of the cgo-heavy test binary anyway; but the measurement is the decision, and it made `main-v2` red on the release path.

`windows-control`, `windows-isolated`, `desktop-windows`, `desktop-windows-go` and `desktop-windows-package` return to `setup-go` `cache: true` exactly as before #10178 (`desktop-windows-go` also drops its save). The `test` matrix keeps setup-go's cache on Windows (`cache: ${{ runner.os == 'Windows' }}`) and runs the composite and save only on the Unix legs. The composite's description records why.

### The cache filled the repository in two pushes, so it is pruned

Eight saves per push measured **~3.3 GiB**; the repository sat at **9.90 of 10 GiB** with 7.10 GiB of `go-*` keys after two pushes. GitHub evicts LRU past the limit, so the next push would have started evicting the pnpm, CodeQL and setup-go caches other jobs depend on — silently, and against the caches that *did* help.

A push-only `prune-go-cache` job (`permissions: actions: write`, job-scoped) runs after the remaining savers and keeps the newest cache per OS×module prefix, deleting the rest. `restore-keys` already pick the newest, so nothing restorable is lost. Peak `go-*` usage becomes one push's worth, ~2.6 GiB.

### Where that leaves item "warm cache"

Proven restores on Linux and macOS, with modest gains (`desktop-go` 5.0 → 3.8m, `desktop-go-race` 7.8 → 6.7m on PR, not cleanly separable from the parallel split). The Windows 11-minute pre-test cost is **not** a cache problem; the next probe is step-level timing on Windows (`go test -x` / `-ldflags=-v`), not more caching.

## Test plan
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml` — no findings; `bash -n` accepts the prune script; the prefix strip yields `go-Linux-X64-desktop-race` for a real key.
- [x] `node --test scripts/desktop-release-artifacts.test.mjs scripts/ci-workflow.test.mjs scripts/notarize-desktop.test.mjs scripts/windows-go-tests.test.mjs`, `bash scripts/release-workflows.test.sh`, `check-motion-ci-contract.mjs`, `go run ./tools/desktopinventory -check` — all pass.
- [ ] Merge push: `desktop-windows-go` back near its 17m baseline with `setup-go` restoring; `prune-go-cache` logs one `keeping` line per prefix and `deleting` for the rest; `gh api repos/…/actions/caches` totals drop to ~one push of `go-*` keys.

Documentation-impact: none - CI cache placement and retention only; no documented product behavior, interface, or release contract changes.
