### PR TITLE
fix: preserve todo state after compaction dedupe

### DIFF
--- a/internal/agent/duplicate_result.go
+++ b/internal/agent/duplicate_result.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -10,7 +11,7 @@ import (
 func (a *Agent) boundProviderVisibleResult(raw, toolName, callID string) (body, notice, original string) {
 	summarized := summarizeCIOutput(raw)
 	body, notice = truncateToolOutputFor(summarized, toolName, callID)
-	deduped := a.dedupeProviderVisibleResult(callID, raw, body)
+	deduped := a.dedupeProviderVisibleResultForTool(callID, raw, body, toolName)
 	if deduped != body {
 		original = raw
 	}
@@ -22,14 +23,46 @@ func (a *Agent) boundProviderVisibleResult(raw, toolName, callID string) (body, 
 }
 
 func (a *Agent) dedupeProviderVisibleResult(callID, raw, visible string) string {
+	return a.dedupeProviderVisibleResultForTool(callID, raw, visible, "")
+}
+
+// dedupeProviderVisibleResultForTool applies the generic result guard while
+// preserving state-machine acknowledgements. todo_write's output contains
+// only counts, so two different valid lists can otherwise look identical.
+func (a *Agent) dedupeProviderVisibleResultForTool(callID, raw, visible, toolName string) string {
 	if a == nil || strings.TrimSpace(raw) == "" {
+		return visible
+	}
+	// todo_write is a host state transition. Its short count-based result is
+	// not a stable identity for the submitted list, so never hide it as a
+	// duplicate. This also keeps a replay visible after compaction.
+	if toolName == "todo_write" {
 		return visible
 	}
 	sum := sha256.Sum256([]byte(raw))
 	fp := hex.EncodeToString(sum[:12])
 	prev, seen := a.turn.loop.rememberFingerprint(fp, callID)
 	if seen && prev != callID {
-		return fmt.Sprintf("duplicate tool result omitted (identical to call_id=%s, fingerprint=%s). Full original remains locally; page it with session:tool_result if needed.", prev, fp)
+		message := fmt.Sprintf("duplicate tool result omitted (identical to call_id=%s, fingerprint=%s). Full original remains locally; page it with session:tool_result if needed.", prev, fp)
+		return message + canonicalTodoStateHint(a)
 	}
 	return visible
+}
+
+// canonicalTodoStateHint gives the model a recovery snapshot when a generic
+// duplicate result is suppressed. The snapshot is deliberately taken from
+// host state, not from the compacted provider transcript.
+func canonicalTodoStateHint(a *Agent) string {
+	if a == nil {
+		return ""
+	}
+	todos := a.CanonicalTodoState()
+	if len(todos) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(todos)
+	if err != nil {
+		return ""
+	}
+	return "\nCurrent canonical todo state: " + string(b)
 }

--- a/internal/agent/duplicate_result_test.go
+++ b/internal/agent/duplicate_result_test.go
@@ -30,6 +30,15 @@ func TestDedupeUsesRawResultBeforeLossySummary(t *testing.T) {
 	}
 }
 
+func TestTodoWriteResultIsNeverHiddenAsGenericDuplicate(t *testing.T) {
+	a := &Agent{}
+	first, _, _ := a.boundProviderVisibleResult("Todos updated: 2 total — 0 completed, 1 in progress, 1 pending.", "todo_write", "c1")
+	second, _, _ := a.boundProviderVisibleResult("Todos updated: 2 total — 0 completed, 1 in progress, 1 pending.", "todo_write", "c2")
+	if first != second || strings.Contains(second, "duplicate tool result") {
+		t.Fatalf("todo_write acknowledgement was deduped: first=%q second=%q", first, second)
+	}
+}
+
 func TestResolvedSkipOutcomeDedupesRepeatedLocalDiscovery(t *testing.T) {
 	a := &Agent{}
 	result := `{"id":"mcp-tool:server/read","input_schema":{"type":"object"}}`

--- a/internal/tool/builtin/todo.go
+++ b/internal/tool/builtin/todo.go
@@ -62,10 +62,16 @@ func (todoWrite) Schema() json.RawMessage {
 // laying out a plan as todos is exactly the point.
 func (todoWrite) ReadOnly() bool { return true }
 
-func (todoWrite) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+func (todoWrite) Execute(ctx context.Context, args json.RawMessage) (output string, err error) {
 	var p struct {
 		Todos []todoItem `json:"todos"`
 	}
+	// 每个校验失败都带上宿主当前清单，模型即使丢失了压缩前的历史也能重试。
+	defer func() {
+		if err != nil {
+			err = withTodoStateHint(ctx, err, p.Todos)
+		}
+	}()
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
 	}
@@ -107,6 +113,24 @@ func (todoWrite) Execute(ctx context.Context, args json.RawMessage) (string, err
 	}
 	return fmt.Sprintf("Todos updated: %d total — %d completed, %d in progress, %d pending.",
 		len(p.Todos), done, active, pending), nil
+}
+
+// withTodoStateHint appends a complete JSON snapshot to validation errors.
+// Prefer the host baseline; when no baseline exists, expose the submitted
+// list so malformed serial-state errors remain actionable.
+func withTodoStateHint(ctx context.Context, err error, submitted []todoItem) error {
+	if err == nil {
+		return nil
+	}
+	current := todoBaseline(ctx)
+	if len(current) == 0 && len(submitted) > 0 {
+		current = toEvidenceTodos(submitted)
+	}
+	snapshot, marshalErr := json.Marshal(current)
+	if marshalErr != nil {
+		return err
+	}
+	return fmt.Errorf("%w; current todo list: %s", err, snapshot)
 }
 
 // verifyUniqueStepIDs keeps a step id an identity: two items claiming the same

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -134,6 +134,26 @@ func TestTodoWriteRejectsDroppingCurrentTodoWithoutReplacementAuth(t *testing.T)
 	}
 }
 
+func TestTodoWriteValidationErrorIncludesCurrentTodoList(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos: []evidence.TodoItem{
+			{Content: "Inspect environment", Status: "completed", StepID: "step-1"},
+			{Content: "Write code", Status: "in_progress", StepID: "step-2"},
+		},
+	})
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	_, err := (todoWrite{}).Execute(ctx, json.RawMessage(`{"todos":[{"content":"Write code","status":"in_progress","step_id":"step-2"}]}`))
+	if err == nil || !strings.Contains(err.Error(), "current todo list") {
+		t.Fatalf("validation error = %v, want a full current-list hint", err)
+	}
+	if !strings.Contains(err.Error(), `"Inspect environment"`) || !strings.Contains(err.Error(), `"step-1"`) {
+		t.Fatalf("validation error omitted the canonical list: %v", err)
+	}
+}
+
 func TestTodoWriteApprovedPlanReplacementPreservesCompletedHistory(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{


### PR DESCRIPTION
## Summary
Fixes #10023 by keeping todo_write state transitions visible after automatic compaction.

## Root Cause
The generic provider-result deduplication fingerprints raw tool output. todo_write only returns aggregate counts, so different valid todo lists can share the same acknowledgement. After compaction, replayed todo_write calls could therefore have their result replaced by the duplicate-result notice, leaving the model without an actionable state transition.

## Changes
- Bypass generic result deduplication for todo_write acknowledgements.
- Include the current canonical todo list in todo validation errors so recovery can reconstruct step IDs and completed history.
- Add regression tests for repeated todo_write acknowledgements and canonical state hints.
- Preserve generic deduplication behavior for all other tools.

## Testing
- go test ./internal/agent ./internal/tool/builtin
- go vet ./internal/agent ./internal/tool/builtin
- go run ./tools/repolint

Full go test ./... was also attempted; cmd/e2ebench requires a WSL /bin/bash environment unavailable on the Windows host.

Documentation-impact: none - This changes internal agent/tool recovery behavior; existing user documentation remains correct.

Cache-impact: low - The change affects tool-result visibility and todo recovery, but does not change prompt-cache keys or persisted cache formats.
Cache-guard: go test ./internal/agent ./internal/tool/builtin; go vet ./internal/agent ./internal/tool/builtin

Fixes #10023