### PR TITLE
ci: 精简并分层前端验证 / streamline frontend validation

### DIFF
--- a/.github/CI_PERFORMANCE.md
+++ b/.github/CI_PERFORMANCE.md
@@ -4,12 +4,29 @@
 
 ## Desktop PR checks
 
-`desktop-prepare` regenerates the desktop host contract (failing on drift) and builds the Linux frontend once.
-Its artifact is consumed by independent `desktop-frontend`, `desktop-browser`,
-and `desktop-go` jobs. The existing required `desktop` check aggregates all
-four results, rejects failures/cancellations/unexpected skips, and accepts a
-path-based skip only when the changes detector succeeds. The other native OS
-checks remain separate.
+`scripts/ci-paths.mjs` is the shared path classifier for normal and memory CI.
+It distinguishes frontend, Go, generated protocol, Electron, native and
+packaging inputs. Explicit documentation such as `desktop/AGENTS.md` skips
+build and soak work, while Markdown inside the frontend remains a build input.
+Unknown paths and unavailable diffs fail closed. Pull requests use merge-base
+diffs; pushes use `before..sha`; normal `main-v2` pushes keep the complete
+qualification matrix after the existing release-notes-only exception.
+
+`desktop-prepare` regenerates the desktop host contract (failing on drift) and
+produces the required `electron/stable` and `electron/canary` frontend variants
+once on Linux. Each artifact carries a versioned manifest with checkout,
+workflow attempt, variant, build inputs, toolchain and every `dist` file hash.
+Linux, macOS and Windows consumers verify it before compilation or packaging.
+Explicit reuse fails on a missing, stale or damaged manifest and never falls
+back to a hidden rebuild. Static frontend files are portable; dependencies,
+native modules and Electron binaries are not shared.
+
+The protected `lint` job aggregates `lint-code` and, when selected, the
+complete `desktop-frontend` result. Motion unit tests remain in that frontend
+plan and run once. `desktop-browser-group` runs application/settings, motion
+and Transcript groups with `max-parallel: 2`; the `desktop-browser` summary
+rejects failed, cancelled or unexpected skips. Go-only changes retain protocol
+and native validation without launching browser or memory work.
 
 `node desktop/frontend/scripts/run-ci-tests.mjs --list` prints the unit test
 plan. It expands the existing dedicated scripts and lifecycle hooks, discovers
@@ -17,6 +34,15 @@ new tests, and schedules each TypeScript suite once with its original loader.
 Unsupported script syntax and conflicting explicit invocations fail closed.
 CI runs two isolated processes at a time; the history performance benchmark
 runs alone after them. Local dedicated `pnpm test:*` commands remain available.
+
+## Timing reports
+
+The CI and memory workflow summaries report stage execution without queue time,
+workflow wall time, recorded job queue time and the sum of runner execution.
+Frontend builds, dependency and browser installation, each browser group and
+each memory shard are listed separately. These measurements describe a single
+run; comparisons should use the same candidate and report the median and range
+of three runs so runner variance is visible.
 
 ## Memory screening
 

--- a/.github/CI_PERFORMANCE.zh-CN.md
+++ b/.github/CI_PERFORMANCE.zh-CN.md
@@ -4,16 +4,36 @@
 
 ## Desktop PR 检查
 
-`desktop-prepare` 统一重新生成桌面宿主契约（有漂移即失败）并构建一次 Linux 前端，产物供
-`desktop-frontend`、`desktop-browser`、`desktop-go` 三个独立 job 使用。
-原有 required check `desktop` 汇总这四项结果，拒绝失败、取消和意外跳过；
-只有路径检测成功且判定无关时，才接受各分组跳过。其他原生系统检查保持独立。
+`scripts/ci-paths.mjs` 是普通 CI 与内存 CI 共用的路径判定器，分别识别前端、
+Go、生成协议、Electron、原生平台和打包输入。`desktop/AGENTS.md` 等明确的说明
+文档不会启动构建和长测；前端目录中会进入产品的 Markdown 仍属于构建输入。
+未知路径或无法获得可靠 diff 时保守失败。PR 使用 merge-base 差异，push 使用
+`before..sha`；保留纯 release-notes 例外后，普通 `main-v2` push 仍运行完整验证矩阵。
+
+`desktop-prepare` 重新生成桌面宿主契约（有漂移即失败），并在 Linux 上分别生成一次
+`electron/stable` 与 `electron/canary` 前端。每份产物都带版本化 manifest，记录
+checkout、workflow attempt、变体、构建输入、工具链以及每个 `dist` 文件的摘要。
+Linux、macOS 和 Windows 消费者在编译或打包前校验。显式复用遇到 manifest 缺失、
+过期、身份不符或文件损坏会直接失败，不会暗中重建。跨平台只共享静态前端文件，
+不共享依赖目录、原生模块或 Electron 二进制。
+
+required `lint` 汇总 `lint-code` 和路径要求执行时的完整 `desktop-frontend` 结果。
+动画单测保留在统一前端计划中且只执行一次。`desktop-browser-group` 将应用与设置、
+动画、Transcript 分为三个矩阵组，`max-parallel: 2`；`desktop-browser` 汇总拒绝失败、
+取消和意外跳过。仅修改 Go 时继续执行协议和原生验证，不启动浏览器或内存长测。
 
 `node desktop/frontend/scripts/run-ci-tests.mjs --list` 可以查看单测清单。
 它展开原有专用脚本和生命周期钩子，自动发现新增测试，并保留每个 TypeScript
 测试原有的 loader，每个套件只执行一次。未知命令语法或冲突调用会直接失败。
 CI 同时运行两个隔离进程，历史性能基准在它们结束后单独运行。
 本地仍可使用原有的 `pnpm test:*` 专用命令。
+
+## 耗时报告
+
+普通 CI 与内存工作流的 Summary 会分别显示不含排队的阶段执行时间、工作流总等待、
+已记录的 job 排队时间之和及 runner 执行时长之和。前端构建、依赖与浏览器安装、
+各浏览器分组和每个内存 shard 单独列出。单次数据只描述该次运行；对比应针对同一
+候选各重复三次，并报告中位数和范围，避免把 runner 波动当作收益。
 
 ## 内存筛查
 

--- a/.github/workflows/app-memory.yml
+++ b/.github/workflows/app-memory.yml
@@ -21,7 +21,7 @@ jobs:
   changes:
     runs-on: ubuntu-22.04
     outputs:
-      run: ${{ steps.paths.outputs.run }}
+      memory: ${{ steps.paths.outputs.memory }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -33,17 +33,21 @@ jobs:
       - id: paths
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "$GITHUB_EVENT_NAME" != pull_request ]; then
-            echo 'run=true' >> "$GITHUB_OUTPUT"
+          args=(--head "$EXPECTED_SOURCE_SHA" --github-output "$GITHUB_OUTPUT" --summary "$GITHUB_STEP_SUMMARY")
+          if [ "$EVENT_NAME" = workflow_dispatch ]; then
+            args+=(--full)
+          elif [ "$EVENT_NAME" = pull_request ]; then
+            args+=(--base "$BASE_SHA" --mode pull_request)
           else
-            git diff --name-only -z "$BASE_SHA...$EXPECTED_SOURCE_SHA" > "$RUNNER_TEMP/memory-paths"
-            node desktop/frontend/bench/app-memory-paths.mjs "$RUNNER_TEMP/memory-paths" >> "$GITHUB_OUTPUT"
+            args+=(--base "$BASE_SHA" --mode push)
           fi
+          node scripts/ci-paths.mjs "${args[@]}"
 
   prepare:
     needs: changes
-    if: needs.changes.outputs.run == 'true'
+    if: needs.changes.outputs.memory == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     defaults:
@@ -128,7 +132,7 @@ jobs:
       - name: Verify all prerequisite jobs
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
-          SHOULD_RUN: ${{ needs.changes.outputs.run }}
+          SHOULD_RUN: ${{ needs.changes.outputs.memory }}
           PREPARE_RESULT: ${{ needs.prepare.result }}
           SHARD_RESULT: ${{ needs.shard.result }}
         run: |
@@ -142,31 +146,31 @@ jobs:
             test "$SHARD_RESULT" = skipped
           fi
       - uses: actions/checkout@v7
-        if: needs.changes.outputs.run == 'true'
+        if: needs.changes.outputs.memory == 'true'
         with:
           ref: ${{ env.EXPECTED_SOURCE_SHA }}
       - uses: actions/setup-node@v7
-        if: needs.changes.outputs.run == 'true'
+        if: needs.changes.outputs.memory == 'true'
         with:
           node-version: "24"
       - uses: actions/download-artifact@v8
-        if: needs.changes.outputs.run == 'true'
+        if: needs.changes.outputs.memory == 'true'
         with:
           pattern: app-memory-shard-*-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/app-memory-reports
       - uses: actions/download-artifact@v8
-        if: needs.changes.outputs.run == 'true'
+        if: needs.changes.outputs.memory == 'true'
         with:
           name: app-memory-build-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/app-memory-build
       - name: Verify same-build complete protocol
-        if: needs.changes.outputs.run == 'true'
+        if: needs.changes.outputs.memory == 'true'
         run: |
           node desktop/frontend/bench/app-memory-aggregate.mjs \
             "$RUNNER_TEMP/app-memory-reports" "$RUNNER_TEMP/app-memory-build/identity.json" \
             "$RUNNER_TEMP/app-memory-report.json" "$EXPECTED_SOURCE_SHA"
       - uses: actions/upload-artifact@v7
-        if: success() && needs.changes.outputs.run == 'true'
+        if: success() && needs.changes.outputs.memory == 'true'
         with:
           name: app-memory-aggregate-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/app-memory-report.json

--- a/.github/workflows/app-memory.yml
+++ b/.github/workflows/app-memory.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -66,9 +67,11 @@ jobs:
           node-version: "24"
           cache: pnpm
           cache-dependency-path: desktop/pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
+      - name: Install memory dependencies
+        run: pnpm install --frozen-lockfile
       - run: node --test bench/app-memory-shards.test.mjs bench/app-memory-paths.test.mjs bench/app-memory-timing.test.mjs
-      - run: pnpm build
+      - name: Build memory frontend
+        run: pnpm build
       - run: node bench/app-memory-prepare.mjs "$RUNNER_TEMP/app-memory-build"
       - uses: actions/upload-artifact@v7
         with:
@@ -102,8 +105,10 @@ jobs:
           node-version: "24"
           cache: pnpm
           cache-dependency-path: desktop/pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm exec playwright install --with-deps chromium
+      - name: Install memory dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install browser runtimes
+        run: pnpm exec playwright install --with-deps chromium
       - uses: actions/download-artifact@v8
         with:
           name: app-memory-build-${{ github.run_id }}-${{ github.run_attempt }}
@@ -176,3 +181,20 @@ jobs:
           path: ${{ runner.temp }}/app-memory-report.json
           if-no-files-found: error
           retention-days: 7
+      - uses: actions/checkout@v7
+        if: always() && needs.changes.outputs.memory == 'true'
+        with:
+          ref: ${{ env.EXPECTED_SOURCE_SHA }}
+          path: .ci-metrics-source
+      - name: Summarize memory timing
+        if: always() && needs.changes.outputs.memory == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > "$RUNNER_TEMP/memory-run.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?filter=latest&per_page=100" > "$RUNNER_TEMP/memory-jobs.json"
+          node .ci-metrics-source/scripts/ci-timings.mjs \
+            --run "$RUNNER_TEMP/memory-run.json" \
+            --jobs "$RUNNER_TEMP/memory-jobs.json" \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --title "App memory timing"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       desktop: ${{ steps.filter.outputs.desktop }}
+      desktop_go: ${{ steps.filter.outputs.desktop_go }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      browser: ${{ steps.filter.outputs.browser }}
+      memory: ${{ steps.filter.outputs.memory }}
+      electron: ${{ steps.filter.outputs.electron }}
+      native: ${{ steps.filter.outputs.native }}
+      packaging: ${{ steps.filter.outputs.packaging }}
       site: ${{ steps.filter.outputs.site }}
       sdk: ${{ steps.filter.outputs.sdk }}
       notes_only: ${{ steps.filter.outputs.notes_only }}
@@ -35,37 +42,24 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
       - id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          code=true; desktop=true; site=true; sdk=true; notes_only=false
-          base=""
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            base="${{ github.event.pull_request.base.sha }}"
-          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-            base="${{ github.event.before }}"
+          args=(--head "$HEAD_SHA" --github-output "$GITHUB_OUTPUT" --summary "$GITHUB_STEP_SUMMARY")
+          if [ "$EVENT_NAME" = pull_request ]; then
+            args+=(--base "$BASE_SHA" --mode pull_request)
+          else
+            # Main pushes retain the complete qualification matrix after the
+            # existing release-notes-only exception is evaluated.
+            args+=(--base "$BASE_SHA" --mode push --full)
           fi
-          if [ -n "$base" ] && git cat-file -e "$base^{commit}" 2>/dev/null; then
-            files=$(git diff --name-only "$base" HEAD)
-            if [ -n "$files" ]; then
-              code=false; desktop=false; site=false; sdk=false
-              # Root-module CI: desktop/ is a separate module, so only the
-              # clearly unrelated paths below can skip it.
-              if echo "$files" | grep -qvE '^(docs/|site/|release-notes/|desktop/|workers/|[^/]+\.md$)'; then code=true; fi
-              # desktop/ imports the root kernel via `replace reasonix => ../`,
-              # so only this clearly-unrelated set is safe to skip.
-              if echo "$files" | grep -qvE '^(docs/|site/|release-notes/|workers/|benchmarks/|npm/|[^/]+\.md$)'; then desktop=true; fi
-              if echo "$files" | grep -q '^site/'; then site=true; fi
-              # sdk/go is a nested module invisible to root `go test ./...`;
-              # its DTOs are generated from internal/extension/protocol, so
-              # both paths must trigger the sdk job.
-              if echo "$files" | grep -qE '^(sdk/|internal/extension/)'; then sdk=true; fi
-              # A push that touches only release-notes/ carries the parent's code
-              # byte for byte. Its heavy jobs skip; scripts/verify-release-push-ci.sh
-              # then requires the nearest ancestor that changed code to be green.
-              if ! echo "$files" | grep -qvE '^release-notes/'; then notes_only=true; fi
-            fi
-          fi
-          { echo "code=$code"; echo "desktop=$desktop"; echo "site=$site"; echo "sdk=$sdk"; echo "notes_only=$notes_only"; } >> "$GITHUB_OUTPUT"
+          node scripts/ci-paths.mjs "${args[@]}"
 
   # The ruleset requires the per-OS check names (test (ubuntu-latest) etc.).
   # A matrix job skipped at job level reports no per-leg checks at all, so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,7 +467,10 @@ jobs:
       - name: Verify desktop validation jobs
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
-          SHOULD_RUN: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false' }}
+          PREPARE_REQUIRED: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false' }}
+          NATIVE_REQUIRED: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.native != 'false' }}
+          FRONTEND_REQUIRED: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.frontend != 'false' || needs.changes.outputs.electron != 'false' }}
+          BROWSER_REQUIRED: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.browser != 'false' }}
           PREPARE_RESULT: ${{ needs.desktop-prepare.result }}
           GO_RESULT: ${{ needs.desktop-go.result }}
           GO_RACE_RESULT: ${{ needs.desktop-go-race.result }}
@@ -475,17 +478,16 @@ jobs:
           BROWSER_RESULT: ${{ needs.desktop-browser.result }}
         run: |
           test "$CHANGES_RESULT" = success
-          expected=skipped
-          if [ "$SHOULD_RUN" = true ]; then expected=success; fi
-          test "$PREPARE_RESULT" = "$expected"
-          test "$GO_RESULT" = "$expected"
-          test "$GO_RACE_RESULT" = "$expected"
-          test "$FRONTEND_RESULT" = "$expected"
-          test "$BROWSER_RESULT" = "$expected"
+          expected() { if [ "$1" = true ]; then echo success; else echo skipped; fi; }
+          test "$PREPARE_RESULT" = "$(expected "$PREPARE_REQUIRED")"
+          test "$GO_RESULT" = "$(expected "$NATIVE_REQUIRED")"
+          test "$GO_RACE_RESULT" = "$(expected "$NATIVE_REQUIRED")"
+          test "$FRONTEND_RESULT" = "$(expected "$FRONTEND_REQUIRED")"
+          test "$BROWSER_RESULT" = "$(expected "$BROWSER_REQUIRED")"
 
   desktop-frontend:
     needs: [changes, desktop-prepare]
-    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.frontend != 'false' || needs.changes.outputs.electron != 'false')
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -525,10 +527,15 @@ jobs:
           REASONIX_TEST_CONCURRENCY: "2"
         run: node frontend/scripts/run-ci-tests.mjs
 
-  desktop-browser:
+  desktop-browser-group:
     needs: [changes, desktop-prepare]
-    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.browser != 'false')
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        group: [app-settings, motion, transcript]
     defaults:
       run:
         working-directory: desktop
@@ -556,13 +563,57 @@ jobs:
             --pnpm-version "$(pnpm --version)"
       - name: Install browser runtimes
         run: PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend exec playwright install --with-deps chromium
-      - name: Test desktop browser contracts
+      - name: Test desktop browser group
+        env:
+          BROWSER_GROUP: ${{ matrix.group }}
+          REASONIX_LAYOUT_ARTIFACTS: ${{ runner.temp }}/desktop-browser/${{ matrix.group }}/layout
         run: |
-          pnpm --dir frontend test:motion-browser
-          PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend test:app-browser
-          PLAYWRIGHT_BROWSERS_PATH=.pw-browsers REASONIX_SETTINGS_BROWSERS=chromium pnpm --dir frontend test:settings-browser
-          xvfb-run -a env REASONIX_TRANSCRIPT_NATIVE_THUMB=1 pnpm --dir frontend test:transcript-browser
-          REASONIX_TRANSCRIPT_READER_BROWSERS=chromium PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend test:transcript-reader-browser
+          set -o pipefail
+          evidence="$RUNNER_TEMP/desktop-browser/$BROWSER_GROUP"
+          mkdir -p "$evidence"
+          case "$BROWSER_GROUP" in
+            app-settings)
+              PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend test:app-browser
+              PLAYWRIGHT_BROWSERS_PATH=.pw-browsers REASONIX_SETTINGS_BROWSERS=chromium pnpm --dir frontend test:settings-browser
+              ;;
+            motion)
+              pnpm --dir frontend test:motion-browser
+              ;;
+            transcript)
+              xvfb-run -a env PLAYWRIGHT_BROWSERS_PATH=.pw-browsers REASONIX_TRANSCRIPT_NATIVE_THUMB=1 pnpm --dir frontend test:transcript-browser
+              REASONIX_TRANSCRIPT_READER_BROWSERS=chromium PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend test:transcript-reader-browser
+              ;;
+            *) exit 2 ;;
+          esac 2>&1 | tee "$evidence/run.log"
+
+      - name: Upload browser group evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: desktop-browser-${{ matrix.group }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/desktop-browser/${{ matrix.group }}
+          if-no-files-found: ignore
+          retention-days: 7
+
+  desktop-browser:
+    needs: [changes, desktop-prepare, desktop-browser-group]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify desktop browser groups
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          SHOULD_RUN: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.browser != 'false' }}
+          PREPARE_RESULT: ${{ needs.desktop-prepare.result }}
+          GROUP_RESULT: ${{ needs.desktop-browser-group.result }}
+        run: |
+          test "$CHANGES_RESULT" = success
+          if [ "$SHOULD_RUN" = true ]; then
+            test "$PREPARE_RESULT" = success
+            test "$GROUP_RESULT" = success
+          else
+            test "$GROUP_RESULT" = skipped
+          fi
 
   desktop-prepare:
     needs: changes
@@ -681,7 +732,7 @@ jobs:
 
   desktop-go:
     needs: [changes, desktop-prepare]
-    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.native != 'false')
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -752,7 +803,7 @@ jobs:
   # changing what is race-checked.
   desktop-go-race:
     needs: [changes, desktop-prepare]
-    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.native != 'false')
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -811,7 +862,7 @@ jobs:
   # compile or exercise the native PTY and FSEvents implementations.
   desktop-macos:
     needs: [changes, desktop-prepare]
-    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.native != 'false')
     runs-on: macos-latest
     defaults:
       run:
@@ -938,7 +989,7 @@ jobs:
   # run on the ubuntu leg above.
   desktop-windows:
     needs: [changes, desktop-prepare]
-    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.native != 'false')
     runs-on: windows-latest
     # A hung native step must not hold the workflow's concurrency group for the
     # six-hour default. This bounds hangs, not duration: the leg's own spread on
@@ -1054,7 +1105,7 @@ jobs:
   # the sum, and a Go flake reruns only this job.
   desktop-windows-go:
     needs: [changes, desktop-prepare]
-    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.native != 'false')
     runs-on: windows-latest
     # Measured 17.1-17.3 minutes on three consecutive main-v2 runs; bound
     # hangs, not duration.
@@ -1338,16 +1389,18 @@ jobs:
           LINT_CODE_REQUIRED: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.code != 'false' || needs.changes.outputs.desktop != 'false' || needs.changes.outputs.sdk != 'false' }}
           FRONTEND_RESULT: ${{ needs.desktop-frontend.result }}
           PREPARE_RESULT: ${{ needs.desktop-prepare.result }}
-          FRONTEND_REQUIRED: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.frontend != 'false' }}
+          FRONTEND_REQUIRED: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.frontend != 'false' || needs.changes.outputs.electron != 'false' }}
         run: |
           test "$CHANGES_RESULT" = success
           lint_expected=skipped
           if [ "$LINT_CODE_REQUIRED" = true ]; then lint_expected=success; fi
           test "$LINT_CODE_RESULT" = "$lint_expected"
-          frontend_expected=skipped
-          if [ "$FRONTEND_REQUIRED" = true ]; then frontend_expected=success; fi
-          test "$PREPARE_RESULT" = "$frontend_expected"
-          test "$FRONTEND_RESULT" = "$frontend_expected"
+          if [ "$FRONTEND_REQUIRED" = true ]; then
+            test "$PREPARE_RESULT" = success
+            test "$FRONTEND_RESULT" = success
+          else
+            test "$FRONTEND_RESULT" = skipped
+          fi
 
   # The site/ auth client has security-sensitive redirect-validation logic
   # (safeNext) covered by node:test unit tests. Those tests use only Node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,10 +504,14 @@ jobs:
       - run: pnpm --dir frontend install --frozen-lockfile
       - uses: actions/download-artifact@v8
         with:
-          name: ${{ needs.desktop-prepare.outputs.artifact_name }}
-          path: desktop/frontend/dist
-      - name: Verify frontend artifact layout
-        run: test -f frontend/dist/index.html
+          name: ${{ needs.desktop-prepare.outputs.stable_artifact_name }}
+          path: desktop/frontend
+      - name: Verify stable frontend artifact
+        run: |
+          node frontend/scripts/artifact-identity.mjs verify \
+            --shell electron --channel stable \
+            --source-sha "$(git rev-parse HEAD)" --run-id "$GITHUB_RUN_ID" --attempt "$GITHUB_RUN_ATTEMPT" \
+            --pnpm-version "$(pnpm --version)"
       - name: Verify CI test coverage and runner
         run: node --test frontend/scripts/ci-test-plan.test.mjs
       - name: Check the Electron shell
@@ -542,10 +546,14 @@ jobs:
       - run: pnpm --dir frontend install --frozen-lockfile
       - uses: actions/download-artifact@v8
         with:
-          name: ${{ needs.desktop-prepare.outputs.artifact_name }}
-          path: desktop/frontend/dist
-      - name: Verify frontend artifact layout
-        run: test -f frontend/dist/index.html
+          name: ${{ needs.desktop-prepare.outputs.stable_artifact_name }}
+          path: desktop/frontend
+      - name: Verify stable frontend artifact
+        run: |
+          node frontend/scripts/artifact-identity.mjs verify \
+            --shell electron --channel stable \
+            --source-sha "$(git rev-parse HEAD)" --run-id "$GITHUB_RUN_ID" --attempt "$GITHUB_RUN_ATTEMPT" \
+            --pnpm-version "$(pnpm --version)"
       - name: Install browser runtimes
         run: PLAYWRIGHT_BROWSERS_PATH=.pw-browsers pnpm --dir frontend exec playwright install --with-deps chromium
       - name: Test desktop browser contracts
@@ -560,7 +568,8 @@ jobs:
     needs: changes
     if: always() && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
     outputs:
-      artifact_name: desktop-frontend-${{ github.run_id }}-${{ github.run_attempt }}
+      stable_artifact_name: desktop-frontend-stable-${{ github.run_id }}-${{ github.run_attempt }}
+      canary_artifact_name: desktop-frontend-canary-${{ github.run_id }}-${{ github.run_attempt }}
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -617,16 +626,56 @@ jobs:
             exit 1
           fi
 
-      - name: Build frontend
+      - name: Build stable frontend
         run: |
           pnpm --dir frontend install --frozen-lockfile
           pnpm --dir frontend build:electron
 
+      - name: Record stable frontend artifact identity
+        run: |
+          node frontend/scripts/artifact-identity.mjs create \
+            --shell electron \
+            --channel stable \
+            --source-sha "$(git rev-parse HEAD)" \
+            --run-id "$GITHUB_RUN_ID" \
+            --attempt "$GITHUB_RUN_ATTEMPT" \
+            --pnpm-version "$(pnpm --version)"
+
       - uses: actions/upload-artifact@v7
         with:
-          name: desktop-frontend-${{ github.run_id }}-${{ github.run_attempt }}
+          name: desktop-frontend-stable-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             desktop/frontend/dist
+            desktop/frontend/.reasonix-frontend-artifact.json
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 3
+
+      # Static checks ran in the stable build. The canary variant still gets a
+      # fresh Vite build and bundle-budget validation because its embedded
+      # channel is part of the shipped bytes.
+      - name: Build canary frontend
+        env:
+          REASONIX_CHANNEL: canary
+        run: node frontend/scripts/build-for-shell.mjs electron --bundle-only
+
+      - name: Record canary frontend artifact identity
+        run: |
+          node frontend/scripts/artifact-identity.mjs create \
+            --shell electron \
+            --channel canary \
+            --source-sha "$(git rev-parse HEAD)" \
+            --run-id "$GITHUB_RUN_ID" \
+            --attempt "$GITHUB_RUN_ATTEMPT" \
+            --pnpm-version "$(pnpm --version)"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: desktop-frontend-canary-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            desktop/frontend/dist
+            desktop/frontend/.reasonix-frontend-artifact.json
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 3
 
@@ -663,10 +712,14 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: ${{ needs.desktop-prepare.outputs.artifact_name }}
-          path: desktop/frontend/dist
-      - name: Verify frontend artifact layout
-        run: test -f frontend/dist/index.html
+          name: ${{ needs.desktop-prepare.outputs.stable_artifact_name }}
+          path: desktop/frontend
+      - name: Verify stable frontend artifact
+        run: |
+          node frontend/scripts/artifact-identity.mjs verify \
+            --shell electron --channel stable \
+            --source-sha "$(git rev-parse HEAD)" --run-id "$GITHUB_RUN_ID" --attempt "$GITHUB_RUN_ATTEMPT" \
+            --pnpm-version "$(pnpm --version)"
       - run: pnpm --dir frontend install --frozen-lockfile
 
       - name: vet
@@ -730,10 +783,14 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: ${{ needs.desktop-prepare.outputs.artifact_name }}
-          path: desktop/frontend/dist
-      - name: Verify frontend artifact layout
-        run: test -f frontend/dist/index.html
+          name: ${{ needs.desktop-prepare.outputs.stable_artifact_name }}
+          path: desktop/frontend
+      - name: Verify stable frontend artifact
+        run: |
+          node frontend/scripts/artifact-identity.mjs verify \
+            --shell electron --channel stable \
+            --source-sha "$(git rev-parse HEAD)" --run-id "$GITHUB_RUN_ID" --attempt "$GITHUB_RUN_ATTEMPT" \
+            --pnpm-version "$(pnpm --version)"
       - run: pnpm --dir frontend install --frozen-lockfile
 
       # The extension work added new shared-state paths to the desktop
@@ -753,8 +810,8 @@ jobs:
   # desktop/ is a separate module, so the root macOS matrix above does not
   # compile or exercise the native PTY and FSEvents implementations.
   desktop-macos:
-    needs: changes
-    if: always() && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
+    needs: [changes, desktop-prepare]
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
     runs-on: macos-latest
     defaults:
       run:
@@ -783,10 +840,17 @@ jobs:
           cache: pnpm
           cache-dependency-path: desktop/pnpm-lock.yaml
 
-      - name: Build frontend
+      - run: pnpm --dir frontend install --frozen-lockfile
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.desktop-prepare.outputs.stable_artifact_name }}
+          path: desktop/frontend
+      - name: Verify stable frontend artifact
         run: |
-          pnpm --dir frontend install --frozen-lockfile
-          pnpm --dir frontend build:electron
+          node frontend/scripts/artifact-identity.mjs verify \
+            --shell electron --channel stable \
+            --source-sha "$(git rev-parse HEAD)" --run-id "$GITHUB_RUN_ID" --attempt "$GITHUB_RUN_ATTEMPT" \
+            --pnpm-version "$(pnpm --version)"
 
       - name: Test integrated terminal, PTY, and FSEvents lifecycle
         run: go test -race -run 'Test(DarwinWorkspaceWatcher|WorkspaceChangeHub|ResolveTerminal|Terminal|EmptyTerminal|UnixTerminalProcess)' .
@@ -820,12 +884,33 @@ jobs:
       # release pipeline packages again anyway), and let pull requests stop
       # after the lint step. Ad-hoc signs (no Apple secrets in CI) and skips
       # the DMG.
+      - name: Remove stable frontend before canary packaging
+        if: github.event_name != 'pull_request'
+        run: rm -rf frontend/dist frontend/.reasonix-frontend-artifact.json
+
+      - uses: actions/download-artifact@v8
+        if: github.event_name != 'pull_request'
+        with:
+          name: ${{ needs.desktop-prepare.outputs.canary_artifact_name }}
+          path: desktop/frontend
+
+      - name: Verify canary frontend artifact
+        if: github.event_name != 'pull_request'
+        run: |
+          node frontend/scripts/artifact-identity.mjs verify \
+            --shell electron --channel canary \
+            --source-sha "$(git rev-parse HEAD)" --run-id "$GITHUB_RUN_ID" --attempt "$GITHUB_RUN_ATTEMPT" \
+            --pnpm-version "$(pnpm --version)"
+
       - name: Package Electron app and verify bundle members
         if: github.event_name != 'pull_request'
         timeout-minutes: 25
         env:
           DESKTOP_BUILD_SKIP_DMG: "1"
+          REASONIX_PACKAGE_REUSE_FRONTEND: "1"
         run: |
+          REASONIX_FRONTEND_PNPM_VERSION="$(pnpm --version)"
+          export REASONIX_FRONTEND_PNPM_VERSION
           ../scripts/desktop-build.sh darwin/arm64 v0.0.0-ci canary
           node packaging/verify.mjs ../dist/Reasonix-darwin-arm64.zip
 
@@ -852,8 +937,8 @@ jobs:
   # regression tests for that contract are named *OnWindows and can never
   # run on the ubuntu leg above.
   desktop-windows:
-    needs: changes
-    if: always() && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
+    needs: [changes, desktop-prepare]
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
     runs-on: windows-latest
     # A hung native step must not hold the workflow's concurrency group for the
     # six-hour default. This bounds hangs, not duration: the leg's own spread on
@@ -903,12 +988,16 @@ jobs:
             }
           }
 
-      # go:embed of frontend/dist needs a built frontend before the package
-      # compiles, same as the ubuntu desktop leg.
-      - name: Build frontend
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.desktop-prepare.outputs.canary_artifact_name }}
+          path: desktop/frontend
+      - name: Verify canary frontend artifact
         run: |
-          pnpm --dir frontend install --frozen-lockfile
-          pnpm --dir frontend build:electron
+          node frontend/scripts/artifact-identity.mjs verify \
+            --shell electron --channel canary \
+            --source-sha "$(git rev-parse HEAD)" --run-id "$GITHUB_RUN_ID" --attempt "$GITHUB_RUN_ATTEMPT" \
+            --pnpm-version "$(pnpm --version)"
 
       # test:motion, test:transcript-browser and test:settings-browser run on
       # ubuntu (desktop-frontend and desktop-browser). They were repeated here
@@ -920,7 +1009,11 @@ jobs:
       # layout. package.mjs builds the frontend itself (build:electron flavor).
       - name: Package Electron shell for native startup smoke
         timeout-minutes: 15
+        env:
+          REASONIX_PACKAGE_REUSE_FRONTEND: "1"
         run: |
+          REASONIX_FRONTEND_PNPM_VERSION="$(pnpm --version)"
+          export REASONIX_FRONTEND_PNPM_VERSION
           pnpm install --frozen-lockfile
           go build -trimpath -ldflags "-s -w -X main.version=v0.0.0-ci -X main.channel=canary" -o build/bin/reasonix-desktop.exe .
           node packaging/package.mjs windows/amd64 v0.0.0-ci canary
@@ -960,8 +1053,8 @@ jobs:
   # the Electron steps makes the leg's wall time the longer half rather than
   # the sum, and a Go flake reruns only this job.
   desktop-windows-go:
-    needs: changes
-    if: always() && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
+    needs: [changes, desktop-prepare]
+    if: always() && needs.desktop-prepare.result == 'success' && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.desktop != 'false')
     runs-on: windows-latest
     # Measured 17.1-17.3 minutes on three consecutive main-v2 runs; bound
     # hangs, not duration.
@@ -1006,12 +1099,16 @@ jobs:
             }
           }
 
-      # go:embed of frontend/dist needs a built frontend before the package
-      # compiles; the electron flavour is what the shell ships.
-      - name: Build frontend
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.desktop-prepare.outputs.stable_artifact_name }}
+          path: desktop/frontend
+      - name: Verify stable frontend artifact
         run: |
-          pnpm --dir frontend install --frozen-lockfile
-          pnpm --dir frontend build:electron
+          node frontend/scripts/artifact-identity.mjs verify \
+            --shell electron --channel stable \
+            --source-sha "$(git rev-parse HEAD)" --run-id "$GITHUB_RUN_ID" --attempt "$GITHUB_RUN_ATTEMPT" \
+            --pnpm-version "$(pnpm --version)"
 
       - name: test (Windows desktop and update helper)
         # 17 minutes measured, ~11 of them before the first test runs; the
@@ -1029,8 +1126,8 @@ jobs:
   # and so a packaging failure costs a short rerun instead of the whole leg.
   # Pushes to main-v2 only: the release pipeline builds installers again anyway.
   desktop-windows-package:
-    needs: changes
-    if: always() && (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true')
+    needs: [changes, desktop-prepare]
+    if: always() && needs.desktop-prepare.result == 'success' && (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true')
     runs-on: windows-latest
     # Packaging measured 13m55s; the overhead benchmark and its workspace
     # install add about six more. Bound hangs, not duration.
@@ -1075,19 +1172,28 @@ jobs:
             }
           }
 
-      # go:embed of frontend/dist needs a built frontend before the package
-      # compiles, same as the test leg.
-      - name: Build frontend
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.desktop-prepare.outputs.canary_artifact_name }}
+          path: desktop/frontend
+      - name: Verify canary frontend artifact
         run: |
-          pnpm --dir frontend install --frozen-lockfile
-          pnpm --dir frontend build:electron
+          node frontend/scripts/artifact-identity.mjs verify \
+            --shell electron --channel canary \
+            --source-sha "$(git rev-parse HEAD)" --run-id "$GITHUB_RUN_ID" --attempt "$GITHUB_RUN_ATTEMPT" \
+            --pnpm-version "$(pnpm --version)"
 
       - name: Install NSIS
         run: pwsh -NoProfile -File ../scripts/install-nsis.ps1
 
       - name: Build Windows installer and portable archive
         timeout-minutes: 20
-        run: ../scripts/desktop-build.sh windows/amd64 v0.0.0-ci canary
+        env:
+          REASONIX_PACKAGE_REUSE_FRONTEND: "1"
+        run: |
+          REASONIX_FRONTEND_PNPM_VERSION="$(pnpm --version)"
+          export REASONIX_FRONTEND_PNPM_VERSION
+          ../scripts/desktop-build.sh windows/amd64 v0.0.0-ci canary
 
       - name: Verify packaged Windows artifacts
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,7 +503,8 @@ jobs:
           node-version: "24"
           cache: pnpm
           cache-dependency-path: desktop/pnpm-lock.yaml
-      - run: pnpm --dir frontend install --frozen-lockfile
+      - name: Install frontend dependencies
+        run: pnpm --dir frontend install --frozen-lockfile
       - uses: actions/download-artifact@v8
         with:
           name: ${{ needs.desktop-prepare.outputs.stable_artifact_name }}
@@ -550,7 +551,8 @@ jobs:
           node-version: "24"
           cache: pnpm
           cache-dependency-path: desktop/pnpm-lock.yaml
-      - run: pnpm --dir frontend install --frozen-lockfile
+      - name: Install frontend dependencies
+        run: pnpm --dir frontend install --frozen-lockfile
       - uses: actions/download-artifact@v8
         with:
           name: ${{ needs.desktop-prepare.outputs.stable_artifact_name }}
@@ -677,10 +679,11 @@ jobs:
             exit 1
           fi
 
+      - name: Install frontend dependencies
+        run: pnpm --dir frontend install --frozen-lockfile
+
       - name: Build stable frontend
-        run: |
-          pnpm --dir frontend install --frozen-lockfile
-          pnpm --dir frontend build:electron
+        run: pnpm --dir frontend build:electron
 
       - name: Record stable frontend artifact identity
         run: |
@@ -771,7 +774,8 @@ jobs:
             --shell electron --channel stable \
             --source-sha "$(git rev-parse HEAD)" --run-id "$GITHUB_RUN_ID" --attempt "$GITHUB_RUN_ATTEMPT" \
             --pnpm-version "$(pnpm --version)"
-      - run: pnpm --dir frontend install --frozen-lockfile
+      - name: Install frontend dependencies
+        run: pnpm --dir frontend install --frozen-lockfile
 
       - name: vet
         run: go vet ./...
@@ -842,7 +846,8 @@ jobs:
             --shell electron --channel stable \
             --source-sha "$(git rev-parse HEAD)" --run-id "$GITHUB_RUN_ID" --attempt "$GITHUB_RUN_ATTEMPT" \
             --pnpm-version "$(pnpm --version)"
-      - run: pnpm --dir frontend install --frozen-lockfile
+      - name: Install frontend dependencies
+        run: pnpm --dir frontend install --frozen-lockfile
 
       # The extension work added new shared-state paths to the desktop
       # runtime (tab/rebuild fences, extension UI). Race-sweep the module so
@@ -891,7 +896,8 @@ jobs:
           cache: pnpm
           cache-dependency-path: desktop/pnpm-lock.yaml
 
-      - run: pnpm --dir frontend install --frozen-lockfile
+      - name: Install frontend dependencies
+        run: pnpm --dir frontend install --frozen-lockfile
       - uses: actions/download-artifact@v8
         with:
           name: ${{ needs.desktop-prepare.outputs.stable_artifact_name }}
@@ -1273,6 +1279,27 @@ jobs:
           path: |
             desktop/electron/artifacts/performance/overhead.json
             desktop/electron/artifacts/performance/diagnostic-report.png
+
+  ci-metrics:
+    needs: [desktop, desktop-macos, desktop-windows, desktop-windows-go, desktop-windows-package]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Summarize queue, execution and stage timing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > "$RUNNER_TEMP/ci-run.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?filter=latest&per_page=100" > "$RUNNER_TEMP/ci-jobs.json"
+          node scripts/ci-timings.mjs \
+            --run "$RUNNER_TEMP/ci-run.json" \
+            --jobs "$RUNNER_TEMP/ci-jobs.json" \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --title "Frontend CI timing"
 
   # Every main-v2 push saves one Go cache per Unix OS and module (~2.6 GiB
   # measured) against a 10 GiB repository limit shared with pnpm, CodeQL and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1151,7 +1151,7 @@ jobs:
 
   # repolint scans desktop/ and sdk/ too, so this job also runs for diffs the
   # `code` filter would otherwise skip.
-  lint:
+  lint-code:
     needs: changes
     if: always() && ((github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.code != 'false' || needs.changes.outputs.desktop != 'false' || needs.changes.outputs.sdk != 'false')
     runs-on: ubuntu-latest
@@ -1167,25 +1167,6 @@ jobs:
         id: gocache
         with:
           module: root
-
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false'
-        uses: pnpm/action-setup@v6.1.0
-        with:
-          version: 10
-          run_install: false
-
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false'
-        uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-          cache: pnpm
-          cache-dependency-path: desktop/pnpm-lock.yaml
-
-      - name: required native motion contracts
-        if: github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false'
-        run: |
-          pnpm --dir desktop/frontend install --frozen-lockfile
-          pnpm --dir desktop/frontend test:motion
 
       - name: repo standards
         run: go run ./tools/repolint
@@ -1235,6 +1216,32 @@ jobs:
           node --test scripts/desktop-release-artifacts.test.mjs scripts/ci-workflow.test.mjs scripts/notarize-desktop.test.mjs scripts/windows-go-tests.test.mjs
           bash scripts/release-workflows.test.sh
           node scripts/check-single-release-public-contract.mjs
+
+  # `lint` is a protected check name. Keep it as the fail-closed aggregate so
+  # frontend unit coverage can run once in desktop-frontend without weakening
+  # the branch gate.
+  lint:
+    needs: [changes, lint-code, desktop-prepare, desktop-frontend]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify lint and frontend validation jobs
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          LINT_CODE_RESULT: ${{ needs.lint-code.result }}
+          LINT_CODE_REQUIRED: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.code != 'false' || needs.changes.outputs.desktop != 'false' || needs.changes.outputs.sdk != 'false' }}
+          FRONTEND_RESULT: ${{ needs.desktop-frontend.result }}
+          PREPARE_RESULT: ${{ needs.desktop-prepare.result }}
+          FRONTEND_REQUIRED: ${{ (github.event_name != 'pull_request' && needs.changes.outputs.notes_only != 'true') || needs.changes.outputs.frontend != 'false' }}
+        run: |
+          test "$CHANGES_RESULT" = success
+          lint_expected=skipped
+          if [ "$LINT_CODE_REQUIRED" = true ]; then lint_expected=success; fi
+          test "$LINT_CODE_RESULT" = "$lint_expected"
+          frontend_expected=skipped
+          if [ "$FRONTEND_REQUIRED" = true ]; then frontend_expected=success; fi
+          test "$PREPARE_RESULT" = "$frontend_expected"
+          test "$FRONTEND_RESULT" = "$frontend_expected"
 
   # The site/ auth client has security-sensitive redirect-validation logic
   # (safeNext) covered by node:test unit tests. Those tests use only Node

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ mem.prof
 /desktop/desktop
 /desktop/frontend/dist/*
 !/desktop/frontend/dist/.gitkeep
+/desktop/frontend/.reasonix-frontend-artifact.json
 /desktop/frontend/sourcemaps/
 /desktop/electron/dist/
 

--- a/desktop/frontend/bench/app-memory-paths.mjs
+++ b/desktop/frontend/bench/app-memory-paths.mjs
@@ -1,23 +1,5 @@
-import { readFileSync } from "node:fs";
-import { pathToFileURL } from "node:url";
+import { classifyPaths } from "../../../scripts/ci-paths.mjs";
 
-// The soak runs the production frontend against browser mocks. These source
-// trees cannot enter that build; native/backend behavior has separate gates.
-// Paths that cannot reach the mock-hosted frontend bundle the soak measures:
-// Go modules, CLI/SDK/site sources, docs and notes, repository tooling and
-// workflows (app-memory.yml is claimed above), and the Electron shell,
-// packaging and installer trees the browser-mocked soak never loads. The
-// desktop workspace manifests (desktop/package.json, desktop/pnpm-lock.yaml)
-// stay unknown on purpose: they resolve the frontend's dependencies.
-const knownIndependent = /^(?:internal\/|cmd\/|sdk\/|site\/|release-notes\/|docs\/|scripts\/|tools\/|workers\/|\.github\/|go\.(?:mod|sum)$|Makefile$|\.golangci[^/]*$|desktop\/(?:[^/]+\.go$|go\.(?:mod|sum)$|cmd\/|internal\/|electron\/|packaging\/|build\/))/;
 export function memoryAffected(files) {
-  return files.some(file => {
-    if (file.startsWith("desktop/frontend/") || file === ".github/workflows/app-memory.yml") return true;
-    if (knownIndependent.test(file) || /^[^/]+\.md$/.test(file)) return false;
-    return true; // Unknown dependency or workflow changes fail closed.
-  });
-}
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const files = readFileSync(process.argv[2], "utf8").split("\0").filter(Boolean);
-  console.log(`run=${memoryAffected(files)}`);
+  return classifyPaths(files).flags.memory;
 }

--- a/desktop/frontend/bench/app-memory-paths.test.mjs
+++ b/desktop/frontend/bench/app-memory-paths.test.mjs
@@ -6,10 +6,10 @@ test("all frontend consumers, configuration and tests trigger the soak", () => {
     assert.equal(memoryAffected([path]), true, path);
 });
 test("known independent backend and documentation changes skip only this mock frontend soak", () => {
-  assert.equal(memoryAffected(["internal/control/turn.go", "desktop/app.go", "sdk/types.ts", "docs/guide.md", "README.md"]), false);
+  assert.equal(memoryAffected(["internal/control/turn.go", "desktop/app.go", "sdk/types.ts", "docs/guide.md", "README.md", "desktop/AGENTS.md"]), false);
 });
 test("repository tooling, workflows and the Electron shell do not reach the browser-mocked bundle", () => {
-  for (const path of [".github/workflows/ci.yml", ".github/actions/go-build-cache/action.yml", "scripts/release-stable.sh", "tools/desktopinventory/sources.go",
+  for (const path of [".github/actions/go-build-cache/action.yml", "scripts/release-stable.sh", "tools/desktopinventory/sources.go",
     "workers/crash-report/src/index.ts", "docs/desktop-migration/inventory.json", "desktop/electron/src/main/dialogs.ts", "desktop/packaging/smoke.mjs",
     "desktop/build/windows/installer/project.nsi", "desktop/go.sum", "go.mod", ".golangci.yml", "Makefile"])
     assert.equal(memoryAffected([path]), false, path);

--- a/desktop/frontend/scripts/artifact-identity.mjs
+++ b/desktop/frontend/scripts/artifact-identity.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const FRONTEND_ARTIFACT_SCHEMA = 1;
+
+function sha256(parts) {
+  const hash = createHash("sha256");
+  for (const part of parts) hash.update(part);
+  return hash.digest("hex");
+}
+
+function git(root, args, options = {}) {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8", ...options }).trim();
+}
+
+function filesBelow(directory, relative = "") {
+  const out = [];
+  for (const entry of readdirSync(path.join(directory, relative), { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const name = path.posix.join(relative.replaceAll("\\", "/"), entry.name);
+    if (entry.isDirectory()) out.push(...filesBelow(directory, name));
+    else out.push(name);
+  }
+  return out;
+}
+
+export function distIdentity(dist) {
+  const files = filesBelow(dist).map(name => {
+    const content = readFileSync(path.join(dist, name));
+    return { name, size: content.length, sha256: sha256([content]) };
+  });
+  return { sha256: sha256(files.flatMap(file => [file.name, "\0", file.sha256, "\0"])), files };
+}
+
+export function buildInputIdentity(root) {
+  const names = git(root, ["ls-files", "-z", "--", "desktop/package.json", "desktop/pnpm-lock.yaml", "desktop/pnpm-workspace.yaml", "desktop/frontend"])
+    .split("\0").filter(name => name && !name.startsWith("desktop/frontend/dist/")).sort();
+  return {
+    // Git blobs are the portable source identity. Reading checkout bytes here
+    // would make a Windows CRLF checkout disagree with the Linux producer.
+    sha256: sha256(names.flatMap(name => [name, "\0", execFileSync("git", ["-C", root, "show", `HEAD:${name}`]), "\0"])),
+    files: names,
+  };
+}
+
+function required(value, name) {
+  if (!String(value ?? "").trim()) throw new Error(`${name} is required`);
+  return String(value).trim();
+}
+
+export function createFrontendArtifact({ root, dist, manifest, shell, channel, sourceSHA, runId, attempt, pnpmVersion }) {
+  const actualSHA = git(root, ["rev-parse", "HEAD"]);
+  const expectedSHA = required(sourceSHA, "source SHA");
+  if (expectedSHA !== actualSHA) throw new Error(`source SHA mismatch: expected ${expectedSHA}, checkout is ${actualSHA}`);
+  if (!statSync(dist).isDirectory()) throw new Error(`frontend dist is not a directory: ${dist}`);
+  const body = {
+    schemaVersion: FRONTEND_ARTIFACT_SCHEMA,
+    sourceSHA: actualSHA,
+    workflow: { runId: required(runId, "run ID"), attempt: required(attempt, "run attempt") },
+    variant: { shell: required(shell, "shell"), channel: required(channel, "channel") },
+    toolchain: { node: process.version, pnpm: required(pnpmVersion, "pnpm version"), platform: process.platform, arch: process.arch },
+    inputs: buildInputIdentity(root),
+    dist: distIdentity(dist),
+  };
+  writeFileSync(manifest, JSON.stringify(body, null, 2) + "\n");
+  return body;
+}
+
+export function verifyFrontendArtifact({ root, dist, manifest, shell, channel, sourceSHA, runId, attempt, pnpmVersion }) {
+  let body;
+  try {
+    body = JSON.parse(readFileSync(manifest, "utf8"));
+  } catch (error) {
+    throw new Error(`frontend artifact manifest is unavailable or invalid: ${error.message}`);
+  }
+  const expected = {
+    schemaVersion: FRONTEND_ARTIFACT_SCHEMA,
+    sourceSHA: sourceSHA || git(root, ["rev-parse", "HEAD"]),
+    shell,
+    channel,
+    runId,
+    attempt,
+    node: process.version,
+    pnpm: pnpmVersion,
+  };
+  const actual = {
+    schemaVersion: body.schemaVersion,
+    sourceSHA: body.sourceSHA,
+    shell: body.variant?.shell,
+    channel: body.variant?.channel,
+    runId: body.workflow?.runId,
+    attempt: body.workflow?.attempt,
+    node: body.toolchain?.node,
+    pnpm: body.toolchain?.pnpm,
+  };
+  for (const [name, value] of Object.entries(expected)) {
+    if (value !== undefined && String(actual[name]) !== String(value))
+      throw new Error(`frontend artifact ${name} mismatch: expected ${value}, got ${actual[name]}`);
+  }
+  const inputs = buildInputIdentity(root);
+  if (body.inputs?.sha256 !== inputs.sha256) throw new Error("frontend artifact build inputs do not match this checkout");
+  const built = distIdentity(dist);
+  if (body.dist?.sha256 !== built.sha256 || JSON.stringify(body.dist.files) !== JSON.stringify(built.files))
+    throw new Error("frontend artifact contents do not match its manifest");
+  return body;
+}
+
+function parseArgs(argv) {
+  const args = { command: argv[0] };
+  for (let i = 1; i < argv.length; i += 2) {
+    if (!argv[i]?.startsWith("--") || argv[i + 1] === undefined) throw new Error(`invalid argument ${argv[i] ?? ""}`);
+    args[argv[i].slice(2).replaceAll("-", "_")] = argv[i + 1];
+  }
+  return args;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const root = path.resolve(args.root ?? path.join(path.dirname(fileURLToPath(import.meta.url)), "../../.."));
+    const options = {
+      root,
+      dist: path.resolve(args.dist ?? path.join(root, "desktop/frontend/dist")),
+      manifest: path.resolve(args.manifest ?? path.join(root, "desktop/frontend/.reasonix-frontend-artifact.json")),
+      shell: args.shell,
+      channel: args.channel,
+      sourceSHA: args.source_sha,
+      runId: args.run_id,
+      attempt: args.attempt,
+      pnpmVersion: args.pnpm_version ?? execFileSync("pnpm", ["--version"], { encoding: "utf8" }).trim(),
+    };
+    const result = args.command === "create" ? createFrontendArtifact(options)
+      : args.command === "verify" ? verifyFrontendArtifact(options)
+        : (() => { throw new Error("command must be create or verify"); })();
+    console.log(`frontend artifact ${args.command}: ${result.sourceSHA} ${result.variant.shell}/${result.variant.channel} ${result.dist.sha256}`);
+  } catch (error) {
+    console.error(`artifact-identity: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/desktop/frontend/scripts/artifact-identity.test.mjs
+++ b/desktop/frontend/scripts/artifact-identity.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createFrontendArtifact, verifyFrontendArtifact } from "./artifact-identity.mjs";
+
+function fixture(t) {
+  const root = mkdtempSync(path.join(os.tmpdir(), "reasonix-frontend-artifact-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  for (const dir of ["desktop/frontend/src", "desktop/frontend/dist"]) mkdirSync(path.join(root, dir), { recursive: true });
+  for (const [name, value] of [["desktop/package.json", "{}"], ["desktop/pnpm-lock.yaml", "lock"],
+    ["desktop/frontend/package.json", "{}"], ["desktop/frontend/src/App.tsx", "export {}"], ["desktop/frontend/dist/index.html", "ok"]])
+    writeFileSync(path.join(root, name), value);
+  execFileSync("git", ["init"], { cwd: root });
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "fixture"], { cwd: root });
+  const sourceSHA = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  const options = { root, dist: path.join(root, "desktop/frontend/dist"), manifest: path.join(root, "manifest.json"),
+    shell: "electron", channel: "stable", sourceSHA, runId: "12", attempt: "3", pnpmVersion: "10.0.0" };
+  createFrontendArtifact(options);
+  return options;
+}
+
+test("matching artifact verifies across producer platforms", t => {
+  const options = fixture(t);
+  const body = verifyFrontendArtifact(options);
+  body.toolchain.platform = body.toolchain.platform === "linux" ? "darwin" : "linux";
+  body.toolchain.arch = "other";
+  writeFileSync(options.manifest, JSON.stringify(body));
+  assert.equal(verifyFrontendArtifact(options).sourceSHA, options.sourceSHA);
+  writeFileSync(path.join(options.root, "desktop/frontend/src/App.tsx"), "export {}\r\n");
+  assert.equal(verifyFrontendArtifact(options).sourceSHA, options.sourceSHA);
+});
+
+test("variant, workflow and toolchain identity mismatches fail", t => {
+  const options = fixture(t);
+  for (const changed of [{ shell: "browser" }, { channel: "canary" }, { runId: "13" }, { attempt: "4" }, { pnpmVersion: "10.1.0" }])
+    assert.throws(() => verifyFrontendArtifact({ ...options, ...changed }), /mismatch/);
+});
+
+test("changed build input, dist, missing and old manifests fail", t => {
+  const options = fixture(t);
+  const body = verifyFrontendArtifact(options);
+  body.inputs.sha256 = "0".repeat(64);
+  writeFileSync(options.manifest, JSON.stringify(body));
+  assert.throws(() => verifyFrontendArtifact(options), /build inputs/);
+  createFrontendArtifact(options);
+  writeFileSync(path.join(options.dist, "index.html"), "changed");
+  assert.throws(() => verifyFrontendArtifact(options), /contents/);
+  writeFileSync(options.manifest, JSON.stringify({ schemaVersion: 0 }));
+  assert.throws(() => verifyFrontendArtifact(options), /schemaVersion mismatch/);
+  assert.throws(() => verifyFrontendArtifact({ ...options, manifest: path.join(options.root, "missing.json") }), /unavailable/);
+});

--- a/desktop/frontend/scripts/build-for-shell.mjs
+++ b/desktop/frontend/scripts/build-for-shell.mjs
@@ -2,12 +2,24 @@
 // Runs the frontend build for one shell. The shell name travels through the
 // environment because npm scripts cannot set variables portably on Windows.
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { shellFromEnv } from "./shell-css.mjs";
 
 const shell = shellFromEnv({ REASONIX_SHELL: process.argv[2] ?? "" });
-const result = spawnSync("pnpm", ["build"], {
-  stdio: "inherit",
-  env: { ...process.env, REASONIX_SHELL: shell },
-  shell: process.platform === "win32",
-});
-process.exit(result.status ?? 1);
+const frontend = fileURLToPath(new URL("..", import.meta.url));
+const bundleOnly = process.argv.includes("--bundle-only");
+const commands = bundleOnly
+  ? [["exec", "vite", "build"], ["exec", "node", "scripts/check-bundle-budget.mjs"]]
+  : [["build"]];
+let status = 0;
+for (const args of commands) {
+  const result = spawnSync("pnpm", args, {
+    cwd: frontend,
+    stdio: "inherit",
+    env: { ...process.env, REASONIX_SHELL: shell },
+    shell: process.platform === "win32",
+  });
+  status = result.status ?? 1;
+  if (status !== 0) break;
+}
+process.exit(status);

--- a/desktop/frontend/scripts/check-motion-ci-contract.mjs
+++ b/desktop/frontend/scripts/check-motion-ci-contract.mjs
@@ -23,11 +23,14 @@ function jobBody(name) {
 
 for (const [job, body, command] of [
   ["desktop-frontend", jobBody("desktop-frontend"), "node frontend/scripts/run-ci-tests.mjs"],
-  ["required lint", jobBody("lint", "site"), "pnpm --dir desktop/frontend test:motion"],
+  ["required lint", jobBody("lint"), "FRONTEND_RESULT: ${{ needs.desktop-frontend.result }}"],
 ]) {
   if (!body.includes(command)) {
     throw new Error(`motion-ci-contract: ${job} must run test:motion`);
   }
+}
+if (jobBody("lint-code").includes("test:motion") || jobBody("lint").includes("test:motion")) {
+  throw new Error("motion-ci-contract: test:motion must run only through the deduplicated frontend plan");
 }
 
 const windowsJob = jobBody("desktop-windows", "lint");

--- a/desktop/frontend/scripts/check-motion-ci-contract.mjs
+++ b/desktop/frontend/scripts/check-motion-ci-contract.mjs
@@ -136,7 +136,7 @@ if (motionScript.includes("transcript-virtualization.test.tsx")) {
 
 const motionBrowserCommand = "pnpm --dir frontend test:motion-browser";
 const motionBrowserRuns = workflow.match(/pnpm --dir frontend test:motion-browser(?:\s|$)/g)?.length ?? 0;
-if (!jobBody("desktop-browser").includes(motionBrowserCommand) || motionBrowserRuns !== 1) {
+if (!jobBody("desktop-browser-group").includes(motionBrowserCommand) || motionBrowserRuns !== 1) {
   throw new Error("motion-ci-contract: the Linux browser job must run test:motion-browser exactly once");
 }
 if (!packageJSON.scripts?.["test:motion-browser"]?.includes("approval-animation.mjs")) {
@@ -195,7 +195,7 @@ if (/transition-duration/.test(globalReducedMotion[1])) {
 if (!ciUnitScripts.includes("test:motion") || !ciUnitScripts.includes("test:transcript")) {
   throw new Error("motion-ci-contract: Linux CI must include all dedicated motion and transcript suites");
 }
-const desktopLinuxJob = jobBody("desktop-browser");
+const desktopLinuxJob = jobBody("desktop-browser-group");
 
 const transcriptBrowserCommand = "pnpm --dir frontend test:transcript-browser";
 const transcriptBrowserRuns = desktopLinuxJob.match(/pnpm --dir frontend test:transcript-browser(?:\s|$)/g)?.length ?? 0;

--- a/desktop/packaging/package.mjs
+++ b/desktop/packaging/package.mjs
@@ -24,6 +24,7 @@ import {
   versionTag,
   walkFiles,
 } from "./lib.mjs";
+import { verifyFrontendArtifact } from "../frontend/scripts/artifact-identity.mjs";
 
 const desktop = dirname(dirname(fileURLToPath(import.meta.url)));
 const repo = dirname(desktop);
@@ -52,7 +53,20 @@ function require(path, what) {
 }
 
 const frontendDist = join(desktop, "frontend", "dist");
-if (process.env.REASONIX_PACKAGE_REUSE_FRONTEND === "1" && existsSync(join(frontendDist, "index.html"))) {
+if (process.env.REASONIX_PACKAGE_REUSE_FRONTEND === "1") {
+  const pnpmVersion = (process.env.REASONIX_FRONTEND_PNPM_VERSION ?? "").trim();
+  if (!pnpmVersion) throw new Error("REASONIX_FRONTEND_PNPM_VERSION is required when reusing a frontend artifact");
+  verifyFrontendArtifact({
+    root: repo,
+    dist: frontendDist,
+    manifest: process.env.REASONIX_FRONTEND_ARTIFACT_MANIFEST || join(desktop, "frontend", ".reasonix-frontend-artifact.json"),
+    shell: "electron",
+    channel,
+    sourceSHA: process.env.GITHUB_SHA || undefined,
+    runId: process.env.GITHUB_RUN_ID || undefined,
+    attempt: process.env.GITHUB_RUN_ATTEMPT || undefined,
+    pnpmVersion,
+  });
   console.log(`==> reusing ${frontendDist}`);
 } else {
   console.log(`==> frontend build:electron (channel ${channel})`);

--- a/docs/desktop-migration/INVENTORY.md
+++ b/docs/desktop-migration/INVENTORY.md
@@ -15,8 +15,8 @@ Every entry carries one class: `keep-business` keeps its Go implementation and c
 | persistence | 11 | 0 | 0 | 11 |
 | shell-file | 1 | 39 | 4 | 44 |
 | artifact | 5 | 0 | 0 | 5 |
-| ci-job | 23 | 0 | 0 | 23 |
-| **all** | | | | **710** |
+| ci-job | 24 | 0 | 0 | 24 |
+| **all** | | | | **711** |
 
 ## Desktop commands (Go `App` methods bound to the UI)
 
@@ -760,6 +760,7 @@ Every entry carries one class: `keep-business` keeps its Go implementation and c
 | `app-memory.yml/shard` |  | .github/workflows/app-memory.yml | keep-business (保留业务实现) | browser memory screening unchanged |
 | `ci.yml/desktop` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | aggregate gate, unchanged |
 | `ci.yml/desktop-browser` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | Playwright browser gates unchanged |
+| `ci.yml/desktop-browser-group` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | Playwright browser gates split into bounded groups |
 | `ci.yml/desktop-frontend` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | React gates unchanged |
 | `ci.yml/desktop-go` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | hostrpc + module tests; no WebKitGTK toolchain |
 | `ci.yml/desktop-go-race` |  | .github/workflows/ci.yml | keep-business (保留业务实现) | desktop module race sweep, split from desktop-go |

--- a/docs/desktop-migration/inventory.json
+++ b/docs/desktop-migration/inventory.json
@@ -5407,6 +5407,13 @@
     },
     {
       "kind": "ci-job",
+      "name": "ci.yml/desktop-browser-group",
+      "location": ".github/workflows/ci.yml",
+      "class": "keep-business",
+      "owner": "Playwright browser gates split into bounded groups"
+    },
+    {
+      "kind": "ci-job",
       "name": "ci.yml/desktop-frontend",
       "location": ".github/workflows/ci.yml",
       "class": "keep-business",

--- a/scripts/check-desktop-build-contract.mjs
+++ b/scripts/check-desktop-build-contract.mjs
@@ -38,7 +38,7 @@ assert.ok(
   "desktop/wails.json must be retired with the Wails shell",
 );
 
-for (const jobName of ["desktop-prepare", "desktop-go", "desktop-frontend", "desktop-browser", "desktop-macos", "desktop-windows"]) {
+for (const jobName of ["desktop-prepare", "desktop-go", "desktop-frontend", "desktop-browser-group", "desktop-macos", "desktop-windows"]) {
   assert.deepEqual(nodeVersions(jobBody(ciWorkflow, jobName)), ["24"]);
 }
 

--- a/scripts/ci-paths.mjs
+++ b/scripts/ci-paths.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, readFileSync } from "node:fs";
+
+const ZERO_SHA = /^0{40}$/;
+const ROOT_DOC = /^[^/]+\.md$/;
+const DESKTOP_DOC = /^(?:desktop\/(?:AGENTS|README)\.md|desktop\/electron\/README\.md|desktop\/third_party\/systray\/PATCHES\.md)$/;
+const ROOT_UNRELATED = /^(?:docs\/|site\/|release-notes\/|desktop\/|workers\/)/;
+const KNOWN_INDEPENDENT = /^(?:docs\/|site\/|release-notes\/|workers\/|benchmarks\/|npm\/|sdk\/|\.github\/|tools\/|scripts\/)/;
+const ROOT_TOOLING = /^(?:Makefile|\.golangci[^/]*)$/;
+const FRONTEND = /^desktop\/frontend\//;
+const DESKTOP_MANIFEST = /^(?:desktop\/(?:package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|\.npmrc)|desktop\/frontend\/(?:package\.json|pnpm-lock\.yaml|vite\.config\.[cm]?[jt]s|tsconfig[^/]*\.json))$/;
+const ELECTRON = /^(?:desktop\/electron\/|desktop\/(?:package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$)/;
+const PACKAGING = /^(?:desktop\/(?:packaging\/|build\/)|scripts\/(?:desktop-build|package-windows-desktop|install-nsis)\b)/;
+const DESKTOP_GO = /^(?:desktop\/(?:[^/]+\.go|go\.(?:mod|sum)|cmd\/|internal\/)|internal\/|cmd\/|go\.(?:mod|sum)$)/;
+const SDK = /^(?:sdk\/|internal\/extension\/)/;
+const CI_CONTROL = /^(?:\.github\/workflows\/(?:ci|app-memory)\.yml|scripts\/ci-paths(?:\.test)?\.mjs)$/;
+
+const FLAG_NAMES = ["code", "desktop", "desktop_go", "frontend", "browser", "memory", "electron", "native", "packaging", "site", "sdk", "notes_only"];
+
+function normalized(path) {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function setReason(reasons, flag, path, reason) {
+  if (!reasons[flag]) reasons[flag] = [];
+  reasons[flag].push(`${path} (${reason})`);
+}
+
+export function classifyPaths(input, { full = false } = {}) {
+  const files = [...new Set(input.map(normalized).filter(Boolean))].sort();
+  const flags = Object.fromEntries(FLAG_NAMES.map(name => [name, false]));
+  const reasons = {};
+  const notesOnly = files.length > 0 && files.every(path => path.startsWith("release-notes/"));
+  if (full && notesOnly) {
+    flags.notes_only = true;
+    setReason(reasons, "notes_only", "event", "release-notes-only push exception");
+    return { files, flags, reasons, unknown: [] };
+  }
+  if (full) {
+    for (const name of FLAG_NAMES) flags[name] = name !== "notes_only";
+    for (const name of FLAG_NAMES.filter(name => name !== "notes_only")) setReason(reasons, name, "event", "full validation");
+    return { files, flags, reasons, unknown: [] };
+  }
+  flags.notes_only = notesOnly;
+  const unknown = [];
+  for (const path of files) {
+    const explicitDoc = ROOT_DOC.test(path) || DESKTOP_DOC.test(path);
+    if (path.startsWith("site/")) {
+      flags.site = true;
+      setReason(reasons, "site", path, "site source");
+    }
+    if (SDK.test(path)) {
+      flags.sdk = true;
+      setReason(reasons, "sdk", path, "SDK or generated protocol source");
+    }
+    if (CI_CONTROL.test(path)) {
+      for (const flag of ["desktop_go", "frontend", "browser", "memory", "electron", "native", "packaging"]) {
+        flags[flag] = true;
+        setReason(reasons, flag, path, "CI routing contract");
+      }
+    }
+    if (!ROOT_UNRELATED.test(path) && !ROOT_DOC.test(path)) {
+      flags.code = true;
+      setReason(reasons, "code", path, "root module input");
+    }
+    if (explicitDoc || ROOT_TOOLING.test(path) || (KNOWN_INDEPENDENT.test(path) && !PACKAGING.test(path))) continue;
+
+    const frontend = FRONTEND.test(path) || DESKTOP_MANIFEST.test(path);
+    const electron = ELECTRON.test(path);
+    const packaging = PACKAGING.test(path);
+    const desktopGo = DESKTOP_GO.test(path);
+    if (frontend) {
+      for (const flag of ["frontend", "browser", "memory"]) {
+        flags[flag] = true;
+        setReason(reasons, flag, path, "frontend build input");
+      }
+    }
+    if (electron) {
+      flags.electron = true;
+      setReason(reasons, "electron", path, "Electron shell input");
+    }
+    if (packaging) {
+      flags.packaging = true;
+      setReason(reasons, "packaging", path, "packaging input");
+    }
+    if (desktopGo) {
+      flags.desktop_go = true;
+      setReason(reasons, "desktop_go", path, "Desktop or shared Go input");
+    }
+    if (!(frontend || electron || packaging || desktopGo)) unknown.push(path);
+  }
+  if (unknown.length > 0) {
+    for (const flag of ["code", "desktop_go", "frontend", "browser", "memory", "electron", "native", "packaging"]) {
+      flags[flag] = true;
+      for (const path of unknown) setReason(reasons, flag, path, "unknown path; fail closed");
+    }
+  }
+  flags.native ||= flags.desktop_go || flags.frontend || flags.electron || flags.packaging;
+  if (flags.native && !reasons.native) setReason(reasons, "native", "derived", "Desktop integration input");
+  flags.desktop = flags.native || flags.browser;
+  if (flags.desktop) setReason(reasons, "desktop", "derived", "one or more Desktop surfaces changed");
+  return { files, flags, reasons, unknown };
+}
+
+export function changedFiles({ base, head = "HEAD", mode = "pull_request", cwd = process.cwd() }) {
+  if (!base || ZERO_SHA.test(base) || !head || ZERO_SHA.test(head)) throw new Error("a non-zero base and head SHA are required");
+  for (const sha of [base, head]) execFileSync("git", ["cat-file", "-e", `${sha}^{commit}`], { cwd, stdio: "ignore" });
+  const range = mode === "pull_request" ? `${base}...${head}` : `${base}..${head}`;
+  return execFileSync("git", ["diff", "--name-only", "-z", range], { cwd, encoding: "utf8" }).split("\0").filter(Boolean);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--full") args.full = true;
+    else if (argv[i].startsWith("--")) args[argv[i].slice(2).replaceAll("-", "_")] = argv[++i];
+    else throw new Error(`unexpected argument ${argv[i]}`);
+  }
+  return args;
+}
+
+function summary(result) {
+  const lines = ["## CI path decision", "", "| Surface | Run | Trigger |", "| --- | --- | --- |"];
+  for (const name of FLAG_NAMES) lines.push(`| ${name} | ${result.flags[name]} | ${(result.reasons[name] ?? ["none"]).join("<br>")} |`);
+  lines.push("", `Changed files: ${result.files.length}`, "", ...result.files.map(path => `- \`${path}\``));
+  return lines.join("\n") + "\n";
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    let files;
+    if (args.files) files = readFileSync(args.files, "utf8").split("\0").filter(Boolean);
+    else if (args.full && !args.base) files = [];
+    else files = changedFiles({ base: args.base, head: args.head, mode: args.mode });
+    const result = classifyPaths(files, { full: args.full });
+    const output = Object.entries(result.flags).map(([key, value]) => `${key}=${value}\n`).join("");
+    if (args.github_output) appendFileSync(args.github_output, output);
+    else process.stdout.write(output);
+    if (args.summary) appendFileSync(args.summary, summary(result));
+  } catch (error) {
+    console.error(`ci-paths: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci-paths.test.mjs
+++ b/scripts/ci-paths.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { changedFiles, classifyPaths } from "./ci-paths.mjs";
+
+test("explicit documentation skips build surfaces", () => {
+  for (const path of ["README.md", "docs/guide.md", "desktop/AGENTS.md", "desktop/README.md", "desktop/electron/README.md"]) {
+    const { flags, unknown } = classifyPaths([path]);
+    assert.equal(flags.desktop, false, path);
+    assert.equal(flags.memory, false, path);
+    assert.deepEqual(unknown, [], path);
+  }
+});
+
+test("frontend inputs select frontend, browser, memory and native validation", () => {
+  for (const path of ["desktop/frontend/src/App.tsx", "desktop/frontend/public/help.md", "desktop/frontend/vite.config.ts", "desktop/pnpm-lock.yaml"]) {
+    const { flags } = classifyPaths([path]);
+    for (const name of ["desktop", "frontend", "browser", "memory", "native"]) assert.equal(flags[name], true, `${path}: ${name}`);
+  }
+});
+
+test("Go, Electron and packaging inputs stay on their owning surfaces", () => {
+  let flags = classifyPaths(["internal/control/controller.go"]).flags;
+  assert.equal(flags.code, true);
+  assert.equal(flags.desktop_go, true);
+  assert.equal(flags.frontend, false);
+  assert.equal(flags.memory, false);
+  flags = classifyPaths(["desktop/electron/src/main/window.ts"]).flags;
+  assert.equal(flags.electron, true);
+  assert.equal(flags.frontend, false);
+  flags = classifyPaths(["desktop/packaging/package.mjs"]).flags;
+  assert.equal(flags.packaging, true);
+  assert.equal(flags.browser, false);
+});
+
+test("mixed changes cannot hide affected work and unknown paths fail closed", () => {
+  let result = classifyPaths(["README.md", "desktop/frontend/src/App.tsx"]);
+  assert.equal(result.flags.memory, true);
+  result = classifyPaths(["shared/new-loader.js"]);
+  assert.deepEqual(result.unknown, ["shared/new-loader.js"]);
+  for (const name of ["code", "desktop", "frontend", "browser", "memory", "electron", "native", "packaging"])
+    assert.equal(result.flags[name], true, name);
+});
+
+test("release notes and full events are deterministic", () => {
+  assert.equal(classifyPaths(["release-notes/v1.md"]).flags.notes_only, true);
+  const notesPush = classifyPaths(["release-notes/v1.md"], { full: true }).flags;
+  assert.equal(notesPush.notes_only, true);
+  assert.equal(notesPush.desktop, false);
+  assert.equal(classifyPaths([]).flags.desktop, false);
+  const full = classifyPaths([], { full: true }).flags;
+  assert.equal(full.notes_only, false);
+  for (const name of ["code", "desktop", "frontend", "browser", "memory", "electron", "native", "packaging", "site", "sdk"])
+    assert.equal(full[name], true, name);
+});
+
+test("push and merge-base diffs retain deletions and renames", t => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "reasonix-ci-paths-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  mkdirSync(path.join(root, "desktop/frontend/src"), { recursive: true });
+  writeFileSync(path.join(root, "desktop/frontend/src/old.ts"), "old");
+  writeFileSync(path.join(root, "desktop/frontend/src/delete.ts"), "delete");
+  execFileSync("git", ["init"], { cwd: root });
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "base"], { cwd: root });
+  const base = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  execFileSync("git", ["mv", "desktop/frontend/src/old.ts", "desktop/frontend/src/new.ts"], { cwd: root });
+  execFileSync("git", ["rm", "desktop/frontend/src/delete.ts"], { cwd: root });
+  execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-am", "change"], { cwd: root });
+  const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  const push = changedFiles({ base, head, mode: "push", cwd: root });
+  const pull = changedFiles({ base, head, mode: "pull_request", cwd: root });
+  for (const files of [push, pull]) {
+    assert.ok(files.includes("desktop/frontend/src/delete.ts"));
+    assert.ok(files.includes("desktop/frontend/src/new.ts"));
+    assert.equal(classifyPaths(files).flags.memory, true);
+  }
+  assert.deepEqual(changedFiles({ base: head, head, mode: "push", cwd: root }), []);
+});
+
+test("invalid diff identities fail instead of producing a skip", () => {
+  assert.throws(() => changedFiles({ base: "0".repeat(40), head: "HEAD" }), /non-zero/);
+  assert.throws(() => changedFiles({ base: "f".repeat(40), head: "HEAD" }));
+});
+
+test("CI routing changes exercise every routed Desktop surface", () => {
+  for (const path of [".github/workflows/ci.yml", ".github/workflows/app-memory.yml", "scripts/ci-paths.mjs"]) {
+    const flags = classifyPaths([path]).flags;
+    for (const name of ["desktop", "desktop_go", "frontend", "browser", "memory", "electron", "native", "packaging"])
+      assert.equal(flags[name], true, `${path}: ${name}`);
+  }
+});

--- a/scripts/ci-timings.mjs
+++ b/scripts/ci-timings.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import { readFileSync, appendFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+function milliseconds(start, end) {
+  if (!start || !end) return null;
+  return Math.max(0, Date.parse(end) - Date.parse(start));
+}
+
+function format(ms) {
+  if (ms === null || !Number.isFinite(ms)) return "running";
+  const seconds = Math.round(ms / 1000);
+  return `${Math.floor(seconds / 60)}m ${String(seconds % 60).padStart(2, "0")}s`;
+}
+
+function stageKind(job, step) {
+  if (/Install (frontend|memory) dependencies/.test(step)) return "dependency install";
+  if (step === "Install browser runtimes") return "browser setup";
+  if (/Build (stable|canary|memory) frontend/.test(step)) return "frontend build";
+  if (job.startsWith("desktop-browser-group") && step === "Test desktop browser group") return "browser group";
+  if (job.startsWith("shard (") && step === "Run complete independent memory process") return "memory shard";
+  return null;
+}
+
+export function timingReport(run, jobsPayload, { now = new Date() } = {}) {
+  const jobs = (jobsPayload.jobs ?? []).filter(job => job.started_at && job.conclusion !== "skipped");
+  const endTimes = jobs.map(job => job.completed_at).filter(Boolean).map(Date.parse);
+  const workflowEnd = endTimes.length === jobs.length && jobs.length > 0 ? Math.max(...endTimes) : now.getTime();
+  const workflowStart = Date.parse(run.created_at ?? run.run_started_at);
+  const rows = [];
+  const stages = [];
+  let runnerSum = 0;
+  let queueSum = 0;
+  for (const job of jobs) {
+    const execution = milliseconds(job.started_at, job.completed_at);
+    const queue = milliseconds(job.created_at, job.started_at);
+    if (execution !== null) runnerSum += execution;
+    if (queue !== null) queueSum += queue;
+    rows.push({ name: job.name, queue, execution, conclusion: job.conclusion ?? "running" });
+    for (const step of job.steps ?? []) {
+      const kind = stageKind(job.name, step.name);
+      if (kind) stages.push({ kind, name: `${job.name} / ${step.name}`, duration: milliseconds(step.started_at, step.completed_at), conclusion: step.conclusion ?? "running" });
+    }
+  }
+  return {
+    workflowElapsed: Math.max(0, workflowEnd - workflowStart),
+    runnerSum,
+    queueSum,
+    rows: rows.sort((a, b) => a.name.localeCompare(b.name)),
+    stages: stages.sort((a, b) => a.name.localeCompare(b.name)),
+  };
+}
+
+export function timingMarkdown(report, title = "CI timing") {
+  const lines = [
+    `## ${title}`,
+    "",
+    `- Total workflow wait: **${format(report.workflowElapsed)}**`,
+    `- Sum of runner execution: **${format(report.runnerSum)}**`,
+    `- Sum of recorded job queue time: **${format(report.queueSum)}**`,
+    "",
+    "Step durations exclude job queue time. Total workflow wait is wall time from workflow creation through the latest completed job.",
+  ];
+  if (report.stages.length) {
+    lines.push("", "| Stage | Step | Execution | Result |", "| --- | --- | ---: | --- |");
+    for (const stage of report.stages) lines.push(`| ${stage.kind} | ${stage.name} | ${format(stage.duration)} | ${stage.conclusion} |`);
+  }
+  lines.push("", "<details><summary>Job timing</summary>", "", "| Job | Queue | Execution | Result |", "| --- | ---: | ---: | --- |");
+  for (const row of report.rows) lines.push(`| ${row.name} | ${format(row.queue)} | ${format(row.execution)} | ${row.conclusion} |`);
+  lines.push("", "</details>", "");
+  return lines.join("\n");
+}
+
+function args(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    if (!argv[i]?.startsWith("--") || argv[i + 1] === undefined) throw new Error(`invalid argument ${argv[i] ?? ""}`);
+    out[argv[i].slice(2)] = argv[i + 1];
+  }
+  return out;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    const options = args(process.argv.slice(2));
+    const run = JSON.parse(readFileSync(options.run, "utf8"));
+    const jobs = JSON.parse(readFileSync(options.jobs, "utf8"));
+    const markdown = timingMarkdown(timingReport(run, jobs), options.title);
+    if (options.summary) appendFileSync(options.summary, markdown);
+    else process.stdout.write(markdown);
+  } catch (error) {
+    console.error(`ci-timings: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci-timings.test.mjs
+++ b/scripts/ci-timings.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { timingMarkdown, timingReport } from "./ci-timings.mjs";
+
+const stamp = seconds => new Date(Date.UTC(2026, 0, 1, 0, 0, seconds)).toISOString();
+
+test("timing report separates queue, execution, wall time and selected stages", () => {
+  const run = { created_at: stamp(0) };
+  const jobs = { jobs: [
+    { name: "desktop-prepare", created_at: stamp(1), started_at: stamp(6), completed_at: stamp(26), conclusion: "success", steps: [
+      { name: "Install frontend dependencies", started_at: stamp(7), completed_at: stamp(12), conclusion: "success" },
+      { name: "Build stable frontend", started_at: stamp(12), completed_at: stamp(20), conclusion: "success" },
+    ] },
+    { name: "desktop-browser-group (motion)", created_at: stamp(2), started_at: stamp(12), completed_at: stamp(32), conclusion: "success", steps: [
+      { name: "Test desktop browser group", started_at: stamp(20), completed_at: stamp(30), conclusion: "success" },
+    ] },
+    { name: "skipped", created_at: stamp(1), conclusion: "skipped", steps: [] },
+  ] };
+  const report = timingReport(run, jobs);
+  assert.equal(report.workflowElapsed, 32_000);
+  assert.equal(report.runnerSum, 40_000);
+  assert.equal(report.queueSum, 15_000);
+  assert.deepEqual(report.stages.map(stage => stage.kind), ["browser group", "frontend build", "dependency install"]);
+  const markdown = timingMarkdown(report, "Measured CI timing");
+  assert.match(markdown, /Total workflow wait: \*\*0m 32s\*\*/);
+  assert.match(markdown, /Sum of runner execution: \*\*0m 40s\*\*/);
+  assert.match(markdown, /Step durations exclude job queue time/);
+});
+
+test("running jobs use the observation time for wall time", () => {
+  const report = timingReport({ created_at: stamp(0) }, { jobs: [
+    { name: "app-memory", created_at: stamp(1), started_at: stamp(2), completed_at: null, conclusion: null, steps: [] },
+  ] }, { now: new Date(stamp(45)) });
+  assert.equal(report.workflowElapsed, 45_000);
+  assert.equal(report.runnerSum, 0);
+});

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -52,6 +52,21 @@ test("required desktop aggregate rejects every failed, cancelled or unexpectedly
   assert.notEqual(run({ ...success, SHOULD_RUN: "false" }), 0);
 });
 
+test("required lint aggregates code lint and the deduplicated frontend suite", () => {
+  const body = job(ci, "lint");
+  const script = shellStep(body, "Verify lint and frontend validation jobs");
+  const success = { CHANGES_RESULT: "success", LINT_CODE_RESULT: "success", LINT_CODE_REQUIRED: "true",
+    PREPARE_RESULT: "success", FRONTEND_RESULT: "success", FRONTEND_REQUIRED: "true" };
+  const run = env => spawnSync("bash", ["-e", "-c", script], { env: { ...process.env, ...env } }).status;
+  assert.equal(run(success), 0);
+  for (const key of ["CHANGES_RESULT", "LINT_CODE_RESULT", "PREPARE_RESULT", "FRONTEND_RESULT"])
+    for (const value of ["failure", "cancelled", "skipped", ""]) assert.notEqual(run({ ...success, [key]: value }), 0, `${key}=${value}`);
+  assert.equal(run({ ...success, LINT_CODE_REQUIRED: "false", LINT_CODE_RESULT: "skipped",
+    FRONTEND_REQUIRED: "false", PREPARE_RESULT: "skipped", FRONTEND_RESULT: "skipped" }), 0);
+  assert.doesNotMatch(job(ci, "lint-code"), /test:motion/);
+  assert.match(body, /needs: \[changes, lint-code, desktop-prepare, desktop-frontend\]/);
+});
+
 test("reuse skips only build work and still gates every publisher on validation", () => {
   const context = {
     inputs: { preflight_artifact_prefix: "desktop-123-1-preflight", orchestrated: true, signing_preflight_verified: true, signing_preflight: false, production_signing_smoke: false },

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -42,14 +42,16 @@ test("macOS signing diagnostics require protected main and cannot publish", () =
 
 test("required desktop aggregate rejects every failed, cancelled or unexpectedly skipped child", () => {
   const script = shellStep(job(ci, "desktop"), "Verify desktop validation jobs");
-  const success = { CHANGES_RESULT: "success", SHOULD_RUN: "true", PREPARE_RESULT: "success", GO_RESULT: "success", GO_RACE_RESULT: "success", FRONTEND_RESULT: "success", BROWSER_RESULT: "success" };
+  const success = { CHANGES_RESULT: "success", PREPARE_REQUIRED: "true", NATIVE_REQUIRED: "true", FRONTEND_REQUIRED: "true", BROWSER_REQUIRED: "true",
+    PREPARE_RESULT: "success", GO_RESULT: "success", GO_RACE_RESULT: "success", FRONTEND_RESULT: "success", BROWSER_RESULT: "success" };
   const run = env => spawnSync("bash", ["-e", "-c", script], { env: { ...process.env, ...env } }).status;
   assert.equal(run(success), 0);
   for (const key of ["PREPARE_RESULT", "GO_RESULT", "GO_RACE_RESULT", "FRONTEND_RESULT", "BROWSER_RESULT", "CHANGES_RESULT"]) {
     for (const value of ["failure", "cancelled", "skipped", ""]) assert.notEqual(run({ ...success, [key]: value }), 0, `${key}=${value}`);
   }
-  assert.equal(run({ ...success, SHOULD_RUN: "false", PREPARE_RESULT: "skipped", GO_RESULT: "skipped", GO_RACE_RESULT: "skipped", FRONTEND_RESULT: "skipped", BROWSER_RESULT: "skipped" }), 0);
-  assert.notEqual(run({ ...success, SHOULD_RUN: "false" }), 0);
+  assert.equal(run({ ...success, PREPARE_REQUIRED: "false", NATIVE_REQUIRED: "false", FRONTEND_REQUIRED: "false", BROWSER_REQUIRED: "false",
+    PREPARE_RESULT: "skipped", GO_RESULT: "skipped", GO_RACE_RESULT: "skipped", FRONTEND_RESULT: "skipped", BROWSER_RESULT: "skipped" }), 0);
+  assert.equal(run({ ...success, FRONTEND_REQUIRED: "false", BROWSER_REQUIRED: "false", FRONTEND_RESULT: "skipped", BROWSER_RESULT: "skipped" }), 0);
 });
 
 test("required lint aggregates code lint and the deduplicated frontend suite", () => {
@@ -63,6 +65,7 @@ test("required lint aggregates code lint and the deduplicated frontend suite", (
     for (const value of ["failure", "cancelled", "skipped", ""]) assert.notEqual(run({ ...success, [key]: value }), 0, `${key}=${value}`);
   assert.equal(run({ ...success, LINT_CODE_REQUIRED: "false", LINT_CODE_RESULT: "skipped",
     FRONTEND_REQUIRED: "false", PREPARE_RESULT: "skipped", FRONTEND_RESULT: "skipped" }), 0);
+  assert.equal(run({ ...success, FRONTEND_REQUIRED: "false", PREPARE_RESULT: "success", FRONTEND_RESULT: "skipped" }), 0);
   assert.doesNotMatch(job(ci, "lint-code"), /test:motion/);
   assert.match(body, /needs: \[changes, lint-code, desktop-prepare, desktop-frontend\]/);
 });
@@ -111,11 +114,11 @@ test("all desktop consumers verify the prepared build and reject a failed prepar
     needs: { changes: { outputs: { desktop: "true" } }, "desktop-prepare": { result: "success" } } };
   const aggregate = job(ci, "desktop");
   for (const [name, variant] of [
-    ["desktop-go", "stable"], ["desktop-frontend", "stable"], ["desktop-browser", "stable"],
+    ["desktop-go", "stable"], ["desktop-frontend", "stable"], ["desktop-browser-group", "stable"],
     ["desktop-macos", "stable"], ["desktop-windows", "canary"], ["desktop-windows-go", "stable"],
   ]) {
     const body = job(ci, name);
-    if (["desktop-go", "desktop-frontend", "desktop-browser"].includes(name)) assert.ok(aggregate.includes(name));
+    if (["desktop-go", "desktop-frontend"].includes(name)) assert.ok(aggregate.includes(name));
     assert.ok(body.includes("needs: [changes, desktop-prepare]"));
     assert.ok(body.includes(`name: \${{ needs.desktop-prepare.outputs.${variant}_artifact_name }}`));
     assert.ok(body.includes(`--shell electron --channel ${variant}`));
@@ -130,4 +133,20 @@ test("all desktop consumers verify the prepared build and reject a failed prepar
     assert.match(body, /canary_artifact_name/);
   }
   assert.match(job(ci, "desktop-macos"), /REASONIX_FRONTEND_PNPM_VERSION="\$\(pnpm --version\)"\n\s+export REASONIX_FRONTEND_PNPM_VERSION/);
+});
+
+test("browser matrix preserves five entry points and fails closed through desktop-browser", () => {
+  const groups = job(ci, "desktop-browser-group");
+  assert.match(groups, /max-parallel: 2/);
+  assert.match(groups, /fail-fast: false/);
+  for (const command of ["test:app-browser", "test:settings-browser", "test:motion-browser", "test:transcript-browser", "test:transcript-reader-browser"])
+    assert.equal(ci.match(new RegExp(`pnpm --dir frontend ${command}(?:\\s|$)`, "g"))?.length, 1, command);
+  const summary = job(ci, "desktop-browser");
+  assert.match(summary, /needs: \[changes, desktop-prepare, desktop-browser-group\]/);
+  const script = shellStep(summary, "Verify desktop browser groups");
+  const run = env => spawnSync("bash", ["-e", "-c", script], { env: { ...process.env, ...env } }).status;
+  assert.equal(run({ CHANGES_RESULT: "success", SHOULD_RUN: "true", PREPARE_RESULT: "success", GROUP_RESULT: "success" }), 0);
+  for (const result of ["failure", "cancelled", "skipped", ""])
+    assert.notEqual(run({ CHANGES_RESULT: "success", SHOULD_RUN: "true", PREPARE_RESULT: "success", GROUP_RESULT: result }), 0);
+  assert.equal(run({ CHANGES_RESULT: "success", SHOULD_RUN: "false", PREPARE_RESULT: "success", GROUP_RESULT: "skipped" }), 0);
 });

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -106,17 +106,28 @@ test("reuse never moves artifact verification past public mutation or trusts can
   for (const name of ["desktop", "cli", "npm"]) assert.ok(job(stable, name).includes("needs: [authorize, signpath-preflight]"));
 });
 
-test("all Linux consumers use the prepared build and reject a failed preparation", () => {
+test("all desktop consumers verify the prepared build and reject a failed preparation", () => {
   const context = { github: { event_name: "pull_request" },
     needs: { changes: { outputs: { desktop: "true" } }, "desktop-prepare": { result: "success" } } };
   const aggregate = job(ci, "desktop");
-  for (const name of ["desktop-go", "desktop-frontend", "desktop-browser"]) {
+  for (const [name, variant] of [
+    ["desktop-go", "stable"], ["desktop-frontend", "stable"], ["desktop-browser", "stable"],
+    ["desktop-macos", "stable"], ["desktop-windows", "canary"], ["desktop-windows-go", "stable"],
+  ]) {
     const body = job(ci, name);
-    assert.ok(aggregate.includes(name));
+    if (["desktop-go", "desktop-frontend", "desktop-browser"].includes(name)) assert.ok(aggregate.includes(name));
     assert.ok(body.includes("needs: [changes, desktop-prepare]"));
-    assert.ok(body.includes("name: ${{ needs.desktop-prepare.outputs.artifact_name }}"));
+    assert.ok(body.includes(`name: \${{ needs.desktop-prepare.outputs.${variant}_artifact_name }}`));
+    assert.ok(body.includes(`--shell electron --channel ${variant}`));
     assert.ok(!body.includes("pnpm --dir frontend build"));
     assert.equal(condition(body, context), true);
     assert.equal(condition(body, { ...context, needs: { ...context.needs, "desktop-prepare": { result: "failure" } } }), false);
   }
+  for (const name of ["desktop-windows", "desktop-windows-package"]) {
+    const body = job(ci, name);
+    assert.match(body, /REASONIX_PACKAGE_REUSE_FRONTEND: "1"/);
+    assert.match(body, /REASONIX_FRONTEND_PNPM_VERSION="\$\(pnpm --version\)"\n\s+export REASONIX_FRONTEND_PNPM_VERSION/);
+    assert.match(body, /canary_artifact_name/);
+  }
+  assert.match(job(ci, "desktop-macos"), /REASONIX_FRONTEND_PNPM_VERSION="\$\(pnpm --version\)"\n\s+export REASONIX_FRONTEND_PNPM_VERSION/);
 });

--- a/tools/desktopinventory/sources.go
+++ b/tools/desktopinventory/sources.go
@@ -15,6 +15,7 @@ var ciJobs = map[string]struct {
 	"ci.yml/desktop":                              {classKeepBusiness, "aggregate gate, unchanged"},
 	"ci.yml/desktop-frontend":                     {classKeepBusiness, "React gates unchanged"},
 	"ci.yml/desktop-browser":                      {classKeepBusiness, "Playwright browser gates unchanged"},
+	"ci.yml/desktop-browser-group":                {classKeepBusiness, "Playwright browser gates split into bounded groups"},
 	"ci.yml/desktop-prepare":                      {classKeepBusiness, "go run . -emit-contract drift gate; pnpm workspace root"},
 	"ci.yml/desktop-go":                           {classKeepBusiness, "hostrpc + module tests; no WebKitGTK toolchain"},
 	"ci.yml/desktop-go-race":                      {classKeepBusiness, "desktop module race sweep, split from desktop-go"},


### PR DESCRIPTION
## Problem and resulting behavior

Desktop documentation changes could start three full App memory shards, motion tests ran twice, browser contracts were serial, and macOS/Windows rebuilt frontend bytes already produced on Linux. This change centralizes path decisions, keeps the protected check names, verifies reusable frontend artifacts, and splits browser coverage into bounded parallel groups.

## Path routing

| Changed input | Frontend | Browser | Memory | Go/race | Native | Packaging |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Explicit docs, including `desktop/AGENTS.md` | — | — | — | — | — | — |
| Frontend source, assets, tests or build inputs | ✓ | ✓ | ✓ | ✓ | ✓ | — |
| Desktop/root Go implementation | — | — | — | ✓ | ✓ | — |
| Generated frontend protocol/shared frontend input | ✓ | ✓ | ✓ | ✓ | ✓ | — |
| Electron shell | ✓ | — | — | ✓ | ✓ | — |
| Packaging/install/update inputs | — | — | — | ✓ | ✓ | ✓ |
| Desktop manifests and lockfiles | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| Unknown path or unreliable diff | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |

PRs use merge-base diffs. Push classifiers use `before..sha`; normal `main-v2` pushes retain full validation after the existing release-notes-only exception. Manual memory runs remain full.

## Validation structure

- `lint-code` owns repository lint. The required `lint` summary fails closed over `lint-code`, preparation and the complete frontend plan when selected.
- `test:motion` remains in the discovered frontend plan and appears once. The plan still contains 413 unique commands on this candidate.
- Browser contracts run as application/settings, motion and Transcript groups with `max-parallel: 2` and `fail-fast: false`. `desktop-browser` remains the final summary check.
- Linux prepares `electron/stable` and `electron/canary` once per workflow attempt. Versioned manifests bind checkout SHA, run/attempt, variant, build inputs, Node/pnpm, producer platform and all `dist` hashes. Linux, macOS and Windows verify before use.
- Explicit packaging reuse now fails on a missing, stale, mismatched or damaged manifest instead of silently rebuilding.
- App memory remains three independent shards with 128 full, 128 windowed, 128 safety and 512 mixed cycles, unchanged snapshots, sampling and verdict rules.

## Local evidence

- 413/413 frontend CI commands passed.
- Stable full Electron build and canary bundle-only build passed all existing bundle budgets.
- 48 path, workflow, artifact, browser-plan and memory-protocol contract tests passed.
- 22 packaging tests passed.
- `actionlint` passed for `ci.yml` and `app-memory.yml`.
- `repolint` passed with 1,212 baselined findings and no new finding.

## Timing

Both workflows now report step execution excluding queue time, total workflow wall time, recorded queue time and summed runner execution. Frontend builds, dependency/browser setup, browser groups and memory shards are separate rows.

Three successful runs of each side were measured. The baseline is the immediately preceding full Desktop validation for PR #10189 at `d31089bc0`; the candidate is this PR at `63b24f02a`. Re-runs kept each side on its respective SHA and did not publish artifacts.

| Workflow metric | Baseline median (range) | Candidate median (range) | Median change |
| --- | ---: | ---: | ---: |
| CI total wait | 22m 37s (17m 49s–23m 21s) | 20m 57s (19m 50s–25m 48s) | -1m 40s (-7.4%) |
| CI runner execution sum | 98m 25s (93m 41s–105m 07s) | 93m 56s (91m 41s–96m 08s) | -4m 29s (-4.6%) |
| App memory total wait | 20m 59s (20m 35s–25m 28s) | 21m 28s (19m 30s–23m 35s) | +0m 29s (+2.3%) |
| App memory runner execution sum | 56m 14s (53m 34s–57m 37s) | 57m 27s (52m 36s–60m 13s) | +1m 13s (+2.2%) |

The browser critical span changed from a 5m 58s median serial job to a 5m 23s median matrix span (4m 53s–5m 32s), while failures now isolate to one group. The largest remaining wall-time source is `desktop-windows-go`, whose candidate runs ranged from 16m 34s to 21m 43s.

Evidence: [baseline CI](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/34690180910), [candidate CI](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/34693041650), [baseline memory](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/34690180907), and [candidate memory](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/34693041640). Candidate CI attempt 3 was excluded and replaced by full attempt 4 because the existing Windows timing test `TestCreationLayoutQuickClicksSerializeWorkspaceRebuild` timed out once; artifact verification and the other 25 jobs passed in that attempt.

## Limits

Browser binaries are intentionally not cached across matrix jobs in this change. Static frontend artifacts are shared across platforms; `node_modules`, native modules and Electron binaries remain platform-local. Release approval, production signing, published artifacts and branch protection are unchanged.

The baseline and candidate are adjacent CI revisions rather than the same Git commit because the previous CI workflow has no manual dispatch entry. Both exercised the full Desktop qualification surface, and the ranges include observed runner contention; the runner execution sum is therefore the primary cost comparison. App memory remains statistically unchanged and is reported without a speedup claim.

Documentation-impact: updated - CI operator guidance was updated under `.github/`, and the generated Desktop migration inventory now records the browser matrix job.
