### PR TITLE
fix(desktop): restore remote wizard choice states / 修复远程向导选中态

### DIFF
--- a/desktop/frontend/src/__tests__/remote-connect-wizard.test.tsx
+++ b/desktop/frontend/src/__tests__/remote-connect-wizard.test.tsx
@@ -201,6 +201,23 @@ ok(railItems().length === 3, "stepper rail lists all three steps");
 ok(railItems()[0]?.className.includes("--current") === true, "step 1 is current on open");
 ok(railItems().every((item) => !item.className.includes("--done")), "no step is done on open");
 ok(document.querySelectorAll(".remote-wizard__seg").length === 3, "auth, download, and credential mode use segmented sliders");
+for (const group of document.querySelectorAll<HTMLElement>(".remote-wizard__seg")) {
+  const choices = [...group.querySelectorAll<HTMLButtonElement>("button")];
+  const selected = choices.filter(button => button.getAttribute("aria-pressed") === "true");
+  ok(selected.length === 1 && selected[0].dataset.selected === "true", "each initial choice has accessible and styled selection");
+  ok(group.classList.contains("settings-options"), "wizard uses the shared selection stylesheet");
+}
+const initialFocus = document.activeElement as HTMLElement;
+const authChoices = [...document.querySelectorAll<HTMLButtonElement>(".remote-wizard__seg") [0].querySelectorAll("button")];
+await act(async () => {
+  authChoices[0].focus();
+  authChoices[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+});
+ok(authChoices[1].getAttribute("aria-pressed") === "true" && authChoices[1].dataset.selected === "true", "keyboard selection updates the auth highlight");
+ok(authChoices[0].dataset.selected === "false", "previous auth choice loses its highlight");
+await act(async () => { authChoices[0].click(); });
+initialFocus.focus();
+
 const hostInput = document.querySelector<HTMLInputElement>(".remote-wizard__suggest input");
 ok(Boolean(hostInput), "config step shows the host input");
 ok(
@@ -533,7 +550,7 @@ await act(async () => {
     localProxy?.click();
     await Promise.resolve();
   });
-  ok(localProxy?.className.includes("--active") === true, "local-proxy segment highlights when selected");
+  ok(localProxy?.getAttribute("aria-pressed") === "true" && localProxy?.dataset.selected === "true", "local-proxy segment highlights when selected");
 }
 await act(async () => {
   buttonByText("Next")?.click();

--- a/desktop/frontend/src/__tests__/remote-connect-wizard.test.tsx
+++ b/desktop/frontend/src/__tests__/remote-connect-wizard.test.tsx
@@ -307,6 +307,12 @@ ok(!document.querySelector(".remote-wizard__suggest-list"), "picking a suggestio
 ok(document.activeElement === hostInput, "picking a suggestion restores focus to the host input");
 const keyInput = [...document.querySelectorAll<HTMLInputElement>("input")].find((i) => i.value.includes("id_ed25519"));
 ok(Boolean(keyInput), "saved key auth switches the form to key mode with the identity file");
+const installChoice = () => document.querySelector<HTMLButtonElement>('.remote-wizard__install [aria-pressed="true"]');
+ok(installChoice()?.textContent?.trim() === "Automatic", "saved auto install policy remains selected");
+await act(async () => { buttonByText("Use installed CLI")?.click(); });
+ok(installChoice()?.textContent?.trim() === "Use installed CLI", "never policy is visible and selectable");
+await act(async () => { buttonByText("Automatic")?.click(); });
+
 await act(async () => {
   document.querySelector<HTMLButtonElement>(".remote-wizard__pick-btn")?.click();
   await flush();

--- a/desktop/frontend/src/components/RemoteConnectWizard.css
+++ b/desktop/frontend/src/components/RemoteConnectWizard.css
@@ -470,3 +470,12 @@
   color: var(--fg-dim);
   overflow-wrap: anywhere;
 }
+
+:root .settings-options.remote-wizard__install {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  height: auto;
+}
+:root .settings-options.remote-wizard__install > button {
+  min-height: 30px;
+}

--- a/desktop/frontend/src/components/RemoteConnectWizard.tsx
+++ b/desktop/frontend/src/components/RemoteConnectWizard.tsx
@@ -601,25 +601,24 @@ export function RemoteConnectWizard({
                 )}
                 <div className="remote-wizard__field">
                   <span>{t("remoteWizard.downloadMethod")}</span>
-                  <SettingsOptions className="remote-wizard__seg" layout="fill" aria-label={t("remoteWizard.downloadMethod")}>
-                    <button
-                      type="button"
-                      className="provider-add-segmented__item"
-                      aria-pressed={form.serveInstall === "upload"}
-                      disabled={busy}
-                      onClick={() => set("serveInstall", "upload")}
-                    >
-                      {t("remoteWizard.downloadUpload")}
-                    </button>
-                    <button
-                      type="button"
-                      className="provider-add-segmented__item"
-                      aria-pressed={form.serveInstall === "npm"}
-                      disabled={busy}
-                      onClick={() => set("serveInstall", "npm")}
-                    >
-                      {t("remoteWizard.downloadRemote")}
-                    </button>
+                  <SettingsOptions className="remote-wizard__seg remote-wizard__install" layout="fill" aria-label={t("remoteWizard.downloadMethod")}>
+                    {([
+                      ["auto", "remoteWizard.downloadAuto"],
+                      ["upload", "remoteWizard.downloadUpload"],
+                      ["npm", "remoteWizard.downloadRemote"],
+                      ["never", "remoteWizard.downloadNever"],
+                    ] as const).map(([value, label]) => (
+                      <button
+                        key={value}
+                        type="button"
+                        className="provider-add-segmented__item"
+                        aria-pressed={form.serveInstall === value}
+                        disabled={busy}
+                        onClick={() => set("serveInstall", value)}
+                      >
+                        {t(label)}
+                      </button>
+                    ))}
                   </SettingsOptions>
                 </div>
                 <div className="remote-wizard__field">

--- a/desktop/frontend/src/components/RemoteConnectWizard.tsx
+++ b/desktop/frontend/src/components/RemoteConnectWizard.tsx
@@ -5,6 +5,7 @@ import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import { useRemoteNavigationCommand } from "../lib/remoteNavigationCommands";
 import { useRemoteStore, waitForRemoteConnection } from "../store/remote";
+import { SettingsOptions } from "./SettingsOptions";
 import { RemoteStatusChip } from "./RemoteHostsPage";
 import type { RemoteDirEntry, RemoteHostInput, RemoteHostView } from "../lib/types";
 
@@ -522,10 +523,11 @@ export function RemoteConnectWizard({
                   </label>
                   <div className="remote-wizard__field">
                     <span>{t("remoteWizard.authMethod")}</span>
-                    <div className="provider-add-segmented remote-wizard__seg" role="group" aria-label={t("remoteWizard.authMethod")}>
+                    <SettingsOptions className="remote-wizard__seg" layout="fill" aria-label={t("remoteWizard.authMethod")}>
                       <button
                         type="button"
-                        className={`provider-add-segmented__item${authMode === "password" ? " provider-add-segmented__item--active" : ""}`}
+                        className="provider-add-segmented__item"
+                        aria-pressed={authMode === "password"}
                         disabled={busy}
                         onClick={() => setAuthMode("password")}
                       >
@@ -533,13 +535,14 @@ export function RemoteConnectWizard({
                       </button>
                       <button
                         type="button"
-                        className={`provider-add-segmented__item${authMode === "key" ? " provider-add-segmented__item--active" : ""}`}
+                        className="provider-add-segmented__item"
+                        aria-pressed={authMode === "key"}
                         disabled={busy}
                         onClick={() => setAuthMode("key")}
                       >
                         {t("remoteWizard.authKey")}
                       </button>
-                    </div>
+                    </SettingsOptions>
                   </div>
                 </div>
                 {authMode === "password" ? (
@@ -598,10 +601,11 @@ export function RemoteConnectWizard({
                 )}
                 <div className="remote-wizard__field">
                   <span>{t("remoteWizard.downloadMethod")}</span>
-                  <div className="provider-add-segmented remote-wizard__seg" role="group" aria-label={t("remoteWizard.downloadMethod")}>
+                  <SettingsOptions className="remote-wizard__seg" layout="fill" aria-label={t("remoteWizard.downloadMethod")}>
                     <button
                       type="button"
-                      className={`provider-add-segmented__item${form.serveInstall === "upload" ? " provider-add-segmented__item--active" : ""}`}
+                      className="provider-add-segmented__item"
+                      aria-pressed={form.serveInstall === "upload"}
                       disabled={busy}
                       onClick={() => set("serveInstall", "upload")}
                     >
@@ -609,20 +613,22 @@ export function RemoteConnectWizard({
                     </button>
                     <button
                       type="button"
-                      className={`provider-add-segmented__item${form.serveInstall === "npm" ? " provider-add-segmented__item--active" : ""}`}
+                      className="provider-add-segmented__item"
+                      aria-pressed={form.serveInstall === "npm"}
                       disabled={busy}
                       onClick={() => set("serveInstall", "npm")}
                     >
                       {t("remoteWizard.downloadRemote")}
                     </button>
-                  </div>
+                  </SettingsOptions>
                 </div>
                 <div className="remote-wizard__field">
                   <span>{t("remote.host.credentialMode")}</span>
-                  <div className="provider-add-segmented remote-wizard__seg" role="group" aria-label={t("remote.host.credentialMode")}>
+                  <SettingsOptions className="remote-wizard__seg" layout="fill" aria-label={t("remote.host.credentialMode")}>
                     <button
                       type="button"
-                      className={`provider-add-segmented__item${form.credentialMode !== "local-proxy" ? " provider-add-segmented__item--active" : ""}`}
+                      className="provider-add-segmented__item"
+                      aria-pressed={form.credentialMode !== "local-proxy"}
                       disabled={busy}
                       onClick={() => set("credentialMode", "remote")}
                     >
@@ -630,13 +636,14 @@ export function RemoteConnectWizard({
                     </button>
                     <button
                       type="button"
-                      className={`provider-add-segmented__item${form.credentialMode === "local-proxy" ? " provider-add-segmented__item--active" : ""}`}
+                      className="provider-add-segmented__item"
+                      aria-pressed={form.credentialMode === "local-proxy"}
                       disabled={busy}
                       onClick={() => set("credentialMode", "local-proxy")}
                     >
                       {t("remote.host.credentialModeLocalProxy")}
                     </button>
-                  </div>
+                  </SettingsOptions>
                 </div>
                 </div>
               </>

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -162,6 +162,8 @@ export const en = {
   "remoteWizard.authPassword": "Password",
   "remoteWizard.authKey": "Key file",
   "remoteWizard.downloadMethod": "CLI download method",
+  "remoteWizard.downloadAuto": "Automatic",
+  "remoteWizard.downloadNever": "Use installed CLI",
   "remoteWizard.downloadRemote": "Download on remote",
   "remoteWizard.downloadUpload": "Download locally & upload",
   "remoteWizard.suggestions": "Saved SSH connections",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -153,6 +153,8 @@ export const zhTW: Record<DictKey, string> = {
   "remoteWizard.authPassword": "密碼",
   "remoteWizard.authKey": "私鑰",
   "remoteWizard.downloadMethod": "資源下載方式",
+  "remoteWizard.downloadAuto": "自動選擇",
+  "remoteWizard.downloadNever": "使用已安裝的 CLI",
   "remoteWizard.downloadRemote": "遠端下載",
   "remoteWizard.downloadUpload": "本地下載上傳",
   "remoteWizard.suggestions": "已儲存的 SSH 連線",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -163,6 +163,8 @@ export const zh: Record<DictKey, string> = {
   "remoteWizard.authPassword": "密码",
   "remoteWizard.authKey": "私钥",
   "remoteWizard.downloadMethod": "资源下载方式",
+  "remoteWizard.downloadAuto": "自动选择",
+  "remoteWizard.downloadNever": "使用已安装的 CLI",
   "remoteWizard.downloadRemote": "远端服务下载",
   "remoteWizard.downloadUpload": "本地下载后上传",
   "remoteWizard.suggestions": "已保存的 SSH 连接",


### PR DESCRIPTION
## Summary

- Restore visible and accessible selection for the remote wizard's authentication, CLI installation, and credential-location choices.
- Preserve saved `auto`, `upload`, `npm`, and `never` installation policies when reopening and saving the wizard.
- Keep keyboard selection and light/dark theme behavior on the shared settings option contract.

## Issues

No linked issue.

## Verification

- `pnpm typecheck`
- `node --import ./scripts/css-stub-register.mjs --import tsx src/__tests__/remote-connect-wizard.test.tsx` (88 assertions pass)

## Documentation impact

Documentation-impact: none - this restores the existing remote wizard controls and saved policy behavior; the embedded documentation does not describe their visual selection implementation.

## Cache impact

Cache-impact: none - the change only affects remote wizard form rendering and local configuration values.
Cache-guard: existing remote connect wizard tests cover initialization, selection, saved values, and keyboard behavior.
System-prompt-review: N/A
